### PR TITLE
feat: transient database

### DIFF
--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -46,6 +46,7 @@ resource "snowflake_database" "test3" {
 ### Optional
 
 - `comment` (String)
+- `is_transient` (Boolean) Specifies a database as transient. Transient databases do not have a Fail-safe period so they do not incur additional storage costs once they leave Time Travel; however, this means they are also not protected by Fail-safe in the event of a data loss.
 - `data_retention_time_in_days` (Number)
 - `from_database` (String) Specify a database to create a clone from.
 - `from_replica` (String) Specify a fully-qualified path to a database to create a replica from. A fully qualified path follows the format of "<organization_name>"."<account_name>"."<db_name>". An example would be: "myorg1"."account1"."db1"

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -46,11 +46,11 @@ resource "snowflake_database" "test3" {
 ### Optional
 
 - `comment` (String)
-- `is_transient` (Boolean) Specifies a database as transient. Transient databases do not have a Fail-safe period so they do not incur additional storage costs once they leave Time Travel; however, this means they are also not protected by Fail-safe in the event of a data loss.
 - `data_retention_time_in_days` (Number)
 - `from_database` (String) Specify a database to create a clone from.
 - `from_replica` (String) Specify a fully-qualified path to a database to create a replica from. A fully qualified path follows the format of "<organization_name>"."<account_name>"."<db_name>". An example would be: "myorg1"."account1"."db1"
 - `from_share` (Map of String) Specify a provider and a share in this map to create a database from a share.
+- `is_transient` (Boolean) Specifies a database as transient. Transient databases do not have a Fail-safe period so they do not incur additional storage costs once they leave Time Travel; however, this means they are also not protected by Fail-safe in the event of a data loss.
 - `replication_configuration` (Block List, Max: 1) When set, specifies the configurations for database replication. (see [below for nested schema](#nestedblock--replication_configuration))
 - `tag` (Block List) Definitions of a tag to associate with the resource. (see [below for nested schema](#nestedblock--tag))
 

--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -75,8 +75,6 @@ var databaseSchema = map[string]*schema.Schema{
 	"tag": tagReferenceSchema,
 }
 
-var databaseProperties = []string{"comment", "data_retention_time_in_days", "tag"}
-
 // Database returns a pointer to the resource representing a database
 func Database() *schema.Resource {
 	return &schema.Resource{
@@ -92,18 +90,51 @@ func Database() *schema.Resource {
 	}
 }
 
+func createDatabase(d *schema.ResourceData, builder *snowflake.DatabaseBuilder, meta interface{}) error {
+	db := meta.(*sql.DB)
+	q := builder.Create()
+	name := d.Get("name").(string)
+
+	err := snowflake.Exec(db, q)
+	if err != nil {
+		return errors.Wrapf(err, "error creating database %v", name)
+	}
+
+	d.SetId(name)
+
+	return ReadDatabase(d, meta)
+}
+
 // CreateDatabase implements schema.CreateFunc
 func CreateDatabase(d *schema.ResourceData, meta interface{}) error {
+	// TODO: Migrate database from share and from replica to iterative approach
 	if _, ok := d.GetOk("from_share"); ok {
 		return createDatabaseFromShare(d, meta)
 	}
 
-	if _, ok := d.GetOk("from_database"); ok {
-		return createDatabaseFromDatabase(d, meta)
-	}
-
 	if _, ok := d.GetOk("from_replica"); ok {
 		return createDatabaseFromReplica(d, meta)
+	}
+
+	name := d.Get("name").(string)
+	builder := snowflake.Database(name)
+
+	// Set optionals
+	if v, ok := d.GetOk("comment"); ok {
+		builder.WithComment(v.(string))
+	}
+
+	if v, ok := d.GetOk("from_database"); ok {
+		builder.Clone(v.(string))
+	}
+
+	if v, ok := d.GetOk("data_retention_days"); ok {
+		builder.WithDataRetentionDays(v.(int))
+	}
+
+	if v, ok := d.GetOk("tag"); ok {
+		tags := getTags(v)
+		builder.WithTags(tags.toSnowflakeTagValues())
 	}
 
 	// If set, verify parameters are valid and attempt to enable replication
@@ -114,14 +145,14 @@ func CreateDatabase(d *schema.ResourceData, meta interface{}) error {
 		if !ignoreEditionCheck {
 			return errors.New("error enabling replication - ignore edition check was set to false")
 		}
-		resource := CreateResource("database", databaseProperties, databaseSchema, snowflake.Database, ReadDatabase)(d, meta)
+		resource := createDatabase(d, builder, meta)
 		if err := enableReplication(d, meta, replicationConfiguration); err != nil {
 			return errors.Wrapf(err, "error enabling replication - account does not exist or System Parameter ENABLE_ACCOUNT_DATABASE_REPLICATION must be set to true")
 		}
 		return resource
 	}
 
-	return CreateResource("database", databaseProperties, databaseSchema, snowflake.Database, ReadDatabase)(d, meta)
+	return createDatabase(d, builder, meta)
 }
 
 func enableReplication(d *schema.ResourceData, meta interface{}, replicationConfig map[string]interface{}) error {
@@ -149,23 +180,6 @@ func createDatabaseFromShare(d *schema.ResourceData, meta interface{}) error {
 	err := snowflake.Exec(db, builder.Create())
 	if err != nil {
 		return errors.Wrapf(err, "error creating database %v from share %v.%v", name, prov, share)
-	}
-
-	d.SetId(name)
-
-	return ReadDatabase(d, meta)
-}
-
-func createDatabaseFromDatabase(d *schema.ResourceData, meta interface{}) error {
-	sourceDb := d.Get("from_database").(string)
-
-	db := meta.(*sql.DB)
-	name := d.Get("name").(string)
-	builder := snowflake.DatabaseFromDatabase(name, sourceDb)
-
-	err := snowflake.Exec(db, builder.Create())
-	if err != nil {
-		return errors.Wrapf(err, "error creating a clone database %v from database %v", name, sourceDb)
 	}
 
 	d.SetId(name)
@@ -265,11 +279,58 @@ func UpdateDatabase(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 	}
-	return UpdateResource("database", databaseProperties, databaseSchema, snowflake.Database, ReadDatabase)(d, meta)
+
+	if d.HasChange("name") {
+		name := d.Get("name")
+		q := builder.Rename(name.(string))
+		err := snowflake.Exec(db, q)
+		if err != nil {
+			return errors.Wrapf(err, "error updating database name on %v", d.Id())
+		}
+		d.SetId(fmt.Sprintf("%v", name.(string)))
+	}
+
+	if d.HasChange("comment") {
+		comment := d.Get("comment")
+		q := builder.ChangeComment(comment.(string))
+		err := snowflake.Exec(db, q)
+		if err != nil {
+			return errors.Wrapf(err, "error updating database comment on %v", d.Id())
+		}
+	}
+
+	if d.HasChange("data_retention_days") {
+		days := d.Get("data_retention_days")
+
+		q := builder.ChangeDataRetentionDays(days.(int))
+		err := snowflake.Exec(db, q)
+		if err != nil {
+			return errors.Wrapf(err, "error updating data retention days on %v", d.Id())
+		}
+	}
+
+	tagChangeErr := handleTagChanges(db, d, builder)
+	if tagChangeErr != nil {
+		return tagChangeErr
+	}
+
+	return ReadDatabase(d, meta)
 }
 
 func DeleteDatabase(d *schema.ResourceData, meta interface{}) error {
-	return DeleteResource("database", snowflake.Database)(d, meta)
+	db := meta.(*sql.DB)
+	name := d.Id()
+
+	q := snowflake.Database(name).Drop()
+
+	err := snowflake.Exec(db, q)
+	if err != nil {
+		return errors.Wrapf(err, "error deleting database %v", d.Id())
+	}
+
+	d.SetId("")
+
+	return nil
 }
 
 func extractInterfaceFromAttribute(config interface{}, attribute string) []interface{} {

--- a/pkg/resources/database_test.go
+++ b/pkg/resources/database_test.go
@@ -30,7 +30,7 @@ func TestDatabaseCreate(t *testing.T) {
 	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`CREATE DATABASE "good_name" COMMENT='great comment`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`CREATE DATABASE "good_name" COMMENT = 'great comment'`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectRead(mock)
 		err := resources.CreateDatabase(d, db)
 		r.NoError(err)
@@ -52,7 +52,7 @@ func TestDatabase_Create_WithValidReplicationConfiguration(t *testing.T) {
 	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`CREATE DATABASE "good_name" COMMENT='great comment`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`CREATE DATABASE "good_name" COMMENT = 'great comment'`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`ALTER DATABASE "good_name" ENABLE REPLICATION TO ACCOUNTS account1, account2`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectRead(mock)
 

--- a/pkg/resources/share.go
+++ b/pkg/resources/share.go
@@ -98,7 +98,7 @@ func setAccounts(d *schema.ResourceData, meta interface{}) error {
 		// 1. Create new temporary DB
 		tempName := fmt.Sprintf("TEMP_%v_%d", name, time.Now().Unix())
 		tempDB := snowflake.Database(tempName)
-		err := snowflake.Exec(db, tempDB.Create().Statement())
+		err := snowflake.Exec(db, tempDB.Create())
 		if err != nil {
 			return errors.Wrapf(err, "error creating temporary DB %v", tempName)
 		}

--- a/pkg/snowflake/database.go
+++ b/pkg/snowflake/database.go
@@ -4,17 +4,169 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 )
 
-// Database returns a pointer to a Builder for a database
-func Database(name string) *Builder {
-	return &Builder{
-		name:       name,
-		entityType: DatabaseType,
+// DatabaseBuilder abstracts the creation of SQL queries for a Snowflake database
+type DatabaseBuilder struct {
+	name                 string
+	comment              string
+	cloneDatabase        string
+	setDataRetentionDays bool
+	dataRetentionDays    int
+	tags                 []TagValue
+}
+
+func (db *DatabaseBuilder) QualifiedName() string {
+	return fmt.Sprintf(`"%v"`, db.name)
+}
+
+// Clone adds CLONE to the DatabaseBuilder to create a clone of another database
+func (db *DatabaseBuilder) Clone(database string) *DatabaseBuilder {
+	db.cloneDatabase = database
+	return db
+}
+
+// WithComment adds a comment to the DatabaseBuilder
+func (db *DatabaseBuilder) WithComment(c string) *DatabaseBuilder {
+	db.comment = c
+	return db
+}
+
+// WithDataRetentionDays adds the days to retain data to the DatabaseBuilder (must
+// be 0-1 for standard edition, 0-90 for enterprise edition)
+func (db *DatabaseBuilder) WithDataRetentionDays(d int) *DatabaseBuilder {
+	db.setDataRetentionDays = true
+	db.dataRetentionDays = d
+	return db
+}
+
+// WithTags sets the tags on the DatabaseBuilder
+func (db *DatabaseBuilder) WithTags(tags []TagValue) *DatabaseBuilder {
+	db.tags = tags
+	return db
+}
+
+// AddTag returns the SQL query that will add a new tag to the database.
+func (db *DatabaseBuilder) AddTag(tag TagValue) string {
+	return fmt.Sprintf(`ALTER DATABASE %s SET TAG "%v" = "%v"`, db.QualifiedName(), tag.Name, tag.Value)
+}
+
+// ChangeTag returns the SQL query that will alter a tag on the database.
+func (db *DatabaseBuilder) ChangeTag(tag TagValue) string {
+	return fmt.Sprintf(`ALTER DATABASE %s SET TAG "%v" = "%v"`, db.QualifiedName(), tag.Name, tag.Value)
+}
+
+// UnsetTag returns the SQL query that will unset a tag on the database.
+func (db *DatabaseBuilder) UnsetTag(tag TagValue) string {
+	return fmt.Sprintf(`ALTER DATABASE %s UNSET TAG "%v" = "%v"`, db.QualifiedName(), tag.Name, tag.Value)
+}
+
+// Database returns a pointer to a Builder that abstracts the DDL operations for a database.
+//
+// Supported DDL operations are:
+//   - CREATE DATABASE
+//   - ALTER DATABASE
+//   - DROP DATABASE
+//   - UNDROP DATABASE
+//   - USE DATABASE
+//   - SHOW DATABASE
+//
+// [Snowflake Reference](https://docs.snowflake.net/manuals/sql-reference/ddl-database.html#database-management)
+func Database(name string) *DatabaseBuilder {
+	return &DatabaseBuilder{
+		name: name,
 	}
+}
+
+// Create returns the SQL query that will create a new database.
+func (db *DatabaseBuilder) Create() string {
+	q := strings.Builder{}
+	q.WriteString(`CREATE`)
+
+	q.WriteString(fmt.Sprintf(` DATABASE %v`, db.QualifiedName()))
+
+	if db.cloneDatabase != "" {
+		q.WriteString(fmt.Sprintf(` CLONE "%v"`, db.cloneDatabase))
+	}
+
+	if db.setDataRetentionDays {
+		q.WriteString(fmt.Sprintf(` DATA_RETENTION_TIME_IN_DAYS = %d`, db.dataRetentionDays))
+	}
+
+	if db.comment != "" {
+		q.WriteString(fmt.Sprintf(` COMMENT = '%v'`, EscapeString(db.comment)))
+	}
+
+	return q.String()
+}
+
+// Rename returns the SQL query that will rename the database.
+func (db *DatabaseBuilder) Rename(newName string) string {
+	oldName := db.QualifiedName()
+	db.name = newName
+	return fmt.Sprintf(`ALTER DATABASE %v RENAME TO %v`, oldName, db.QualifiedName())
+}
+
+// Swap returns the SQL query that Swaps all objects (tables, views, etc.) and
+// metadata, including identifiers, between the two specified databases.
+func (db *DatabaseBuilder) Swap(targetDatabase string) string {
+	sourceDatabase := db.QualifiedName()
+	db.name = targetDatabase
+	return fmt.Sprintf(`ALTER DATABASE %v SWAP WITH %v`, sourceDatabase, db.QualifiedName())
+}
+
+// ChangeComment returns the SQL query that will update the comment on the database.
+func (db *DatabaseBuilder) ChangeComment(c string) string {
+	return fmt.Sprintf(`ALTER DATABASE %v SET COMMENT = '%v'`, db.QualifiedName(), EscapeString(c))
+}
+
+// RemoveComment returns the SQL query that will remove the comment on the database.
+func (db *DatabaseBuilder) RemoveComment() string {
+	return fmt.Sprintf(`ALTER DATABASE %v UNSET COMMENT`, db.QualifiedName())
+}
+
+// ChangeDataRetentionDays returns the SQL query that will update the data retention days on the database.
+func (db *DatabaseBuilder) ChangeDataRetentionDays(d int) string {
+	return fmt.Sprintf(`ALTER DATABASE %v SET DATA_RETENTION_TIME_IN_DAYS = %d`, db.QualifiedName(), d)
+}
+
+// RemoveDataRetentionDays returns the SQL query that will remove the data retention days on the database.
+func (db *DatabaseBuilder) RemoveDataRetentionDays() string {
+	return fmt.Sprintf(`ALTER DATABASE %v UNSET DATA_RETENTION_TIME_IN_DAYS`, db.QualifiedName())
+}
+
+// Drop returns the SQL query that will drop a database.
+func (db *DatabaseBuilder) Drop() string {
+	return fmt.Sprintf(`DROP DATABASE %v`, db.QualifiedName())
+}
+
+// Undrop returns the SQL query that will undrop a database.
+func (db *DatabaseBuilder) Undrop() string {
+	return fmt.Sprintf(`UNDROP DATABASE %v`, db.QualifiedName())
+}
+
+// Use returns the SQL query that will use a database.
+func (db *DatabaseBuilder) Use() string {
+	return fmt.Sprintf(`USE DATABASE %v`, db.QualifiedName())
+}
+
+// Show returns the SQL query that will show a database.
+func (db *DatabaseBuilder) Show() string {
+	return fmt.Sprintf(`SHOW DATABASES LIKE '%v'`, db.name)
+}
+
+// EnableReplicationAccounts returns the SQL query that will enable replication to provided accounts
+func (db *DatabaseBuilder) EnableReplicationAccounts(dbName string, accounts string) string {
+	return fmt.Sprintf(`ALTER DATABASE "%v" ENABLE REPLICATION TO ACCOUNTS %v`, dbName, accounts)
+}
+
+// DisableReplicationAccounts returns the SQL query that will disable replication to provided accounts
+func (db *DatabaseBuilder) DisableReplicationAccounts(dbName string, accounts string) string {
+	return fmt.Sprintf(`ALTER DATABASE "%v" DISABLE REPLICATION TO ACCOUNTS %v`, dbName, accounts)
 }
 
 // DatabaseShareBuilder is a basic builder that just creates databases from shares
@@ -38,25 +190,6 @@ func (dsb *DatabaseShareBuilder) Create() string {
 	return fmt.Sprintf(`CREATE DATABASE "%v" FROM SHARE "%v"."%v"`, dsb.name, dsb.provider, dsb.share)
 }
 
-// DatabaseCloneBuilder is a basic builder that just creates databases from a source database
-type DatabaseCloneBuilder struct {
-	name     string
-	database string
-}
-
-// DatabaseFromDatabase returns a pointer to a builder that can create a database from a source database
-func DatabaseFromDatabase(name, database string) *DatabaseCloneBuilder {
-	return &DatabaseCloneBuilder{
-		name:     name,
-		database: database,
-	}
-}
-
-// Create returns the SQL statement required to create a database from a source database
-func (dsb *DatabaseCloneBuilder) Create() string {
-	return fmt.Sprintf(`CREATE DATABASE "%v" CLONE "%v"`, dsb.name, dsb.database)
-}
-
 // DatabaseReplicaBuilder is a basic builder that just creates databases from an available replication source
 type DatabaseReplicaBuilder struct {
 	name    string
@@ -74,6 +207,23 @@ func DatabaseFromReplica(name, replica string) *DatabaseReplicaBuilder {
 // Create returns the SQL statement required to create a database from an available replication source
 func (dsb *DatabaseReplicaBuilder) Create() string {
 	return fmt.Sprintf(`CREATE DATABASE "%v" AS REPLICA OF "%v"`, dsb.name, dsb.replica)
+}
+
+// GetRemovedAccountsFromReplicationConfiguration compares two old and new configurations and returns any values that
+// were deleted from the old configuration.
+func (db *DatabaseBuilder) GetRemovedAccountsFromReplicationConfiguration(oldAcc []interface{}, newAcc []interface{}) []interface{} {
+	accountMap := make(map[string]bool)
+	var removedAccounts []interface{}
+	// insert all values from new configuration into mapping
+	for _, v := range newAcc {
+		accountMap[v.(string)] = true
+	}
+	for _, v := range oldAcc {
+		if !accountMap[v.(string)] {
+			removedAccounts = append(removedAccounts, v.(string))
+		}
+	}
+	return removedAccounts
 }
 
 type database struct {
@@ -133,31 +283,4 @@ func ListDatabase(sdb *sqlx.DB, databaseName string) (*database, error) {
 		}
 	}
 	return db, errors.Wrapf(err, "unable to scan row for %s", stmt)
-}
-
-// EnableReplicationAccounts returns the SQL query that will enable replication to provided accounts
-func (db *Builder) EnableReplicationAccounts(dbName string, accounts string) string {
-	return fmt.Sprintf(`ALTER DATABASE "%v" ENABLE REPLICATION TO ACCOUNTS %v`, dbName, accounts)
-}
-
-// DisableReplicationAccounts returns the SQL query that will disable replication to provided accounts
-func (db *Builder) DisableReplicationAccounts(dbName string, accounts string) string {
-	return fmt.Sprintf(`ALTER DATABASE "%v" DISABLE REPLICATION TO ACCOUNTS %v`, dbName, accounts)
-}
-
-// GetRemovedAccountsFromReplicationConfiguration compares two old and new configurations and returns any values that
-// were deleted from the old configuration.
-func (db *Builder) GetRemovedAccountsFromReplicationConfiguration(oldAcc []interface{}, newAcc []interface{}) []interface{} {
-	accountMap := make(map[string]bool)
-	var removedAccounts []interface{}
-	// insert all values from new configuration into mapping
-	for _, v := range newAcc {
-		accountMap[v.(string)] = true
-	}
-	for _, v := range oldAcc {
-		if !accountMap[v.(string)] {
-			removedAccounts = append(removedAccounts, v.(string))
-		}
-	}
-	return removedAccounts
 }

--- a/pkg/snowflake/database.go
+++ b/pkg/snowflake/database.go
@@ -14,6 +14,7 @@ import (
 type DatabaseBuilder struct {
 	name                 string
 	comment              string
+	transient            bool
 	cloneDatabase        string
 	setDataRetentionDays bool
 	dataRetentionDays    int
@@ -27,6 +28,12 @@ func (db *DatabaseBuilder) QualifiedName() string {
 // Clone adds CLONE to the DatabaseBuilder to create a clone of another database
 func (db *DatabaseBuilder) Clone(database string) *DatabaseBuilder {
 	db.cloneDatabase = database
+	return db
+}
+
+// Transient adds the TRANSIENT flag to the DatabaseBuilder
+func (db *DatabaseBuilder) Transient() *DatabaseBuilder {
+	db.transient = true
 	return db
 }
 
@@ -86,6 +93,10 @@ func Database(name string) *DatabaseBuilder {
 func (db *DatabaseBuilder) Create() string {
 	q := strings.Builder{}
 	q.WriteString(`CREATE`)
+
+	if db.transient {
+		q.WriteString(` TRANSIENT`)
+	}
 
 	q.WriteString(fmt.Sprintf(` DATABASE %v`, db.QualifiedName()))
 

--- a/pkg/snowflake/database_test.go
+++ b/pkg/snowflake/database_test.go
@@ -22,14 +22,17 @@ func TestCreateDatabase(t *testing.T) {
 
 	r.Equal(`CREATE DATABASE "test"`, db.Create())
 
+	db.Transient()
+	r.Equal(`CREATE TRANSIENT DATABASE "test"`, db.Create())
+
 	db.Clone("other")
-	r.Equal(`CREATE DATABASE "test" CLONE "other"`, db.Create())
+	r.Equal(`CREATE TRANSIENT DATABASE "test" CLONE "other"`, db.Create())
 
 	db.WithDataRetentionDays(7)
-	r.Equal(`CREATE DATABASE "test" CLONE "other" DATA_RETENTION_TIME_IN_DAYS = 7`, db.Create())
+	r.Equal(`CREATE TRANSIENT DATABASE "test" CLONE "other" DATA_RETENTION_TIME_IN_DAYS = 7`, db.Create())
 
 	db.WithComment("Yee'haw")
-	r.Equal(`CREATE DATABASE "test" CLONE "other" DATA_RETENTION_TIME_IN_DAYS = 7 COMMENT = 'Yee\'haw'`, db.Create())
+	r.Equal(`CREATE TRANSIENT DATABASE "test" CLONE "other" DATA_RETENTION_TIME_IN_DAYS = 7 COMMENT = 'Yee\'haw'`, db.Create())
 }
 
 func TestDatabaseCreateFromShare(t *testing.T) {

--- a/pkg/snowflake/database_test.go
+++ b/pkg/snowflake/database_test.go
@@ -10,44 +10,26 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake"
 )
 
-func TestDatabase(t *testing.T) {
+func TestQualifiedNameDatabase(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("db1")
-	r.NotNil(db)
+	db := snowflake.Database("test")
+	r.Equal(`"test"`, db.QualifiedName())
+}
 
-	q := db.Show()
-	r.Equal("SHOW DATABASES LIKE 'db1'", q)
+func TestCreateDatabase(t *testing.T) {
+	r := require.New(t)
+	db := snowflake.Database("test")
 
-	q = db.Drop()
-	r.Equal(`DROP DATABASE "db1"`, q)
+	r.Equal(`CREATE DATABASE "test"`, db.Create())
 
-	q = db.Rename("db2")
-	r.Equal(`ALTER DATABASE "db1" RENAME TO "db2"`, q)
+	db.Clone("other")
+	r.Equal(`CREATE DATABASE "test" CLONE "other"`, db.Create())
 
-	ab := db.Alter()
-	r.NotNil(ab)
+	db.WithDataRetentionDays(7)
+	r.Equal(`CREATE DATABASE "test" CLONE "other" DATA_RETENTION_TIME_IN_DAYS = 7`, db.Create())
 
-	ab.SetString(`foo`, `bar`)
-	q = ab.Statement()
-
-	r.Equal(`ALTER DATABASE "db1" SET FOO='bar'`, q)
-
-	ab.SetBool(`bam`, false)
-	q = ab.Statement()
-
-	r.Equal(`ALTER DATABASE "db1" SET FOO='bar' BAM=false`, q)
-
-	c := db.Create()
-	c.SetString("foo", "bar")
-	c.SetBool("bam", false)
-	q = c.Statement()
-	r.Equal(`CREATE DATABASE "db1" FOO='bar' BAM=false`, q)
-
-	// test escaping
-	c2 := db.Create()
-	c2.SetString("foo", "ba'r")
-	q = c2.Statement()
-	r.Equal(`CREATE DATABASE "db1" FOO='ba\'r'`, q)
+	db.WithComment("Yee'haw")
+	r.Equal(`CREATE DATABASE "test" CLONE "other" DATA_RETENTION_TIME_IN_DAYS = 7 COMMENT = 'Yee\'haw'`, db.Create())
 }
 
 func TestDatabaseCreateFromShare(t *testing.T) {
@@ -57,18 +39,74 @@ func TestDatabaseCreateFromShare(t *testing.T) {
 	r.Equal(`CREATE DATABASE "db1" FROM SHARE "abc123"."share1"`, q)
 }
 
-func TestDatabaseCreateFromDatabase(t *testing.T) {
-	r := require.New(t)
-	db := snowflake.DatabaseFromDatabase("db1", "abc123")
-	q := db.Create()
-	r.Equal(`CREATE DATABASE "db1" CLONE "abc123"`, q)
-}
-
 func TestDatabaseCreateFromReplica(t *testing.T) {
 	r := require.New(t)
 	db := snowflake.DatabaseFromReplica("db1", "abc123")
 	q := db.Create()
 	r.Equal(`CREATE DATABASE "db1" AS REPLICA OF "abc123"`, q)
+}
+
+func TestDatabaseRename(t *testing.T) {
+	r := require.New(t)
+	db := snowflake.Database("db1")
+
+	r.Equal(`ALTER DATABASE "db1" RENAME TO "db2"`, db.Rename("db2"))
+}
+
+func TestDatabaseSwap(t *testing.T) {
+	r := require.New(t)
+	db := snowflake.Database("test")
+	r.Equal(`ALTER DATABASE "test" SWAP WITH "target"`, db.Swap("target"))
+}
+
+func TestDatabaseChangeComment(t *testing.T) {
+	r := require.New(t)
+	db := snowflake.Database("test")
+	r.Equal(`ALTER DATABASE "test" SET COMMENT = 'test\' db'`, db.ChangeComment("test' db"))
+}
+
+func TestDatabaseRemoveComment(t *testing.T) {
+	r := require.New(t)
+	db := snowflake.Database("test")
+	r.Equal(`ALTER DATABASE "test" UNSET COMMENT`, db.RemoveComment())
+}
+
+func TestDatabaseChangeDataRetentionDays(t *testing.T) {
+	r := require.New(t)
+	db := snowflake.Database("test")
+	r.Equal(`ALTER DATABASE "test" SET DATA_RETENTION_TIME_IN_DAYS = 22`, db.ChangeDataRetentionDays(22))
+}
+
+func TestDatabaseRemoveDataRetentionDays(t *testing.T) {
+	r := require.New(t)
+	db := snowflake.Database("test")
+	r.Equal(`ALTER DATABASE "test" UNSET DATA_RETENTION_TIME_IN_DAYS`, db.RemoveDataRetentionDays())
+}
+
+func TestDatabaseDrop(t *testing.T) {
+	r := require.New(t)
+	db := snowflake.Database("db1")
+
+	r.Equal(`DROP DATABASE "db1"`, db.Drop())
+}
+
+func TestDatabaseUndrop(t *testing.T) {
+	r := require.New(t)
+	db := snowflake.Database("test")
+	r.Equal(`UNDROP DATABASE "test"`, db.Undrop())
+}
+
+func TestDatabaseUse(t *testing.T) {
+	r := require.New(t)
+	db := snowflake.Database("test")
+	r.Equal(`USE DATABASE "test"`, db.Use())
+}
+
+func TestDatabaseShow(t *testing.T) {
+	r := require.New(t)
+	db := snowflake.Database("db1")
+
+	r.Equal("SHOW DATABASES LIKE 'db1'", db.Show())
 }
 
 func TestListDatabases(t *testing.T) {


### PR DESCRIPTION
This PR adds support for transient databases (closes [#1152](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1152)). 

It was a bit tricky to add this functionality with the current database implementation so I've slightly refactored it to an iterative approach, following how it's done for the [schema resource](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/pkg/resources/schema.go). Hopefully it will make it easier to implement other functionalities.
I only modified the code for database and database clone, so database from share and database from replication are still using the old implementation.
I've added some extra tests and ran the acceptance tests using a trial snowflake account as suggested in the readme.
Also installed the provider locally and did some extra testing, everything seems to be working fine.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
* [x] added extra unit tests
* [x] install provider locally for extra testing

## References
* https://docs.snowflake.com/en/sql-reference/sql/create-database.html#optional-parameters 