### PR TITLE
fix: Reverted enable_multiple_grants

### DIFF
--- a/docs/resources/account_grant.md
+++ b/docs/resources/account_grant.md
@@ -25,7 +25,6 @@ resource snowflake_account_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `privilege` (String) The privilege to grant on the account.
 - `roles` (Set of String) Grants privilege to these roles.
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.

--- a/docs/resources/database_grant.md
+++ b/docs/resources/database_grant.md
@@ -33,7 +33,6 @@ resource snowflake_database_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `privilege` (String) The privilege to grant on the database.
 - `roles` (Set of String) Grants privilege to these roles.
 - `shares` (Set of String) Grants privilege to these shares.

--- a/docs/resources/external_table_grant.md
+++ b/docs/resources/external_table_grant.md
@@ -43,7 +43,6 @@ resource snowflake_external_table_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `external_table_name` (String) The name of the external table on which to grant privileges immediately (only valid if on_future is false).
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future external tables in the given schema. When this is true and no schema_name is provided apply this grant on all future external tables in the given database. The external_table_name and shares fields must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future external table.

--- a/docs/resources/file_format_grant.md
+++ b/docs/resources/file_format_grant.md
@@ -39,7 +39,6 @@ resource snowflake_file_format_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `file_format_name` (String) The name of the file format on which to grant privileges immediately (only valid if on_future is false).
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future file formats in the given schema. When this is true and no schema_name is provided apply this grant on all future file formats in the given database. The file_format_name field must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future file format.

