### PR TITLE
chore: bump go version from 1.17 to 1.19

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,7 +45,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.19'
 
       - name: Install dependencies
         run: make setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
         if: ${{ steps.release.outputs.release_created }}
 
       - name: Run GoReleaser

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.19'
       - name: Install dependencies
         run: make setup
       - name: make ${{ matrix.target }}

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test-acceptance: fmt deps ## runs all tests, including the acceptance tests whic
 .PHONY: test-acceptance
 
 deps:
-	go mod tidy -compat=1.17
+	go mod tidy -compat=1.19
 .PHONY: deps
 
 install: ## install the terraform-provider-snowflake binary in $GOPATH/bin
@@ -97,7 +97,7 @@ check-docs: docs ## check that docs have been generated
 .PHONY: check-docs
 
 check-mod:
-	go mod tidy -compat=1.17
+	go mod tidy -compat=1.19
 	git diff --exit-code -- go.mod go.sum
 .PHONY: check-mod
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Snowflake-Labs/terraform-provider-snowflake
 
-go 1.17
+go 1.19
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
Bump go version from 1.17 to 1.19

Related to https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/1117 .

## Test Plan
* [x] acceptance tests

