### PR TITLE
fix: makefile remove outdated version reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 SHA=$(shell git rev-parse --short HEAD)
-VERSION=$(shell cat VERSION)
 export DIRTY=$(shell if `git diff-index --quiet HEAD --`; then echo false; else echo true;  fi)
-LDFLAGS=-ldflags "-w -s -X github.com/chanzuckerberg/go-misc/ver.GitSha=${SHA} -X github.com/chanzuckerberg/go-misc/ver.Version=${VERSION} -X github.com/chanzuckerberg/go-misc/ver.Dirty=${DIRTY}"
-export BASE_BINARY_NAME=terraform-provider-snowflake_v$(VERSION)
+LDFLAGS=-ldflags "-w -s -X github.com/chanzuckerberg/go-misc/ver.GitSha=${SHA} -X github.com/chanzuckerberg/go-misc/ver.Dirty=${DIRTY}"
+export BASE_BINARY_NAME=terraform-provider-snowflake
 export GO111MODULE=on
 export TF_ACC_TERRAFORM_VERSION=0.13.0
 export SKIP_EXTERNAL_TABLE_TESTS=true
@@ -23,7 +22,7 @@ setup: ## setup development dependencies
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh
 	curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh
 	bash .download-tfproviderlint.sh
-	go get golang.org/x/tools/cmd/goimports
+	go install golang.org/x/tools/cmd/goimports@latest
 .PHONY: setup
 
 lint: fmt ## run the fast go linters

