### PR TITLE
feat: An example of how to write update functionality

### DIFF
--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -71,7 +71,11 @@ func CreateDatabase(d *schema.ResourceData, meta interface{}) error {
 		return createDatabaseFromDatabase(d, meta)
 	}
 
-	return CreateResource("database", databaseProperties, databaseSchema, snowflake.Database, ReadDatabase)(d, meta)
+	return CreateResource(
+		"database",
+		databaseProperties,
+		databaseSchema,
+		snowflake.Database, ReadDatabase)(d, meta)
 }
 
 func createDatabaseFromShare(d *schema.ResourceData, meta interface{}) error {

--- a/pkg/snowflake/external_function.go
+++ b/pkg/snowflake/external_function.go
@@ -137,6 +137,14 @@ func (fb *ExternalFunctionBuilder) WithComment(c string) *ExternalFunctionBuilde
 	return fb
 }
 
+// ChangeComment returns the SQL query that will update the comment on the external_function.
+func (fb *ExternalFunctionBuilder) ChangeComment(c string) string {
+	return fmt.Sprintf(
+		`ALTER FUNCTION %v SET COMMENT = '%v'`,
+		fb.QualifiedNameWithArgTypes(),
+		EscapeString(c))
+}
+
 // ExternalFunction returns a pointer to a Builder that abstracts the DDL operations for an external function.
 //
 // Supported DDL operations are:

--- a/pkg/snowflake/external_function_test.go
+++ b/pkg/snowflake/external_function_test.go
@@ -40,3 +40,26 @@ func TestExternalFunctionShow(t *testing.T) {
 	s := ExternalFunction("test_function", "test_db", "test_schema")
 	r.Equal(s.Show(), `SHOW EXTERNAL FUNCTIONS LIKE 'test_function' IN SCHEMA "test_db"."test_schema"`)
 }
+
+func TestExternalFunctionChangeComment(t *testing.T) {
+	r := require.New(t)
+
+	argTypes := []map[string]string{}
+	argTypes = append(argTypes,
+		map[string]string{"type": "BOOL"},
+		map[string]string{"type": "VARIANT"},
+		map[string]string{"type": "STRING"},
+		map[string]string{"type": "NUMBER"},
+	)
+
+	fb := &ExternalFunctionBuilder{
+		name:   "ext_function",
+		db:     "a_database",
+		schema: "a_schema",
+		args:   argTypes,
+	}
+	stmt := fb.ChangeComment("My New Comment")
+
+	expected := `ALTER FUNCTION "a_database"."a_schema"."ext_function"  (BOOL, VARIANT, STRING, NUMBER) SET COMMENT = 'My New Comment'`
+	r.Equal(expected, stmt)
+}


### PR DESCRIPTION
We allow external_functions to update their comments.

NOTE: still missing a bit on the unit testing but wanted to open this earlier just in case