### PR TITLE
docs: Fix pipe_grant doc

### DIFF
--- a/docs/resources/pipe_grant.md
+++ b/docs/resources/pipe_grant.md
@@ -16,7 +16,7 @@ description: |-
 resource snowflake_pipe_grant grant {
   database_name = "db"
   schema_name   = "schema"
-  sequence_name = "sequence"
+  pipe_name     = "pipe"
 
   privilege = "operate"
   roles = [

--- a/examples/resources/snowflake_pipe_grant/resource.tf
+++ b/examples/resources/snowflake_pipe_grant/resource.tf
@@ -1,7 +1,7 @@
 resource snowflake_pipe_grant grant {
   database_name = "db"
   schema_name   = "schema"
-  sequence_name = "sequence"
+  pipe_name     = "pipe"
 
   privilege = "operate"
   roles = [


### PR DESCRIPTION
<!-- summary of changes -->
* https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/pipe_grant
* This PR fix https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/985
* current `pipe_grant` document contains `sequence_name = "sequence"` but it must be like `pipe_name = "pipe"

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/985