### PR TITLE
feat: Added Missing Grant Updates + Removed ForceNew

### DIFF
--- a/pkg/resources/database_grant.go
+++ b/pkg/resources/database_grant.go
@@ -3,8 +3,8 @@ package resources
 import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pkg/errors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/pkg/errors"
 )
 
 var validDatabasePrivileges = NewPrivilegeSet(
@@ -36,7 +36,6 @@ var databaseGrantSchema = map[string]*schema.Schema{
 		Type:        schema.TypeSet,
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Optional:    true,
-		ForceNew:    true,
 		Description: "Grants privilege to these roles.",
 	},
 	"shares": {

--- a/pkg/resources/external_table_grant.go
+++ b/pkg/resources/external_table_grant.go
@@ -45,14 +45,12 @@ var externalTableGrantSchema = map[string]*schema.Schema{
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Optional:    true,
 		Description: "Grants privilege to these roles.",
-		ForceNew:    true,
 	},
 	"shares": {
 		Type:        schema.TypeSet,
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Optional:    true,
 		Description: "Grants privilege to these shares (only valid if on_future is false).",
-		ForceNew:    true,
 	},
 	"on_future": {
 		Type:        schema.TypeBool,
@@ -84,6 +82,7 @@ func ExternalTableGrant() *TerraformGrantResource {
 			Create: CreateExternalTableGrant,
 			Read:   ReadExternalTableGrant,
 			Delete: DeleteExternalTableGrant,
+			Update: UpdateExternalTableGrant,
 
 			Schema: externalTableGrantSchema,
 			Importer: &schema.ResourceImporter{
@@ -215,4 +214,57 @@ func DeleteExternalTableGrant(d *schema.ResourceData, meta interface{}) error {
 		builder = snowflake.ExternalTableGrant(dbName, schemaName, externalTableName)
 	}
 	return deleteGenericGrant(d, meta, builder)
+}
+
+// UpdateExternalTableGrant implements schema.UpdateFunc
+func UpdateExternalTableGrant(d *schema.ResourceData, meta interface{}) error {
+	// for now the only thing we can update are roles or shares
+	// if nothing changed, nothing to update and we're done
+	if !d.HasChanges("roles", "shares") {
+		return nil
+	}
+
+	rolesToAdd := []string{}
+	rolesToRevoke := []string{}
+	sharesToAdd := []string{}
+	sharesToRevoke := []string{}
+	if d.HasChange("roles") {
+		rolesToAdd, rolesToRevoke = changeDiff(d, "roles")
+	}
+	if d.HasChange("shares") {
+		sharesToAdd, sharesToRevoke = changeDiff(d, "shares")
+	}
+	grantID, err := grantIDFromString(d.Id())
+	if err != nil {
+		return err
+	}
+
+	dbName := grantID.ResourceName
+	schemaName := grantID.SchemaName
+	externalTableName := grantID.ObjectName
+	futureExternalTables := (externalTableName == "")
+
+	// create the builder
+	var builder snowflake.GrantBuilder
+	if futureExternalTables {
+		builder = snowflake.FutureExternalTableGrant(dbName, schemaName)
+	} else {
+		builder = snowflake.ExternalTableGrant(dbName, schemaName, externalTableName)
+	}
+
+	// first revoke
+	err = deleteGenericGrantRolesAndShares(
+		meta, builder, grantID.Privilege, rolesToRevoke, sharesToRevoke)
+	if err != nil {
+		return err
+	}
+	// then add
+	err = createGenericGrantRolesAndShares(
+		meta, builder, grantID.Privilege, grantID.GrantOption, rolesToAdd, sharesToAdd)
+	if err != nil {
+		return err
+	}
+
+	// Done, refresh state
+	return ReadExternalTableGrant(d, meta)
 }

--- a/pkg/resources/file_format_grant.go
+++ b/pkg/resources/file_format_grant.go
@@ -44,7 +44,6 @@ var fileFormatGrantSchema = map[string]*schema.Schema{
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Optional:    true,
 		Description: "Grants privilege to these roles.",
-		ForceNew:    true,
 	},
 	"on_future": {
 		Type:        schema.TypeBool,
@@ -76,6 +75,7 @@ func FileFormatGrant() *TerraformGrantResource {
 			Create: CreateFileFormatGrant,
 			Read:   ReadFileFormatGrant,
 			Delete: DeleteFileFormatGrant,
+			Update: UpdateFileFormat,
 
 			Schema: fileFormatGrantSchema,
 			Importer: &schema.ResourceImporter{
@@ -204,4 +204,54 @@ func DeleteFileFormatGrant(d *schema.ResourceData, meta interface{}) error {
 		builder = snowflake.FileFormatGrant(dbName, schemaName, fileFormatName)
 	}
 	return deleteGenericGrant(d, meta, builder)
+}
+
+// UpdateFileFormatGrant implements schema.UpdateFunc
+func UpdateFileFormatGrant(d *schema.ResourceData, meta interface{}) error {
+	// for now the only thing we can update are roles or shares
+	// if nothing changed, nothing to update and we're done
+	if !d.HasChanges("roles") {
+		return nil
+	}
+
+	rolesToAdd := []string{}
+	rolesToRevoke := []string{}
+
+	if d.HasChange("roles") {
+		rolesToAdd, rolesToRevoke = changeDiff(d, "roles")
+	}
+
+	grantID, err := grantIDFromString(d.Id())
+	if err != nil {
+		return err
+	}
+
+	dbName := grantID.ResourceName
+	schemaName := grantID.SchemaName
+	fileFormatName := grantID.ObjectName
+	futureFileFormats := (fileFormatName == "")
+
+	// create the builder
+	var builder snowflake.GrantBuilder
+	if futureFileFormats {
+		builder = snowflake.FutureFileFormatGrant(dbName, schemaName)
+	} else {
+		builder = snowflake.FileFormatGrant(dbName, schemaName, fileFormatName)
+	}
+
+	// first revoke
+	err = deleteGenericGrantRolesAndShares(
+		meta, builder, grantID.Privilege, rolesToRevoke, []string{})
+	if err != nil {
+		return err
+	}
+	// then add
+	err = createGenericGrantRolesAndShares(
+		meta, builder, grantID.Privilege, grantID.GrantOption, rolesToAdd, []string{})
+	if err != nil {
+		return err
+	}
+
+	// Done, refresh state
+	return ReadFileFormatGrant(d, meta)
 }

--- a/pkg/resources/function_grant.go
+++ b/pkg/resources/function_grant.go
@@ -72,14 +72,12 @@ var functionGrantSchema = map[string]*schema.Schema{
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Optional:    true,
 		Description: "Grants privilege to these roles.",
-		ForceNew:    true,
 	},
 	"shares": {
 		Type:        schema.TypeSet,
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Optional:    true,
 		Description: "Grants privilege to these shares (only valid if on_future is false).",
-		ForceNew:    true,
 	},
 	"on_future": {
 		Type:        schema.TypeBool,
@@ -111,6 +109,7 @@ func FunctionGrant() *TerraformGrantResource {
 			Create: CreateFunctionGrant,
 			Read:   ReadFunctionGrant,
 			Delete: DeleteFunctionGrant,
+			Update: UpdateFunctionGrant,
 
 			Schema: functionGrantSchema,
 			Importer: &schema.ResourceImporter{
@@ -285,4 +284,63 @@ func DeleteFunctionGrant(d *schema.ResourceData, meta interface{}) error {
 		builder = snowflake.FunctionGrant(dbName, schemaName, functionName, argumentTypes)
 	}
 	return deleteGenericGrant(d, meta, builder)
+}
+
+// UpdateFunctionGrant implements schema.UpdateFunc
+func UpdateFunctionGrant(d *schema.ResourceData, meta interface{}) error {
+	// for now the only thing we can update are roles or shares
+	// if nothing changed, nothing to update and we're done
+	if !d.HasChanges("roles", "shares") {
+		return nil
+	}
+
+	rolesToAdd := []string{}
+	rolesToRevoke := []string{}
+	sharesToAdd := []string{}
+	sharesToRevoke := []string{}
+	if d.HasChange("roles") {
+		rolesToAdd, rolesToRevoke = changeDiff(d, "roles")
+	}
+	if d.HasChange("shares") {
+		sharesToAdd, sharesToRevoke = changeDiff(d, "shares")
+	}
+	grantID, err := grantIDFromString(d.Id())
+	if err != nil {
+		return err
+	}
+
+	dbName := grantID.ResourceName
+	schemaName := grantID.SchemaName
+	functionName := grantID.ObjectName
+	futureFunctions := (functionName == "")
+
+	// create the builder
+	var builder snowflake.GrantBuilder
+	if futureFunctions {
+		builder = snowflake.FutureFunctionGrant(dbName, schemaName)
+	} else {
+		functionSignatureMap, err := parseCallableObjectName(grantID.ObjectName)
+		if err != nil {
+			return err
+		}
+		functionName := functionSignatureMap["callableName"].(string)
+		argumentTypes := functionSignatureMap["argumentTypes"].([]string)
+		builder = snowflake.FunctionGrant(dbName, schemaName, functionName, argumentTypes)
+	}
+
+	// first revoke
+	err = deleteGenericGrantRolesAndShares(
+		meta, builder, grantID.Privilege, rolesToRevoke, sharesToRevoke)
+	if err != nil {
+		return err
+	}
+	// then add
+	err = createGenericGrantRolesAndShares(
+		meta, builder, grantID.Privilege, grantID.GrantOption, rolesToAdd, sharesToAdd)
+	if err != nil {
+		return err
+	}
+
+	// Done, refresh state
+	return ReadFunctionGrant(d, meta)
 }

--- a/pkg/resources/masking_policy_grant.go
+++ b/pkg/resources/masking_policy_grant.go
@@ -37,7 +37,6 @@ var maskingPolicyGrantSchema = map[string]*schema.Schema{
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Optional:    true,
 		Description: "Grants privilege to these roles.",
-		ForceNew:    true,
 	},
 	"schema_name": {
 		Type:        schema.TypeString,
@@ -68,6 +67,7 @@ func MaskingPolicyGrant() *TerraformGrantResource {
 			Create: CreateMaskingPolicyGrant,
 			Read:   ReadMaskingPolicyGrant,
 			Delete: DeleteMaskingPolicyGrant,
+			Update: UpdateMaskingPolicyGrant,
 
 			Schema: maskingPolicyGrantSchema,
 			Importer: &schema.ResourceImporter{
@@ -164,4 +164,48 @@ func DeleteMaskingPolicyGrant(d *schema.ResourceData, meta interface{}) error {
 	builder := snowflake.MaskingPolicyGrant(dbName, schemaName, maskingPolicyName)
 
 	return deleteGenericGrant(d, meta, builder)
+}
+
+// UpdateMaskingPolicyGrant implements schema.UpdateFunc
+func UpdateMaskingPolicyGrant(d *schema.ResourceData, meta interface{}) error {
+	// for now the only thing we can update are roles or shares
+	// if nothing changed, nothing to update and we're done
+	if !d.HasChanges("roles") {
+		return nil
+	}
+
+	rolesToAdd := []string{}
+	rolesToRevoke := []string{}
+
+	if d.HasChange("roles") {
+		rolesToAdd, rolesToRevoke = changeDiff(d, "roles")
+	}
+
+	grantID, err := grantIDFromString(d.Id())
+	if err != nil {
+		return err
+	}
+
+	dbName := grantID.ResourceName
+	schemaName := grantID.SchemaName
+	maskingPolicyName := grantID.ObjectName
+
+	// create the builder
+	builder := snowflake.MaskingPolicyGrant(dbName, schemaName, maskingPolicyName)
+
+	// first revoke
+	err = deleteGenericGrantRolesAndShares(
+		meta, builder, grantID.Privilege, rolesToRevoke, []string{})
+	if err != nil {
+		return err
+	}
+	// then add
+	err = createGenericGrantRolesAndShares(
+		meta, builder, grantID.Privilege, grantID.GrantOption, rolesToAdd, []string{})
+	if err != nil {
+		return err
+	}
+
+	// Done, refresh state
+	return ReadMaskingPolicyGrant(d, meta)
 }

--- a/pkg/resources/row_access_policy_grant.go
+++ b/pkg/resources/row_access_policy_grant.go
@@ -37,7 +37,6 @@ var rowAccessPolicyGrantSchema = map[string]*schema.Schema{
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Optional:    true,
 		Description: "Grants privilege to these roles.",
-		ForceNew:    true,
 	},
 	"schema_name": {
 		Type:        schema.TypeString,
@@ -164,4 +163,48 @@ func DeleteRowAccessPolicyGrant(d *schema.ResourceData, meta interface{}) error 
 	builder := snowflake.RowAccessPolicyGrant(dbName, schemaName, rowAccessPolicyName)
 
 	return deleteGenericGrant(d, meta, builder)
+}
+
+// UpdateRowAccessPolicyGrant implements schema.UpdateFunc
+func UpdateRowAccessPolicyGrant(d *schema.ResourceData, meta interface{}) error {
+	// for now the only thing we can update are roles or shares
+	// if nothing changed, nothing to update and we're done
+	if !d.HasChanges("roles") {
+		return nil
+	}
+
+	rolesToAdd := []string{}
+	rolesToRevoke := []string{}
+
+	if d.HasChange("roles") {
+		rolesToAdd, rolesToRevoke = changeDiff(d, "roles")
+	}
+
+	grantID, err := grantIDFromString(d.Id())
+	if err != nil {
+		return err
+	}
+
+	dbName := grantID.ResourceName
+	schemaName := grantID.SchemaName
+	rowAccessPolicyName := grantID.ObjectName
+
+	// create the builder
+	builder := snowflake.RowAccessPolicyGrant(dbName, schemaName, rowAccessPolicyName)
+
+	// first revoke
+	err = deleteGenericGrantRolesAndShares(
+		meta, builder, grantID.Privilege, rolesToRevoke, []string{})
+	if err != nil {
+		return err
+	}
+	// then add
+	err = createGenericGrantRolesAndShares(
+		meta, builder, grantID.Privilege, grantID.GrantOption, rolesToAdd, []string{})
+	if err != nil {
+		return err
+	}
+
+	// Done, refresh state
+	return ReadRowAccessPolicyGrant(d, meta)
 }

--- a/pkg/resources/row_access_policy_grant.go
+++ b/pkg/resources/row_access_policy_grant.go
@@ -67,6 +67,7 @@ func RowAccessPolicyGrant() *TerraformGrantResource {
 			Create: CreateRowAccessPolicyGrant,
 			Read:   ReadRowAccessPolicyGrant,
 			Delete: DeleteRowAccessPolicyGrant,
+			Update: UpdateRowAccessPolicyGrant,
 
 			Schema: rowAccessPolicyGrantSchema,
 			Importer: &schema.ResourceImporter{

--- a/pkg/resources/stream_grant.go
+++ b/pkg/resources/stream_grant.go
@@ -44,7 +44,6 @@ var streamGrantSchema = map[string]*schema.Schema{
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Optional:    true,
 		Description: "Grants privilege to these roles.",
-		ForceNew:    true,
 	},
 	"on_future": {
 		Type:        schema.TypeBool,
@@ -76,6 +75,7 @@ func StreamGrant() *TerraformGrantResource {
 			Create: CreateStreamGrant,
 			Read:   ReadStreamGrant,
 			Delete: DeleteStreamGrant,
+			Update: UpdateStreamGrant,
 
 			Schema: streamGrantSchema,
 			Importer: &schema.ResourceImporter{
@@ -204,4 +204,48 @@ func DeleteStreamGrant(d *schema.ResourceData, meta interface{}) error {
 		builder = snowflake.StreamGrant(dbName, schemaName, streamName)
 	}
 	return deleteGenericGrant(d, meta, builder)
+}
+
+// UpdateStreamGrant implements schema.UpdateFunc
+func UpdateStreamGrant(d *schema.ResourceData, meta interface{}) error {
+	// for now the only thing we can update are roles or shares
+	// if nothing changed, nothing to update and we're done
+	if !d.HasChanges("roles") {
+		return nil
+	}
+
+	rolesToAdd := []string{}
+	rolesToRevoke := []string{}
+
+	if d.HasChange("roles") {
+		rolesToAdd, rolesToRevoke = changeDiff(d, "roles")
+	}
+
+	grantID, err := grantIDFromString(d.Id())
+	if err != nil {
+		return err
+	}
+
+	dbName := grantID.ResourceName
+	schemaName := grantID.SchemaName
+	streamName := grantID.ObjectName
+
+	// create the builder
+	builder := snowflake.StreamGrant(dbName, schemaName, streamName)
+
+	// first revoke
+	err = deleteGenericGrantRolesAndShares(
+		meta, builder, grantID.Privilege, rolesToRevoke, []string{})
+	if err != nil {
+		return err
+	}
+	// then add
+	err = createGenericGrantRolesAndShares(
+		meta, builder, grantID.Privilege, grantID.GrantOption, rolesToAdd, []string{})
+	if err != nil {
+		return err
+	}
+
+	// Done, refresh state
+	return ReadStreamGrant(d, meta)
 }


### PR DESCRIPTION
Added missing update function on resource grants and removed ForceNew from Shares + Roles. This is added to mitigate the current side effects of ForceNew when you add a Share or Role to an existing Grant. Currently existings grants are revoked and then recreated when you add a share or role to a existing grant that has no implementation of the update function and has ForceNew set to true. This causes current queries / users sessions that uses the existing grants to fail because the existing grants where revoked to be recreated a couple of seconds later. This feature makes it possible to only apply the difference. 

This has already been done for a couple of resource grants and works properly.

## Test Plan
* [x] acceptance tests
* [x] unit tests

