### PR TITLE
fix pipe_grant doc: pipe_name instead of sequence_name

### DIFF
--- a/docs/resources/pipe_grant.md
+++ b/docs/resources/pipe_grant.md
@@ -3,7 +3,7 @@
 page_title: "snowflake_pipe_grant Resource - terraform-provider-snowflake"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # snowflake_pipe_grant (Resource)
@@ -15,8 +15,8 @@ description: |-
 ```terraform
 resource snowflake_pipe_grant grant {
   database_name = "db"
-  schema_name   = "schema"
-  sequence_name = "sequence"
+  schema_name = "schema"
+  pipe_name = "pipe"
 
   privilege = "operate"
   roles = [


### PR DESCRIPTION
Fixes the `pipe_grant` document by replacing `sequence_name` by `pipe_name`
 
## References

* Current [documentation](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/pipe_grant) 