### PR TITLE
fix: Pass file_format values as-is in external table configuration

### DIFF
--- a/docs/resources/external_table.md
+++ b/docs/resources/external_table.md
@@ -14,10 +14,11 @@ description: |-
 
 ```terraform
 resource snowflake_external_table external_table {
-  database = "db"
-  schema   = "schema"
-  name     = "external_table"
-  comment  = "External table"
+  database    = "db"
+  schema      = "schema"
+  name        = "external_table"
+  comment     = "External table"
+  file_format = "TYPE = CSV FIELD_DELIMITER = '|'"
 
   column {
     name = "id"

--- a/examples/resources/snowflake_external_table/resource.tf
+++ b/examples/resources/snowflake_external_table/resource.tf
@@ -1,8 +1,9 @@
 resource snowflake_external_table external_table {
-  database = "db"
-  schema   = "schema"
-  name     = "external_table"
-  comment  = "External table"
+  database    = "db"
+  schema      = "schema"
+  name        = "external_table"
+  comment     = "External table"
+  file_format = "TYPE = CSV FIELD_DELIMITER = '|'"
 
   column {
     name = "id"

--- a/pkg/resources/external_table_test.go
+++ b/pkg/resources/external_table_test.go
@@ -27,13 +27,13 @@ func TestExternalTableCreate(t *testing.T) {
 		"comment":     "great comment",
 		"column":      []interface{}{map[string]interface{}{"name": "column1", "type": "OBJECT", "as": "a"}, map[string]interface{}{"name": "column2", "type": "VARCHAR", "as": "b"}},
 		"location":    "location",
-		"file_format": "format",
+		"file_format": "FORMAT_NAME = 'format'",
 		"pattern":     "pattern",
 	}
 	d := externalTable(t, "database_name|schema_name|good_name", in)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`CREATE EXTERNAL TABLE "database_name"."schema_name"."good_name" \("column1" OBJECT AS a, "column2" VARCHAR AS b\) WITH LOCATION = location REFRESH_ON_CREATE = true AUTO_REFRESH = true PATTERN = 'pattern' FILE_FORMAT = \( format \) COMMENT = 'great comment'`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`CREATE EXTERNAL TABLE "database_name"."schema_name"."good_name" \("column1" OBJECT AS a, "column2" VARCHAR AS b\) WITH LOCATION = location REFRESH_ON_CREATE = true AUTO_REFRESH = true PATTERN = 'pattern' FILE_FORMAT = \( FORMAT_NAME = 'format' \) COMMENT = 'great comment'`).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		expectExternalTableRead(mock)
 		err := resources.CreateExternalTable(d, db)

--- a/pkg/snowflake/external_table.go
+++ b/pkg/snowflake/external_table.go
@@ -141,7 +141,7 @@ func (tb *ExternalTableBuilder) Create() string {
 		q.WriteString(fmt.Sprintf(` PATTERN = '%v'`, EscapeString(tb.pattern)))
 	}
 
-	q.WriteString(fmt.Sprintf(` FILE_FORMAT = ( %v )`, EscapeString(tb.fileFormat)))
+	q.WriteString(fmt.Sprintf(` FILE_FORMAT = ( %v )`, tb.fileFormat))
 
 	if tb.awsSNSTopic != "" {
 		q.WriteString(fmt.Sprintf(` AWS_SNS_TOPIC = '%v'`, EscapeString(tb.awsSNSTopic)))

--- a/pkg/snowflake/external_table_test.go
+++ b/pkg/snowflake/external_table_test.go
@@ -12,13 +12,13 @@ func TestExternalTableCreate(t *testing.T) {
 	s.WithColumns([]map[string]string{{"name": "column1", "type": "OBJECT", "as": "expression1"}, {"name": "column2", "type": "VARCHAR", "as": "expression2"}})
 	s.WithLocation("location")
 	s.WithPattern("pattern")
-	s.WithFileFormat("file format")
+	s.WithFileFormat("TYPE = CSV FIELD_DELIMITER = '|'")
 	r.Equal(s.QualifiedName(), `"test_db"."test_schema"."test_table"`)
 
-	r.Equal(s.Create(), `CREATE EXTERNAL TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT AS expression1, "column2" VARCHAR AS expression2) WITH LOCATION = location REFRESH_ON_CREATE = false AUTO_REFRESH = false PATTERN = 'pattern' FILE_FORMAT = ( file format )`)
+	r.Equal(s.Create(), `CREATE EXTERNAL TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT AS expression1, "column2" VARCHAR AS expression2) WITH LOCATION = location REFRESH_ON_CREATE = false AUTO_REFRESH = false PATTERN = 'pattern' FILE_FORMAT = ( TYPE = CSV FIELD_DELIMITER = '|' )`)
 
 	s.WithComment("Test Comment")
-	r.Equal(s.Create(), `CREATE EXTERNAL TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT AS expression1, "column2" VARCHAR AS expression2) WITH LOCATION = location REFRESH_ON_CREATE = false AUTO_REFRESH = false PATTERN = 'pattern' FILE_FORMAT = ( file format ) COMMENT = 'Test Comment'`)
+	r.Equal(s.Create(), `CREATE EXTERNAL TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT AS expression1, "column2" VARCHAR AS expression2) WITH LOCATION = location REFRESH_ON_CREATE = false AUTO_REFRESH = false PATTERN = 'pattern' FILE_FORMAT = ( TYPE = CSV FIELD_DELIMITER = '|' ) COMMENT = 'Test Comment'`)
 }
 
 func TestExternalTableUpdate(t *testing.T) {


### PR DESCRIPTION
Common use of `FILE_FORMAT` within `CREATE EXTERNAL TABLE` includes specifying
a previously created format name (`FORMAT_NAME = 'NAME'`) or the various
type options (`TYPE=CSV FIELD_DELIMITER='|'`).

Both of these require defining string literals with the single quote
character (`'`) that should not be escaped (`\'`).

This change removes the escaping of single quotes performed for the
`file_format` values to allow them to be specified without failing
the query compilation.

Some examples have also been added to the documentation
to make it easier to understand how values for file_format
need to be passed for external tables.

## Test Plan

  - [x] acceptance tests (`make test-acceptance` with env-vars set to a trial account)
  - [x] unit tests (`make test`)
  - [x] manual test with **FORMAT_NAME = 'NAME'**
  - [x] manual test with **TYPE = CSV FIELD_DELIMITER = '|' NULL_IF = ('0', '')**
  - [x] executed modified example

## References

* Fixes #1046
* Snowflake Docs: [CREATE EXTERNAL TABLE](https://docs.snowflake.com/en/sql-reference/sql/create-external-table.html)