### PR TITLE
fix: memory aliasing

### DIFF
--- a/pkg/snowflake/database.go
+++ b/pkg/snowflake/database.go
@@ -302,6 +302,7 @@ func ListDatabase(sdb *sqlx.DB, databaseName string) (*database, error) {
 	}
 	db := &database{}
 	for _, d := range dbs {
+		d := d
 		if d.DBName.String == databaseName {
 			db = &d
 			break


### PR DESCRIPTION
## Summary 

This PR fixes implicit memory aliasing in for loop.
In this case, it is not critical because this seems break the loop quickly but it might be better to be fixed for safe.
Please check this modification.