### PR TITLE
fix: make platform info compatible with quoted identifiers

### DIFF
--- a/pkg/snowflake/system_get_snowflake_platform_info.go
+++ b/pkg/snowflake/system_get_snowflake_platform_info.go
@@ -7,11 +7,11 @@ import (
 )
 
 func SystemGetSnowflakePlatformInfoQuery() string {
-	return `SELECT SYSTEM$GET_SNOWFLAKE_PLATFORM_INFO() AS "info"`
+	return `SELECT SYSTEM$GET_SNOWFLAKE_PLATFORM_INFO() AS "INFO"`
 }
 
 type RawSnowflakePlatformInfo struct {
-	Info string `db:"info"`
+	Info string `db:"INFO"`
 }
 
 type snowflakePlatformInfoInternal struct {

--- a/pkg/snowflake/system_get_snowflake_platform_info_test.go
+++ b/pkg/snowflake/system_get_snowflake_platform_info_test.go
@@ -10,7 +10,7 @@ func TestSystemGetSnowflakePlatformInfoQuery(t *testing.T) {
 	r := require.New(t)
 	sb := SystemGetSnowflakePlatformInfoQuery()
 
-	r.Equal(sb, `SELECT SYSTEM$GET_SNOWFLAKE_PLATFORM_INFO() AS "info"`)
+	r.Equal(sb, `SELECT SYSTEM$GET_SNOWFLAKE_PLATFORM_INFO() AS "INFO"`)
 }
 
 func TestSystemGetSnowflakePlatformInfoGetStructuredConfigAws(t *testing.T) {


### PR DESCRIPTION
Currently the GET_SNOWFLAKE_PLATFORM_INFO fails because the results column is in lowercase when `QUOTED_IDENTIFIER_IGNORE_CASE  = TRUE` is on account level. Solution would be to use UPPERCASE for the column so that the success of this function is not dependent on the `QUOTED_IDENTIFIER_IGNORE_CASE ` parameter

## Test Plan
* [x] acceptance tests

## References
https://docs.snowflake.com/en/sql-reference/parameters.html#quoted-identifiers-ignore-case

* 