### PR TITLE
fix: oauth integration

### DIFF
--- a/docs/resources/oauth_integration.md
+++ b/docs/resources/oauth_integration.md
@@ -8,8 +8,6 @@ description: |-
 
 # snowflake_oauth_integration (Resource)
 
-
-
 ## Example Usage
 
 ```terraform

--- a/docs/resources/oauth_integration.md
+++ b/docs/resources/oauth_integration.md
@@ -8,6 +8,8 @@ description: |-
 
 # snowflake_oauth_integration (Resource)
 
+
+
 ## Example Usage
 
 ```terraform
@@ -34,6 +36,7 @@ resource "snowflake_oauth_integration" "tableau_desktop" {
 - `blocked_roles_list` (Set of String) List of roles that a user cannot explicitly consent to using after authenticating. Do not include ACCOUNTADMIN, ORGADMIN or SECURITYADMIN as they are already implicitly enforced and will cause in-place updates.
 - `comment` (String) Specifies a comment for the OAuth integration.
 - `enabled` (Boolean) Specifies whether this OAuth integration is enabled or disabled.
+- `oauth_client_type` (String) Specifies the type of client being registered. Snowflake supports both confidential and public clients.
 - `oauth_issue_refresh_tokens` (Boolean) Specifies whether to allow the client to exchange a refresh token for an access token when the current access token has expired.
 - `oauth_redirect_uri` (String) Specifies the client URI. After a user is authenticated, the web browser is redirected to this URI.
 - `oauth_refresh_token_validity` (Number) Specifies how long refresh tokens should be valid (in seconds). OAUTH_ISSUE_REFRESH_TOKENS must be set to TRUE.

--- a/pkg/resources/oauth_integration_acceptance_test.go
+++ b/pkg/resources/oauth_integration_acceptance_test.go
@@ -42,6 +42,7 @@ func oauthIntegrationConfig(name string, integrationType string) string {
 	resource "snowflake_oauth_integration" "test" {
 		name                         = "%s"
 		oauth_client                 = "%s"
+		oauth_client_type            = "PUBLIC"
 		enabled                      = true
   		oauth_issue_refresh_tokens   = true
   		oauth_refresh_token_validity = 3600

--- a/pkg/resources/task.go
+++ b/pkg/resources/task.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	taskIDDelimiter           = '|'
+	taskIDDelimiter = '|'
 )
 
 var taskSchema = map[string]*schema.Schema{


### PR DESCRIPTION
Resolves #785 


When using https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/oauth_integration with a custom client we need two required arguments. [oauth_redirect_uri](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/oauth_integration#oauth_redirect_uri) and oauth_client type. Today only `oauth_redirect_uri` is supported.

This PR aims to solve that.

When I use
```
resource "snowflake_oauth_integration" "new_integration" {
  provider           = snowflake.SYSADMIN
  name               = "NEW_INTEGRATION"
  oauth_client       = "CUSTOM"
  enabled            = true
  oauth_redirect_uri = "MY_URL"
}
```
I get the following error.
```
│ Error: error creating security integration: 002029 (42601): SQL compilation error:
│ Missing option(s): OAUTH_CLIENT_TYPE
```
When using below Terraform code
```
resource "snowflake_oauth_integration" "new_integration" {
  provider           = snowflake.SYSADMIN
  name               = "NEW_INTEGRATION"
  oauth_client_type  = "CONFIDENTIAL"
  oauth_client       = "CUSTOM"
  enabled            = true
  oauth_redirect_uri = "MY_URL"
}
```
I get
```
│ An argument named "oauth_client_type" is not expected here.
```

## References
See https://docs.snowflake.com/en/sql-reference/sql/create-security-integration-oauth-snowflake.html#additional-required-parameters-custom-clients to prove this is needed.
