### PR TITLE
fix: add support in procedure for return type table()

### DIFF
--- a/pkg/resources/procedure.go
+++ b/pkg/resources/procedure.go
@@ -269,7 +269,7 @@ func ReadProcedure(d *schema.ResourceData, meta interface{}) error {
 			}
 		case "returns":
 			// Format in Snowflake DB is RETURN_TYPE(<some number>) or RETURN_TYPE
-			re := regexp.MustCompile(`^([A-Z0-9_]+)(\([0-9]*\))?$`)
+			re := regexp.MustCompile(`^([A-Z0-9_]+)\s?(\([0-9]*\))?$`)
 			match := re.FindStringSubmatch(desc.Value.String)
 			if err = d.Set("return_type", match[1]); err != nil {
 				return err


### PR DESCRIPTION
Snowflake returns `return_type` `table()` as `table ()`. The provider regex doesn't match the space and caused the create and import operations to fail. As part of this PR the space matching is fixed.

## Test Plan
I've added the required specific test case in the test suite.

## References
https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1050