### PR TITLE
fix: doc of snowflake_pipe.

### DIFF
--- a/docs/resources/pipe.md
+++ b/docs/resources/pipe.md
@@ -25,7 +25,6 @@ resource snowflake_pipe pipe {
 
   aws_sns_topic_arn    = "..."
   notification_channel = "..."
-  owner                = "role1"
 }
 ```
 


### PR DESCRIPTION
Fix doc #793 


## Test Plan
N/A

## References
<!-- issues documentation links, etc  -->
#793 

* `owner` is Read-Only. So I think that `owner` should not defined in `snowflake_pipe` resource.
  * https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/pkg/resources/pipe.go