### PR TITLE
fix: Procedure Resource Panics with NOT NULL in Return Type

### DIFF
--- a/pkg/resources/procedure.go
+++ b/pkg/resources/procedure.go
@@ -253,10 +253,15 @@ func ReadProcedure(d *schema.ResourceData, meta interface{}) error {
 			}
 		case "returns":
 			// Format in Snowflake DB is RETURN_TYPE(<some number>) or RETURN_TYPE
-			re := regexp.MustCompile(`^([A-Z0-9_]+)(\([0-9]*\))?$`)
+			re := regexp.MustCompile(`^([A-Z0-9_]+)(\([0-9]*\))?(\sNOT NULL)?$`)
 			match := re.FindStringSubmatch(desc.Value.String)
-			if err = d.Set("return_type", match[1]); err != nil {
-				return err
+
+			if len(match) > 0 {
+				if err = d.Set("return_type", match[0]); err != nil {
+					return err
+				}
+			} else {
+				return fmt.Errorf("unexpected return type %v returned from Snowflake", desc.Value.String)
 			}
 		case "language":
 			// To ignore


### PR DESCRIPTION
The procedure resource does a regex match for the return type it receives out of DESCRIBE PROCEDURE which fails to match against return types that specify a NOT NULL constraint.  It also updates state to just the type of the match and does not include length which causes thrash on the resources.

This PR will do three things:

1. Support optional specification of NOT NULL in the regex
2. Check that match has a length greater than 0 before indexing into it (this was causing the panic)
3. Set the state to match[0] which is the full type to avoid plan thrash


## Test Plan
* Additional unit tests to verify the above outcomes