--- a/docs/resources/function_grant.md
+++ b/docs/resources/function_grant.md
@@ -55,7 +55,6 @@ resource snowflake_function_grant grant {
 ### Optional
 
 - `arguments` (Block List) List of the arguments for the function (must be present if function has arguments and function_name is present) (see [below for nested schema](#nestedblock--arguments))
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `function_name` (String) The name of the function on which to grant privileges immediately (only valid if on_future is false).
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future functions in the given schema. When this is true and no schema_name is provided apply this grant on all future functions in the given database. The function_name, arguments, return_type, and shares fields must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future function. Must be one of `USAGE` or `OWNERSHIP`.

--- a/docs/resources/integration_grant.md
+++ b/docs/resources/integration_grant.md
@@ -32,7 +32,6 @@ resource snowflake_integration_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `privilege` (String) The privilege to grant on the integration.
 - `roles` (Set of String) Grants privilege to these roles.
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.

--- a/docs/resources/masking_policy_grant.md
+++ b/docs/resources/masking_policy_grant.md
@@ -23,7 +23,6 @@ description: |-
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `privilege` (String) The privilege to grant on the masking policy.
 - `roles` (Set of String) Grants privilege to these roles.
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.

--- a/docs/resources/materialized_view_grant.md
+++ b/docs/resources/materialized_view_grant.md
@@ -43,7 +43,6 @@ resource "snowflake_materialized_view_grant" "grant" {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `materialized_view_name` (String) The name of the materialized view on which to grant privileges immediately (only valid if on_future is false).
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future materialized views in the given schema. When this is true and no schema_name is provided apply this grant on all future materialized views in the given database. The materialized_view_name and shares fields must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future materialized view view.

--- a/docs/resources/pipe_grant.md
+++ b/docs/resources/pipe_grant.md
@@ -39,7 +39,6 @@ resource snowflake_pipe_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future pipes in the given schema. When this is true and no schema_name is provided apply this grant on all future pipes in the given database. The pipe_name field must be unset in order to use on_future.
 - `pipe_name` (String) The name of the pipe on which to grant privileges immediately (only valid if on_future is false).
 - `privilege` (String) The privilege to grant on the current or future pipe.

--- a/docs/resources/procedure_grant.md
+++ b/docs/resources/procedure_grant.md
@@ -55,7 +55,6 @@ resource snowflake_procedure_grant grant {
 ### Optional
 
 - `arguments` (Block List) List of the arguments for the procedure (must be present if procedure has arguments and procedure_name is present) (see [below for nested schema](#nestedblock--arguments))
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future procedures in the given schema. When this is true and no schema_name is provided apply this grant on all future procedures in the given database. The procedure_name and shares fields must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future procedure.
 - `procedure_name` (String) The name of the procedure on which to grant privileges immediately (only valid if on_future is false).

--- a/docs/resources/resource_monitor_grant.md
+++ b/docs/resources/resource_monitor_grant.md
@@ -30,7 +30,6 @@ resource "snowflake_resource_monitor_grant" "grant" {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `privilege` (String) The privilege to grant on the resource monitor.
 - `roles` (Set of String) Grants privilege to these roles.
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.

--- a/docs/resources/role_grants.md
+++ b/docs/resources/role_grants.md
@@ -55,7 +55,6 @@ resource "snowflake_role_grants" "grants" {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `roles` (Set of String) Grants role to this specified role.
 - `users` (Set of String) Grants role to this specified user.
 

--- a/docs/resources/row_access_policy_grant.md
+++ b/docs/resources/row_access_policy_grant.md
@@ -39,7 +39,6 @@ resource "snowflake_row_access_policy_grant" "grant" {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `privilege` (String) The privilege to grant on the row access policy.
 - `roles` (Set of String) Grants privilege to these roles.
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.

--- a/docs/resources/schema_grant.md
+++ b/docs/resources/schema_grant.md
@@ -35,7 +35,6 @@ resource snowflake_schema_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `on_future` (Boolean) When this is set to true, apply this grant on all future schemas in the given database. The schema_name and shares fields must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future schema. Note that if "OWNERSHIP" is specified, ensure that the role that terraform is using is granted access.
 - `roles` (Set of String) Grants privilege to these roles.

--- a/docs/resources/sequence_grant.md
+++ b/docs/resources/sequence_grant.md
@@ -39,7 +39,6 @@ resource snowflake_sequence_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future sequences in the given schema. When this is true and no schema_name is provided apply this grant on all future sequences in the given database. The sequence_name field must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future sequence.
 - `roles` (Set of String) Grants privilege to these roles.

--- a/docs/resources/stage_grant.md
+++ b/docs/resources/stage_grant.md
@@ -38,7 +38,6 @@ resource snowflake_stage_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future stages in the given schema. When this is true and no schema_name is provided apply this grant on all future stages in the given database. The stage_name field must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the stage.
 - `roles` (Set of String) Grants privilege to these roles.

--- a/docs/resources/stream_grant.md
+++ b/docs/resources/stream_grant.md
@@ -39,7 +39,6 @@ resource snowflake_stream_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future streams in the given schema. When this is true and no schema_name is provided apply this grant on all future streams in the given database. The stream_name field must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future stream.
 - `roles` (Set of String) Grants privilege to these roles.

--- a/docs/resources/table_grant.md
+++ b/docs/resources/table_grant.md
@@ -36,7 +36,6 @@ resource snowflake_table_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future tables in the given schema. When this is true and no schema_name is provided apply this grant on all future tables in the given database. The table_name and shares fields must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future table.
 - `roles` (Set of String) Grants privilege to these roles.

--- a/docs/resources/tag_grant.md
+++ b/docs/resources/tag_grant.md
@@ -34,7 +34,6 @@ resource "snowflake_tag_grant" "example" {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `privilege` (String) The privilege to grant on the tag.
 - `roles` (Set of String) Grants privilege to these roles.
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.

--- a/docs/resources/task_grant.md
+++ b/docs/resources/task_grant.md
@@ -39,7 +39,6 @@ resource snowflake_task_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future tasks in the given schema. When this is true and no schema_name is provided apply this grant on all future tasks in the given database. The task_name field must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future task.
 - `roles` (Set of String) Grants privilege to these roles.

--- a/docs/resources/user_grant.md
+++ b/docs/resources/user_grant.md
@@ -35,7 +35,6 @@ resource snowflake_user_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `roles` (Set of String) Grants privilege to these roles.
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.
 

--- a/docs/resources/view_grant.md
+++ b/docs/resources/view_grant.md
@@ -43,7 +43,6 @@ resource snowflake_view_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future views in the given schema. When this is true and no schema_name is provided apply this grant on all future views in the given database. The view_name and shares fields must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future view.
 - `roles` (Set of String) Grants privilege to these roles.

--- a/docs/resources/warehouse_grant.md
+++ b/docs/resources/warehouse_grant.md
@@ -34,7 +34,6 @@ resource snowflake_warehouse_grant grant {
 
 ### Optional
 
-- `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `privilege` (String) The privilege to grant on the warehouse.
 - `roles` (Set of String) Grants privilege to these roles.
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.

--- a/pkg/resources/account_grant.go
+++ b/pkg/resources/account_grant.go
@@ -53,12 +53,6 @@ var accountGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-	},
 }
 
 // AccountGrant returns a pointer to the resource representing an account grant
@@ -83,7 +77,6 @@ func AccountGrant() *TerraformGrantResource {
 func CreateAccountGrant(d *schema.ResourceData, meta interface{}) error {
 	priv := d.Get("privilege").(string)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	builder := snowflake.AccountGrant()
 
@@ -96,7 +89,6 @@ func CreateAccountGrant(d *schema.ResourceData, meta interface{}) error {
 		ResourceName: "ACCOUNT",
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grantID.String()
 	if err != nil {

--- a/pkg/resources/database_grant.go
+++ b/pkg/resources/database_grant.go
@@ -3,8 +3,8 @@ package resources
 import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pkg/errors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/pkg/errors"
 )
 
 var validDatabasePrivileges = NewPrivilegeSet(
@@ -52,12 +52,6 @@ var databaseGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-	},
 }
 
 // DatabaseGrant returns a pointer to the resource representing a database grant
@@ -84,7 +78,6 @@ func CreateDatabaseGrant(d *schema.ResourceData, meta interface{}) error {
 	builder := snowflake.DatabaseGrant(dbName)
 	priv := d.Get("privilege").(string)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	err := createGenericGrant(d, meta, builder)
 	if err != nil {
@@ -95,7 +88,6 @@ func CreateDatabaseGrant(d *schema.ResourceData, meta interface{}) error {
 		ResourceName: dbName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/database_grant_acceptance_test.go
+++ b/pkg/resources/database_grant_acceptance_test.go
@@ -57,9 +57,6 @@ func TestAcc_DatabaseGrant(t *testing.T) {
 				ResourceName:      "snowflake_database_grant.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"enable_multiple_grants", // feature flag attribute not defined in Snowflake, can't be imported
-				},
 			},
 		},
 	})

--- a/pkg/resources/external_table_grant.go
+++ b/pkg/resources/external_table_grant.go
@@ -68,13 +68,6 @@ var externalTableGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // ExternalTableGrant returns a pointer to the resource representing a external table grant
@@ -105,7 +98,6 @@ func CreateExternalTableGrant(d *schema.ResourceData, meta interface{}) error {
 	priv := d.Get("privilege").(string)
 	futureExternalTables := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (externalTableName == "") && !futureExternalTables {
 		return errors.New("external_table_name must be set unless on_future is true.")
@@ -135,7 +127,6 @@ func CreateExternalTableGrant(d *schema.ResourceData, meta interface{}) error {
 		ObjectName:   externalTableName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/file_format_grant.go
+++ b/pkg/resources/file_format_grant.go
@@ -60,13 +60,6 @@ var fileFormatGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // FileFormatGrant returns a pointer to the resource representing a file format grant
@@ -97,7 +90,6 @@ func CreateFileFormatGrant(d *schema.ResourceData, meta interface{}) error {
 	priv := d.Get("privilege").(string)
 	futureFileFormats := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (fileFormatName == "") && !futureFileFormats {
 		return errors.New("file_format_name must be set unless on_future is true.")
@@ -124,7 +116,6 @@ func CreateFileFormatGrant(d *schema.ResourceData, meta interface{}) error {
 		ObjectName:   fileFormatName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/function_grant.go
+++ b/pkg/resources/function_grant.go
@@ -95,13 +95,6 @@ var functionGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // FunctionGrant returns a pointer to the resource representing a function grant
@@ -144,7 +137,6 @@ func CreateFunctionGrant(d *schema.ResourceData, meta interface{}) error {
 	futureFunctions := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
 	arguments = d.Get("arguments").([]interface{})
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (functionName == "") && !futureFunctions {
 		return errors.New("function_name must be set unless on_future is true.")
@@ -177,7 +169,6 @@ func CreateFunctionGrant(d *schema.ResourceData, meta interface{}) error {
 		ObjectName:   functionSignature,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/grant_helpers.go
+++ b/pkg/resources/grant_helpers.go
@@ -81,19 +81,17 @@ type grantID struct {
 	SchemaName   string
 	ObjectName   string
 	Privilege    string
-	Roles        []string
 	GrantOption  bool
 }
 
 // String() takes in a grantID object and returns a pipe-delimited string:
-// resourceName|schemaName|ObjectName|Privilege|Roles|GrantOption
+// resourceName|schemaName|ObjectName|Privilege|GrantOption
 func (gi *grantID) String() (string, error) {
 	var buf bytes.Buffer
 	csvWriter := csv.NewWriter(&buf)
 	csvWriter.Comma = grantIDDelimiter
 	grantOption := fmt.Sprintf("%v", gi.GrantOption)
-	roles := strings.Join(gi.Roles, ",")
-	dataIdentifiers := [][]string{{gi.ResourceName, gi.SchemaName, gi.ObjectName, gi.Privilege, roles, grantOption}}
+	dataIdentifiers := [][]string{{gi.ResourceName, gi.SchemaName, gi.ObjectName, gi.Privilege, grantOption}}
 	err := csvWriter.WriteAll(dataIdentifiers)
 	if err != nil {
 		return "", err
@@ -102,7 +100,7 @@ func (gi *grantID) String() (string, error) {
 	return strGrantID, nil
 }
 
-// grantIDFromString() takes in a pipe-delimited string: resourceName|schemaName|ObjectName|Privilege|Roles
+// grantIDFromString() takes in a pipe-delimited string: resourceName|schemaName|ObjectName|Privilege
 // and returns a grantID object
 func grantIDFromString(stringID string) (*grantID, error) {
 	reader := csv.NewReader(strings.NewReader(stringID))
@@ -115,45 +113,20 @@ func grantIDFromString(stringID string) (*grantID, error) {
 	if len(lines) != 1 {
 		return nil, fmt.Errorf("1 line per grant")
 	}
-
-	// Len 1 is allowing for legacy IDs where role names are not included
-	if len(lines[0]) < 1 || len(lines[0]) > 6 {
-		return nil, fmt.Errorf("1 to 6 fields allowed in ID")
+	if len(lines[0]) != 4 && len(lines[0]) != 5 {
+		return nil, fmt.Errorf("4 or 5 fields allowed")
 	}
 
-	// Splitting string list if new ID structure, will cause issues if roles names passed are "true" or "false".
-	// Checking for true/false to eliminate scenarios where it would pick up the grant option.
-	// Roles will be empty list if legacy IDs are used, roles from grants are not
-	// used in Read functions, just for uniqueness in IDs of resources
-	roles := []string{}
-	if len(lines[0]) > 4 && lines[0][4] != "true" && lines[0][4] != "false" {
-		roles = strings.Split(lines[0][4], ",")
-	}
-
-	// Allowing legacy IDs to check grant option
 	grantOption := false
-	if len(lines[0]) == 6 && lines[0][5] == "true" {
+	if len(lines[0]) == 5 && lines[0][4] == "true" {
 		grantOption = true
-	} else if len(lines[0]) == 5 && lines[0][4] == "true" {
-		grantOption = true
-	}
-
-	schemaName := ""
-	objectName := ""
-	privilege := ""
-
-	if len(lines[0]) > 3 {
-		schemaName = lines[0][1]
-		objectName = lines[0][2]
-		privilege = lines[0][3]
 	}
 
 	grantResult := &grantID{
 		ResourceName: lines[0][0],
-		SchemaName:   schemaName,
-		ObjectName:   objectName,
-		Privilege:    privilege,
-		Roles:        roles,
+		SchemaName:   lines[0][1],
+		ObjectName:   lines[0][2],
+		Privilege:    lines[0][3],
 		GrantOption:  grantOption,
 	}
 	return grantResult, nil
@@ -203,7 +176,7 @@ func createGenericGrant(d *schema.ResourceData, meta interface{}, builder snowfl
 func readGenericGrant(
 	d *schema.ResourceData,
 	meta interface{},
-	grantSchema map[string]*schema.Schema,
+	schema map[string]*schema.Schema,
 	builder snowflake.GrantBuilder,
 	futureObjects bool,
 	validPrivileges PrivilegeSet) error {
@@ -284,17 +257,11 @@ func readGenericGrant(
 		}
 	}
 
-	existingRoles := d.Get("roles").(*schema.Set)
-	multipleGrantFeatureFlag := d.Get("enable_multiple_grants").(bool)
 	var roles, shares []string
-
 	// Now see which roles have our privilege
 	for roleName, privileges := range rolePrivileges {
 		// Where priv is not all so it should match exactly
-		// Match to currently assigned roles or let everything through if no specific role grants
-		if privileges.hasString(priv) && !multipleGrantFeatureFlag {
-			roles = append(roles, roleName)
-		} else if privileges.hasString(priv) && (existingRoles.Contains(roleName) || existingRoles.Len() == 0) && multipleGrantFeatureFlag {
+		if privileges.hasString(priv) {
 			roles = append(roles, roleName)
 		}
 	}
@@ -316,7 +283,7 @@ func readGenericGrant(
 		return err
 	}
 
-	_, sharesOk := grantSchema["shares"]
+	_, sharesOk := schema["shares"]
 	if sharesOk && !futureObjects {
 		err = d.Set("shares", shares)
 		if err != nil {
@@ -327,7 +294,6 @@ func readGenericGrant(
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/pkg/resources/grant_helpers_internal_test.go
+++ b/pkg/resources/grant_helpers_internal_test.go
@@ -10,7 +10,7 @@ import (
 func TestGrantIDFromString(t *testing.T) {
 	r := require.New(t)
 	// Vanilla without GrantOption
-	id := "database_name|schema|view_name|privilege|test1,test2"
+	id := "database_name|schema|view_name|privilege"
 	grant, err := grantIDFromString(id)
 	r.NoError(err)
 
@@ -21,7 +21,7 @@ func TestGrantIDFromString(t *testing.T) {
 	r.Equal(false, grant.GrantOption)
 
 	// Vanilla with GrantOption
-	id = "database_name|schema|view_name|privilege|test1,test2|true"
+	id = "database_name|schema|view_name|privilege|true"
 	grant, err = grantIDFromString(id)
 	r.NoError(err)
 
@@ -41,10 +41,20 @@ func TestGrantIDFromString(t *testing.T) {
 	r.Equal("privilege", grant.Privilege)
 	r.Equal(false, grant.GrantOption)
 
-	// too many fields
-	id = "database_name|schema|view_name|privilege|false|2|too-many"
+	// Bad ID -- not enough fields
+	id = "database|name-privilege"
 	_, err = grantIDFromString(id)
-	r.Equal(fmt.Errorf("1 to 6 fields allowed in ID"), err)
+	r.Equal(fmt.Errorf("4 or 5 fields allowed"), err)
+
+	// Bad ID -- privilege in wrong area
+	id = "database||name-privilege"
+	_, err = grantIDFromString(id)
+	r.Equal(fmt.Errorf("4 or 5 fields allowed"), err)
+
+	// too many fields
+	id = "database_name|schema|view_name|privilege|false|2"
+	_, err = grantIDFromString(id)
+	r.Equal(fmt.Errorf("4 or 5 fields allowed"), err)
 
 	// 0 lines
 	id = ""
@@ -60,24 +70,24 @@ func TestGrantIDFromString(t *testing.T) {
 
 func TestGrantStruct(t *testing.T) {
 	r := require.New(t)
+
 	// Vanilla
 	grant := &grantID{
 		ResourceName: "database_name",
 		SchemaName:   "schema",
 		ObjectName:   "view_name",
 		Privilege:    "priv",
-		Roles:        []string{"test1", "test2"},
 		GrantOption:  true,
 	}
 	gID, err := grant.String()
 	r.NoError(err)
-	r.Equal("database_name|schema|view_name|priv|test1,test2|true", gID)
+	r.Equal("database_name|schema|view_name|priv|true", gID)
 
 	// Empty grant
 	grant = &grantID{}
 	gID, err = grant.String()
 	r.NoError(err)
-	r.Equal("|||||false", gID)
+	r.Equal("||||false", gID)
 
 	// Grant with extra delimiters
 	grant = &grantID{
@@ -85,7 +95,6 @@ func TestGrantStruct(t *testing.T) {
 		SchemaName:   "schema|name",
 		ObjectName:   "view|name",
 		Privilege:    "priv",
-		Roles:        []string{"test3", "test4"},
 		GrantOption:  false,
 	}
 	gID, err = grant.String()
@@ -96,75 +105,5 @@ func TestGrantStruct(t *testing.T) {
 	r.Equal("schema|name", newGrant.SchemaName)
 	r.Equal("view|name", newGrant.ObjectName)
 	r.Equal("priv", newGrant.Privilege)
-	r.Equal([]string{"test3", "test4"}, newGrant.Roles)
 	r.Equal(false, newGrant.GrantOption)
-}
-
-func TestGrantLegacyID(t *testing.T) {
-	// Testing that grants with legacy ID structure resolves to expected output
-	r := require.New(t)
-	gID := "database_name|schema|view_name|priv|true"
-	grant, err := grantIDFromString(gID)
-	r.NoError(err)
-	r.Equal("database_name", grant.ResourceName)
-	r.Equal("schema", grant.SchemaName)
-	r.Equal("view_name", grant.ObjectName)
-	r.Equal("priv", grant.Privilege)
-	r.Equal([]string{}, grant.Roles)
-	r.Equal(true, grant.GrantOption)
-
-	gID = "database_name|schema|view_name|priv|false"
-	grant, err = grantIDFromString(gID)
-	r.NoError(err)
-	r.Equal("database_name", grant.ResourceName)
-	r.Equal("schema", grant.SchemaName)
-	r.Equal("view_name", grant.ObjectName)
-	r.Equal("priv", grant.Privilege)
-	r.Equal([]string{}, grant.Roles)
-	r.Equal(false, grant.GrantOption)
-
-	gID = "database_name|schema|view_name|priv"
-	grant, err = grantIDFromString(gID)
-	r.NoError(err)
-	r.Equal("database_name", grant.ResourceName)
-	r.Equal("schema", grant.SchemaName)
-	r.Equal("view_name", grant.ObjectName)
-	r.Equal("priv", grant.Privilege)
-	r.Equal([]string{}, grant.Roles)
-	r.Equal(false, grant.GrantOption)
-
-}
-
-func TestGrantIDFromStringRoleGrant(t *testing.T) {
-	r := require.New(t)
-	gID := "role_a||||role1,role2|"
-	grant, err := grantIDFromString(gID)
-	r.NoError(err)
-	r.Equal("role_a", grant.ResourceName)
-	r.Equal("", grant.SchemaName)
-	r.Equal("", grant.ObjectName)
-	r.Equal("", grant.Privilege)
-	r.Equal([]string{"role1", "role2"}, grant.Roles)
-	r.Equal(false, grant.GrantOption)
-
-	// Testing the legacy ID structure passes as expected
-	gID = "role_a"
-	grant, err = grantIDFromString(gID)
-	r.NoError(err)
-	r.Equal("role_a", grant.ResourceName)
-	r.Equal("", grant.SchemaName)
-	r.Equal("", grant.ObjectName)
-	r.Equal("", grant.Privilege)
-	r.Equal([]string{}, grant.Roles)
-	r.Equal(false, grant.GrantOption)
-
-	gID = "role_b||||role3,role4|false"
-	grant, err = grantIDFromString(gID)
-	r.NoError(err)
-	r.Equal("role_b", grant.ResourceName)
-	r.Equal("", grant.SchemaName)
-	r.Equal("", grant.ObjectName)
-	r.Equal("", grant.Privilege)
-	r.Equal([]string{"role3", "role4"}, grant.Roles)
-	r.Equal(false, grant.GrantOption)
 }

--- a/pkg/resources/integration_grant.go
+++ b/pkg/resources/integration_grant.go
@@ -39,13 +39,6 @@ var integrationGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // IntegrationGrant returns a pointer to the resource representing a integration grant
@@ -70,7 +63,6 @@ func CreateIntegrationGrant(d *schema.ResourceData, meta interface{}) error {
 	w := d.Get("integration_name").(string)
 	priv := d.Get("privilege").(string)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	builder := snowflake.IntegrationGrant(w)
 
@@ -83,7 +75,6 @@ func CreateIntegrationGrant(d *schema.ResourceData, meta interface{}) error {
 		ResourceName: w,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/masking_policy_grant.go
+++ b/pkg/resources/masking_policy_grant.go
@@ -52,13 +52,6 @@ var maskingPolicyGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // MaskingPolicyGrant returns a pointer to the resource representing a masking policy grant
@@ -88,7 +81,6 @@ func CreateMaskingPolicyGrant(d *schema.ResourceData, meta interface{}) error {
 	schemaName := d.Get("schema_name").(string)
 	priv := d.Get("privilege").(string)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	builder := snowflake.MaskingPolicyGrant(dbName, schemaName, maskingPolicyName)
 
@@ -103,7 +95,6 @@ func CreateMaskingPolicyGrant(d *schema.ResourceData, meta interface{}) error {
 		ObjectName:   maskingPolicyName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/materialized_view_grant.go
+++ b/pkg/resources/materialized_view_grant.go
@@ -74,13 +74,6 @@ var materializedViewGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // ViewGrant returns a pointer to the resource representing a view grant
@@ -111,7 +104,6 @@ func CreateMaterializedViewGrant(d *schema.ResourceData, meta interface{}) error
 	priv := d.Get("privilege").(string)
 	futureMaterializedViews := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (schemaName == "") && !futureMaterializedViews {
 		return errors.New("schema_name must be set unless on_future is true.")
@@ -142,7 +134,6 @@ func CreateMaterializedViewGrant(d *schema.ResourceData, meta interface{}) error
 		ObjectName:   materializedViewName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/pipe_grant.go
+++ b/pkg/resources/pipe_grant.go
@@ -61,13 +61,6 @@ var pipeGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // PipeGrant returns a pointer to the resource representing a pipe grant
@@ -98,7 +91,6 @@ func CreatePipeGrant(d *schema.ResourceData, meta interface{}) error {
 	priv := d.Get("privilege").(string)
 	futurePipes := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (pipeName == "") && !futurePipes {
 		return errors.New("pipe_name must be set unless on_future is true.")
@@ -125,7 +117,6 @@ func CreatePipeGrant(d *schema.ResourceData, meta interface{}) error {
 		ObjectName:   pipeName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/procedure_grant.go
+++ b/pkg/resources/procedure_grant.go
@@ -95,13 +95,6 @@ var procedureGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // ProcedureGrant returns a pointer to the resource representing a procedure grant
@@ -144,7 +137,6 @@ func CreateProcedureGrant(d *schema.ResourceData, meta interface{}) error {
 	futureProcedures := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
 	arguments = d.Get("arguments").([]interface{})
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (procedureName == "") && !futureProcedures {
 		return errors.New("procedure_name must be set unless on_future is true.")
@@ -177,7 +169,6 @@ func CreateProcedureGrant(d *schema.ResourceData, meta interface{}) error {
 		ObjectName:   procedureSignature,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/resource_monitor_grant.go
+++ b/pkg/resources/resource_monitor_grant.go
@@ -40,13 +40,6 @@ var resourceMonitorGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // ResourceMonitorGrant returns a pointer to the resource representing a resource monitor grant
@@ -69,7 +62,6 @@ func CreateResourceMonitorGrant(d *schema.ResourceData, meta interface{}) error 
 	priv := d.Get("privilege").(string)
 	grantOption := d.Get("with_grant_option").(bool)
 	builder := snowflake.ResourceMonitorGrant(w)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	err := createGenericGrant(d, meta, builder)
 	if err != nil {
@@ -80,7 +72,6 @@ func CreateResourceMonitorGrant(d *schema.ResourceData, meta interface{}) error 
 		ResourceName: w,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/role_grants_acceptance_test.go
+++ b/pkg/resources/role_grants_acceptance_test.go
@@ -154,7 +154,7 @@ func TestAcc_GrantRole(t *testing.T) {
 				ResourceName:            "snowflake_role_grants.w",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"roles", "users", "enable_multiple_grants"},
+				ImportStateVerifyIgnore: []string{"roles", "users"},
 			},
 		},
 	})

--- a/pkg/resources/row_access_policy_grant.go
+++ b/pkg/resources/row_access_policy_grant.go
@@ -52,13 +52,6 @@ var rowAccessPolicyGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // RowAccessPolicyGrant returns a pointer to the resource representing a row access policy grant
@@ -88,7 +81,6 @@ func CreateRowAccessPolicyGrant(d *schema.ResourceData, meta interface{}) error 
 	schemaName := d.Get("schema_name").(string)
 	priv := d.Get("privilege").(string)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	builder := snowflake.RowAccessPolicyGrant(dbName, schemaName, rowAccessPolicyName)
 
@@ -103,7 +95,6 @@ func CreateRowAccessPolicyGrant(d *schema.ResourceData, meta interface{}) error 
 		ObjectName:   rowAccessPolicyName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/schema_grant.go
+++ b/pkg/resources/schema_grant.go
@@ -79,12 +79,6 @@ var schemaGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-	},
 }
 
 // SchemaGrant returns a pointer to the resource representing a view grant
@@ -117,7 +111,6 @@ func CreateSchemaGrant(d *schema.ResourceData, meta interface{}) error {
 	priv := d.Get("privilege").(string)
 	onFuture := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (schemaName == "") && !onFuture {
 		return errors.New("schema_name must be set unless on_future is true.")
@@ -140,7 +133,6 @@ func CreateSchemaGrant(d *schema.ResourceData, meta interface{}) error {
 		SchemaName:   schemaName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grantID.String()
 	if err != nil {

--- a/pkg/resources/schema_grant_acceptance_test.go
+++ b/pkg/resources/schema_grant_acceptance_test.go
@@ -40,9 +40,6 @@ func TestAcc_SchemaGrant(t *testing.T) {
 				ResourceName:      "snowflake_schema_grant.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"enable_multiple_grants", // feature flag attribute not defined in Snowflake, can't be imported
-				},
 			},
 		},
 	})
@@ -72,9 +69,6 @@ func TestAcc_SchemaFutureGrants(t *testing.T) {
 				ResourceName:      "snowflake_view_grant.select_on_future_views",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"enable_multiple_grants", // feature flag attribute not defined in Snowflake, can't be imported
-				},
 			},
 		},
 	})

--- a/pkg/resources/sequence_grant.go
+++ b/pkg/resources/sequence_grant.go
@@ -60,13 +60,6 @@ var sequenceGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // SequenceGrant returns a pointer to the resource representing a sequence grant
@@ -97,7 +90,6 @@ func CreateSequenceGrant(d *schema.ResourceData, meta interface{}) error {
 	priv := d.Get("privilege").(string)
 	futureSequences := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (sequenceName == "") && !futureSequences {
 		return errors.New("sequence_name must be set unless on_future is true.")
@@ -124,7 +116,6 @@ func CreateSequenceGrant(d *schema.ResourceData, meta interface{}) error {
 		ObjectName:   sequenceName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/stage_grant.go
+++ b/pkg/resources/stage_grant.go
@@ -64,13 +64,6 @@ var stageGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // StageGrant returns a pointer to the resource representing a stage grant

--- a/pkg/resources/stage_grant_acceptance_test.go
+++ b/pkg/resources/stage_grant_acceptance_test.go
@@ -36,9 +36,6 @@ func TestAcc_StageGrant_defaults(t *testing.T) {
 				ResourceName:      "snowflake_stage_grant.g",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"enable_multiple_grants", // feature flag attribute not defined in Snowflake, can't be imported
-				},
 			},
 		},
 	})

--- a/pkg/resources/stream_grant.go
+++ b/pkg/resources/stream_grant.go
@@ -60,13 +60,6 @@ var streamGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // StreamGrant returns a pointer to the resource representing a stream grant
@@ -97,7 +90,6 @@ func CreateStreamGrant(d *schema.ResourceData, meta interface{}) error {
 	priv := d.Get("privilege").(string)
 	futureStreams := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (streamName == "") && !futureStreams {
 		return errors.New("stream_name must be set unless on_future is true.")
@@ -124,7 +116,6 @@ func CreateStreamGrant(d *schema.ResourceData, meta interface{}) error {
 		ObjectName:   streamName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/table_grant.go
+++ b/pkg/resources/table_grant.go
@@ -72,12 +72,6 @@ var tableGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-	},
 }
 
 // TableGrant returns a pointer to the resource representing a Table grant
@@ -118,7 +112,6 @@ func CreateTableGrant(d *schema.ResourceData, meta interface{}) error {
 	priv := d.Get("privilege").(string)
 	onFuture := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (schemaName == "") && !onFuture {
 		return errors.New("schema_name must be set unless on_future is true.")
@@ -146,7 +139,6 @@ func CreateTableGrant(d *schema.ResourceData, meta interface{}) error {
 		SchemaName:   schemaName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	if !onFuture {
 		grantID.ObjectName = tableName

--- a/pkg/resources/table_grant_acceptance_test.go
+++ b/pkg/resources/table_grant_acceptance_test.go
@@ -35,9 +35,6 @@ func TestAccTableGrant_defaults(t *testing.T) {
 				ResourceName:      "snowflake_table_grant.g",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"enable_multiple_grants", // feature flag attribute not defined in Snowflake, can't be imported
-				},
 			},
 		},
 	})

--- a/pkg/resources/tag_grant.go
+++ b/pkg/resources/tag_grant.go
@@ -51,13 +51,6 @@ var tagGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // TagGrant returns a pointer to the resource representing a tag grant
@@ -85,7 +78,6 @@ func CreateTagGrant(d *schema.ResourceData, meta interface{}) error {
 	schemaName := d.Get("schema_name").(string)
 	priv := d.Get("privilege").(string)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	builder := snowflake.TagGrant(dbName, schemaName, tagName)
 
@@ -100,7 +92,6 @@ func CreateTagGrant(d *schema.ResourceData, meta interface{}) error {
 		ObjectName:   tagName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/task_grant.go
+++ b/pkg/resources/task_grant.go
@@ -61,13 +61,6 @@ var taskGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-		ForceNew:    true,
-	},
 }
 
 // TaskGrant returns a pointer to the resource representing a task grant
@@ -98,7 +91,6 @@ func CreateTaskGrant(d *schema.ResourceData, meta interface{}) error {
 	priv := d.Get("privilege").(string)
 	futureTasks := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (taskName == "") && !futureTasks {
 		return errors.New("task_name must be set unless on_future is true.")
@@ -125,7 +117,6 @@ func CreateTaskGrant(d *schema.ResourceData, meta interface{}) error {
 		ObjectName:   taskName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/task_grant_acceptance_test.go
+++ b/pkg/resources/task_grant_acceptance_test.go
@@ -46,9 +46,6 @@ func TestAcc_TaskGrant(t *testing.T) {
 				ResourceName:      "snowflake_task_grant.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"enable_multiple_grants", // feature flag attribute not defined in Snowflake, can't be imported
-				},
 			},
 		},
 	})

--- a/pkg/resources/user_grant.go
+++ b/pkg/resources/user_grant.go
@@ -37,12 +37,6 @@ var userGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-	},
 }
 
 // UserGrant returns a pointer to the resource representing a user grant
@@ -70,7 +64,6 @@ func CreateUserGrant(d *schema.ResourceData, meta interface{}) error {
 	priv := d.Get("privilege").(string)
 	grantOption := d.Get("with_grant_option").(bool)
 	builder := snowflake.UserGrant(w)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	err := createGenericGrant(d, meta, builder)
 	if err != nil {
@@ -81,7 +74,6 @@ func CreateUserGrant(d *schema.ResourceData, meta interface{}) error {
 		ResourceName: w,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/user_grant_acceptance_test.go
+++ b/pkg/resources/user_grant_acceptance_test.go
@@ -33,9 +33,6 @@ func TestAcc_UserGrant(t *testing.T) {
 				ResourceName:      "snowflake_user_grant.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"enable_multiple_grants", // feature flag attribute not defined in Snowflake, can't be imported
-				},
 			},
 		},
 	})

--- a/pkg/resources/view_grant.go
+++ b/pkg/resources/view_grant.go
@@ -67,12 +67,6 @@ var viewGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-	},
 }
 
 // ViewGrant returns a pointer to the resource representing a view grant
@@ -113,7 +107,6 @@ func CreateViewGrant(d *schema.ResourceData, meta interface{}) error {
 	priv := d.Get("privilege").(string)
 	futureViews := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (schemaName == "") && !futureViews {
 		return errors.New("schema_name must be set unless on_future is true.")
@@ -144,7 +137,6 @@ func CreateViewGrant(d *schema.ResourceData, meta interface{}) error {
 		ObjectName:   viewName,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/view_grant_acceptance_test.go
+++ b/pkg/resources/view_grant_acceptance_test.go
@@ -84,9 +84,6 @@ func TestAcc_FutureViewGrantChange(t *testing.T) {
 				ResourceName:      "snowflake_view_grant.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"enable_multiple_grants", // feature flag attribute not defined in Snowflake, can't be imported
-				},
 			},
 		},
 	})

--- a/pkg/resources/warehouse_grant.go
+++ b/pkg/resources/warehouse_grant.go
@@ -41,12 +41,6 @@ var warehouseGrantSchema = map[string]*schema.Schema{
 		Default:     false,
 		ForceNew:    true,
 	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
-		Default:     false,
-	},
 }
 
 // WarehouseGrant returns a pointer to the resource representing a warehouse grant
@@ -74,7 +68,6 @@ func CreateWarehouseGrant(d *schema.ResourceData, meta interface{}) error {
 	priv := d.Get("privilege").(string)
 	grantOption := d.Get("with_grant_option").(bool)
 	builder := snowflake.WarehouseGrant(w)
-	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	err := createGenericGrant(d, meta, builder)
 	if err != nil {
@@ -85,7 +78,6 @@ func CreateWarehouseGrant(d *schema.ResourceData, meta interface{}) error {
 		ResourceName: w,
 		Privilege:    priv,
 		GrantOption:  grantOption,
-		Roles:        roles,
 	}
 	dataIDInput, err := grant.String()
 	if err != nil {

--- a/pkg/resources/warehouse_grant_acceptance_test.go
+++ b/pkg/resources/warehouse_grant_acceptance_test.go
@@ -33,9 +33,6 @@ func TestAcc_WarehouseGrant(t *testing.T) {
 				ResourceName:      "snowflake_warehouse_grant.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"enable_multiple_grants", // feature flag attribute not defined in Snowflake, can't be imported
-				},
 			},
 		},
 	})


### PR DESCRIPTION
Revert for enable_multiple_grants because it does not work properly as intended and is causing side effects. One of the biggest side effects is that because the roles are part of the id, when a role is added to an existing object grant, the id changes, which in turn triggers the resource to be replaced which means that the current roles will be revoked then granted again. This causes a significant disruption when users that are using the affected roles are running a query when the grants are being rolled out.

This side effect was only noticed by us now because we were creating new grants with the new id format which includes the roles in the id itself. For our old grant resources this is not the case because it was still using the id format that excluded the roles prior to the introduction of the enable_multiple_grants feature.

## Test Plan
* [x] acceptance tests
* [x] unit tests

## References
* #824 
* #922
* #941
* #967 