### PR TITLE
fix: missing `t.Helper()` for thelper function

### DIFF
--- a/pkg/resources/database_grant_acceptance_test.go
+++ b/pkg/resources/database_grant_acceptance_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func testRolesAndShares(t *testing.T, path string, roles, shares []string) func(*terraform.State) error {
+	t.Helper()
 	return func(state *terraform.State) error {
 		is := state.RootModule().Resources[path].Primary
 

--- a/pkg/resources/external_table_grant_acceptance_test.go
+++ b/pkg/resources/external_table_grant_acceptance_test.go
@@ -36,6 +36,7 @@ func TestAcc_ExternalTableFutureGrant(t *testing.T) {
 }
 
 func externalTableGrantConfigFuture(t *testing.T, database_name, schema_name, role string) string {
+	t.Helper()
 	r := require.New(t)
 
 	config := `

--- a/pkg/resources/external_table_internal_test.go
+++ b/pkg/resources/external_table_internal_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func ExternalTestTableIDFromString(t *testing.T) {
+	t.Helper()
 	r := require.New(t)
 	// Vanilla
 	id := "database_name|schema_name|table"
@@ -40,6 +41,7 @@ func ExternalTestTableIDFromString(t *testing.T) {
 }
 
 func ExternalTestTableStruct(t *testing.T) {
+	t.Helper()
 	r := require.New(t)
 
 	// Vanilla

--- a/pkg/resources/file_format_grant_acceptance_test.go
+++ b/pkg/resources/file_format_grant_acceptance_test.go
@@ -36,6 +36,7 @@ func TestAcc_FileFormatGrantFutureGrant(t *testing.T) {
 }
 
 func fileFormatGrantConfigFuture(t *testing.T, database_name, schema_name, role string) string {
+	t.Helper()
 	r := require.New(t)
 
 	config := `

--- a/pkg/resources/function_grant_acceptance_test.go
+++ b/pkg/resources/function_grant_acceptance_test.go
@@ -37,6 +37,7 @@ func TestAcc_FunctionFutureGrant(t *testing.T) {
 }
 
 func functionGrantConfigFuture(t *testing.T, database_name, schema_name, role string) string {
+	t.Helper()
 	r := require.New(t)
 
 	config := `

--- a/pkg/resources/function_test.go
+++ b/pkg/resources/function_test.go
@@ -16,6 +16,7 @@ import (
 const functionBody string = "def add_py(i, j): return i+j"
 
 func prepDummyFunctionResource(t *testing.T) *schema.ResourceData {
+	t.Helper()
 	argument1 := map[string]interface{}{"name": "data", "type": "varchar"}
 	argument2 := map[string]interface{}{"name": "event_dt", "type": "date"}
 	in := map[string]interface{}{

--- a/pkg/resources/helpers_test.go
+++ b/pkg/resources/helpers_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func database(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Database().Schema, params)
 	r.NotNil(d)
@@ -19,6 +20,7 @@ func database(t *testing.T, id string, params map[string]interface{}) *schema.Re
 }
 
 func databaseGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.DatabaseGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -27,6 +29,7 @@ func databaseGrant(t *testing.T, id string, params map[string]interface{}) *sche
 }
 
 func schemaGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.SchemaGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -35,6 +38,7 @@ func schemaGrant(t *testing.T, id string, params map[string]interface{}) *schema
 }
 
 func stageGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.StageGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -43,6 +47,7 @@ func stageGrant(t *testing.T, id string, params map[string]interface{}) *schema.
 }
 
 func tableGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.TableGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -51,6 +56,7 @@ func tableGrant(t *testing.T, id string, params map[string]interface{}) *schema.
 }
 
 func viewGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.ViewGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -59,6 +65,7 @@ func viewGrant(t *testing.T, id string, params map[string]interface{}) *schema.R
 }
 
 func materializedViewGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.MaterializedViewGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -67,6 +74,7 @@ func materializedViewGrant(t *testing.T, id string, params map[string]interface{
 }
 
 func resourceMonitorGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.ResourceMonitorGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -75,6 +83,7 @@ func resourceMonitorGrant(t *testing.T, id string, params map[string]interface{}
 }
 
 func integrationGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.IntegrationGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -83,6 +92,7 @@ func integrationGrant(t *testing.T, id string, params map[string]interface{}) *s
 }
 
 func accountGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.AccountGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -91,6 +101,7 @@ func accountGrant(t *testing.T, id string, params map[string]interface{}) *schem
 }
 
 func managedAccount(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.ManagedAccount().Schema, params)
 	r.NotNil(d)
@@ -99,6 +110,7 @@ func managedAccount(t *testing.T, id string, params map[string]interface{}) *sch
 }
 
 func maskingPolicy(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.MaskingPolicy().Schema, params)
 	r.NotNil(d)
@@ -107,6 +119,7 @@ func maskingPolicy(t *testing.T, id string, params map[string]interface{}) *sche
 }
 
 func networkPolicy(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.NetworkPolicy().Schema, params)
 	r.NotNil(d)
@@ -115,6 +128,7 @@ func networkPolicy(t *testing.T, id string, params map[string]interface{}) *sche
 }
 
 func pipe(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Pipe().Schema, params)
 	r.NotNil(d)
@@ -123,6 +137,7 @@ func pipe(t *testing.T, id string, params map[string]interface{}) *schema.Resour
 }
 
 func resourceMonitor(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.ResourceMonitor().Schema, params)
 	r.NotNil(d)
@@ -131,6 +146,7 @@ func resourceMonitor(t *testing.T, id string, params map[string]interface{}) *sc
 }
 
 func sequence(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Sequence().Schema, params)
 	r.NotNil(d)
@@ -139,6 +155,7 @@ func sequence(t *testing.T, id string, params map[string]interface{}) *schema.Re
 }
 
 func share(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Share().Schema, params)
 	r.NotNil(d)
@@ -147,6 +164,7 @@ func share(t *testing.T, id string, params map[string]interface{}) *schema.Resou
 }
 
 func stage(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Stage().Schema, params)
 	r.NotNil(d)
@@ -155,6 +173,7 @@ func stage(t *testing.T, id string, params map[string]interface{}) *schema.Resou
 }
 
 func stream(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Stream().Schema, params)
 	r.NotNil(d)
@@ -163,6 +182,7 @@ func stream(t *testing.T, id string, params map[string]interface{}) *schema.Reso
 }
 
 func tag(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Tag().Schema, params)
 	r.NotNil(d)
@@ -178,6 +198,7 @@ func providers() map[string]*schema.Provider {
 }
 
 func role(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Role().Schema, params)
 	r.NotNil(d)
@@ -186,6 +207,7 @@ func role(t *testing.T, id string, params map[string]interface{}) *schema.Resour
 }
 
 func roleGrants(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.RoleGrants().Schema, params)
 	r.NotNil(d)
@@ -194,6 +216,7 @@ func roleGrants(t *testing.T, id string, params map[string]interface{}) *schema.
 }
 
 func userOwnershipGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.UserOwnershipGrant().Schema, params)
 	r.NotNil(d)
@@ -202,6 +225,7 @@ func userOwnershipGrant(t *testing.T, id string, params map[string]interface{}) 
 }
 
 func roleOwnershipGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.RoleOwnershipGrant().Schema, params)
 	r.NotNil(d)
@@ -210,6 +234,7 @@ func roleOwnershipGrant(t *testing.T, id string, params map[string]interface{}) 
 }
 
 func apiIntegration(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.APIIntegration().Schema, params)
 	r.NotNil(d)
@@ -218,6 +243,7 @@ func apiIntegration(t *testing.T, id string, params map[string]interface{}) *sch
 }
 
 func samlIntegration(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.SAMLIntegration().Schema, params)
 	r.NotNil(d)
@@ -226,6 +252,7 @@ func samlIntegration(t *testing.T, id string, params map[string]interface{}) *sc
 }
 
 func scimIntegration(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.SCIMIntegration().Schema, params)
 	r.NotNil(d)
@@ -234,6 +261,7 @@ func scimIntegration(t *testing.T, id string, params map[string]interface{}) *sc
 }
 
 func oauthIntegration(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.OAuthIntegration().Schema, params)
 	r.NotNil(d)
@@ -242,6 +270,7 @@ func oauthIntegration(t *testing.T, id string, params map[string]interface{}) *s
 }
 
 func externalOauthIntegration(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.ExternalOauthIntegration().Schema, params)
 	r.NotNil(d)
@@ -250,6 +279,7 @@ func externalOauthIntegration(t *testing.T, id string, params map[string]interfa
 }
 
 func externalFunction(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.ExternalFunction().Schema, params)
 	r.NotNil(d)
@@ -258,6 +288,7 @@ func externalFunction(t *testing.T, id string, params map[string]interface{}) *s
 }
 
 func procedure(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Procedure().Schema, params)
 	r.NotNil(d)
@@ -266,13 +297,16 @@ func procedure(t *testing.T, id string, params map[string]interface{}) *schema.R
 }
 
 func storageIntegration(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.StorageIntegration().Schema, params)
 	r.NotNil(d)
 	d.SetId(id)
 	return d
 }
+
 func notificationIntegration(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.NotificationIntegration().Schema, params)
 	r.NotNil(d)
@@ -281,6 +315,7 @@ func notificationIntegration(t *testing.T, id string, params map[string]interfac
 }
 
 func table(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Table().Schema, params)
 	r.NotNil(d)
@@ -289,6 +324,7 @@ func table(t *testing.T, id string, params map[string]interface{}) *schema.Resou
 }
 
 func externalTable(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.ExternalTable().Schema, params)
 	r.NotNil(d)
@@ -297,6 +333,7 @@ func externalTable(t *testing.T, id string, params map[string]interface{}) *sche
 }
 
 func task(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Task().Schema, params)
 	r.NotNil(d)
@@ -305,6 +342,7 @@ func task(t *testing.T, id string, params map[string]interface{}) *schema.Resour
 }
 
 func user(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.User().Schema, params)
 	r.NotNil(d)
@@ -313,6 +351,7 @@ func user(t *testing.T, id string, params map[string]interface{}) *schema.Resour
 }
 
 func view(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.View().Schema, params)
 	r.NotNil(d)
@@ -321,6 +360,7 @@ func view(t *testing.T, id string, params map[string]interface{}) *schema.Resour
 }
 
 func materializedView(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.MaterializedView().Schema, params)
 	r.NotNil(d)
@@ -329,6 +369,7 @@ func materializedView(t *testing.T, id string, params map[string]interface{}) *s
 }
 
 func warehouse(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Warehouse().Schema, params)
 	r.NotNil(d)
@@ -337,6 +378,7 @@ func warehouse(t *testing.T, id string, params map[string]interface{}) *schema.R
 }
 
 func externalTableGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.ExternalTableGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -345,6 +387,7 @@ func externalTableGrant(t *testing.T, id string, params map[string]interface{}) 
 }
 
 func fileFormatGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.FileFormatGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -353,6 +396,7 @@ func fileFormatGrant(t *testing.T, id string, params map[string]interface{}) *sc
 }
 
 func sequenceGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.SequenceGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -361,6 +405,7 @@ func sequenceGrant(t *testing.T, id string, params map[string]interface{}) *sche
 }
 
 func streamGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.StreamGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -369,6 +414,7 @@ func streamGrant(t *testing.T, id string, params map[string]interface{}) *schema
 }
 
 func functionGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.FunctionGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -377,6 +423,7 @@ func functionGrant(t *testing.T, id string, params map[string]interface{}) *sche
 }
 
 func procedureGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.ProcedureGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -385,6 +432,7 @@ func procedureGrant(t *testing.T, id string, params map[string]interface{}) *sch
 }
 
 func maskingPolicyGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.MaskingPolicyGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -393,6 +441,7 @@ func maskingPolicyGrant(t *testing.T, id string, params map[string]interface{}) 
 }
 
 func pipeGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.PipeGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -401,6 +450,7 @@ func pipeGrant(t *testing.T, id string, params map[string]interface{}) *schema.R
 }
 
 func taskGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.TaskGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -409,6 +459,7 @@ func taskGrant(t *testing.T, id string, params map[string]interface{}) *schema.R
 }
 
 func rowAccessPolicy(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.RowAccessPolicy().Schema, params)
 	r.NotNil(d)
@@ -417,6 +468,7 @@ func rowAccessPolicy(t *testing.T, id string, params map[string]interface{}) *sc
 }
 
 func rowAccessPolicyGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.RowAccessPolicyGrant().Resource.Schema, params)
 	r.NotNil(d)
@@ -425,6 +477,7 @@ func rowAccessPolicyGrant(t *testing.T, id string, params map[string]interface{}
 }
 
 func function(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.Function().Schema, params)
 	r.NotNil(d)
@@ -433,6 +486,7 @@ func function(t *testing.T, id string, params map[string]interface{}) *schema.Re
 }
 
 func tagGrant(t *testing.T, id string, params map[string]interface{}) *schema.ResourceData {
+	t.Helper()
 	r := require.New(t)
 	d := schema.TestResourceDataRaw(t, resources.TagGrant().Resource.Schema, params)
 	r.NotNil(d)

--- a/pkg/resources/materialized_view_grant_acceptance_test.go
+++ b/pkg/resources/materialized_view_grant_acceptance_test.go
@@ -36,6 +36,7 @@ func TestAcc_MaterializedViewFutureGrant(t *testing.T) {
 }
 
 func materializedViewGrantConfigFuture(t *testing.T, database_name, schema_name, role string) string {
+	t.Helper()
 	r := require.New(t)
 
 	config := `

--- a/pkg/resources/procedure_grant_acceptance_test.go
+++ b/pkg/resources/procedure_grant_acceptance_test.go
@@ -37,6 +37,7 @@ func TestAcc_ProcedureFutureGrant(t *testing.T) {
 }
 
 func procedureGrantConfigFuture(t *testing.T, database_name, schema_name, role string) string {
+	t.Helper()
 	r := require.New(t)
 
 	config := `

--- a/pkg/resources/procedure_test.go
+++ b/pkg/resources/procedure_test.go
@@ -16,6 +16,7 @@ import (
 const procedureBody string = "hi"
 
 func prepDummyProcedureResource(t *testing.T) *schema.ResourceData {
+	t.Helper()
 	argument1 := map[string]interface{}{"name": "data", "type": "varchar"}
 	argument2 := map[string]interface{}{"name": "event_dt", "type": "date"}
 	in := map[string]interface{}{
@@ -34,12 +35,14 @@ func prepDummyProcedureResource(t *testing.T) *schema.ResourceData {
 }
 
 func TestProcedure(t *testing.T) {
+	t.Helper()
 	r := require.New(t)
 	err := resources.Procedure().InternalValidate(provider.Provider().Schema, true)
 	r.NoError(err)
 }
 
 func TestProcedureCreate(t *testing.T) {
+	t.Helper()
 	r := require.New(t)
 	d := prepDummyProcedureResource(t)
 
@@ -72,6 +75,7 @@ func expectProcedureRead(mock sqlmock.Sqlmock, returnType string) {
 }
 
 func TestProcedureRead(t *testing.T) {
+	t.Helper()
 	r := require.New(t)
 
 	d := procedure(t, "my_db|my_schema|my_proc|VARCHAR-DATE", map[string]interface{}{})
@@ -113,6 +117,7 @@ func TestProcedureRead(t *testing.T) {
 }
 
 func TestProcedureDelete(t *testing.T) {
+	t.Helper()
 	r := require.New(t)
 
 	d := procedure(t, "my_db|my_schema|my_proc|VARCHAR-DATE", map[string]interface{}{})

--- a/pkg/resources/role_grants_acceptance_test.go
+++ b/pkg/resources/role_grants_acceptance_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func MustParseInt(t *testing.T, input string) int64 {
+	t.Helper()
 	i, err := strconv.ParseInt(input, 10, 64)
 	if err != nil {
 		t.Error(err)
@@ -56,6 +57,7 @@ func listSetEqual(a, b []string) bool {
 }
 
 func testCheckRolesAndUsers(t *testing.T, path string, roles, users []string) func(state *terraform.State) error {
+	t.Helper()
 	return func(state *terraform.State) error {
 		is := state.RootModule().Resources[path].Primary
 		if c, ok := is.Attributes["roles.#"]; !ok || MustParseInt(t, c) != int64(len(roles)) {

--- a/pkg/resources/sequence_grant_acceptance_test.go
+++ b/pkg/resources/sequence_grant_acceptance_test.go
@@ -36,6 +36,7 @@ func TestAcc_SequenceFutureGrant(t *testing.T) {
 }
 
 func sequenceGrantConfigFuture(t *testing.T, database_name, schema_name, role string) string {
+	t.Helper()
 	r := require.New(t)
 
 	config := `

--- a/pkg/resources/stage_grant_acceptance_test.go
+++ b/pkg/resources/stage_grant_acceptance_test.go
@@ -107,6 +107,7 @@ func TestAcc_StageFutureGrant(t *testing.T) {
 }
 
 func stageGrantConfigFuture(t *testing.T, database_name, schema_name, role string) string {
+	t.Helper()
 	r := require.New(t)
 
 	config := `

--- a/pkg/resources/stream_grant_acceptance_test.go
+++ b/pkg/resources/stream_grant_acceptance_test.go
@@ -62,6 +62,7 @@ func TestAcc_StreamGrant_future(t *testing.T) {
 }
 
 func streamGrantConfigExisting(t *testing.T, database_name, schema_name, role, stream_name, table_name string) string {
+	t.Helper()
 	r := require.New(t)
 
 	config := `
@@ -126,6 +127,7 @@ resource "snowflake_stream_grant" "test" {
 }
 
 func streamGrantConfigFuture(t *testing.T, database_name, schema_name, role string) string {
+	t.Helper()
 	r := require.New(t)
 
 	config := `

--- a/pkg/resources/view_grant_acceptance_test.go
+++ b/pkg/resources/view_grant_acceptance_test.go
@@ -93,6 +93,7 @@ func TestAcc_FutureViewGrantChange(t *testing.T) {
 }
 
 func viewGrantConfigShares(t *testing.T, database_name, view_name, role, share_name string) string {
+	t.Helper()
 	r := require.New(t)
 
 	tmpl := template.Must(template.New("shares").Parse(`
@@ -158,6 +159,7 @@ resource "snowflake_view_grant" "test" {
 }
 
 func viewGrantConfigFuture(t *testing.T, database_name, view_name string, role string, future bool) string {
+	t.Helper()
 	r := require.New(t)
 
 	view_name_config := "view_name = snowflake_view.test.name"

--- a/pkg/testhelpers/fixtures.go
+++ b/pkg/testhelpers/fixtures.go
@@ -7,6 +7,7 @@ import (
 )
 
 func MustFixture(t *testing.T, name string) string {
+	t.Helper()
 	b, err := Fixture(name)
 	if err != nil {
 		t.Error(err)

--- a/pkg/testhelpers/helpers.go
+++ b/pkg/testhelpers/helpers.go
@@ -9,6 +9,7 @@ import (
 )
 
 func WithMockDb(t *testing.T, f func(*sql.DB, sqlmock.Sqlmock)) {
+	t.Helper()
 	r := require.New(t)
 	db, mock, err := sqlmock.New()
 	r.NoError(err)


### PR DESCRIPTION
<!-- summary of changes -->
## Summary

This PR adds `t.Helper()` to test helper functions.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests