### PR TITLE
fix: Show Parameters Warehouse

### DIFF
--- a/.github/workflows/team-slack-bot.yml
+++ b/.github/workflows/team-slack-bot.yml
@@ -1,11 +1,15 @@
 name: slack-notifications-prs-issues
 
-on: [pull_request, issues]
+on:
+  pull_request:
+    types: [opened]
+  issues:
+    types: [opened]
 
 jobs:
   slack-action:
-    runs-on: windows-latest
-    name: Test 2 [windows-latest]
+    runs-on: ubuntu-latest
+    name: Notify Team in Slack
 
     steps:
       - name: Send Slack Message
@@ -14,7 +18,7 @@ jobs:
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: C03KS51EF3R
-          slack-text: Event "${{ github.event_name }}"
+          slack-text: A new ${{ github.event_name }} has been published. Please review ${{ github.event.pull_request.html_url }}
 
       - name: Result from "Send Slack Message"
         run: echo '${{ steps.send-message.outputs.slack-result }}'


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

When I try to use the command **SHOW PARAMETERS** with double quotes or quotes I receive an error in the Terraform, the problem is the print where I did the change. From my fork now it is working well.

The ignore quote cant be added during the process in the terraform plan/apply (terraform opens multiple sessions in snowflake) that's why we need to fix them.

<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->
* [x] …

## References
<!-- issues documentation links, etc  -->
Link with the issue where I've open some days ago. 

https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1104
* 