### PR TITLE
fix: Update 'user_ownership_grant' schema validation

### DIFF
--- a/pkg/resources/user_ownership_grant.go
+++ b/pkg/resources/user_ownership_grant.go
@@ -16,17 +16,13 @@ var userOwnershipGrantSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Required:    true,
 		Description: "The name of the user ownership is granted on.",
-		ValidateFunc: func(val interface{}, key string) ([]string, []error) {
-			var additionalCharsToIgnoreValidation []string
-			return snowflake.ValidateIdentifier(val, additionalCharsToIgnoreValidation)
-		},
 	},
 	"to_role_name": {
 		Type:        schema.TypeString,
 		Required:    true,
 		Description: "The name of the role to grant ownership. Please ensure that the role that terraform is using is granted access.",
 		ValidateFunc: func(val interface{}, key string) ([]string, []error) {
-			var additionalCharsToIgnoreValidation []string
+			additionalCharsToIgnoreValidation := []string{".", " ", ":", "(", ")"}
 			return snowflake.ValidateIdentifier(val, additionalCharsToIgnoreValidation)
 		},
 	},


### PR DESCRIPTION
<!-- summary of changes -->
Make `user_ownership_grant` resource schema validation consistent with upstream resources schemas - [user.name](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/da886d4e05f7bb9443168f0fa04b8b397a1db5c7/pkg/resources/user.go#L36) and [role.name](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/da886d4e05f7bb9443168f0fa04b8b397a1db5c7/pkg/resources/role.go#L17) 

Also per https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html#double-quoted-identifiers user name could be anything. And it is double-quoted as per https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/da886d4e05f7bb9443168f0fa04b8b397a1db5c7/pkg/snowflake/user_ownership_grant.go#L36

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
* [ ] unut tests

## References
<!-- issues documentation links, etc  -->

* Fixes https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1184