### PR TITLE
fix: add sweepers

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -73,6 +73,17 @@ jobs:
           SNOWFLAKE_ACCOUNT_THIRD: ${{ secrets.SNOWFLAKE_ACCOUNT_THIRD }}
         run: make test-acceptance
 
+      - name: sweepers cleanup
+        if: always()
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_ROLE: ${{ secrets.SNOWFLAKE_ROLE }}
+          SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
+        run: make sweep
+
       - name: find comment
         if: ${{ always() }}
         uses: peter-evans/find-comment@v1

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ setup: ## setup development dependencies
 	curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh
 .PHONY: setup
 
+sweep:
+	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
+	go test ./pkg/resources -v -timeout 10m -sweep=prod
+
 lint:  ## run the fast go linters
 	./bin/reviewdog -conf .reviewdog.yml  -diff "git diff main"
 .PHONY: lint

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"crypto/rsa"
+	"database/sql"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -504,4 +505,42 @@ func GetOauthAccessToken(
 		return "", errors.Wrap(err, "Error parsing JSON from Snowflake")
 	}
 	return result.AccessToken, nil
+}
+
+func GetDatabaseHandleFromEnv() (db *sql.DB, err error) {
+	account := os.Getenv("SNOWFLAKE_ACCOUNT")
+	user := os.Getenv("SNOWFLAKE_USER")
+	password := os.Getenv("SNOWFLAKE_PASSWORD")
+	browserAuth := os.Getenv("SNOWFLAKE_BROWSER_AUTH") == "true"
+	privateKeyPath := os.Getenv("SNOWFLAKE_PRIVATE_KEY_PATH")
+	privateKey := os.Getenv("SNOWFLAKE_PRIVATE_KEY")
+	privateKeyPassphrase := os.Getenv("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE")
+	oauthAccessToken := os.Getenv("SNOWFLAKE_OAUTH_ACCESS_TOKEN")
+	region := os.Getenv("SNOWFLAKE_REGION")
+	role := os.Getenv("SNOWFLAKE_ROLE")
+	host := os.Getenv("SNOWFLAKE_HOST")
+	warehouse := os.Getenv("SNOWFLAKE_WAREHOUSE")
+
+	dsn, err := DSN(
+		account,
+		user,
+		password,
+		browserAuth,
+		privateKeyPath,
+		privateKey,
+		privateKeyPassphrase,
+		oauthAccessToken,
+		region,
+		role,
+		host,
+		warehouse,
+	)
+	if err != nil {
+		return nil, err
+	}
+	db, err = sql.Open("snowflake", dsn)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -22,10 +22,6 @@ func TestProvider(t *testing.T) {
 	r.NoError(err)
 }
 
-// func TestConfigureProvider(t *testing.T) {
-// 	// r := require.New(t)
-// }
-
 func TestDSN(t *testing.T) {
 	type args struct {
 		account,
@@ -181,7 +177,7 @@ func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req), nil
 }
 
-//NewTestClient returns *http.Client with Transport replaced to avoid making real calls
+// NewTestClient returns *http.Client with Transport replaced to avoid making real calls
 func NewTestClient(fn RoundTripFunc) *http.Client {
 	return &http.Client{
 		Transport: RoundTripFunc(fn),

--- a/pkg/resources/database_acceptance_test.go
+++ b/pkg/resources/database_acceptance_test.go
@@ -15,8 +15,8 @@ func TestAcc_Database(t *testing.T) {
 		t.Skip("Skipping TestAccDatabase")
 	}
 
-	prefix := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
-	prefix2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	prefix := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	prefix2 := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    providers(),

--- a/pkg/resources/database_test.go
+++ b/pkg/resources/database_test.go
@@ -23,14 +23,14 @@ func TestDatabaseCreate(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name":    "good_name",
+		"name":    "tst-terraform-good_name",
 		"comment": "great comment",
 	}
 	d := schema.TestResourceDataRaw(t, resources.Database().Schema, in)
 	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`CREATE DATABASE "good_name" COMMENT = 'great comment'`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`CREATE DATABASE "tst-terraform-good_name" COMMENT = 'great comment'`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectRead(mock)
 		err := resources.CreateDatabase(d, db)
 		r.NoError(err)
@@ -41,7 +41,7 @@ func TestDatabase_Create_WithValidReplicationConfiguration(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name":    "good_name",
+		"name":    "tst-terraform-good_name",
 		"comment": "great comment",
 		"replication_configuration": []interface{}{map[string]interface{}{
 			"accounts":             []interface{}{"account1", "account2"},
@@ -52,8 +52,8 @@ func TestDatabase_Create_WithValidReplicationConfiguration(t *testing.T) {
 	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`CREATE DATABASE "good_name" COMMENT = 'great comment'`).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectExec(`ALTER DATABASE "good_name" ENABLE REPLICATION TO ACCOUNTS account1, account2`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`CREATE DATABASE "tst-terraform-good_name" COMMENT = 'great comment'`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`ALTER DATABASE "tst-terraform-good_name" ENABLE REPLICATION TO ACCOUNTS account1, account2`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectRead(mock)
 
 		err := resources.CreateDatabase(d, db)
@@ -65,7 +65,7 @@ func TestDatabase_Create_WithReplicationConfig_AndFalseIgnoreEditionCheck(t *tes
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name":    "good_name",
+		"name":    "tst-terraform-good_name",
 		"comment": "great comment",
 		"replication_configuration": []interface{}{map[string]interface{}{
 			"accounts":             []interface{}{"acc_to_replicate"},
@@ -83,21 +83,21 @@ func TestDatabase_Create_WithReplicationConfig_AndFalseIgnoreEditionCheck(t *tes
 
 func expectRead(mock sqlmock.Sqlmock) {
 	dbRows := sqlmock.NewRows([]string{"created_on", "name", "is_default", "is_current", "origin", "owner", "comment", "options", "retention_time"}).AddRow("created_on", "good_name", "is_default", "is_current", "origin", "owner", "mock comment", "options", "1")
-	mock.ExpectQuery("SHOW DATABASES LIKE 'good_name'").WillReturnRows(dbRows)
+	mock.ExpectQuery("SHOW DATABASES LIKE 'tst-terraform-good_name'").WillReturnRows(dbRows)
 }
 
 func TestDatabaseRead(t *testing.T) {
 	r := require.New(t)
 
-	d := database(t, "good_name", map[string]interface{}{
-		"name": "good_name",
+	d := database(t, "tst-terraform-good_name", map[string]interface{}{
+		"name": "tst-terraform-good_name",
 	})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expectRead(mock)
 		err := resources.ReadDatabase(d, db)
 		r.NoError(err)
-		r.Equal("good_name", d.Get("name").(string))
+		r.Equal("tst-terraform-good_name", d.Get("name").(string))
 		r.Equal("mock comment", d.Get("comment").(string))
 		r.Equal(1, d.Get("data_retention_time_in_days").(int))
 	})
@@ -106,10 +106,10 @@ func TestDatabaseRead(t *testing.T) {
 func TestDatabaseDelete(t *testing.T) {
 	r := require.New(t)
 
-	d := database(t, "drop_it", map[string]interface{}{"name": "drop_it"})
+	d := database(t, "tst-terraform-good_name-drop_it", map[string]interface{}{"name": "tst-terraform-good_name-drop_it"})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`DROP DATABASE "drop_it"`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`DROP DATABASE "tst-terraform-good_name-drop_it"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := resources.DeleteDatabase(d, db)
 		r.NoError(err)
 	})
@@ -119,7 +119,7 @@ func TestDatabaseCreateFromShare(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name": "good_name",
+		"name": "tst-terraform-good_name",
 		"from_share": map[string]interface{}{
 			"provider": "abc123",
 			"share":    "my_share",
@@ -129,7 +129,7 @@ func TestDatabaseCreateFromShare(t *testing.T) {
 	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`CREATE DATABASE "good_name" FROM SHARE "abc123"."my_share"`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`CREATE DATABASE "tst-terraform-good_name" FROM SHARE "abc123"."my_share"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectRead(mock)
 		err := resources.CreateDatabase(d, db)
 		r.NoError(err)
@@ -140,14 +140,14 @@ func TestDatabaseCreateFromDatabase(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name":          "good_name",
+		"name":          "tst-terraform-good_name",
 		"from_database": "abc123",
 	}
 	d := schema.TestResourceDataRaw(t, resources.Database().Schema, in)
 	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`CREATE DATABASE "good_name" CLONE "abc123"`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`CREATE DATABASE "tst-terraform-good_name" CLONE "abc123"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectRead(mock)
 		err := resources.CreateDatabase(d, db)
 		r.NoError(err)
@@ -158,14 +158,14 @@ func TestDatabaseCreateFromReplica(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name":         "good_name",
+		"name":         "tst-terraform-good_name",
 		"from_replica": "abc123",
 	}
 	d := schema.TestResourceDataRaw(t, resources.Database().Schema, in)
 	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`CREATE DATABASE "good_name" AS REPLICA OF "abc123"`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`CREATE DATABASE "tst-terraform-good_name" AS REPLICA OF "abc123"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectRead(mock)
 		err := resources.CreateDatabase(d, db)
 		r.NoError(err)
@@ -176,7 +176,7 @@ func TestDatabaseCreateTransient(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name":         "good_name",
+		"name":         "tst-terraform-good_name",
 		"comment":      "great comment",
 		"is_transient": true,
 	}
@@ -184,7 +184,7 @@ func TestDatabaseCreateTransient(t *testing.T) {
 	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`CREATE TRANSIENT DATABASE "good_name" COMMENT = 'great comment'`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`CREATE TRANSIENT DATABASE "tst-terraform-good_name" COMMENT = 'great comment'`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectRead(mock)
 		err := resources.CreateDatabase(d, db)
 		r.NoError(err)
@@ -195,7 +195,7 @@ func TestDatabaseCreateTransientFromDatabase(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name":          "good_name",
+		"name":          "tst-terraform-good_name",
 		"from_database": "abc123",
 		"is_transient":  true,
 	}
@@ -203,7 +203,7 @@ func TestDatabaseCreateTransientFromDatabase(t *testing.T) {
 	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`CREATE TRANSIENT DATABASE "good_name" CLONE "abc123"`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`CREATE TRANSIENT DATABASE "tst-terraform-good_name" CLONE "abc123"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectRead(mock)
 		err := resources.CreateDatabase(d, db)
 		r.NoError(err)

--- a/pkg/resources/database_test.go
+++ b/pkg/resources/database_test.go
@@ -82,7 +82,7 @@ func TestDatabase_Create_WithReplicationConfig_AndFalseIgnoreEditionCheck(t *tes
 }
 
 func expectRead(mock sqlmock.Sqlmock) {
-	dbRows := sqlmock.NewRows([]string{"created_on", "name", "is_default", "is_current", "origin", "owner", "comment", "options", "retention_time"}).AddRow("created_on", "good_name", "is_default", "is_current", "origin", "owner", "mock comment", "options", "1")
+	dbRows := sqlmock.NewRows([]string{"created_on", "name", "is_default", "is_current", "origin", "owner", "comment", "options", "retention_time"}).AddRow("created_on", "tst-terraform-good_name", "is_default", "is_current", "origin", "owner", "mock comment", "options", "1")
 	mock.ExpectQuery("SHOW DATABASES LIKE 'tst-terraform-good_name'").WillReturnRows(dbRows)
 }
 

--- a/pkg/resources/role_acceptance_test.go
+++ b/pkg/resources/role_acceptance_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestAcc_Role(t *testing.T) {
-	prefix := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
-	prefix2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	prefix := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	prefix2 := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    providers(),

--- a/pkg/resources/role_grants_acceptance_test.go
+++ b/pkg/resources/role_grants_acceptance_test.go
@@ -88,11 +88,11 @@ func testCheckRolesAndUsers(t *testing.T, path string, roles, users []string) fu
 }
 
 func TestAcc_GrantRole(t *testing.T) {
-	role1 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
-	role2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
-	role3 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
-	user1 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
-	user2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	role1 := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	role2 := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	role3 := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	user1 := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	user2 := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	basicChecks := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr("snowflake_role.r", "name", role1),

--- a/pkg/resources/role_ownership_grant_acceptance_test.go
+++ b/pkg/resources/role_ownership_grant_acceptance_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestAcc_RoleOwnershipGrant_defaults(t *testing.T) {
-	onRoleName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-	toRoleName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	onRoleName := "tst-terraform" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	toRoleName := "tst-terraform" +acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    providers(),

--- a/pkg/resources/snowflake_sweeper_test.go
+++ b/pkg/resources/snowflake_sweeper_test.go
@@ -1,0 +1,147 @@
+package resources_test
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/jmoiron/sqlx"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func getWarehousesSweeper(name string) *resource.Sweeper {
+	return &resource.Sweeper{
+		Name: name,
+		F: func(ununsed string) error {
+			db, err := provider.GetDatabaseHandleFromEnv()
+			if err != nil {
+				return fmt.Errorf("Error getting db handle: %w", err)
+			}
+
+			warehouses, err := snowflake.ListWarehouses(db)
+			if err != nil {
+				return fmt.Errorf("Error listing warehouses: %w", err)
+			}
+
+			for _, wh := range warehouses {
+				log.Printf("[DEBUG] Testing if warehouse %s starts with tst-terraform", wh.Name)
+				if strings.HasPrefix(wh.Name, "tst-terraform") {
+					log.Printf("[DEBUG] deleting warehouse %s", wh.Name)
+					whBuilder := snowflake.Warehouse(name).Builder
+					stmt := whBuilder.Drop()
+					err = snowflake.Exec(db, stmt)
+					if err != nil {
+						return fmt.Errorf("Error deleting warehouse %q %w", wh.Name, err)
+					}
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func getDatabaseSweepers(name string) *resource.Sweeper {
+	return &resource.Sweeper{
+		Name: name,
+		F: func(ununsed string) error {
+			db, err := provider.GetDatabaseHandleFromEnv()
+			if err != nil {
+				return fmt.Errorf("Error getting db handle: %w", err)
+			}
+			dbx := sqlx.NewDb(db, "snowflake")
+			databases, err := snowflake.ListDatabases(dbx)
+			if err != nil {
+				return fmt.Errorf("Error listing databases: %w", err)
+			}
+
+			for _, database := range databases {
+				log.Printf("[DEBUG] Testing if database %s starts with tst-terraform", database.DBName.String)
+				if strings.HasPrefix(database.DBName.String, "tst-terraform") {
+					log.Printf("[DEBUG] deleting database %s", database.DBName.String)
+					stmt := snowflake.Database(database.DBName.String).Drop()
+					err = snowflake.Exec(db, stmt)
+					if err != nil {
+						return fmt.Errorf("Error deleting database %q %w", database.DBName.String, err)
+					}
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func getRolesSweeper(name string) *resource.Sweeper {
+	return &resource.Sweeper{
+		Name: name,
+		F: func(ununsed string) error {
+			db, err := provider.GetDatabaseHandleFromEnv()
+			if err != nil {
+				return fmt.Errorf("Error getting db handle: %w", err)
+			}
+
+			roles, err := snowflake.ListRoles(db)
+			if err != nil {
+				return fmt.Errorf("Error listing roles: %w", err)
+			}
+
+			for _, role := range roles {
+				log.Printf("[DEBUG] Testing if role %s starts with tst-terraform", role.Name.String)
+				if strings.HasPrefix(role.Name.String, "tst-terraform") {
+					log.Printf("[DEBUG] deleting role %s", role.Name.String)
+					stmt := snowflake.Role(role.Name.String).Drop()
+					err = snowflake.Exec(db, stmt)
+					if err != nil {
+						return fmt.Errorf("Error deleting role %q %w", role.Name.String, err)
+					}
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func getUsersSweeper(name string) *resource.Sweeper {
+	return &resource.Sweeper{
+		Name: name,
+		F: func(ununsed string) error {
+			db, err := provider.GetDatabaseHandleFromEnv()
+			if err != nil {
+				return fmt.Errorf("Error getting db handle: %w", err)
+			}
+
+			users, err := snowflake.ListUsers("*",db)
+			if err != nil {
+				return fmt.Errorf("Error listing users: %w", err)
+			}
+
+			for _, user := range users {
+				log.Printf("[DEBUG] Testing if user %s starts with tst-terraform", user.Name.String)
+				if strings.HasPrefix(user.Name.String, "tst-terraform") {
+					log.Printf("[DEBUG] deleting user %s", user.Name.String)
+					stmt := snowflake.User(user.Name.String).Drop()
+					err = snowflake.Exec(db, stmt)
+					if err != nil {
+						return fmt.Errorf("Error deleting user %q %w", user.Name.String, err)
+					}
+				}
+			}
+			return nil
+		},
+	}
+}
+
+// Sweepers usually go along with the tests. In TF[CE]'s case everything depends on the organization,
+// which means that if we delete it then all the other entities will  be deleted automatically.
+func init() {
+	resource.AddTestSweepers("wh_sweeper", getWarehousesSweeper("wh_sweeper"))
+	resource.AddTestSweepers("db_sweeper", getDatabaseSweepers("db_sweeper"))
+	resource.AddTestSweepers("role_sweeper", getRolesSweeper("role_sweeper"))
+	resource.AddTestSweepers("user_sweeper", getUsersSweeper("user_sweeper"))
+}

--- a/pkg/resources/user_acceptance_test.go
+++ b/pkg/resources/user_acceptance_test.go
@@ -32,8 +32,8 @@ func checkBool(path, attr string, value bool) func(*terraform.State) error {
 
 func TestAcc_User(t *testing.T) {
 	r := require.New(t)
-	prefix := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
-	prefix2 := strings.ToUpper(randomdata.Email())
+	prefix := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	prefix2 := "tst-terraform" + strings.ToUpper(randomdata.Email())
 	sshkey1, err := testhelpers.Fixture("userkey1")
 	r.NoError(err)
 	sshkey2, err := testhelpers.Fixture("userkey2")

--- a/pkg/resources/user_ownership_grant_acceptance_test.go
+++ b/pkg/resources/user_ownership_grant_acceptance_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestAcc_UserOwnershipGrant_defaults(t *testing.T) {
-	user := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
-	role := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	user := "tst-terraform" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	role := "tst-terraform" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    providers(),

--- a/pkg/resources/user_public_keys_acceptance_test.go
+++ b/pkg/resources/user_public_keys_acceptance_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAcc_UserPublicKeys(t *testing.T) {
 	r := require.New(t)
-	prefix := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	prefix := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	sshkey1, err := testhelpers.Fixture("userkey1")
 	r.NoError(err)
 	sshkey2, err := testhelpers.Fixture("userkey2")

--- a/pkg/resources/warehouse_acceptance_test.go
+++ b/pkg/resources/warehouse_acceptance_test.go
@@ -15,8 +15,8 @@ func TestAcc_Warehouse(t *testing.T) {
 		t.Skip("Skipping TestAccWarehouse")
 	}
 
-	prefix := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
-	prefix2 := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	prefix := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	prefix2 := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    providers(),

--- a/pkg/resources/warehouse_test.go
+++ b/pkg/resources/warehouse_test.go
@@ -23,14 +23,14 @@ func TestWarehouseCreate(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name":    "good_name",
+		"name":    "tst-terraform-sfwh",
 		"comment": "great comment",
 	}
 	d := schema.TestResourceDataRaw(t, resources.Warehouse().Schema, in)
 	r.NotNil(d)
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`CREATE WAREHOUSE "good_name" COMMENT='great comment`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`CREATE WAREHOUSE "tst-terraform-sfwh" COMMENT='great comment`).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadWarehouse(mock)
 		err := resources.CreateWarehouse(d, db)
 		r.NoError(err)
@@ -38,19 +38,19 @@ func TestWarehouseCreate(t *testing.T) {
 }
 
 func expectReadWarehouse(mock sqlmock.Sqlmock) {
-	rows := sqlmock.NewRows([]string{"name", "comment", "size"}).AddRow("good_name", "mock comment", "SMALL")
-	mock.ExpectQuery("SHOW WAREHOUSES LIKE 'good_name'").WillReturnRows(rows)
+	rows := sqlmock.NewRows([]string{"name", "comment", "size"}).AddRow("tst-terraform-sfwh", "mock comment", "SMALL")
+	mock.ExpectQuery("SHOW WAREHOUSES LIKE 'tst-terraform-sfwh").WillReturnRows(rows)
 
 	rows = sqlmock.NewRows(
 		[]string{"key", "value", "default", "level", "description", "type"},
 	).AddRow("MAX_CONCURRENCY_LEVEL", 8, 8, "WAREHOUSE", "", "NUMBER")
-	mock.ExpectQuery("SHOW PARAMETERS IN WAREHOUSE \"good_name\"").WillReturnRows(rows)
+	mock.ExpectQuery("SHOW PARAMETERS IN WAREHOUSE \"tst-terraform-sfwh\"").WillReturnRows(rows)
 }
 
 func TestWarehouseRead(t *testing.T) {
 	r := require.New(t)
 
-	d := warehouse(t, "good_name", map[string]interface{}{"name": "good_name"})
+	d := warehouse(t, "tst-terraform-sfwh", map[string]interface{}{"name": "tst-terraform-sfwh"})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		expectReadWarehouse(mock)
@@ -71,10 +71,10 @@ func TestWarehouseRead(t *testing.T) {
 func TestWarehouseDelete(t *testing.T) {
 	r := require.New(t)
 
-	d := warehouse(t, "drop_it", map[string]interface{}{"name": "drop_it"})
+	d := warehouse(t, "tst-terraform-sfwh-dropit", map[string]interface{}{"name": "tst-terraform-sfwh-dropit"})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-		mock.ExpectExec(`DROP WAREHOUSE "drop_it"`).WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec(`DROP WAREHOUSE "tst-terraform-sfwh-dropit"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := resources.DeleteWarehouse(d, db)
 		r.NoError(err)
 	})

--- a/pkg/snowflake/role.go
+++ b/pkg/snowflake/role.go
@@ -2,6 +2,7 @@ package snowflake
 
 import (
 	"database/sql"
+	"log"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -22,4 +23,21 @@ func ScanRole(row *sqlx.Row) (*role, error) {
 	r := &role{}
 	err := row.StructScan(r)
 	return r, err
+}
+
+func ListRoles(db *sql.DB) ([]*role, error) {
+	stmt := "SHOW ROLES"
+	rows, err := Query(db, stmt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	roles := []*role{}
+	err = sqlx.StructScan(rows, &roles)
+	if err == sql.ErrNoRows {
+		log.Println("[DEBUG] no roles found")
+		return nil, nil
+	}
+	return roles, nil
 }


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
This change adds sweepers to cleanup resources that sometimes get orphaned in test account. Including:
- warehouses
- databases
- users
- roles

every other resource will automatically be removed if these are deleted

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* 