### PR TITLE
fix: Database from share comment on create and docs

### DIFF
--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -13,13 +13,13 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource "snowflake_database" "test" {
+resource "snowflake_database" "simple" {
   name                        = "testing"
   comment                     = "test comment"
   data_retention_time_in_days = 3
 }
 
-resource "snowflake_database" "test2" {
+resource "snowflake_database" "with_replication" {
   name    = "testing_2"
   comment = "test comment 2"
   replication_configuration {
@@ -36,7 +36,7 @@ resource "snowflake_database" "from_replica" {
 }
 
 resource "snowflake_database" "from_share" {
-  name    = "testing_3"
+  name    = "testing_4"
   comment = "test comment"
   from_share = {
     provider = "org1\".\"account1"

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -23,16 +23,25 @@ resource "snowflake_database" "test2" {
   name    = "testing_2"
   comment = "test comment 2"
   replication_configuration {
-    accounts             = [ "test_account1", "test_account_2"]
+    accounts             = ["test_account1", "test_account_2"]
     ignore_edition_check = true
   }
 }
 
-resource "snowflake_database" "test3" {
+resource "snowflake_database" "from_replica" {
   name                        = "testing_3"
   comment                     = "test comment"
   data_retention_time_in_days = 3
-  from_replica = "org1\".\"account1\".\"primary_db_name"
+  from_replica                = "org1\".\"account1\".\"primary_db_name"
+}
+
+resource "snowflake_database" "from_share" {
+  name    = "testing_3"
+  comment = "test comment"
+  from_share = {
+    provider = "org1\".\"account1"
+    share    = "share1"
+  }
 }
 ```
 

--- a/examples/resources/snowflake_database/resource.tf
+++ b/examples/resources/snowflake_database/resource.tf
@@ -1,21 +1,30 @@
-resource "snowflake_database" "test" {
+resource "snowflake_database" "simple" {
   name                        = "testing"
   comment                     = "test comment"
   data_retention_time_in_days = 3
 }
 
-resource "snowflake_database" "test2" {
+resource "snowflake_database" "with_replication" {
   name    = "testing_2"
   comment = "test comment 2"
   replication_configuration {
-    accounts             = [ "test_account1", "test_account_2"]
+    accounts             = ["test_account1", "test_account_2"]
     ignore_edition_check = true
   }
 }
 
-resource "snowflake_database" "test3" {
+resource "snowflake_database" "from_replica" {
   name                        = "testing_3"
   comment                     = "test comment"
   data_retention_time_in_days = 3
-  from_replica = "org1\".\"account1\".\"primary_db_name"
+  from_replica                = "org1\".\"account1\".\"primary_db_name"
+}
+
+resource "snowflake_database" "from_share" {
+  name    = "testing_4"
+  comment = "test comment"
+  from_share = {
+    provider = "org1\".\"account1"
+    share    = "share1"
+  }
 }

--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -146,6 +146,10 @@ func createDatabaseFromShare(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	builder := snowflake.DatabaseFromShare(name, prov.(string), share.(string))
 
+	if comment, ok := d.GetOk("comment"); ok {
+		builder.WithComment(comment.(string))
+	}
+
 	err := snowflake.Exec(db, builder.Create())
 	if err != nil {
 		return errors.Wrapf(err, "error creating database %v from share %v.%v", name, prov, share)

--- a/pkg/resources/file_format_test.go
+++ b/pkg/resources/file_format_test.go
@@ -47,13 +47,13 @@ func TestFileFormatCreateInvalidOptions(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name":          "test_file_format",
-		"database":      "test_db",
-		"schema":        "test_schema",
-		"format_type":   "JSON",
-		"null_if":       []interface{}{"NULL"},
+		"name":            "test_file_format",
+		"database":        "test_db",
+		"schema":          "test_schema",
+		"format_type":     "JSON",
+		"null_if":         []interface{}{"NULL"},
 		"field_delimiter": ",",
-		"comment":       "great comment",
+		"comment":         "great comment",
 	}
 	d := schema.TestResourceDataRaw(t, resources.FileFormat().Schema, in)
 	r.NotNil(d)

--- a/pkg/snowflake/database.go
+++ b/pkg/snowflake/database.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
@@ -22,6 +23,7 @@ type DatabaseShareBuilder struct {
 	name     string
 	provider string
 	share    string
+	comment  string
 }
 
 // DatabaseFromShare returns a pointer to a builder that can create a database from a share
@@ -33,9 +35,22 @@ func DatabaseFromShare(name, provider, share string) *DatabaseShareBuilder {
 	}
 }
 
+// WithComment adds a comment to the DatabaseShareBuilder
+func (dsb *DatabaseShareBuilder) WithComment(comment string) *DatabaseShareBuilder {
+	dsb.comment = comment
+	return dsb
+}
+
 // Create returns the SQL statement required to create a database from a share
 func (dsb *DatabaseShareBuilder) Create() string {
-	return fmt.Sprintf(`CREATE DATABASE "%v" FROM SHARE "%v"."%v"`, dsb.name, dsb.provider, dsb.share)
+	var q strings.Builder
+	q.WriteString(fmt.Sprintf(`CREATE DATABASE "%v" FROM SHARE "%v"."%v"`, dsb.name, dsb.provider, dsb.share))
+
+	if dsb.comment != "" {
+		q.WriteString(fmt.Sprintf(` COMMENT = '%v'`, dsb.comment))
+	}
+
+	return q.String()
 }
 
 // DatabaseCloneBuilder is a basic builder that just creates databases from a source database

--- a/pkg/snowflake/database_test.go
+++ b/pkg/snowflake/database_test.go
@@ -55,6 +55,11 @@ func TestDatabaseCreateFromShare(t *testing.T) {
 	db := snowflake.DatabaseFromShare("db1", "abc123", "share1")
 	q := db.Create()
 	r.Equal(`CREATE DATABASE "db1" FROM SHARE "abc123"."share1"`, q)
+
+	db = snowflake.DatabaseFromShare("db1", "org1\".\"account1", "share1")
+	db.WithComment("This is comment")
+	q = db.Create()
+	r.Equal(`CREATE DATABASE "db1" FROM SHARE "org1"."account1"."share1" COMMENT = 'This is comment'`, q)
 }
 
 func TestDatabaseCreateFromDatabase(t *testing.T) {


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

Fix setting comment on databases `from_share` creation, it is currently only applied on subsequent updates.

Also make examples in docs more illustrative of using fully-qualified provider name.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->

## References
<!-- issues documentation links, etc  -->

* Raised and discussed in #1107
* Partially inspired by #1114