### PR TITLE
fix: Add error handling to tag_masking_policy_association.go to fix lint

### DIFF
--- a/pkg/resources/tag_masking_policy_association.go
+++ b/pkg/resources/tag_masking_policy_association.go
@@ -202,8 +202,17 @@ func ReadTagMaskingPolicyAssociation(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-	d.Set("tag_id", tagIdString)
-	d.Set("masking_policy_id", mpIdString)
+	err = d.Set("tag_id", tagIdString)
+
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("masking_policy_id", mpIdString)
+
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

Adding error handling to two function calls in tag_masking_policy_association.go to fix lint popping up in every PR.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests

## References
<!-- issues documentation links, etc  -->

* 