### PR TITLE
fix: Correctly read INSERT_ONLY mode for streams

### DIFF
--- a/pkg/resources/stream.go
+++ b/pkg/resources/stream.go
@@ -275,7 +275,7 @@ func ReadStream(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	err = d.Set("insert_only", stream.InsertOnly)
+	err = d.Set("insert_only", stream.Mode.String == "INSERT_ONLY")
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/stream_test.go
+++ b/pkg/resources/stream_test.go
@@ -121,6 +121,20 @@ func TestStreamReadAppendOnlyMode(t *testing.T) {
 	})
 }
 
+func TestStreamReadInsertOnlyMode(t *testing.T) {
+	r := require.New(t)
+
+	d := stream(t, "database_name|schema_name|stream_name", map[string]interface{}{"name": "stream_name", "comment": "grand comment"})
+
+	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		rows := sqlmock.NewRows([]string{"name", "database_name", "schema_name", "owner", "comment", "table_name", "type", "stale", "mode"}).AddRow("stream_name", "database_name", "schema_name", "owner_name", "grand comment", "target_table", "DELTA", false, "INSERT_ONLY")
+		mock.ExpectQuery(`SHOW STREAMS LIKE 'stream_name' IN SCHEMA "database_name"."schema_name"`).WillReturnRows(rows)
+		err := resources.ReadStream(d, db)
+		r.NoError(err)
+		r.Equal(true, d.Get("insert_only").(bool))
+	})
+}
+
 func TestStreamReadDefaultMode(t *testing.T) {
 	r := require.New(t)
 

--- a/pkg/snowflake/stream.go
+++ b/pkg/snowflake/stream.go
@@ -144,8 +144,6 @@ type descStreamRow struct {
 	SchemaName      sql.NullString `db:"schema_name"`
 	Owner           sql.NullString `db:"owner"`
 	Comment         sql.NullString `db:"comment"`
-	AppendOnly      bool           `db:"append_only"`
-	InsertOnly      bool           `db:"insert_only"`
 	ShowInitialRows bool           `db:"show_initial_rows"`
 	TableName       sql.NullString `db:"table_name"`
 	Type            sql.NullString `db:"type"`


### PR DESCRIPTION
This change removes the `append_only`/`insert_only` fields from the Stream row struct, as they are not returned neither by `SHOW STREAMS` nor `DESCRIBE STREAM`.

To find if an existing stream is `INSERT_ONLY`, it now checks the `mode` field, as it has been already done for the `APPEND_ONLY` mode.

## Test Plan
* [x] acceptance tests
* [x] unit tests