### PR TITLE
fix: remove stage from statefile if not found

### DIFF
--- a/pkg/resources/external_table.go
+++ b/pkg/resources/external_table.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake"
@@ -150,8 +151,8 @@ type externalTableID struct {
 	ExternalTableName string
 }
 
-//String() takes in a externalTableID object and returns a pipe-delimited string:
-//DatabaseName|SchemaName|ExternalTableName
+// String() takes in a externalTableID object and returns a pipe-delimited string:
+// DatabaseName|SchemaName|ExternalTableName
 func (si *externalTableID) String() (string, error) {
 	var buf bytes.Buffer
 	csvWriter := csv.NewWriter(&buf)
@@ -276,7 +277,7 @@ func ReadExternalTable(d *schema.ResourceData, meta interface{}) error {
 	externalTable, err := snowflake.ScanExternalTable(row)
 	if err != nil {
 		if err.Error() == snowflake.ErrNoRowInRS {
-			fmt.Println("Good !!")
+			log.Printf("[DEBUG] external table (%s) not found", d.Id())
 			d.SetId("")
 			return nil
 		} else {

--- a/pkg/resources/stage.go
+++ b/pkg/resources/stage.go
@@ -236,6 +236,13 @@ func ReadStage(d *schema.ResourceData, meta interface{}) error {
 
 	q := snowflake.Stage(stage, dbName, schema).Describe()
 	stageDesc, err := snowflake.DescStage(db, q)
+	if err == sql.ErrNoRows {
+		// If not found, mark resource to be removed from statefile during apply or refresh
+		log.Printf("[DEBUG] stage (%s) not found", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if driverErr, ok := err.(*gosnowflake.SnowflakeError); ok {
 		// 002003 (02000): SQL compilation error:
 		// 'XXX' does not exist or not authorized.


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

Fixes issue when stage is deleted out of band. Previously error would get:

```
 Error: 002003 (02000): SQL compilation error:
│ Stage '"test"."test".EXAMPLE_STAGE' does not exist or not authorized.
```

Now correctly realizes that the resources has been deleted and opts to create it again.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* 