### PR TITLE
fix: crash when procedure returns has no number

### DIFF
--- a/pkg/resources/procedure.go
+++ b/pkg/resources/procedure.go
@@ -252,8 +252,8 @@ func ReadProcedure(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 		case "returns":
-			// Format in Snowflake DB is returnType(<some number>)
-			re := regexp.MustCompile(`^(.*)\([0-9]*\)$`)
+			// Format in Snowflake DB is RETURN_TYPE(<some number>) or RETURN_TYPE
+			re := regexp.MustCompile(`^([A-Z0-9_]+)(\([0-9]*\))?$`)
 			match := re.FindStringSubmatch(desc.Value.String)
 			if err = d.Set("return_type", match[1]); err != nil {
 				return err


### PR DESCRIPTION
Fixes a crash produced when stored procedure return type has no parenthesized number suffix (e.g. `VARCHAR(10)`). JavaScript stored procedures support return types like `FLOAT` and `BOOLEAN`.

Example stack trace below:

```
snowflake_procedure.drop_test_schemas: Creating...
╷
│ Error: Plugin did not respond
│
│   with snowflake_procedure.drop_test_schemas,
│   on main.tf line 7, in resource "snowflake_procedure" "proc":
│    1: resource "snowflake_procedure" "proc" {
│
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-snowflake_v0.25.19 plugin:

panic: runtime error: index out of range [1] with length 0

goroutine 26 [running]:
github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources.ReadProcedure(0xc000669200, 0x1ecc680, 0xc000166a90, 0x0, 0x0)
	github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources/procedure.go:258 +0x1408
github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources.CreateProcedure(0xc000669200, 0x1ecc680, 0xc000166a90, 0x1, 0xffffffffffffffff)
	github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources/procedure.go:184 +0x925
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc00038c2a0, 0x20c8558, 0xc0005db400, 0xc000669200, 0x1ecc680, 0xc000166a90, 0x0, 0x0, 0x0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/resource.go:318 +0x1ee
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc00038c2a0, 0x20c8558, 0xc0005db400, 0xc000576690, 0xc000514c80, 0x1ecc680, 0xc000166a90, 0x0, 0x0, 0x0, ...)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/resource.go:456 +0x67b
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc0002b80f0, 0x20c8558, 0xc0005db400, 0xc0002c2be0, 0xc0005db400, 0x1e8ad20, 0xc000416300)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.0/helper/schema/grpc_provider.go:955 +0x8ef
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ApplyResourceChange(0xc000535f40, 0x20c8600, 0xc0005db400, 0xc000576460, 0xc000535f40, 0xc000416300, 0xc0001abba0)
	github.com/hashicorp/terraform-plugin-go@v0.3.1/tfprotov5/server/server.go:332 +0xb5
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler(0x1e8ad20, 0xc000535f40, 0x20c8600, 0xc000416300, 0xc0005688a0, 0x0, 0x20c8600, 0xc000416300, 0xc0006c0c00, 0x3d7)
	github.com/hashicorp/terraform-plugin-go@v0.3.1/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:380 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000318380, 0x20d2d58, 0xc000102f00, 0xc0002717a0, 0xc00024a720, 0x2750220, 0x0, 0x0, 0x0)
	google.golang.org/grpc@v1.39.0/server.go:1292 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc000318380, 0x20d2d58, 0xc000102f00, 0xc0002717a0, 0x0)
	google.golang.org/grpc@v1.39.0/server.go:1617 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc0003001e0, 0xc000318380, 0x20d2d58, 0xc000102f00, 0xc0002717a0)
	google.golang.org/grpc@v1.39.0/server.go:940 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.39.0/server.go:938 +0x1fd

Error: The terraform-provider-snowflake_v0.25.19 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

## Test Plan

* [ ] acceptance tests

## References

* [Working with Stored Procedures](https://docs.snowflake.com/en/sql-reference/stored-procedures-usage.html#sql-and-javascript-data-type-mapping)
* [DESCRIBE PROCEDURE](https://docs.snowflake.com/en/sql-reference/sql/desc-procedure.html#examples)