### PR TITLE
resources/grant_helpers: ignore with_grant_option in resource when privilege is OWNERSHIP

### DIFF
--- a/pkg/resources/grant_helpers.go
+++ b/pkg/resources/grant_helpers.go
@@ -238,6 +238,11 @@ func readGenericGrant(
 		if grant.Privilege == priv && grant.GrantOption == grantOption {
 			relevantGrants = append(relevantGrants, grant)
 		}
+		// Ignore with_grant_option in resource when privilege is OWNERSHIP
+		// Because OWNERSHIP always must have WITH GRANT OPTION
+		if grant.Privilege == priv && grant.Privilege == string(privilegeOwnership) {
+			relevantGrants = append(relevantGrants, grant)
+		}
 	}
 
 	// If no relevant grants, set id to blank and return


### PR DESCRIPTION
Changes in https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/1154 causes inconsistent result after apply.

Currently, `resources/xxx_grant.go` (xxx is almost of resources) supports the pair of `privilege = OWNERSHIP` and `with_grant_option = false` (default value) . However, OWNERSHIP always have GRANT OPTION.

It is better that if `privilege = OWNERSHIP` is specified, `with_grant_option = false` should not be allowed, but I propose this  modification because of the large impact area and cause regression.

## Test Plan
* [x] acceptance tests
* [x] tested on my environment

## References
* https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1226
* https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/1154