### PR TITLE
fix: Handling 2022_03 breaking changes

### DIFF
--- a/pkg/datasources/file_formats_acceptance_test.go
+++ b/pkg/datasources/file_formats_acceptance_test.go
@@ -65,6 +65,7 @@ func fileFormats(databaseName string, schemaName string, fileFormatName string) 
 		null_if = ["NULL"]
 		error_on_column_count_mismatch = true
 		replace_invalid_characters = true
+		validate_utf8 = true
 		empty_field_as_null = false 
 		skip_byte_order_mark = false
 		encoding = "UTF-16"

--- a/pkg/datasources/file_formats_acceptance_test.go
+++ b/pkg/datasources/file_formats_acceptance_test.go
@@ -65,7 +65,6 @@ func fileFormats(databaseName string, schemaName string, fileFormatName string) 
 		null_if = ["NULL"]
 		error_on_column_count_mismatch = true
 		replace_invalid_characters = true
-		validate_utf8 = false
 		empty_field_as_null = false 
 		skip_byte_order_mark = false
 		encoding = "UTF-16"

--- a/pkg/resources/file_format_acceptance_test.go
+++ b/pkg/resources/file_format_acceptance_test.go
@@ -223,6 +223,7 @@ resource "snowflake_file_format" "test" {
 	null_if = ["NULL"]
 	error_on_column_count_mismatch = true
 	replace_invalid_characters = true
+	validate_utf8 = true
 	empty_field_as_null = false 
 	skip_byte_order_mark = false
 	encoding = "UTF-16"

--- a/pkg/resources/file_format_acceptance_test.go
+++ b/pkg/resources/file_format_acceptance_test.go
@@ -40,7 +40,7 @@ func TestAcc_FileFormatCSV(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_file_format.test", "null_if.0", "NULL"),
 					resource.TestCheckResourceAttr("snowflake_file_format.test", "error_on_column_count_mismatch", "true"),
 					resource.TestCheckResourceAttr("snowflake_file_format.test", "replace_invalid_characters", "true"),
-					resource.TestCheckResourceAttr("snowflake_file_format.test", "validate_utf8", "false"),
+					resource.TestCheckResourceAttr("snowflake_file_format.test", "validate_utf8", "true"),
 					resource.TestCheckResourceAttr("snowflake_file_format.test", "empty_field_as_null", "false"),
 					resource.TestCheckResourceAttr("snowflake_file_format.test", "skip_byte_order_mark", "false"),
 					resource.TestCheckResourceAttr("snowflake_file_format.test", "encoding", "UTF-16"),

--- a/pkg/resources/file_format_acceptance_test.go
+++ b/pkg/resources/file_format_acceptance_test.go
@@ -223,7 +223,6 @@ resource "snowflake_file_format" "test" {
 	null_if = ["NULL"]
 	error_on_column_count_mismatch = true
 	replace_invalid_characters = true
-	validate_utf8 = false
 	empty_field_as_null = false 
 	skip_byte_order_mark = false
 	encoding = "UTF-16"

--- a/pkg/resources/share.go
+++ b/pkg/resources/share.go
@@ -198,7 +198,7 @@ func DeleteShare(d *schema.ResourceData, meta interface{}) error {
 }
 
 // StripAccountFromName removes the accout prefix from a resource (e.g. a share)
-// that returns it (e.g. yt12345.my_share should just be my_share)
+// that returns it (e.g. yt12345.my_share or org.acc.my_share should just be my_share)
 func StripAccountFromName(s string) string {
-	return s[strings.Index(s, ".")+1:]
+	return s[strings.LastIndex(s, ".")+1:]
 }

--- a/pkg/resources/share_test.go
+++ b/pkg/resources/share_test.go
@@ -65,8 +65,11 @@ func TestStripAccountFromName(t *testing.T) {
 	s := "yt12345.my_share"
 	r.Equal("my_share", resources.StripAccountFromName(s))
 
-	s = "yt12345.my.share"
-	r.Equal("my.share", resources.StripAccountFromName(s))
+	s = "yt12345.my_share"
+	r.Equal("my_share", resources.StripAccountFromName(s))
+
+	s = "org.account.my_share"
+	r.Equal("my_share", resources.StripAccountFromName(s))
 
 	s = "no_account_for_some_reason"
 	r.Equal("no_account_for_some_reason", resources.StripAccountFromName(s))

--- a/pkg/resources/task.go
+++ b/pkg/resources/task.go
@@ -333,8 +333,9 @@ func ReadTask(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if t.Predecessors != nil {
-		err = d.Set("after", t.GetPredecessorName())
+	predecessorName := t.GetPredecessorName()
+	if predecessorName != "" {
+		err = d.Set("after", predecessorName)
 		if err != nil {
 			return err
 		}

--- a/pkg/resources/task.go
+++ b/pkg/resources/task.go
@@ -170,7 +170,8 @@ func getActiveRootTask(data *schema.ResourceData, meta interface{}) (*snowflake.
 			return nil, errors.Wrapf(err, "failed to locate the root node of: %v", name)
 		}
 
-		if task.Predecessors == nil {
+		currentName := task.GetPredecessorName()
+		if currentName == "" {
 			log.Printf("[DEBUG] found root task: %v", name)
 			// we only want to deal with suspending the root task when its enabled (started)
 			if task.IsEnabled() {
@@ -179,7 +180,7 @@ func getActiveRootTask(data *schema.ResourceData, meta interface{}) (*snowflake.
 			return nil, nil
 		}
 
-		name = task.GetPredecessorName()
+		name = currentName
 	}
 }
 

--- a/pkg/snowflake/task.go
+++ b/pkg/snowflake/task.go
@@ -357,11 +357,12 @@ func (t *task) GetPredecessorName() string {
 		return ""
 	}
 
-	// Since >=6.21, Snowflake returns this as a JSON array (even empty)
+	// Since 2022_03, Snowflake returns this as a JSON array (even empty)
 	var fullNames []string
 	if err := json.Unmarshal([]byte(*t.Predecessors), &fullNames); err == nil {
 		for _, fullName := range fullNames {
-			return fullName[strings.LastIndex(fullName, ".")+1:] // only supports one (as <6.21 implementation)
+			name := fullName[strings.LastIndex(fullName, ".")+1:]
+			return strings.Trim(name, "\\\"")
 		}
 		return ""
 	}

--- a/pkg/snowflake/task.go
+++ b/pkg/snowflake/task.go
@@ -2,6 +2,7 @@ package snowflake
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log"
 	"sort"
@@ -353,6 +354,15 @@ func (t *task) IsEnabled() bool {
 
 func (t *task) GetPredecessorName() string {
 	if t.Predecessors == nil {
+		return ""
+	}
+
+	// Since >=6.21, Snowflake returns this as a JSON array (even empty)
+	var fullNames []string
+	if err := json.Unmarshal([]byte(*t.Predecessors), &fullNames); err == nil {
+		for _, fullName := range fullNames {
+			return fullName[strings.LastIndex(fullName, ".")+1:] // only supports one (as <6.21 implementation)
+		}
 		return ""
 	}
 


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

2022_03 bundle (enabled in 6.21 release) changes the following behavior:

* Share `NAME` column in accounts using the new org naming is returned as `ORG.ACCOUNT.SHARE`, instead of the old `ACCOUNT.SHARE`
* Task `PREDECESSORS` column is now always returned as a JSON array (even when it's empty)
* File format `VALIDATE_UTF8` option is obsoleted, attempting to set it to false now fails

Note that the existing task implementation only handles one task root and this change continues that. While you can only specify one `AFTER` in `CREATE TASK`, you can add more with `ALTER TASK ... ADD AFTER`. Supporting this would require a breaking change to make the `after` parameter a list and handle state for multiple roots, this should be done in a separate contribution.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->

## References
<!-- issues documentation links, etc  -->

* [6.21 Release Notes](https://community.snowflake.com/s/article/6-21-Behavior-Change-Release-Notes-June-22-23-2022)
* [Pending Behavior Change Log](https://community.snowflake.com/s/article/Pending-Behavior-Change-Log)
* [SHOW TASKS Command & TASK_DEPENDENTS Function: PREDECESSORS / PREDECESSOR Column](https://community.snowflake.com/s/article/SHOW-TASKS-Command-and-TASK-DEPENDENTS-Function-PREDECESSORS-PREDECESSOR-Column)
* [SHOW SHARES Command & Data Sharing UI: Changes to Output](https://community.snowflake.com/s/article/show-shares-command-ui-data-sharing-changes)
* [VALIDATE_UTF8 File Format Option](https://community.snowflake.com/s/article/VALIDATE-UTF8-File-Format-Option-Obsoleted)