### PR TITLE
fix: warehouse import when auto_suspend is set to null

### DIFF
--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -195,7 +195,7 @@ func ReadWarehouse(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	err = d.Set("auto_suspend", w.AutoSuspend)
+	err = d.Set("auto_suspend", w.AutoSuspend.Int64)
 	if err != nil {
 		return err
 	}

--- a/pkg/snowflake/warehouse.go
+++ b/pkg/snowflake/warehouse.go
@@ -55,35 +55,35 @@ func Warehouse(name string) *WarehouseBuilder {
 // warehouse is a go representation of a grant that can be used in conjunction
 // with github.com/jmoiron/sqlx
 type warehouse struct {
-	Name            string    `db:"name"`
-	State           string    `db:"state"`
-	Type            string    `db:"type"`
-	Size            string    `db:"size"`
-	MinClusterCount int64     `db:"min_cluster_count"`
-	MaxClusterCount int64     `db:"max_cluster_count"`
-	StartedClusters int64     `db:"started_clusters"`
-	Running         int64     `db:"running"`
-	Queued          int64     `db:"queued"`
-	IsDefault       string    `db:"is_default"`
-	IsCurrent       string    `db:"is_current"`
-	AutoSuspend     int64     `db:"auto_suspend"`
-	AutoResume      bool      `db:"auto_resume"`
-	Available       string    `db:"available"`
-	Provisioning    string    `db:"provisioning"`
-	Quiescing       string    `db:"quiescing"`
-	Other           string    `db:"other"`
-	CreatedOn       time.Time `db:"created_on"`
-	ResumedOn       time.Time `db:"resumed_on"`
-	UpdatedOn       time.Time `db:"updated_on"`
-	Owner           string    `db:"owner"`
-	Comment         string    `db:"comment"`
-	ResourceMonitor string    `db:"resource_monitor"`
-	Actives         int64     `db:"actives"`
-	Pendings        int64     `db:"pendings"`
-	Failed          int64     `db:"failed"`
-	Suspended       int64     `db:"suspended"`
-	UUID            string    `db:"uuid"`
-	ScalingPolicy   string    `db:"scaling_policy"`
+	Name            string        `db:"name"`
+	State           string        `db:"state"`
+	Type            string        `db:"type"`
+	Size            string        `db:"size"`
+	MinClusterCount int64         `db:"min_cluster_count"`
+	MaxClusterCount int64         `db:"max_cluster_count"`
+	StartedClusters int64         `db:"started_clusters"`
+	Running         int64         `db:"running"`
+	Queued          int64         `db:"queued"`
+	IsDefault       string        `db:"is_default"`
+	IsCurrent       string        `db:"is_current"`
+	AutoSuspend     sql.NullInt64 `db:"auto_suspend"`
+	AutoResume      bool          `db:"auto_resume"`
+	Available       string        `db:"available"`
+	Provisioning    string        `db:"provisioning"`
+	Quiescing       string        `db:"quiescing"`
+	Other           string        `db:"other"`
+	CreatedOn       time.Time     `db:"created_on"`
+	ResumedOn       time.Time     `db:"resumed_on"`
+	UpdatedOn       time.Time     `db:"updated_on"`
+	Owner           string        `db:"owner"`
+	Comment         string        `db:"comment"`
+	ResourceMonitor string        `db:"resource_monitor"`
+	Actives         int64         `db:"actives"`
+	Pendings        int64         `db:"pendings"`
+	Failed          int64         `db:"failed"`
+	Suspended       int64         `db:"suspended"`
+	UUID            string        `db:"uuid"`
+	ScalingPolicy   string        `db:"scaling_policy"`
 }
 
 // warehouseParams struct to represent a row of parameters


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->
Fixes 
```
sql: Scan error on column index 8, name "auto_suspend": converting NULL to int64 is unsupported
```
by using `sql.NullInt64` instead of `int64`
 

- [x] unit tests