### PR TITLE
fix: function resource - python packages

### DIFF
--- a/pkg/resources/function.go
+++ b/pkg/resources/function.go
@@ -336,17 +336,17 @@ func ReadFunction(d *schema.ResourceData, meta interface{}) error {
 				}
 			}
 		case "packages":
-			packagesString := strings.ReplaceAll(strings.ReplaceAll(desc.Value.String, "[", ""), "]", "")
+			packagesString := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(desc.Value.String, "[", ""), "]", ""), "'", "")
 			if packagesString != "" { // Do nothing for Java / Python functions without packages
-				packages := strings.Split(packagesString, ", ")
+				packages := strings.Split(packagesString, ",")
 				if err = d.Set("packages", packages); err != nil {
 					return err
 				}
 			}
 		case "imports":
-			importsString := strings.ReplaceAll(strings.ReplaceAll(desc.Value.String, "[", ""), "]", "")
+			importsString := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(desc.Value.String, "[", ""), "]", ""), "'", "")
 			if importsString != "" { // Do nothing for Java functions without imports
-				imports := strings.Split(importsString, ", ")
+				imports := strings.Split(importsString, ",")
 				if err = d.Set("imports", imports); err != nil {
 					return err
 				}


### PR DESCRIPTION
### Problem statement
The snowflake describe function outputs the python packages from a function as a list of strings like `['pytz','pandas']`. The resource was reading this in as one item instead of two. This would result in terraform detecting changes when there actually were no changes.

Something like:
```
-"'pytz','pandas'",
+"pytz",
+"pandas",
```

### Summary of changes
Corrected the split by removing a space and removed single quotes from the string values.

Verified this was working as expected in my fork.

## Test Plan
* [ ] acceptance tests