### PR TITLE
chore: update docs style of grant modules

### DIFF
--- a/docs/resources/database_grant.md
+++ b/docs/resources/database_grant.md
@@ -13,8 +13,8 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_database_grant grant {
-  database_name = "db"
+resource "snowflake_database_grant" "grant" {
+  database_name = "database"
 
   privilege = "USAGE"
   roles     = ["role1", "role2"]

--- a/docs/resources/external_table_grant.md
+++ b/docs/resources/external_table_grant.md
@@ -13,21 +13,15 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_external_table_grant grant {
-  database_name       = "db"
+resource "snowflake_external_table_grant" "grant" {
+  database_name       = "database"
   schema_name         = "schema"
   external_table_name = "external_table"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
-  shares = [
-    "share1",
-    "share2",
-  ]
+  shares = ["share1", "share2"]
 
   on_future         = false
   with_grant_option = false

--- a/docs/resources/file_format_grant.md
+++ b/docs/resources/file_format_grant.md
@@ -13,16 +13,13 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_file_format_grant grant {
-  database_name     = "db"
+resource "snowflake_file_format_grant" "grant" {
+  database_name     = "database"
   schema_name       = "schema"
   file_format_name  = "file_format"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
   on_future         = false
   with_grant_option = false

--- a/docs/resources/function_grant.md
+++ b/docs/resources/function_grant.md
@@ -13,8 +13,8 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_function_grant grant {
-  database_name   = "db"
+resource "snowflake_function_grant" "grant" {
+  database_name   = "database"
   schema_name     = "schema"
   function_name  = "function"
 
@@ -29,15 +29,9 @@ resource snowflake_function_grant grant {
   return_type = "string"
 
   privilege = "USAGE"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  roles = ["role1", "role2"]
 
-  shares = [
-    "share1",
-    "share2",
-  ]
+  shares = ["share1", "share2"]
 
   on_future         = false
   with_grant_option = false

--- a/docs/resources/materialized_view_grant.md
+++ b/docs/resources/materialized_view_grant.md
@@ -14,20 +14,14 @@ description: |-
 
 ```terraform
 resource "snowflake_materialized_view_grant" "grant" {
-  database_name          = "db"
+  database_name          = "database"
   schema_name            = "schema"
   materialized_view_name = "materialized_view"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
-  shares = [
-    "share1",
-    "share2",
-  ]
+  shares = ["share1", "share2"]
 
   on_future         = false
   with_grant_option = false

--- a/docs/resources/pipe_grant.md
+++ b/docs/resources/pipe_grant.md
@@ -13,16 +13,13 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_pipe_grant grant {
-  database_name = "db"
+resource "snowflake_pipe_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
   pipe_name     = "pipe"
 
-  privilege = "operate"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "OPERATE"
+  roles = ["role1", "role2"]
 
   on_future         = false
   with_grant_option = false

--- a/docs/resources/procedure_grant.md
+++ b/docs/resources/procedure_grant.md
@@ -13,8 +13,8 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_procedure_grant grant {
-  database_name   = "db"
+resource "snowflake_procedure_grant" "grant" {
+  database_name   = "database"
   schema_name     = "schema"
   procedure_name  = "procedure"
 
@@ -28,16 +28,10 @@ resource snowflake_procedure_grant grant {
   }
   return_type = "string"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
-  shares = [
-    "share1",
-    "share2",
-  ]
+  shares = ["share1", "share2"]
 
   on_future         = false
   with_grant_option = false

--- a/docs/resources/row_access_policy_grant.md
+++ b/docs/resources/row_access_policy_grant.md
@@ -14,15 +14,12 @@ description: |-
 
 ```terraform
 resource "snowflake_row_access_policy_grant" "grant" {
-  database_name          = "db"
+  database_name          = "database"
   schema_name            = "schema"
   row_access_policy_name = "row_access_policy"
 
   privilege = "APPLY"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  roles = ["role1", "role2"]
 
   with_grant_option = false
 }

--- a/docs/resources/schema_grant.md
+++ b/docs/resources/schema_grant.md
@@ -13,8 +13,8 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_schema_grant grant {
-  database_name = "db"
+resource "snowflake_schema_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
 
   privilege = "USAGE"

--- a/docs/resources/sequence_grant.md
+++ b/docs/resources/sequence_grant.md
@@ -13,16 +13,13 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_sequence_grant grant {
-  database_name = "db"
+resource "snowflake_sequence_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
   sequence_name = "sequence"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
   on_future         = false
   with_grant_option = false

--- a/docs/resources/stage_grant.md
+++ b/docs/resources/stage_grant.md
@@ -13,8 +13,8 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_stage_grant grant {
-  database_name = "db"
+resource "snowflake_stage_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
   stage_name    = "stage"
 

--- a/docs/resources/stream_grant.md
+++ b/docs/resources/stream_grant.md
@@ -13,16 +13,13 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_stream_grant grant {
-  database_name = "db"
+resource "snowflake_stream_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
   stream_name   = "view"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
   on_future         = false
   with_grant_option = false

--- a/docs/resources/table_grant.md
+++ b/docs/resources/table_grant.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_table_grant grant {
+resource "snowflake_table_grant" "grant" {
   database_name = "database"
   schema_name   = "schema"
   table_name    = "table"

--- a/docs/resources/task_grant.md
+++ b/docs/resources/task_grant.md
@@ -13,16 +13,13 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_task_grant grant {
-  database_name = "db"
+resource "snowflake_task_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
   task_name = "task"
 
-  privilege = "operate"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "OPERATE"
+  roles = ["role1", "role2"]
 
   on_future         = false
   with_grant_option = false

--- a/docs/resources/user_grant.md
+++ b/docs/resources/user_grant.md
@@ -13,13 +13,11 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_user_grant grant {
+resource "snowflake_user_grant" "grant" {
   user_name = "user"
   privilege = "MONITOR"
 
-  roles = [
-    "role1",
-  ]
+  roles = ["role1", "role2"]
 
   with_grant_option = false
 }

--- a/docs/resources/view_grant.md
+++ b/docs/resources/view_grant.md
@@ -13,21 +13,15 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_view_grant grant {
-  database_name = "db"
+resource "snowflake_view_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
   view_name     = "view"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
-  shares = [
-    "share1",
-    "share2",
-  ]
+  shares = ["share1", "share2"]
 
   on_future         = false
   with_grant_option = false

--- a/docs/resources/warehouse_grant.md
+++ b/docs/resources/warehouse_grant.md
@@ -13,13 +13,11 @@ description: |-
 ## Example Usage
 
 ```terraform
-resource snowflake_warehouse_grant grant {
-  warehouse_name = "wh"
+resource "snowflake_warehouse_grant" "grant" {
+  warehouse_name = "warehouse"
   privilege      = "MODIFY"
 
-  roles = [
-    "role1",
-  ]
+  roles = ["role1", "role2"]
 
   with_grant_option = false
 }

--- a/examples/resources/snowflake_database_grant/resource.tf
+++ b/examples/resources/snowflake_database_grant/resource.tf
@@ -1,5 +1,5 @@
-resource snowflake_database_grant grant {
-  database_name = "db"
+resource "snowflake_database_grant" "grant" {
+  database_name = "database"
 
   privilege = "USAGE"
   roles     = ["role1", "role2"]

--- a/examples/resources/snowflake_external_table_grant/resource.tf
+++ b/examples/resources/snowflake_external_table_grant/resource.tf
@@ -1,18 +1,12 @@
-resource snowflake_external_table_grant grant {
-  database_name       = "db"
+resource "snowflake_external_table_grant" "grant" {
+  database_name       = "database"
   schema_name         = "schema"
   external_table_name = "external_table"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
-  shares = [
-    "share1",
-    "share2",
-  ]
+  shares = ["share1", "share2"]
 
   on_future         = false
   with_grant_option = false

--- a/examples/resources/snowflake_file_format_grant/resource.tf
+++ b/examples/resources/snowflake_file_format_grant/resource.tf
@@ -1,13 +1,10 @@
-resource snowflake_file_format_grant grant {
-  database_name     = "db"
+resource "snowflake_file_format_grant" "grant" {
+  database_name     = "database"
   schema_name       = "schema"
   file_format_name  = "file_format"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
   on_future         = false
   with_grant_option = false

--- a/examples/resources/snowflake_function_grant/resource.tf
+++ b/examples/resources/snowflake_function_grant/resource.tf
@@ -1,5 +1,5 @@
-resource snowflake_function_grant grant {
-  database_name   = "db"
+resource "snowflake_function_grant" "grant" {
+  database_name   = "database"
   schema_name     = "schema"
   function_name  = "function"
 
@@ -14,15 +14,9 @@ resource snowflake_function_grant grant {
   return_type = "string"
 
   privilege = "USAGE"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  roles = ["role1", "role2"]
 
-  shares = [
-    "share1",
-    "share2",
-  ]
+  shares = ["share1", "share2"]
 
   on_future         = false
   with_grant_option = false

--- a/examples/resources/snowflake_materialized_view_grant/resource.tf
+++ b/examples/resources/snowflake_materialized_view_grant/resource.tf
@@ -1,18 +1,12 @@
 resource "snowflake_materialized_view_grant" "grant" {
-  database_name          = "db"
+  database_name          = "database"
   schema_name            = "schema"
   materialized_view_name = "materialized_view"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
-  shares = [
-    "share1",
-    "share2",
-  ]
+  shares = ["share1", "share2"]
 
   on_future         = false
   with_grant_option = false

--- a/examples/resources/snowflake_pipe_grant/resource.tf
+++ b/examples/resources/snowflake_pipe_grant/resource.tf
@@ -1,13 +1,10 @@
-resource snowflake_pipe_grant grant {
-  database_name = "db"
+resource "snowflake_pipe_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
   pipe_name     = "pipe"
 
-  privilege = "operate"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "OPERATE"
+  roles = ["role1", "role2"]
 
   on_future         = false
   with_grant_option = false

--- a/examples/resources/snowflake_procedure_grant/resource.tf
+++ b/examples/resources/snowflake_procedure_grant/resource.tf
@@ -1,5 +1,5 @@
-resource snowflake_procedure_grant grant {
-  database_name   = "db"
+resource "snowflake_procedure_grant" "grant" {
+  database_name   = "database"
   schema_name     = "schema"
   procedure_name  = "procedure"
 
@@ -13,16 +13,10 @@ resource snowflake_procedure_grant grant {
   }
   return_type = "string"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
-  shares = [
-    "share1",
-    "share2",
-  ]
+  shares = ["share1", "share2"]
 
   on_future         = false
   with_grant_option = false

--- a/examples/resources/snowflake_row_access_policy_grant/resource.tf
+++ b/examples/resources/snowflake_row_access_policy_grant/resource.tf
@@ -1,13 +1,10 @@
 resource "snowflake_row_access_policy_grant" "grant" {
-  database_name          = "db"
+  database_name          = "database"
   schema_name            = "schema"
   row_access_policy_name = "row_access_policy"
 
   privilege = "APPLY"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  roles = ["role1", "role2"]
 
   with_grant_option = false
 }

--- a/examples/resources/snowflake_schema_grant/resource.tf
+++ b/examples/resources/snowflake_schema_grant/resource.tf
@@ -1,5 +1,5 @@
-resource snowflake_schema_grant grant {
-  database_name = "db"
+resource "snowflake_schema_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
 
   privilege = "USAGE"

--- a/examples/resources/snowflake_sequence_grant/resource.tf
+++ b/examples/resources/snowflake_sequence_grant/resource.tf
@@ -1,13 +1,10 @@
-resource snowflake_sequence_grant grant {
-  database_name = "db"
+resource "snowflake_sequence_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
   sequence_name = "sequence"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
   on_future         = false
   with_grant_option = false

--- a/examples/resources/snowflake_stage_grant/resource.tf
+++ b/examples/resources/snowflake_stage_grant/resource.tf
@@ -1,5 +1,5 @@
-resource snowflake_stage_grant grant {
-  database_name = "db"
+resource "snowflake_stage_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
   stage_name    = "stage"
 

--- a/examples/resources/snowflake_stream_grant/resource.tf
+++ b/examples/resources/snowflake_stream_grant/resource.tf
@@ -1,13 +1,10 @@
-resource snowflake_stream_grant grant {
-  database_name = "db"
+resource "snowflake_stream_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
   stream_name   = "view"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
   on_future         = false
   with_grant_option = false

--- a/examples/resources/snowflake_table_grant/resource.tf
+++ b/examples/resources/snowflake_table_grant/resource.tf
@@ -1,4 +1,4 @@
-resource snowflake_table_grant grant {
+resource "snowflake_table_grant" "grant" {
   database_name = "database"
   schema_name   = "schema"
   table_name    = "table"

--- a/examples/resources/snowflake_task_grant/resource.tf
+++ b/examples/resources/snowflake_task_grant/resource.tf
@@ -1,13 +1,10 @@
-resource snowflake_task_grant grant {
-  database_name = "db"
+resource "snowflake_task_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
   task_name = "task"
 
-  privilege = "operate"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "OPERATE"
+  roles = ["role1", "role2"]
 
   on_future         = false
   with_grant_option = false

--- a/examples/resources/snowflake_user_grant/resource.tf
+++ b/examples/resources/snowflake_user_grant/resource.tf
@@ -1,10 +1,8 @@
-resource snowflake_user_grant grant {
+resource "snowflake_user_grant" "grant" {
   user_name = "user"
   privilege = "MONITOR"
 
-  roles = [
-    "role1",
-  ]
+  roles = ["role1", "role2"]
 
   with_grant_option = false
 }

--- a/examples/resources/snowflake_view_grant/resource.tf
+++ b/examples/resources/snowflake_view_grant/resource.tf
@@ -1,18 +1,12 @@
-resource snowflake_view_grant grant {
-  database_name = "db"
+resource "snowflake_view_grant" "grant" {
+  database_name = "database"
   schema_name   = "schema"
   view_name     = "view"
 
-  privilege = "select"
-  roles = [
-    "role1",
-    "role2",
-  ]
+  privilege = "SELECT"
+  roles = ["role1", "role2"]
 
-  shares = [
-    "share1",
-    "share2",
-  ]
+  shares = ["share1", "share2"]
 
   on_future         = false
   with_grant_option = false

--- a/examples/resources/snowflake_warehouse_grant/resource.tf
+++ b/examples/resources/snowflake_warehouse_grant/resource.tf
@@ -1,10 +1,8 @@
-resource snowflake_warehouse_grant grant {
-  warehouse_name = "wh"
+resource "snowflake_warehouse_grant" "grant" {
+  warehouse_name = "warehouse"
   privilege      = "MODIFY"
 
-  roles = [
-    "role1",
-  ]
+  roles = ["role1", "role2"]
 
   with_grant_option = false
 }


### PR DESCRIPTION
## Summary

In this PR, I want to fix the styles of the terraform snowflake provider documentation to be the same format. There are some expression of the variables in the example (like below) and it is not suitable for the official documentation.

This PR only includes updates for modules that grant privileges:

- use UPPERCASE for granting privilege (`privilege = "select"` => `privilege = "SELECT"`)
- do not use abbr like `database_name = "db"` => `database_name = "database"` and `warehouse_name = "wh"` => `warehouse_name = "warehouse"` because some other examples already use "database" for their definitions.

Furthermore, changing the definitions with double quotations seems better as follows.
**before**
```
resource snowflake_warehouse_grant grant {
  warehouse_name = "wh"
  privilege      = "MODIFY"

  roles = [
    "role1",
  ]

  with_grant_option = false
}
```

**after**
```
resource "snowflake_warehouse_grant" "grant" {
  warehouse_name = "warehouse"
  privilege      = "MODIFY"

  roles = ["role1", "role2"]

  with_grant_option = false
}
```