### PR TITLE
fix: snowflake_function - Allow defining language = SQL

### DIFF
--- a/pkg/resources/function.go
+++ b/pkg/resources/function.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var languages = []string{"javascript", "java"}
+var languages = []string{"javascript", "java", "sql"}
 
 var functionSchema = map[string]*schema.Schema{
 	"name": {


### PR DESCRIPTION
As found in Snowflake-Labs/terraform-provider-snowflake#1048, defining a SQL UDF explicitly with `language = "SQL"` is disallowed. When omitted, it works.
I would propose allowing to explicitly set language = "SQL", too (when executing in Snowflake, it works by omitting or defining `LANGUAGE SQL` either way).

<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

## Test Plan
* executing `CREATE OR REPLACE FUNCTION ... LANGUAGE SQL` works

## References
* fixes #1048