### PR TITLE
fix: storage integration for S3gov

### DIFF
--- a/pkg/resources/storage_integration.go
+++ b/pkg/resources/storage_integration.go
@@ -52,7 +52,7 @@ var storageIntegrationSchema = map[string]*schema.Schema{
 	"storage_provider": {
 		Type:         schema.TypeString,
 		Required:     true,
-		ValidateFunc: validation.StringInSlice([]string{"S3", "GCS", "AZURE", "S3GOV"}, false),
+		ValidateFunc: validation.StringInSlice([]string{"S3", "S3gov", "GCS", "AZURE", "S3GOV"}, false),
 	},
 	"storage_aws_external_id": {
 		Type:        schema.TypeString,


### PR DESCRIPTION
Creating storage integration using snowflake TF provider for for fedramp high aws gov account  is not supported. When creating storage integration for fedramp gov account in asw the  “STORAGE_PROVIDER“ input needs to be “S3gov”. The current version snowflake TF provider only supports [S3,AZURE,GCP]

Creating API Integration using the provider  for for fedramp high aws gov account  is not supported. When creating API  ntegration for fedramp gov account in AWS the input for “api_provider” need to be “aws_gov_api_gateway“. 
## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests

## References
<!-- issues documentation links, etc  -->

* 