### PR TITLE
feat: Adding support for orgaznization and account names when creating db f…

### DIFF
--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -49,13 +49,26 @@ resource "snowflake_database" "test3" {
 - `data_retention_time_in_days` (Number)
 - `from_database` (String) Specify a database to create a clone from.
 - `from_replica` (String) Specify a fully-qualified path to a database to create a replica from. A fully qualified path follows the format of "<organization_name>"."<account_name>"."<db_name>". An example would be: "myorg1"."account1"."db1"
-- `from_share` (Map of String) Specify a provider and a share in this map to create a database from a share.
+- `from_share` (Map of String) Specify a organization_name, account_name and a share in this map to create a database from a share. (see [below for block shema](#block--from_share))
 - `replication_configuration` (Block List, Max: 1) When set, specifies the configurations for database replication. (see [below for nested schema](#nestedblock--replication_configuration))
 - `tag` (Block List) Definitions of a tag to associate with the resource. (see [below for nested schema](#nestedblock--tag))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="block--from_share"></a>
+### Nested Schema for `from_share`
+
+Required:
+
+- `organization_name` (String)
+- `account_name` (String)
+
+Optional:
+
+- `provider` (String) Account locator. Deprecated alternative to `organization_name.account_name`, see more [here](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#format-2-legacy-account-locator-in-a-region)
+
 
 <a id="nestedblock--replication_configuration"></a>
 ### Nested Schema for `replication_configuration`

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -49,26 +49,13 @@ resource "snowflake_database" "test3" {
 - `data_retention_time_in_days` (Number)
 - `from_database` (String) Specify a database to create a clone from.
 - `from_replica` (String) Specify a fully-qualified path to a database to create a replica from. A fully qualified path follows the format of "<organization_name>"."<account_name>"."<db_name>". An example would be: "myorg1"."account1"."db1"
-- `from_share` (Map of String) Specify a organization_name, account_name and a share in this map to create a database from a share. (see [below for block shema](#block--from_share))
+- `from_share` (Map of String) Specify a organization_name, account_name and a share in this map to create a database from a share.
 - `replication_configuration` (Block List, Max: 1) When set, specifies the configurations for database replication. (see [below for nested schema](#nestedblock--replication_configuration))
 - `tag` (Block List) Definitions of a tag to associate with the resource. (see [below for nested schema](#nestedblock--tag))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
-<a id="block--from_share"></a>
-### Nested Schema for `from_share`
-
-Required:
-
-- `organization_name` (String)
-- `account_name` (String)
-
-Optional:
-
-- `provider` (String) Account locator. Deprecated alternative to `organization_name.account_name`, see more [here](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#format-2-legacy-account-locator-in-a-region)
-
 
 <a id="nestedblock--replication_configuration"></a>
 ### Nested Schema for `replication_configuration`

--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -140,7 +140,7 @@ func createDatabaseFromShare(d *schema.ResourceData, meta interface{}) error {
 	organizationName := in["organization_name"]
 	accountName := in["account_name"]
 
-	if share == nil || (prov == nil && (organizationName == nil || accountName == nil)) {
+	if share == nil {
 		return fmt.Errorf("from_share must contain the share key, but it had %+v", in)
 	}
 

--- a/pkg/snowflake/database_test.go
+++ b/pkg/snowflake/database_test.go
@@ -52,9 +52,21 @@ func TestDatabase(t *testing.T) {
 
 func TestDatabaseCreateFromShare(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.DatabaseFromShare("db1", "abc123", "share1")
+	db := snowflake.DatabaseFromShare("db1", "share1")
+	db.WithProvider("abc123")
 	q := db.Create()
 	r.Equal(`CREATE DATABASE "db1" FROM SHARE "abc123"."share1"`, q)
+
+	db = snowflake.DatabaseFromShare("db1", "share1")
+	db.WithOrg("org1", "account1")
+	q = db.Create()
+	r.Equal(`CREATE DATABASE "db1" FROM SHARE "org1"."account1"."share1"`, q)
+
+	db = snowflake.DatabaseFromShare("db1", "share1")
+	db.WithOrg("org1", "account1")
+	db.WithComment("This is comment")
+	q = db.Create()
+	r.Equal(`CREATE DATABASE "db1" FROM SHARE "org1"."account1"."share1" COMMENT = 'This is comment'`, q)
 }
 
 func TestDatabaseCreateFromDatabase(t *testing.T) {


### PR DESCRIPTION
Allowes to create database from share using `organization_name.account_name` notation. Add deprecation warning when using `provider` (based on [this](https://community.snowflake.com/s/article/show-shares-command-ui-data-sharing-changes) and [this](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#format-2-legacy-account-locator-in-a-region)).

Supports adding comments when creating a database from share (didn't work before).

```
resource "snowflake_database" "db_from_share" {
  comment = "This is a comment"
  from_share = {
	  account_name = "ACCOUNT_NAME"
	  organization_name = "ORGANIZATION_NAME"
	  share = "SHARE_NAME"
	}
  name = "DB_FROM_SHARE"
}
```

<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->
* [x] tested in own environment
* [ ] acceptance tests 

## References
resolves #1107 