### PR TITLE
fix: golangci does not work and fix lint format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,19 @@
 run:
-  linters:
-    enable:
-      - gofmt
-      - whitespace
-      - unparam
-      - scopelint
-      - godot
+  timeout: 5m
+  skip-files: []
+  # skip-dirs:
+
+linters-settings:
+  misspell:
+    locale: US
+
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+    - whitespace
+    # - unparam
+    - exportloopref
+    - godot
+    # - gocritic
+    - misspell

--- a/pkg/datasources/databases.go
+++ b/pkg/datasources/databases.go
@@ -117,7 +117,6 @@ func ReadDatabases(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 		databases = append(databases, dbR)
-
 	}
 	databasesErr := d.Set("databases", databases)
 	if databasesErr != nil {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -362,8 +362,8 @@ func DSN(
 	host string,
 	protocol string,
 	port int,
-	warehouse string) (string, error) {
-
+	warehouse string,
+) (string, error) {
 	// us-west-2 is Snowflake's default region, but if you actually specify that it won't trigger the default code
 	//  https://github.com/snowflakedb/gosnowflake/blob/52137ce8c32eaf93b0bd22fc5c7297beff339812/dsn.go#L61
 	if region == "us-west-2" {
@@ -502,7 +502,6 @@ func GetOauthAccessToken(
 	clientID,
 	clientSecret string,
 	data url.Values) (string, error) {
-
 	client := &http.Client{}
 	request, err := GetOauthRequest(strings.NewReader(data.Encode()), endPoint, clientID, clientSecret)
 	if err != nil {

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -51,6 +51,7 @@ func TestDSN(t *testing.T) {
 			"user4:pass4@zha1234.us-east-1.privatelink.snowflakecomputing.com:8443?account=acct4&application=terraform-provider-snowflake&ocspFailOpen=true&role=role4&validateDefaultParameters=true", false},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := provider.DSN(tt.args.account, tt.args.user, tt.args.password, tt.args.browserAuth, "", "", "", "", tt.args.region, tt.args.role, tt.args.host, tt.args.protocol, tt.args.port, "")
 			if (err != nil) != tt.wantErr {
@@ -90,6 +91,7 @@ func TestOAuthDSN(t *testing.T) {
 			"", true},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := provider.DSN(tt.args.account, tt.args.user, "", false, "", "", "", tt.args.oauthAccessToken, tt.args.region, tt.args.role, tt.args.host, tt.args.protocol, tt.args.port, "")
 
@@ -125,6 +127,7 @@ func TestGetOauthDATA(t *testing.T) {
 			false},
 	}
 	for _, tt := range cases {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := provider.GetOauthData(tt.param.refreshToken, tt.param.redirectURL)
 			want, err := url.ParseQuery(tt.want)
@@ -135,7 +138,6 @@ func TestGetOauthDATA(t *testing.T) {
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("GetData() = %v, want %v", got, tt.want)
 			}
-
 		})
 	}
 }
@@ -162,6 +164,7 @@ func TestGetOauthResponse(t *testing.T) {
 			false},
 	}
 	for _, tt := range cases {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := provider.GetOauthRequest(strings.NewReader(tt.param.dataStuff), tt.param.endpoint, tt.param.clientid, tt.param.clientscret)
 			if err != nil {
@@ -216,6 +219,7 @@ func TestGetOauthAccessToken(t *testing.T) {
 			"404", "", false},
 	}
 	for _, tt := range cases {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			client := NewTestClient(func(req *http.Request) *http.Response {
 				// Test request parameters

--- a/pkg/resources/database_grant_acceptance_test.go
+++ b/pkg/resources/database_grant_acceptance_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func testRolesAndShares(t *testing.T, path string, roles, shares []string) func(*terraform.State) error {
+func testRolesAndShares(t *testing.T, path string, roles []string) func(*terraform.State) error {
 	t.Helper()
 	return func(state *terraform.State) error {
 		is := state.RootModule().Resources[path].Primary
@@ -49,7 +49,7 @@ func TestAcc_DatabaseGrant(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_database_grant.test", "roles.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_database_grant.test", "shares.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_database_grant.test", "shares.#", "1"),
-					testRolesAndShares(t, "snowflake_database_grant.test", []string{roleName}, []string{shareName}),
+					testRolesAndShares(t, "snowflake_database_grant.test", []string{roleName}),
 				),
 			},
 			// IMPORT

--- a/pkg/resources/file_format.go
+++ b/pkg/resources/file_format.go
@@ -774,7 +774,6 @@ func UpdateFileFormat(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return errors.Wrapf(err, "error updating file format file extension on %v", d.Id())
 		}
-
 	}
 
 	if d.HasChange("skip_header") {

--- a/pkg/resources/function_test.go
+++ b/pkg/resources/function_test.go
@@ -20,18 +20,18 @@ func prepDummyFunctionResource(t *testing.T) *schema.ResourceData {
 	argument1 := map[string]interface{}{"name": "data", "type": "varchar"}
 	argument2 := map[string]interface{}{"name": "event_dt", "type": "date"}
 	in := map[string]interface{}{
-		"name":                 "my_funct",
-		"database":             "my_db",
-		"schema":               "my_schema",
-		"arguments":            []interface{}{argument1, argument2},
-		"language":             "PYTHON",
-		"null_input_behaviour": "CALLED ON NULL INPUT",
-		"return_behavior":      "VOLATILE",
-		"runtime_version":      "3.8",
-		"packages":             []interface{}{"numpy", "pandas"},
-		"handler":              "add_py",
-		"return_type":          "varchar",
-		"statement":            functionBody, //var message = DATA + DATA;return message
+		"name":                "my_funct",
+		"database":            "my_db",
+		"schema":              "my_schema",
+		"arguments":           []interface{}{argument1, argument2},
+		"language":            "PYTHON",
+		"null_input_behavior": "CALLED ON NULL INPUT",
+		"return_behavior":     "VOLATILE",
+		"runtime_version":     "3.8",
+		"packages":            []interface{}{"numpy", "pandas"},
+		"handler":             "add_py",
+		"return_type":         "varchar",
+		"statement":           functionBody, //var message = DATA + DATA;return message
 	}
 	d := function(t, "my_db|my_schema|my_funct|VARCHAR-DATE", in)
 	return d

--- a/pkg/resources/grant_helpers.go
+++ b/pkg/resources/grant_helpers.go
@@ -206,7 +206,8 @@ func readGenericGrant(
 	grantSchema map[string]*schema.Schema,
 	builder snowflake.GrantBuilder,
 	futureObjects bool,
-	validPrivileges PrivilegeSet) error {
+	validPrivileges PrivilegeSet,
+) error {
 	db := meta.(*sql.DB)
 	var grants []*grant
 	var err error

--- a/pkg/resources/grant_helpers_internal_test.go
+++ b/pkg/resources/grant_helpers_internal_test.go
@@ -132,7 +132,6 @@ func TestGrantLegacyID(t *testing.T) {
 	r.Equal("priv", grant.Privilege)
 	r.Equal([]string{}, grant.Roles)
 	r.Equal(false, grant.GrantOption)
-
 }
 
 func TestGrantIDFromStringRoleGrant(t *testing.T) {

--- a/pkg/resources/notification_integration.go
+++ b/pkg/resources/notification_integration.go
@@ -13,17 +13,17 @@ import (
 
 var notificationIntegrationSchema = map[string]*schema.Schema{
 	// The first part of the schema is shared between all integration vendors
-	"name": &schema.Schema{
+	"name": {
 		Type:     schema.TypeString,
 		Required: true,
 		ForceNew: true,
 	},
-	"enabled": &schema.Schema{
+	"enabled": {
 		Type:     schema.TypeBool,
 		Optional: true,
 		Default:  true,
 	},
-	"type": &schema.Schema{
+	"type": {
 		Type:         schema.TypeString,
 		Optional:     true,
 		Default:      "QUEUE",
@@ -31,7 +31,7 @@ var notificationIntegrationSchema = map[string]*schema.Schema{
 		Description:  "A type of integration",
 		ForceNew:     true,
 	},
-	"direction": &schema.Schema{
+	"direction": {
 		Type:         schema.TypeString,
 		Optional:     true,
 		ValidateFunc: validation.StringInSlice([]string{"INBOUND", "OUTBOUND"}, true),
@@ -39,24 +39,24 @@ var notificationIntegrationSchema = map[string]*schema.Schema{
 		ForceNew:     true,
 	},
 	// This part of the schema is the cloudProviderParams in the Snowflake documentation and differs between vendors
-	"notification_provider": &schema.Schema{
+	"notification_provider": {
 		Type:         schema.TypeString,
 		Optional:     true,
 		ValidateFunc: validation.StringInSlice([]string{"AZURE_STORAGE_QUEUE", "AWS_SQS", "AWS_SNS", "GCP_PUBSUB"}, true),
 		Description:  "The third-party cloud message queuing service (e.g. AZURE_STORAGE_QUEUE, AWS_SQS, AWS_SNS)",
 		ForceNew:     true,
 	},
-	"azure_storage_queue_primary_uri": &schema.Schema{
+	"azure_storage_queue_primary_uri": {
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "The queue ID for the Azure Queue Storage queue created for Event Grid notifications",
 	},
-	"azure_tenant_id": &schema.Schema{
+	"azure_tenant_id": {
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "The ID of the Azure Active Directory tenant used for identity management",
 	},
-	"aws_sqs_external_id": &schema.Schema{
+	"aws_sqs_external_id": {
 		Type:        schema.TypeString,
 		Computed:    true,
 		Description: "The external ID that Snowflake will use when assuming the AWS role",
@@ -66,17 +66,17 @@ var notificationIntegrationSchema = map[string]*schema.Schema{
 		Computed:    true,
 		Description: "The Snowflake user that will attempt to assume the AWS role.",
 	},
-	"aws_sqs_arn": &schema.Schema{
+	"aws_sqs_arn": {
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "AWS SQS queue ARN for notification integration to connect to",
 	},
-	"aws_sqs_role_arn": &schema.Schema{
+	"aws_sqs_role_arn": {
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "AWS IAM role ARN for notification integration to assume",
 	},
-	"aws_sns_external_id": &schema.Schema{
+	"aws_sns_external_id": {
 		Type:        schema.TypeString,
 		Computed:    true,
 		Description: "The external ID that Snowflake will use when assuming the AWS role",
@@ -86,32 +86,32 @@ var notificationIntegrationSchema = map[string]*schema.Schema{
 		Computed:    true,
 		Description: "The Snowflake user that will attempt to assume the AWS role.",
 	},
-	"aws_sns_topic_arn": &schema.Schema{
+	"aws_sns_topic_arn": {
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "AWS SNS Topic ARN for notification integration to connect to",
 	},
-	"aws_sns_role_arn": &schema.Schema{
+	"aws_sns_role_arn": {
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "AWS IAM role ARN for notification integration to assume",
 	},
-	"comment": &schema.Schema{
+	"comment": {
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "A comment for the integration",
 	},
-	"created_on": &schema.Schema{
+	"created_on": {
 		Type:        schema.TypeString,
 		Computed:    true,
 		Description: "Date and time when the notification integration was created.",
 	},
-	"gcp_pubsub_subscription_name": &schema.Schema{
+	"gcp_pubsub_subscription_name": {
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "The subscription id that Snowflake will listen to when using the GCP_PUBSUB provider.",
 	},
-	"gcp_pubsub_service_account": &schema.Schema{
+	"gcp_pubsub_service_account": {
 		Type:        schema.TypeString,
 		Computed:    true,
 		Description: "The GCP service account identifier that Snowflake will use when assuming the GCP role",

--- a/pkg/resources/notification_integration_test.go
+++ b/pkg/resources/notification_integration_test.go
@@ -70,14 +70,15 @@ func TestNotificationIntegrationCreate(t *testing.T) {
 			expectSQL: `^CREATE NOTIFICATION INTEGRATION "test_notification_integration" COMMENT='great comment' GCP_PUBSUB_SUBSCRIPTION_NAME='some-gcp-sub-name' NOTIFICATION_PROVIDER='GCP_PUBSUB' TYPE='QUEUE' ENABLED=true$`,
 		},
 	}
-	for _, testCase := range testCases {
+	for _, tc := range testCases {
+		tc := tc
 		r := require.New(t)
-		d := schema.TestResourceDataRaw(t, resources.NotificationIntegration().Schema, testCase.raw)
+		d := schema.TestResourceDataRaw(t, resources.NotificationIntegration().Schema, tc.raw)
 		r.NotNil(d)
 
 		WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-			mock.ExpectExec(testCase.expectSQL).WillReturnResult(sqlmock.NewResult(1, 1))
-			expectReadNotificationIntegration(mock, testCase.notificationProvider)
+			mock.ExpectExec(tc.expectSQL).WillReturnResult(sqlmock.NewResult(1, 1))
+			expectReadNotificationIntegration(mock, tc.notificationProvider)
 
 			err := resources.CreateNotificationIntegration(d, db)
 			r.NoError(err)
@@ -102,13 +103,14 @@ func TestNotificationIntegrationRead(t *testing.T) {
 			notificationProvider: "GCP_PUBSUB",
 		},
 	}
-	for _, testCase := range testCases {
+	for _, tc := range testCases {
+		tc := tc
 		r := require.New(t)
 
 		d := notificationIntegration(t, "test_notification_integration", map[string]interface{}{"name": "test_notification_integration"})
 
 		WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-			expectReadNotificationIntegration(mock, testCase.notificationProvider)
+			expectReadNotificationIntegration(mock, tc.notificationProvider)
 
 			err := resources.ReadNotificationIntegration(d, db)
 			r.NoError(err)

--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -61,12 +61,12 @@ var pipeSchema = map[string]*schema.Schema{
 		ForceNew:    true,
 		Description: "Specifies the Amazon Resource Name (ARN) for the SNS topic for your S3 bucket.",
 	},
-	"integration": &schema.Schema{
+	"integration": {
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "Specifies an integration for the pipe.",
 	},
-	"notification_channel": &schema.Schema{
+	"notification_channel": {
 		Type:        schema.TypeString,
 		Computed:    true,
 		Description: "Amazon Resource Name of the Amazon SQS queue for the stage named in the DEFINITION column.",
@@ -76,7 +76,7 @@ var pipeSchema = map[string]*schema.Schema{
 		Computed:    true,
 		Description: "Name of the role that owns the pipe.",
 	},
-	"error_integration": &schema.Schema{
+	"error_integration": {
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "Specifies the name of the notification integration used for error notifications.",

--- a/pkg/resources/pipe_internal_test.go
+++ b/pkg/resources/pipe_internal_test.go
@@ -159,10 +159,11 @@ func TestPipeCopyStatementDiffSuppress(t *testing.T) {
 		},
 	}
 
-	for name, testCase := range testCases {
+	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			r := require.New(t)
-			r.Equal(testCase.expected, pipeCopyStatementDiffSuppress("", testCase.declared, testCase.showPipes, nil))
+			r.Equal(tc.expected, pipeCopyStatementDiffSuppress("", tc.declared, tc.showPipes, nil))
 		})
 	}
 }

--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -38,7 +38,6 @@ func CreateResource(
 				case schema.TypeSet:
 					valList := expandStringList(val.(*schema.Set).List())
 					qb.SetStringList(field, valList)
-
 				}
 			}
 		}
@@ -108,7 +107,6 @@ func UpdateResource(
 					valList := expandStringList(val.(*schema.Set).List())
 					qb.SetStringList(field, valList)
 				}
-
 			}
 			if d.HasChange("tag") {
 				log.Println("[DEBUG] updating tags")

--- a/pkg/resources/role_grants.go
+++ b/pkg/resources/role_grants.go
@@ -186,7 +186,6 @@ func readGrants(db *sql.DB, roleName string) ([]*roleGrant, error) {
 			return nil, err
 		}
 		grants = append(grants, g)
-
 	}
 
 	for _, g := range grants {
@@ -252,7 +251,6 @@ func revokeRoleFromUser(db *sql.DB, role1, user string) error {
 		}
 	}
 	return err
-
 }
 
 func UpdateRoleGrants(d *schema.ResourceData, meta interface{}) error {

--- a/pkg/resources/role_grants_internal_test.go
+++ b/pkg/resources/role_grants_internal_test.go
@@ -50,9 +50,7 @@ func Test_revokeRoleFromRole(t *testing.T) {
 		mock.ExpectExec(`REVOKE ROLE "foo" FROM ROLE "bar"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := revokeRoleFromRole(db, "foo", "bar")
 		r.NoError(err)
-
 	})
-
 }
 func Test_revokeRoleFromUser(t *testing.T) {
 	r := require.New(t)
@@ -60,7 +58,5 @@ func Test_revokeRoleFromUser(t *testing.T) {
 		mock.ExpectExec(`REVOKE ROLE "foo" FROM USER "bar"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := revokeRoleFromUser(db, "foo", "bar")
 		r.NoError(err)
-
 	})
-
 }

--- a/pkg/resources/role_grants_test.go
+++ b/pkg/resources/role_grants_test.go
@@ -81,7 +81,6 @@ func TestRoleGrantsDelete(t *testing.T) {
 	})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-
 		mock.ExpectExec(`REVOKE ROLE "drop_it" FROM ROLE "role1"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`REVOKE ROLE "drop_it" FROM ROLE "role2"`).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`REVOKE ROLE "drop_it" FROM USER "user1"`).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/pkg/resources/role_ownership_grant_test.go
+++ b/pkg/resources/role_ownership_grant_test.go
@@ -76,7 +76,6 @@ func TestRoleOwnershipGrantDelete(t *testing.T) {
 	})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-
 		mock.ExpectExec(`GRANT OWNERSHIP ON ROLE "good_name" TO ROLE "ACCOUNTADMIN" COPY CURRENT GRANTS`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := resources.DeleteRoleOwnershipGrant(d, db)
 		r.NoError(err)

--- a/pkg/resources/schema_grant_acceptance_test.go
+++ b/pkg/resources/schema_grant_acceptance_test.go
@@ -49,7 +49,6 @@ func TestAcc_SchemaGrant(t *testing.T) {
 }
 
 func TestAcc_SchemaFutureGrants(t *testing.T) {
-
 	sName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	roleNameTable := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	roleNameView := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))

--- a/pkg/resources/schema_grant_test.go
+++ b/pkg/resources/schema_grant_test.go
@@ -24,6 +24,7 @@ func TestSchemaGrantCreate(t *testing.T) {
 	r := require.New(t)
 
 	for _, testPriv := range []string{"USAGE", "MODIFY", "CREATE TAG"} {
+		testPriv := testPriv
 		in := map[string]interface{}{
 			"schema_name":       "test-schema",
 			"database_name":     "test-db",

--- a/pkg/resources/stage_grant_acceptance_test.go
+++ b/pkg/resources/stage_grant_acceptance_test.go
@@ -28,7 +28,7 @@ func TestAcc_StageGrant_defaults(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_role.r", "name", name),
 					resource.TestCheckResourceAttr("snowflake_stage_grant.g", "database_name", name),
 					resource.TestCheckResourceAttr("snowflake_stage_grant.g", "schema_name", name),
-					testRolesAndShares(t, "snowflake_stage_grant.g", []string{name}, []string{}),
+					testRolesAndShares(t, "snowflake_stage_grant.g", []string{name}),
 				),
 			},
 			// IMPORT

--- a/pkg/resources/stage_grant_test.go
+++ b/pkg/resources/stage_grant_test.go
@@ -24,6 +24,7 @@ func TestStageGrantCreate(t *testing.T) {
 	r := require.New(t)
 
 	for _, testPriv := range []string{"USAGE", "READ"} {
+		testPriv := testPriv
 		in := map[string]interface{}{
 			"stage_name":        "test-stage",
 			"schema_name":       "test-schema",

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -291,7 +291,6 @@ type columnIdentity struct {
 func (identity *columnIdentity) toSnowflakeColumnIdentity() *snowflake.ColumnIdentity {
 	snowIdentity := snowflake.ColumnIdentity{}
 	return snowIdentity.WithStartNum(identity.startNum).WithStep(identity.stepNum)
-
 }
 
 type column struct {
@@ -399,7 +398,6 @@ func getColumnDefault(def map[string]interface{}) *columnDefault {
 
 func getColumnIdentity(identity map[string]interface{}) *columnIdentity {
 	if len(identity) > 0 {
-
 		startNum := identity["start_num"].(int)
 		stepNum := identity["step_num"].(int)
 		return &columnIdentity{startNum, stepNum}
@@ -462,7 +460,6 @@ func getPrimaryKey(from interface{}) (to primarykey) {
 func (pk primarykey) toSnowflakePrimaryKey() snowflake.PrimaryKey {
 	snowPk := snowflake.PrimaryKey{}
 	return *snowPk.WithName(pk.name).WithKeys(pk.keys)
-
 }
 
 // CreateTable implements schema.CreateFunc.
@@ -668,22 +665,18 @@ func UpdateTable(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 		for _, cA := range changed {
-
 			if cA.changedDataType {
 				q := builder.ChangeColumnType(cA.newColumn.name, cA.newColumn.dataType)
 				err := snowflake.Exec(db, q)
 				if err != nil {
 					return errors.Wrapf(err, "error changing property on %v", d.Id())
-
 				}
 			}
 			if cA.changedNullConstraint {
-
 				q := builder.ChangeNullConstraint(cA.newColumn.name, cA.newColumn.nullable)
 				err := snowflake.Exec(db, q)
 				if err != nil {
 					return errors.Wrapf(err, "error changing property on %v", d.Id())
-
 				}
 			}
 			if cA.dropedDefault {
@@ -691,7 +684,6 @@ func UpdateTable(d *schema.ResourceData, meta interface{}) error {
 				err := snowflake.Exec(db, q)
 				if err != nil {
 					return errors.Wrapf(err, "error changing property on %v", d.Id())
-
 				}
 			}
 			if cA.changedComment {
@@ -699,10 +691,8 @@ func UpdateTable(d *schema.ResourceData, meta interface{}) error {
 				err := snowflake.Exec(db, q)
 				if err != nil {
 					return errors.Wrapf(err, "error changing property on %v", d.Id())
-
 				}
 			}
-
 		}
 	}
 	if d.HasChange("primary_key") {

--- a/pkg/resources/table_grant_acceptance_test.go
+++ b/pkg/resources/table_grant_acceptance_test.go
@@ -27,7 +27,7 @@ func TestAccTableGrant_defaults(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table_grant.g", "schema_name", name),
 					resource.TestCheckResourceAttr("snowflake_table_grant.g", "table_name", name),
 					resource.TestCheckResourceAttr("snowflake_table_grant.g", "privilege", "SELECT"),
-					testRolesAndShares(t, "snowflake_table_grant.g", []string{name}, []string{}),
+					testRolesAndShares(t, "snowflake_table_grant.g", []string{name}),
 				),
 			},
 			// IMPORT

--- a/pkg/resources/tag_association.go
+++ b/pkg/resources/tag_association.go
@@ -94,7 +94,6 @@ func CreateTagAssociation(d *schema.ResourceData, meta interface{}) error {
 		log.Println("[DEBUG] validating tag creation")
 
 		err = resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate)-time.Minute, func() *resource.RetryError {
-
 			resp, err := snowflake.ListTagAssociations(builder, db)
 
 			if err != nil {
@@ -122,7 +121,6 @@ func CreateTagAssociation(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(dataIDInput)
 	return ReadTagAssociation(d, meta)
-
 }
 
 // ReadSchema implements schema.ReadFunc.

--- a/pkg/resources/tag_grant.go
+++ b/pkg/resources/tag_grant.go
@@ -193,7 +193,6 @@ func UpdateTagGrant(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return ReadTagGrant(d, meta)
-
 }
 
 // DeleteTagGrant implements schema.DeleteFunc.

--- a/pkg/resources/task.go
+++ b/pkg/resources/task.go
@@ -400,7 +400,6 @@ func ReadTask(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 		}
-
 	}
 
 	return nil
@@ -408,7 +407,6 @@ func ReadTask(d *schema.ResourceData, meta interface{}) error {
 
 // CreateTask implements schema.CreateFunc.
 func CreateTask(d *schema.ResourceData, meta interface{}) error {
-
 	var err error
 	db := meta.(*sql.DB)
 	database := d.Get("database").(string)
@@ -536,7 +534,6 @@ func UpdateTask(d *schema.ResourceData, meta interface{}) error {
 				return errors.Wrapf(err, "error updating user_task_managed_initial_warehouse_size on task %v", d.Id())
 			}
 		}
-
 	}
 
 	if d.HasChange("error_integration") {

--- a/pkg/resources/task_internal_test.go
+++ b/pkg/resources/task_internal_test.go
@@ -44,5 +44,4 @@ func TestTaskIDFromString(t *testing.T) {
 		database|schema|task`
 	_, err = taskIDFromString(id)
 	r.Equal(fmt.Errorf("1 line per task"), err)
-
 }

--- a/pkg/resources/user_ownership_grant_test.go
+++ b/pkg/resources/user_ownership_grant_test.go
@@ -92,7 +92,6 @@ func TestUserOwnershipGrantDelete(t *testing.T) {
 	})
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
-
 		mock.ExpectExec(`GRANT OWNERSHIP ON USER "user1" TO ROLE "ACCOUNTADMIN" COPY CURRENT GRANTS`).WillReturnResult(sqlmock.NewResult(1, 1))
 		err := resources.DeleteUserOwnershipGrant(d, db)
 		r.NoError(err)

--- a/pkg/resources/user_public_keys.go
+++ b/pkg/resources/user_public_keys.go
@@ -15,7 +15,7 @@ var userPublicKeyProperties = []string{
 	"rsa_public_key_2",
 }
 
-// sanitize input to supress diffs, etc.
+// sanitize input to suppress diffs, etc.
 func publicKeyStateFunc(v interface{}) string {
 	value := v.(string)
 	value = strings.TrimSuffix(value, "\n")

--- a/pkg/resources/view_grant_acceptance_test.go
+++ b/pkg/resources/view_grant_acceptance_test.go
@@ -32,7 +32,6 @@ func TestAcc_ViewGrantBasic(t *testing.T) {
 }
 
 func TestAcc_ViewGrantShares(t *testing.T) {
-
 	databaseName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	viewName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	roleName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))

--- a/pkg/resources/view_test.go
+++ b/pkg/resources/view_test.go
@@ -119,6 +119,7 @@ func TestDiffSuppressStatement(t *testing.T) {
 		{"view 2", args{"", testhelpers.MustFixture(t, "view_2a.sql"), testhelpers.MustFixture(t, "view_2b.sql"), nil}, true},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := resources.DiffSuppressStatement(tt.args.k, tt.args.old, tt.args.new, tt.args.d); got != tt.want {
 				t.Errorf("DiffSuppressStatement() = %v, want %v", got, tt.want)

--- a/pkg/snowflake/current_account_test.go
+++ b/pkg/snowflake/current_account_test.go
@@ -49,7 +49,8 @@ func TestCurrentAccountRead(t *testing.T) {
 		},
 	}
 
-	for name, testCase := range testCases {
+	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			r := require.New(t)
 			mockDB, mock, err := sqlmock.New()
@@ -57,16 +58,16 @@ func TestCurrentAccountRead(t *testing.T) {
 			defer mockDB.Close()
 			sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
 
-			rows := sqlmock.NewRows([]string{"account", "region"}).AddRow(testCase.account, testCase.region)
+			rows := sqlmock.NewRows([]string{"account", "region"}).AddRow(tc.account, tc.region)
 			mock.ExpectQuery(`SELECT CURRENT_ACCOUNT\(\) AS "account", CURRENT_REGION\(\) AS "region";`).WillReturnRows(rows)
 
 			acc, err := snowflake.ReadCurrentAccount(sqlxDB.DB)
 			r.NoError(err)
-			r.Equal(testCase.account, acc.Account)
-			r.Equal(testCase.region, acc.Region)
+			r.Equal(tc.account, acc.Account)
+			r.Equal(tc.region, acc.Region)
 			url, err := acc.AccountURL()
 			r.NoError(err)
-			r.Equal(testCase.url, url)
+			r.Equal(tc.url, url)
 		})
 	}
 }

--- a/pkg/snowflake/database.go
+++ b/pkg/snowflake/database.go
@@ -302,6 +302,7 @@ func ListDatabase(sdb *sqlx.DB, databaseName string) (*database, error) {
 	}
 	db := &database{}
 	for _, d := range dbs {
+		d := d
 		if d.DBName.String == databaseName {
 			db = &d
 			break

--- a/pkg/snowflake/escaping_test.go
+++ b/pkg/snowflake/escaping_test.go
@@ -57,10 +57,11 @@ func TestAddressEscape(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.id, func(t *testing.T) {
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.id, func(t *testing.T) {
 			r := require.New(t)
-			r.Equal(testCase.expected, snowflake.AddressEscape(testCase.name...))
+			r.Equal(tc.expected, snowflake.AddressEscape(tc.name...))
 		})
 	}
 }

--- a/pkg/snowflake/file_format.go
+++ b/pkg/snowflake/file_format.go
@@ -240,7 +240,7 @@ func (ffb *FileFormatBuilder) WithDisableSnowflakeData(n bool) *FileFormatBuilde
 	return ffb
 }
 
-// WithDisableAutoConvert adds disbale auto convert to the FileFormatBuilder.
+// WithDisableAutoConvert adds disable auto convert to the FileFormatBuilder.
 func (ffb *FileFormatBuilder) WithDisableAutoConvert(n bool) *FileFormatBuilder {
 	ffb.disableAutoConvert = n
 	return ffb

--- a/pkg/snowflake/grant_test.go
+++ b/pkg/snowflake/grant_test.go
@@ -242,7 +242,6 @@ func TestWarehouseGrant(t *testing.T) {
 
 	revoke = wg.Role("bob").Revoke("OWNERSHIP")
 	r.Equal([]string{`SET currentRole=CURRENT_ROLE()`, `GRANT OWNERSHIP ON WAREHOUSE "test_warehouse" TO ROLE IDENTIFIER($currentRole) COPY CURRENT GRANTS`}, revoke)
-
 }
 
 // lintignore:AT003

--- a/pkg/snowflake/parser_test.go
+++ b/pkg/snowflake/parser_test.go
@@ -55,6 +55,7 @@ from bar;`
 		{"full", args{full}, "SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES", false},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewViewSelectStatementExtractor(tt.args.input)
 			got, err := e.Extract()
@@ -119,6 +120,7 @@ from bar;`
 		{"full", args{full}, "SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES", false},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			e := NewViewSelectStatementExtractor(tt.args.input)
 			got, err := e.ExtractMaterializedView()
@@ -152,6 +154,7 @@ func TestViewSelectStatementExtractor_consumeToken(t *testing.T) {
 		{"basic - not found", fields{[]rune("fob"), 0}, args{"foo"}, 0},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			e := &ViewSelectStatementExtractor{
 				input: tt.fields.input,
@@ -181,6 +184,7 @@ func TestViewSelectStatementExtractor_consumeSpace(t *testing.T) {
 		{"middle", fields{[]rune("foo \t\n bar"), 3}, 7},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			fmt.Println(tt.name)
 			e := &ViewSelectStatementExtractor{
@@ -210,6 +214,7 @@ func TestViewSelectStatementExtractor_consumeComment(t *testing.T) {
 		{"escaped", fields{[]rune(`comment='fo\'o'`), 0}, 15},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			e := &ViewSelectStatementExtractor{
 				input: tt.fields.input,
@@ -239,6 +244,7 @@ func TestViewSelectStatementExtractor_consumeClusterBy(t *testing.T) {
 		{"double", fields{[]rune("(c1, c2)"), 0}, 8},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			e := &ViewSelectStatementExtractor{
 				input: tt.fields.input,

--- a/pkg/snowflake/pipe_test.go
+++ b/pkg/snowflake/pipe_test.go
@@ -27,7 +27,6 @@ func TestPipeCreate(t *testing.T) {
 
 	s.WithIntegration("myintegration")
 	r.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE INTEGRATION = 'myintegration' AWS_SNS_TOPIC = 'arn:aws:sns:us-east-1:1234567890123456:mytopic' COMMENT = 'Yeehaw' AS test copy statement `)
-
 }
 
 func TestPipeChangeComment(t *testing.T) {

--- a/pkg/snowflake/replication.go
+++ b/pkg/snowflake/replication.go
@@ -40,11 +40,11 @@ type replication struct {
 	AccountLocator   sql.NullString `db:"account_locator"`
 }
 
-func ScanReplication(rows *sqlx.Rows, AccName string) (*replication, error) {
+func ScanReplication(rows *sqlx.Rows, accName string) (*replication, error) {
 	for rows.Next() {
 		r := &replication{}
 		err := rows.StructScan(r)
-		if r.AccountName.String == AccName {
+		if r.AccountName.String == accName {
 			return r, err
 		}
 	}

--- a/pkg/snowflake/role_grant_test.go
+++ b/pkg/snowflake/role_grant_test.go
@@ -22,5 +22,4 @@ func TestRoleGrant(t *testing.T) {
 
 	r2 := rg.Role("role2").Revoke()
 	r.Equal(`REVOKE ROLE "role1" FROM ROLE "role2"`, r2)
-
 }

--- a/pkg/snowflake/stage.go
+++ b/pkg/snowflake/stage.go
@@ -275,7 +275,6 @@ func DescStage(db *sql.DB, query string) (*descStageResult, error) {
 	defer rows.Close()
 
 	for rows.Next() {
-
 		row := &descStageRow{}
 		if err := rows.StructScan(row); err != nil {
 			return r, err

--- a/pkg/snowflake/table.go
+++ b/pkg/snowflake/table.go
@@ -51,7 +51,6 @@ type ColumnIdentity struct {
 func (id *ColumnIdentity) WithStartNum(start int) *ColumnIdentity {
 	id.startNum = start
 	return id
-
 }
 
 func (id *ColumnIdentity) WithStep(step int) *ColumnIdentity {
@@ -153,7 +152,6 @@ func (c *Column) WithIdentity(id *ColumnIdentity) *Column {
 }
 
 func (c *Column) getColumnDefinition(withInlineConstraints bool, withComment bool) string {
-
 	if c == nil {
 		return ""
 	}
@@ -179,7 +177,6 @@ func (c *Column) getColumnDefinition(withInlineConstraints bool, withComment boo
 	}
 
 	return colDef.String()
-
 }
 
 func FlattenTablePrimaryKey(pkds []primaryKeyDescription) []interface{} {
@@ -212,14 +209,12 @@ func FlattenTablePrimaryKey(pkds []primaryKeyDescription) []interface{} {
 		}
 
 		keys = append(keys, pk.ColumnName.String)
-
 	}
 
 	flat["name"] = name
 	flat["keys"] = keys
 	flattened = append(flattened, flat)
 	return flattened
-
 }
 
 type Columns []Column
@@ -383,7 +378,6 @@ func (tb *TableBuilder) UnsetTag(tag TagValue) string {
 
 // Function to get clustering definition.
 func (tb *TableBuilder) GetClusterKeyString() string {
-
 	return JoinStringList(tb.clusterBy[:], ", ")
 }
 
@@ -403,9 +397,7 @@ func (tb *TableBuilder) GetTagValueString() string {
 }
 
 func JoinStringList(instrings []string, delimiter string) string {
-
 	return fmt.Sprint(strings.Join(instrings[:], delimiter))
-
 }
 
 func quoteStringList(instrings []string) []string {
@@ -413,10 +405,8 @@ func quoteStringList(instrings []string) []string {
 	for _, word := range instrings {
 		quoted := fmt.Sprintf(`"%s"`, word)
 		clean = append(clean, quoted)
-
 	}
 	return clean
-
 }
 
 func (tb *TableBuilder) getCreateStatementBody() string {
@@ -429,7 +419,6 @@ func (tb *TableBuilder) getCreateStatementBody() string {
 		q.WriteString(colDef)
 		if tb.primaryKey.name != "" {
 			q.WriteString(fmt.Sprintf(` ,CONSTRAINT "%v" PRIMARY KEY(%v)`, tb.primaryKey.name, JoinStringList(quoteStringList(tb.primaryKey.keys), ",")))
-
 		} else {
 			q.WriteString(fmt.Sprintf(` ,PRIMARY KEY(%v)`, JoinStringList(quoteStringList(tb.primaryKey.keys), ",")))
 		}
@@ -458,7 +447,6 @@ func ClusterStatementToList(clusterStatement string) []string {
 	}
 
 	return clean
-
 }
 
 // Table returns a pointer to a Builder that abstracts the DDL operations for a table.
@@ -505,7 +493,6 @@ func (tb *TableBuilder) Create() string {
 	if tb.clusterBy != nil {
 		//add optional clustering statement
 		q.WriteString(fmt.Sprintf(` CLUSTER BY LINEAR(%v)`, tb.GetClusterKeyString()))
-
 	}
 
 	q.WriteString(fmt.Sprintf(` DATA_RETENTION_TIME_IN_DAYS = %d`, tb.dataRetentionTimeInDays))
@@ -704,13 +691,11 @@ func (td *tableDescription) ColumnIdentity() *ColumnIdentity {
 		return nil
 	}
 	if strings.Contains(td.Default.String, "IDENTITY") {
-
 		split := strings.Split(td.Default.String, " ")
 		start, _ := strconv.Atoi(split[2])
 		step, _ := strconv.Atoi(split[4])
 
 		return &ColumnIdentity{start, step}
-
 	}
 	return nil
 }

--- a/pkg/snowflake/table_constraint.go
+++ b/pkg/snowflake/table_constraint.go
@@ -183,7 +183,6 @@ func (b *TableConstraintBuilder) Create() string {
 	}
 
 	return q.String()
-
 }
 
 // Rename returns the SQL query that will rename the table constraint.

--- a/pkg/snowflake/task.go
+++ b/pkg/snowflake/task.go
@@ -402,7 +402,6 @@ func ScanTaskParameters(rows *sqlx.Rows) ([]*taskParams, error) {
 			return nil, err
 		}
 		t = append(t, r)
-
 	}
 	return t, nil
 }

--- a/pkg/snowflake/validation.go
+++ b/pkg/snowflake/validation.go
@@ -37,7 +37,6 @@ func ValidateIdentifier(val interface{}, exclusions []string) (warns []string, e
 		}
 	}
 	return
-
 }
 
 func isIdentifierRune(r rune, excludedCharacters map[string]bool) bool {

--- a/pkg/snowflake/validation_test.go
+++ b/pkg/snowflake/validation_test.go
@@ -23,6 +23,7 @@ func TestValidateIdentifier(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.candidate, func(t *testing.T) {
 			_, errs := snowflake.ValidateIdentifier(tc.candidate, []string{})
 			actual := len(errs) == 0

--- a/pkg/testhelpers/helpers.go
+++ b/pkg/testhelpers/helpers.go
@@ -22,5 +22,4 @@ func WithMockDb(t *testing.T, f func(*sql.DB, sqlmock.Sqlmock)) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
-
 }


### PR DESCRIPTION
# Summary 

golangci lint does not work because of including unnecessary indent in the .golangci.yml.
Fixing the broken .golangci.yml and fixing invalid expressions in the existing go files are done in this PR.

Also, this PR fixes the invalid expression modified in https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/1274, so the previous one will be closed after creating this pull request.