### PR TITLE
fix: disallowing account locators within shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ You will also need to generate a Github API token and add the secret:
 
 * `REVIEWDOG_GITHUB_API_TOKEN` - A token for reviewdog to use to access your github account with privileges to read/write discussion.
 
+## Roadmap
+
+| Task                                                                                                                              | Estimated Time Required | In Progress? | Finished? | Date Completed |
+|-----------------------------------------------------------------------------------------------------------------------------------|-------------------------|--------------|-----------|----------------|
+| Database Sharing                                                                                                                  | August 1st              | no           | - [ ]     | n/a            |
+| Tag Reference for Database Replication                                                                                            | August 1st              | no           | - [ ]     | n/a            |
+| Session parameter support in provider [configuration](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1036) | TBD                     | no           | - [ ]     | n/a            |
+| Columns on Table Column Rename should not Drop Column                                                                             | TBD                     | no           | - [ ]     | n/a            |    
+| Snowflake remote backend for Terraform using a hybrid table and internal stage                                                    | TBD                     | no           | - [ ]     | n/a            |    
+
 ## Releasing
 
 ## Running a release

--- a/docs/resources/share.md
+++ b/docs/resources/share.md
@@ -16,6 +16,7 @@ description: |-
 resource snowflake_share test {
 	name           = "share_name"
 	comment        = "cool comment"
+	accounts       = "organizationName.accountName"
 }
 ```
 
@@ -28,7 +29,7 @@ resource snowflake_share test {
 
 ### Optional
 
-- `accounts` (List of String) A list of accounts to be added to the share.
+- `accounts` (List of String) A list of accounts to be added to the share. Values should not be the account locator, but in the form of 'organization_name.account_name
 - `comment` (String) Specifies a comment for the managed account.
 
 ### Read-Only

--- a/examples/resources/snowflake_share/resource.tf
+++ b/examples/resources/snowflake_share/resource.tf
@@ -1,4 +1,5 @@
 resource snowflake_share test {
 	name           = "share_name"
 	comment        = "cool comment"
+	accounts       = "organizationName.accountName"
 }

--- a/pkg/resources/share.go
+++ b/pkg/resources/share.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/validation"
 )
 
 var shareProperties = []string{
@@ -31,10 +32,14 @@ var shareSchema = map[string]*schema.Schema{
 	},
 	"accounts": {
 		// Changed from Set to List to use DiffSuppressFunc: https://github.com/hashicorp/terraform-plugin-sdk/issues/160
-		Type:             schema.TypeList,
-		Elem:             &schema.Schema{Type: schema.TypeString},
-		Optional:         true,
-		Description:      "A list of accounts to be added to the share.",
+		Type: schema.TypeList,
+		Elem: &schema.Schema{
+			Type:         schema.TypeString,
+			ValidateFunc: validation.ValidateIsNotAccountLocator,
+		},
+		Optional: true,
+		Description: "A list of accounts to be added to the share. Values should not be the account locator, but " +
+			"in the form of 'organization_name.account_name",
 		DiffSuppressFunc: diffCaseInsensitive,
 	},
 }
@@ -197,7 +202,7 @@ func DeleteShare(d *schema.ResourceData, meta interface{}) error {
 	return DeleteResource("this does not seem to be used", snowflake.Share)(d, meta)
 }
 
-// StripAccountFromName removes the accout prefix from a resource (e.g. a share)
+// StripAccountFromName removes the account prefix from a resource (e.g. a share)
 // that returns it (e.g. yt12345.my_share or org.acc.my_share should just be my_share)
 func StripAccountFromName(s string) string {
 	return s[strings.LastIndex(s, ".")+1:]

--- a/pkg/resources/share_test.go
+++ b/pkg/resources/share_test.go
@@ -26,7 +26,7 @@ func TestShareCreate(t *testing.T) {
 	in := map[string]interface{}{
 		"name":     "test-share",
 		"comment":  "great comment",
-		"accounts": []interface{}{"bob123", "sue456"},
+		"accounts": []interface{}{"bob.123", "sue.456"},
 	}
 	d := schema.TestResourceDataRaw(t, resources.Share().Schema, in)
 	r.NotNil(d)
@@ -35,7 +35,7 @@ func TestShareCreate(t *testing.T) {
 		mock.ExpectExec(`^CREATE SHARE "test-share" COMMENT='great comment'$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`^CREATE DATABASE "TEMP_test-share_\d*"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`^GRANT REFERENCE_USAGE ON DATABASE "TEMP_test-share_\d*" TO SHARE "test-share"$`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`^ALTER SHARE "test-share" SET ACCOUNTS=bob123,sue456$`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`^ALTER SHARE "test-share" SET ACCOUNTS=bob.123,sue.456$`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		mock.ExpectBegin()
 		mock.ExpectExec(`^REVOKE REFERENCE_USAGE ON DATABASE "TEMP_test-share_\d*" FROM SHARE "test-share"$`).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -56,3 +56,27 @@ func TestValidatePrivilege(t *testing.T) {
 	r.Empty(w)
 	r.Empty(errs)
 }
+
+var validAccounts = []string{
+	"testOrg.testAcc",
+	"testingOrg2.testingAcc2",
+	"abc.12345",
+}
+
+var invalidAccounts = []interface{}{
+	"abc12345",
+	"xyz56789",
+}
+
+func TestValidateIsNotAccountLocator(t *testing.T) {
+	r := require.New(t)
+	for _, p := range validAccounts {
+		_, errs := ValidateIsNotAccountLocator(p, "test_valid_accounts")
+		r.Len(errs, 0, "account locators are not allowed - please use 'organization_name.account_name]", p, errs)
+	}
+
+	for _, p := range invalidAccounts {
+		_, errs := ValidateIsNotAccountLocator(p, "test_invalid_accounts")
+		r.NotZero(len(errs), "account locators are not allowed - please use 'organization_name.account_name]", p, errs)
+	}
+}


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->
fix: disallowing account locators within shares as the values are used interchangeably but terraform state relies on the orgName.accName value
<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* 