### PR TITLE
fix: revert grant helpers change

### DIFF
--- a/pkg/resources/grant_helpers.go
+++ b/pkg/resources/grant_helpers.go
@@ -233,25 +233,12 @@ func readGenericGrant(
 	priv := d.Get("privilege").(string)
 	grantOption := d.Get("with_grant_option").(bool)
 
-	var relevantGrants []*grant
-	for _, grant := range grants {
-		if grant.Privilege == priv && grant.GrantOption == grantOption {
-			relevantGrants = append(relevantGrants, grant)
-		}
-	}
-
-	// If no relevant grants, set id to blank and return
-	if len(relevantGrants) == 0 {
-		d.SetId("")
-		return nil
-	}
-
 	// Map of roles to privileges
 	rolePrivileges := map[string]PrivilegeSet{}
 	sharePrivileges := map[string]PrivilegeSet{}
 
 	// List of all grants for each schema_database
-	for _, grant := range relevantGrants {
+	for _, grant := range grants {
 		switch grant.GranteeType {
 		case "ROLE":
 			roleName := grant.GranteeName


### PR DESCRIPTION
seeing this as of 0.44

```
15:19:20  │ Error: Provider produced inconsistent result after apply
15:19:20  │ 
15:19:20  │ When applying changes to
15:19:20  │ module.site_core_schemas["**_QA_MILESTONE-TOKENIZED_DATA"].snowflake_schema_grant.dbo_grant,
15:19:20  │ provider "provider[\"registry.terraform.io/snowflake-labs/snowflake\"]"
15:19:20  │ produced an unexpected new value: Root resource was present, but now
15:19:20  │ absent.
15:19:20  │ 
15:19:20  │ This is a bug in the provider, which should be reported in the provider's
```

problem identified to be with merged PR #1154

reverting changes.
## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests

## References
<!-- issues documentation links, etc  -->

* 