### PR TITLE
feat: weekly check of github action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,11 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-
+  - package-ecosystem: gomod
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
Signed-off-by: Kevin Neville <kevin@neville.se>

See warnings in https://github.com/Snowflake-Labs/terraform-provider-snowflake/actions/runs/3361622276. I believe this is due to the old version of the actions. This PR makes sure we get automated PRs for these actions.

This should be merged after my other PR, https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/1316, that first updates all the versions and addresses breaking changes to one of the actions.
