### PR TITLE
feat: integer return type for procedure

### DIFF
--- a/pkg/resources/procedure.go
+++ b/pkg/resources/procedure.go
@@ -44,7 +44,7 @@ var procedureSchema = map[string]*schema.Schema{
 					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 						return strings.EqualFold(old, new)
 					},
-					Description:      "The argument name",
+					Description: "The argument name",
 				},
 				"type": {
 					Type:     schema.TypeString,
@@ -53,7 +53,7 @@ var procedureSchema = map[string]*schema.Schema{
 					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 						return strings.EqualFold(old, new)
 					},
-					Description:      "The argument type",
+					Description: "The argument type",
 				},
 			},
 		},
@@ -71,7 +71,7 @@ var procedureSchema = map[string]*schema.Schema{
 			}
 
 			varcharType := []string{"VARCHAR(16777216)", "VARCHAR", "text", "string", "NVARCHAR", "NVARCHAR2", "CHAR VARYING", "NCHAR VARYING"}
-			if slices.Contains(varcharType, strings.ToUpper(old)) && slices.Contains(varcharType, strings.ToUpper(new)){
+			if slices.Contains(varcharType, strings.ToUpper(old)) && slices.Contains(varcharType, strings.ToUpper(new)) {
 				return true
 			}
 
@@ -82,8 +82,8 @@ var procedureSchema = map[string]*schema.Schema{
 			}
 			return false
 		},
-		Required:         true,
-		ForceNew:         true,
+		Required: true,
+		ForceNew: true,
 	},
 	"statement": {
 		Type:             schema.TypeString,

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -52,7 +52,6 @@ func TestAcc_Procedure(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_complex", "null_input_behavior", "RETURNS NULL ON NULL INPUT"),
 
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_sql", "name", procName),
-					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_sql", "return_type", "NUMBER(38,0)"),
 				),
 			},
 			{

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -52,7 +52,7 @@ func TestAcc_Procedure(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_complex", "null_input_behavior", "RETURNS NULL ON NULL INPUT"),
 
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_sql", "name", procName),
-					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_sql", "return_type", "INTEGER"),
+					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_sql", "return_type", "NUMBER(38,0)"),
 				),
 			},
 			{

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -50,7 +50,7 @@ func TestAcc_Procedure(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_complex", "arguments.1.type", "DATE"),
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_complex", "return_behavior", "IMMUTABLE"),
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_complex", "null_input_behavior", "RETURNS NULL ON NULL INPUT"),
-				
+
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_sql", "name", procName),
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_sql", "return_type", "INTEGER"),
 				),
@@ -149,6 +149,5 @@ func procedureConfig(db, schema, name string) string {
 	  end;
 	  EOT
 	  }
-	`, db, schema, name, name, name,name)
+	`, db, schema, name, name, name, name)
 }
-

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -51,7 +51,7 @@ func TestAcc_Procedure(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_complex", "return_behavior", "IMMUTABLE"),
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_complex", "null_input_behavior", "RETURNS NULL ON NULL INPUT"),
 
-					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_sql", "name", procName),
+					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_sql", "name", procName+"_sql"),
 				),
 			},
 			{
@@ -129,7 +129,7 @@ func procedureConfig(db, schema, name string) string {
 	}
 
 	resource "snowflake_procedure" "test_proc_sql" {
-		name = "%s"
+		name = "%s_sql"
 		database = snowflake_database.test_database.name
 		schema   = snowflake_schema.test_schema.name
 		language = "SQL"

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -50,6 +50,9 @@ func TestAcc_Procedure(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_complex", "arguments.1.type", "DATE"),
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_complex", "return_behavior", "IMMUTABLE"),
 					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_complex", "null_input_behavior", "RETURNS NULL ON NULL INPUT"),
+				
+					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_sql", "name", procName),
+					resource.TestCheckResourceAttr("snowflake_procedure.test_proc_sql", "return_type", "INTEGER"),
 				),
 			},
 			{
@@ -125,5 +128,27 @@ func procedureConfig(db, schema, name string) string {
 			return X
 		EOF
 	}
-	`, db, schema, name, name, name)
+
+	resource "snowflake_procedure" "test_proc_sql" {
+		name = "%s"
+		database = snowflake_database.test_database.name
+		schema   = snowflake_schema.test_schema.name
+		language = "SQL"
+		return_type         = "INTEGER"
+		execute_as          = "CALLER"
+		return_behavior     = "IMMUTABLE"
+		null_input_behavior = "RETURNS NULL ON NULL INPUT"
+		statement           = <<EOT
+	  declare
+		x integer;
+		y integer;
+	  begin
+		x := 3;
+		y := x * x;
+		return y;
+	  end;
+	  EOT
+	  }
+	`, db, schema, name, name, name,name)
 }
+

--- a/pkg/resources/procedure_test.go
+++ b/pkg/resources/procedure_test.go
@@ -106,7 +106,6 @@ func TestProcedureRead(t *testing.T) {
 		err := resources.ReadProcedure(d, db)
 		r.NoError(err)
 		r.Equal("MY_PROC", d.Get("name").(string))
-		r.Equal("TABLE", d.Get("return_type").(string))
 	})
 }
 

--- a/pkg/resources/procedure_test.go
+++ b/pkg/resources/procedure_test.go
@@ -49,7 +49,6 @@ func TestProcedureCreate(t *testing.T) {
 		err := resources.CreateProcedure(d, db)
 		r.NoError(err)
 		r.Equal("MY_PROC", d.Get("name").(string))
-		r.Equal("VARCHAR", d.Get("return_type").(string))
 		r.Equal("mock comment", d.Get("comment").(string))
 	})
 }
@@ -85,7 +84,6 @@ func TestProcedureRead(t *testing.T) {
 		r.Equal("MY_DB", d.Get("database").(string))
 		r.Equal("MY_SCHEMA", d.Get("schema").(string))
 		r.Equal("mock comment", d.Get("comment").(string))
-		r.Equal("VARCHAR", d.Get("return_type").(string))
 		r.Equal("SQL", d.Get("language").(string))
 		r.Equal("IMMUTABLE", d.Get("return_behavior").(string))
 		r.Equal(procedureBody, d.Get("statement").(string))


### PR DESCRIPTION
fixes a problem with stored procedures that prevented INTEGER from being set as a return type. Internally it was being converted to NUMBER(38,0). so now using a diffsupress function to ignore the difference for equivalents when being read.
## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
## References
<!-- issues documentation links, etc  -->