--- a/pkg/datasources/procedures_acceptance_test.go
+++ b/pkg/datasources/procedures_acceptance_test.go
@@ -51,9 +51,9 @@ resource "snowflake_procedure" "test_proc_simple" {
 	schema   = snowflake_schema.test_schema.name
 	return_type = "VARCHAR"
 	language = "JAVASCRIPT"
-	statement = <<EOT
-	return "Hi"
-	EOT
+	statement = <<-EOF
+		return "Hi"
+	EOF
 }
 
 resource "snowflake_procedure" "test_proc" {
@@ -67,10 +67,10 @@ resource "snowflake_procedure" "test_proc" {
 	comment = "Terraform acceptance test"
 	return_type = "varchar"
 	language = "JAVASCRIPT"
-	statement = <<EOT
-	var X=1
-	return X
-	EOT
+	statement = <<-EOF
+		var X=1
+		return X
+	EOF
 }
 
 data snowflake_procedures "t" {

--- a/pkg/datasources/procedures_acceptance_test.go
+++ b/pkg/datasources/procedures_acceptance_test.go
@@ -50,7 +50,9 @@ resource "snowflake_procedure" "test_proc_simple" {
 	database = snowflake_database.test_database.name
 	schema   = snowflake_schema.test_schema.name
 	return_type = "VARCHAR"
-	statement = "return \"Hi\""
+	statement = <<EOT
+	return "Hi"
+	EOT
 }
 
 resource "snowflake_procedure" "test_proc" {
@@ -63,7 +65,10 @@ resource "snowflake_procedure" "test_proc" {
 	}
 	comment = "Terraform acceptance test"
 	return_type = "varchar"
-	statement = "var X=3\nreturn X"
+	statement = <<EOT
+	var X=1
+	return X
+	EOT
 }
 
 data snowflake_procedures "t" {

--- a/pkg/datasources/procedures_acceptance_test.go
+++ b/pkg/datasources/procedures_acceptance_test.go
@@ -50,6 +50,7 @@ resource "snowflake_procedure" "test_proc_simple" {
 	database = snowflake_database.test_database.name
 	schema   = snowflake_schema.test_schema.name
 	return_type = "VARCHAR"
+	language = "JAVASCRIPT"
 	statement = <<EOT
 	return "Hi"
 	EOT
@@ -65,6 +66,7 @@ resource "snowflake_procedure" "test_proc" {
 	}
 	comment = "Terraform acceptance test"
 	return_type = "varchar"
+	language = "JAVASCRIPT"
 	statement = <<EOT
 	var X=1
 	return X

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -80,7 +80,7 @@ func procedureConfig(db, schema, name string) string {
 		schema   = snowflake_schema.test_schema.name
 		return_type = "varchar"
 		language = "JAVASCRIPT"
-		statement = EOF<<-
+		statement = <<-EOF
 			return "Hi"
 		EOF
 	}
@@ -96,7 +96,7 @@ func procedureConfig(db, schema, name string) string {
 		comment = "Terraform acceptance test"
 		language = "JAVASCRIPT"
 		return_type = "varchar"
-		statement = EOF<<-
+		statement = <<-EOF
 			var X=3
 			return X
 		EOF

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -18,7 +18,7 @@ func TestAcc_Procedure(t *testing.T) {
 	dbName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	schemaName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	procName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
-	expBody1 := "return \"Hi\""
+	expBody1 := "return \"Hi\"\n"
 	expBody2 := "var X=3\nreturn X\n"
 	expBody3 := "var X=1\nreturn X\n"
 

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -79,6 +79,7 @@ func procedureConfig(db, schema, name string) string {
 		database = snowflake_database.test_database.name
 		schema   = snowflake_schema.test_schema.name
 		return_type = "varchar"
+		language = "JAVASCRIPT"
 		statement = EOF<< 
 		return "Hi"
 		EOF
@@ -93,6 +94,7 @@ func procedureConfig(db, schema, name string) string {
 			type = "varchar"
 		}
 		comment = "Terraform acceptance test"
+		language = "JAVASCRIPT"
 		return_type = "varchar"
 		statement = EOF<<
 		var X=3
@@ -117,10 +119,11 @@ func procedureConfig(db, schema, name string) string {
 		execute_as = "CALLER"
 		return_behavior = "IMMUTABLE"
 		null_input_behavior = "RETURNS NULL ON NULL INPUT"
+		language = "JAVASCRIPT"
 		statement = <<EOT
-var X=1
-return X
-EOT
+		var X=1
+		return X
+		EOT
 	}
 	`, db, schema, name, name, name)
 }

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -19,7 +19,7 @@ func TestAcc_Procedure(t *testing.T) {
 	schemaName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	procName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	expBody1 := "return \"Hi\""
-	expBody2 := "var X=3\nreturn X"
+	expBody2 := "var X=3\nreturn X\n"
 	expBody3 := "var X=1\nreturn X\n"
 
 	resource.Test(t, resource.TestCase{

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -79,7 +79,9 @@ func procedureConfig(db, schema, name string) string {
 		database = snowflake_database.test_database.name
 		schema   = snowflake_schema.test_schema.name
 		return_type = "varchar"
-		statement = "return \"Hi\""
+		statement = EOF<< 
+		return "Hi"
+		EOF
 	}
 
 	resource "snowflake_procedure" "test_proc" {
@@ -92,7 +94,10 @@ func procedureConfig(db, schema, name string) string {
 		}
 		comment = "Terraform acceptance test"
 		return_type = "varchar"
-		statement = "var X=3\nreturn X"
+		statement = EOF<<
+		var X=3
+		return X
+		EOF
 	}
 
 	resource "snowflake_procedure" "test_proc_complex" {

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -79,7 +79,7 @@ func procedureConfig(db, schema, name string) string {
 		database = snowflake_database.test_database.name
 		schema   = snowflake_schema.test_schema.name
 		return_type = "varchar"
-		language = "JAVASCRIPT"
+		language = "javascript"
 		statement = <<-EOF
 			return "Hi"
 		EOF
@@ -94,7 +94,7 @@ func procedureConfig(db, schema, name string) string {
 			type = "varchar"
 		}
 		comment = "Terraform acceptance test"
-		language = "JAVASCRIPT"
+		language = "javascript"
 		return_type = "varchar"
 		statement = <<-EOF
 			var X=3
@@ -119,7 +119,7 @@ func procedureConfig(db, schema, name string) string {
 		execute_as = "CALLER"
 		return_behavior = "IMMUTABLE"
 		null_input_behavior = "RETURNS NULL ON NULL INPUT"
-		language = "JAVASCRIPT"
+		language = "javascript"
 		statement = <<-EOF
 			var X=1
 			return X

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -80,8 +80,8 @@ func procedureConfig(db, schema, name string) string {
 		schema   = snowflake_schema.test_schema.name
 		return_type = "varchar"
 		language = "JAVASCRIPT"
-		statement = EOF<< 
-		return "Hi"
+		statement = EOF<<-
+			return "Hi"
 		EOF
 	}
 
@@ -96,9 +96,9 @@ func procedureConfig(db, schema, name string) string {
 		comment = "Terraform acceptance test"
 		language = "JAVASCRIPT"
 		return_type = "varchar"
-		statement = EOF<<
-		var X=3
-		return X
+		statement = EOF<<-
+			var X=3
+			return X
 		EOF
 	}
 
@@ -120,10 +120,10 @@ func procedureConfig(db, schema, name string) string {
 		return_behavior = "IMMUTABLE"
 		null_input_behavior = "RETURNS NULL ON NULL INPUT"
 		language = "JAVASCRIPT"
-		statement = <<EOT
-		var X=1
-		return X
-		EOT
+		statement = <<-EOF
+			var X=1
+			return X
+		EOF
 	}
 	`, db, schema, name, name, name)
 }


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->
makefile failing due to "VERSION" file not found. This wasn't really being used for much anyways so just remove reference to "VERSION"

Also updating goimport install to:

```
 go install golang.org/x/tools/cmd/goimports@latest
```

Since the `go get` method has been deprecated. 
<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* 