### PR TITLE
fix: allow custom characters to be ignored from validation

### DIFF
--- a/pkg/resources/role_grants.go
+++ b/pkg/resources/role_grants.go
@@ -25,7 +25,8 @@ func RoleGrants() *schema.Resource {
 				Required:    true,
 				Description: "The name of the role we are granting.",
 				ValidateFunc: func(val interface{}, key string) ([]string, []error) {
-					return snowflake.ValidateIdentifier(val)
+					additionalCharsToIgnoreValidation := []string{"."}
+					return snowflake.ValidateIdentifier(val, additionalCharsToIgnoreValidation)
 				},
 			},
 			"roles": {

--- a/pkg/resources/role_ownership_grant.go
+++ b/pkg/resources/role_ownership_grant.go
@@ -17,7 +17,8 @@ var roleOwnershipGrantSchema = map[string]*schema.Schema{
 		Required:    true,
 		Description: "The name of the role ownership is granted on.",
 		ValidateFunc: func(val interface{}, key string) ([]string, []error) {
-			return snowflake.ValidateIdentifier(val)
+			var additionalCharsToIgnoreValidation []string
+			return snowflake.ValidateIdentifier(val, additionalCharsToIgnoreValidation)
 		},
 	},
 	"to_role_name": {
@@ -25,7 +26,8 @@ var roleOwnershipGrantSchema = map[string]*schema.Schema{
 		Required:    true,
 		Description: "The name of the role to grant ownership. Please ensure that the role that terraform is using is granted access.",
 		ValidateFunc: func(val interface{}, key string) ([]string, []error) {
-			return snowflake.ValidateIdentifier(val)
+			var additionalCharsToIgnoreValidation []string
+			return snowflake.ValidateIdentifier(val, additionalCharsToIgnoreValidation)
 		},
 	},
 	"current_grants": {

--- a/pkg/resources/user_ownership_grant.go
+++ b/pkg/resources/user_ownership_grant.go
@@ -17,7 +17,8 @@ var userOwnershipGrantSchema = map[string]*schema.Schema{
 		Required:    true,
 		Description: "The name of the user ownership is granted on.",
 		ValidateFunc: func(val interface{}, key string) ([]string, []error) {
-			return snowflake.ValidateIdentifier(val)
+			var additionalCharsToIgnoreValidation []string
+			return snowflake.ValidateIdentifier(val, additionalCharsToIgnoreValidation)
 		},
 	},
 	"to_role_name": {
@@ -25,7 +26,8 @@ var userOwnershipGrantSchema = map[string]*schema.Schema{
 		Required:    true,
 		Description: "The name of the role to grant ownership. Please ensure that the role that terraform is using is granted access.",
 		ValidateFunc: func(val interface{}, key string) ([]string, []error) {
-			return snowflake.ValidateIdentifier(val)
+			var additionalCharsToIgnoreValidation []string
+			return snowflake.ValidateIdentifier(val, additionalCharsToIgnoreValidation)
 		},
 	},
 	"current_grants": {

--- a/pkg/snowflake/validation.go
+++ b/pkg/snowflake/validation.go
@@ -1,10 +1,12 @@
 package snowflake
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+)
 
 // ValidateIdentifier implements a strict definition of valid identifiers from
 // https://docs.snowflake.net/manuals/sql-reference/identifiers-syntax.html
-func ValidateIdentifier(val interface{}) (warns []string, errs []error) {
+func ValidateIdentifier(val interface{}, exclusions []string) (warns []string, errs []error) {
 	name, ok := val.(string)
 	if !ok {
 		errs = append(errs, errors.Errorf("Unable to assert identifier as string type."))
@@ -22,22 +24,26 @@ func ValidateIdentifier(val interface{}) (warns []string, errs []error) {
 	}
 
 	// TODO handle quoted identifiers
+	excludedCharacterMap := make(map[string]bool)
+	for _, char := range exclusions {
+		excludedCharacterMap[char] = true
+	}
 	for k, r := range name {
 		if k == 0 && !isInitialIdentifierRune(r) {
 			errs = append(errs, errors.Errorf("'%s' can not start an identifier.", string(r)))
 			continue
 		}
 
-		if !isIdentifierRune(r) {
-			errs = append(errs, errors.Errorf("'%s' is not a valid identifier character.", string(r)))
+		if !isIdentifierRune(r, excludedCharacterMap) {
+			errs = append(errs, errors.Errorf("'%s' is not valid identifier character.", string(r)))
 		}
 	}
 	return
 
 }
 
-func isIdentifierRune(r rune) bool {
-	return isInitialIdentifierRune(r) || r == '$' || (r >= '0' && r <= '9')
+func isIdentifierRune(r rune, excludedCharacters map[string]bool) bool {
+	return isInitialIdentifierRune(r) || excludedCharacters[string(r)] == true || r == '$' || (r >= '0' && r <= '9')
 }
 
 func isInitialIdentifierRune(r rune) bool {

--- a/pkg/snowflake/validation.go
+++ b/pkg/snowflake/validation.go
@@ -41,7 +41,7 @@ func ValidateIdentifier(val interface{}, exclusions []string) (warns []string, e
 }
 
 func isIdentifierRune(r rune, excludedCharacters map[string]bool) bool {
-	return isInitialIdentifierRune(r) || excludedCharacters[string(r)] == true || r == '$' || (r >= '0' && r <= '9')
+	return isInitialIdentifierRune(r) || excludedCharacters[string(r)] || r == '$' || (r >= '0' && r <= '9')
 }
 
 func isInitialIdentifierRune(r rune) bool {

--- a/pkg/snowflake/validation.go
+++ b/pkg/snowflake/validation.go
@@ -1,8 +1,6 @@
 package snowflake
 
-import (
-	"github.com/pkg/errors"
-)
+import "github.com/pkg/errors"
 
 // ValidateIdentifier implements a strict definition of valid identifiers from
 // https://docs.snowflake.net/manuals/sql-reference/identifiers-syntax.html

--- a/pkg/snowflake/validation_test.go
+++ b/pkg/snowflake/validation_test.go
@@ -24,7 +24,7 @@ func TestValidateIdentifier(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.candidate, func(t *testing.T) {
-			_, errs := snowflake.ValidateIdentifier(tc.candidate)
+			_, errs := snowflake.ValidateIdentifier(tc.candidate, []string{})
 			actual := len(errs) == 0
 
 			if actual == tc.valid {


### PR DESCRIPTION
Adding fix for issue: https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1054

Created a new struct parameter for adding characters to exclude from the validation check.

role_ownership_grants is now able to take in periods or "." in the role_name parameter

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
tested locally and was able to resolve the error for ` Error: '.' is not a valid identifier character.`

## References
<!-- issues documentation links, etc  -->
https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1054
* 