### PR TITLE
feat: add support for `notify_users` to `snowflake_resource_monitor` resource

### DIFF
--- a/docs/resources/resource_monitor.md
+++ b/docs/resources/resource_monitor.md
@@ -24,6 +24,8 @@ resource snowflake_resource_monitor monitor {
   notify_triggers            = [40]
   suspend_triggers           = [50]
   suspend_immediate_triggers = [90]
+
+  notify_users = ["USERONE", "USERTWO"]
 }
 ```
 
@@ -45,6 +47,7 @@ resource snowflake_resource_monitor monitor {
 - `suspend_immediate_triggers` (Set of Number) A list of percentage thresholds at which to immediately suspend all warehouses.
 - `suspend_triggers` (Set of Number) A list of percentage thresholds at which to suspend all warehouses.
 - `warehouses` (Set of String) A list of warehouses to apply the resource monitor to.
+- `notify_users` (Set of String) Specifies the list of users to receive email notifications on resource monitors. The user identifier is the value of the `name` column from the output of `snowflake_user`. Each user listed must have a verified email address.
 
 ### Read-Only
 

--- a/docs/resources/resource_monitor.md
+++ b/docs/resources/resource_monitor.md
@@ -42,12 +42,12 @@ resource snowflake_resource_monitor monitor {
 - `end_timestamp` (String) The date and time when the resource monitor suspends the assigned warehouses.
 - `frequency` (String) The frequency interval at which the credit usage resets to 0. If you set a frequency for a resource monitor, you must also set START_TIMESTAMP.
 - `notify_triggers` (Set of Number) A list of percentage thresholds at which to send an alert to subscribed users.
+- `notify_users` (Set of String) Specifies the list of users to receive email notifications on resource monitors.
 - `set_for_account` (Boolean) Specifies whether the resource monitor should be applied globally to your Snowflake account.
 - `start_timestamp` (String) The date and time when the resource monitor starts monitoring credit usage for the assigned warehouses.
 - `suspend_immediate_triggers` (Set of Number) A list of percentage thresholds at which to immediately suspend all warehouses.
 - `suspend_triggers` (Set of Number) A list of percentage thresholds at which to suspend all warehouses.
 - `warehouses` (Set of String) A list of warehouses to apply the resource monitor to.
-- `notify_users` (Set of String) Specifies the list of users to receive email notifications on resource monitors. The user identifier is the value of the `name` column from the output of `snowflake_user`. Each user listed must have a verified email address.
 
 ### Read-Only
 

--- a/examples/resources/snowflake_resource_monitor/resource.tf
+++ b/examples/resources/snowflake_resource_monitor/resource.tf
@@ -9,4 +9,6 @@ resource snowflake_resource_monitor monitor {
   notify_triggers            = [40]
   suspend_triggers           = [50]
   suspend_immediate_triggers = [90]
+
+  notify_users = ["USERONE", "USERTWO"]
 }

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -206,6 +206,13 @@ func ReadResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	if len(rm.NotifyUsers.String) > 0 {
+		err = d.Set("notify_users", strings.Split(rm.NotifyUsers.String, ", "))
+		if err != nil {
+			return err
+		}
+	}
+
 	// Snowflake returns credit_quota as a float, but only accepts input as an int
 	if rm.CreditQuota.Valid {
 		cqf, err := strconv.ParseFloat(rm.CreditQuota.String, 64)

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -21,6 +21,15 @@ var resourceMonitorSchema = map[string]*schema.Schema{
 		Description: "Identifier for the resource monitor; must be unique for your account.",
 		ForceNew:    true,
 	},
+	"notify_users": {
+		Type:        schema.TypeList,
+		Elem:        &schema.Schema{
+			Type: schema.TypeString,
+		},
+		Optional:    true,
+		ForceNew:    true,
+		Description: "Specifies the list of users to receive email notifications on resource monitors.",
+	},
 	"credit_quota": {
 		Type:        schema.TypeInt,
 		Optional:    true,

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -117,6 +117,9 @@ func CreateResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 
 	cb := snowflake.ResourceMonitor(name).Create()
 	// Set optionals
+	if v, ok := d.GetOk("notify_users"); ok {
+		cb.SetStringList("notify_users", expandStringList(v.([]interface{})))
+	}
 	if v, ok := d.GetOk("credit_quota"); ok {
 		cb.SetInt("credit_quota", v.(int))
 	}

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -22,7 +22,7 @@ var resourceMonitorSchema = map[string]*schema.Schema{
 		ForceNew:    true,
 	},
 	"notify_users": {
-		Type:        schema.TypeList,
+		Type:        schema.TypeSet,
 		Elem:        &schema.Schema{
 			Type: schema.TypeString,
 		},
@@ -118,7 +118,7 @@ func CreateResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 	cb := snowflake.ResourceMonitor(name).Create()
 	// Set optionals
 	if v, ok := d.GetOk("notify_users"); ok {
-		cb.SetStringList("notify_users", expandStringList(v.([]interface{})))
+		cb.SetStringList("notify_users", expandStringList(v.(*schema.Set).List()))
 	}
 	if v, ok := d.GetOk("credit_quota"); ok {
 		cb.SetInt("credit_quota", v.(int))

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -23,12 +23,12 @@ var resourceMonitorSchema = map[string]*schema.Schema{
 	},
 	"notify_users": {
 		Type:        schema.TypeSet,
-		Elem:        &schema.Schema{
-			Type: schema.TypeString,
-		},
 		Optional:    true,
 		ForceNew:    true,
 		Description: "Specifies the list of users to receive email notifications on resource monitors.",
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
 	},
 	"credit_quota": {
 		Type:        schema.TypeInt,

--- a/pkg/resources/resource_monitor_acceptance_test.go
+++ b/pkg/resources/resource_monitor_acceptance_test.go
@@ -89,7 +89,7 @@ func resourceMonitorNotifyUsersConfig(accName string, accNotifyUsers []string) (
 	}
 	config := fmt.Sprintf(`
 resource "snowflake_resource_monitor" "test" {
-  name            = "%v"
+	name            = "%v"
 	set_for_account = false
 	notify_users    = %v
 }

--- a/pkg/resources/resource_monitor_acceptance_test.go
+++ b/pkg/resources/resource_monitor_acceptance_test.go
@@ -1,11 +1,11 @@
 package resources_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
-	"encoding/json"
-	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -59,8 +59,8 @@ func TestAcc_ResourceMonitorNotifyUsers(t *testing.T) {
 		t.Error(err)
 	}
 	checks := []resource.TestCheckFunc{
-	  resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "name", name),
-	  resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "set_for_account", "false"),
+		resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "name", name),
+		resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "set_for_account", "false"),
 	}
 	for _, s := range users {
 		checks = append(checks, resource.TestCheckTypeSetElemAttr("snowflake_resource_monitor.test", "notify_users.*", s))
@@ -71,7 +71,7 @@ func TestAcc_ResourceMonitorNotifyUsers(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
-				Check: resource.ComposeTestCheckFunc(checks...),
+				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 			{
 				ResourceName:      "snowflake_resource_monitor.test",

--- a/pkg/resources/resource_monitor_acceptance_test.go
+++ b/pkg/resources/resource_monitor_acceptance_test.go
@@ -23,6 +23,7 @@ func TestAcc_ResourceMonitor(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "name", name),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "credit_quota", "100"),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "set_for_account", "false"),
+					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "notify_users", "USERONE, USERTWO"),
 				),
 			},
 			// IMPORT
@@ -41,6 +42,7 @@ resource "snowflake_resource_monitor" "test" {
 	name            = "%v"
 	credit_quota    = 100
 	set_for_account = false
+	notify_users    = ["USERONE", "USERTWO"]
 }
 `, accName)
 }

--- a/pkg/resources/resource_monitor_acceptance_test.go
+++ b/pkg/resources/resource_monitor_acceptance_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"encoding/json"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -43,4 +45,19 @@ resource "snowflake_resource_monitor" "test" {
 	set_for_account = false
 }
 `, accName)
+}
+
+func resourceMonitorNotifyUsersConfig(accName string, accNotifyUsers []string) (string, error) {
+	notifyUsers, err := json.Marshal(accNotifyUsers)
+	if err != nil {
+		return "", err
+	}
+	config := fmt.Sprintf(`
+resource "snowflake_resource_monitor" "test" {
+  name            = "%v"
+	set_for_account = false
+	notify_users    = %v
+}
+`, accName, string(notifyUsers))
+	return config, nil
 }

--- a/pkg/resources/resource_monitor_acceptance_test.go
+++ b/pkg/resources/resource_monitor_acceptance_test.go
@@ -23,7 +23,8 @@ func TestAcc_ResourceMonitor(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "name", name),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "credit_quota", "100"),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "set_for_account", "false"),
-					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "notify_users", "USERONE, USERTWO"),
+					resource.TestCheckTypeSetElemAttr("snowflake_resource_monitor.test", "notify_users.*", "USERONE"),
+					resource.TestCheckTypeSetElemAttr("snowflake_resource_monitor.test", "notify_users.*", "USERTWO"),
 				),
 			},
 			// IMPORT

--- a/pkg/resources/resource_monitor_acceptance_test.go
+++ b/pkg/resources/resource_monitor_acceptance_test.go
@@ -23,8 +23,6 @@ func TestAcc_ResourceMonitor(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "name", name),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "credit_quota", "100"),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "set_for_account", "false"),
-					resource.TestCheckTypeSetElemAttr("snowflake_resource_monitor.test", "notify_users.*", "USERONE"),
-					resource.TestCheckTypeSetElemAttr("snowflake_resource_monitor.test", "notify_users.*", "USERTWO"),
 				),
 			},
 			// IMPORT
@@ -43,7 +41,6 @@ resource "snowflake_resource_monitor" "test" {
 	name            = "%v"
 	credit_quota    = 100
 	set_for_account = false
-	notify_users    = ["USERONE", "USERTWO"]
 }
 `, accName)
 }

--- a/pkg/resources/resource_monitor_test.go
+++ b/pkg/resources/resource_monitor_test.go
@@ -52,10 +52,10 @@ func expectReadResourceMonitor(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
 		"name", "credit_quota", "used_credits", "remaining_credits", "level",
 		"frequency", "start_time", "end_time", "notify_at", "suspend_at",
-		"suspend_immediately_at", "created_on", "owner", "comment",
+		"suspend_immediately_at", "created_on", "owner", "comment", "notify_users",
 	}).AddRow(
 		"good_name", 100.00, 0.00, 100.00, "ACCOUNT", "MONTHLY", "2001-01-01 00:00:00.000 -0700",
-		"", "75%,88%", "99%", "105%", "2001-01-01 00:00:00.000 -0700", "ACCOUNTADMIN", "")
+		"", "75%,88%", "99%", "105%", "2001-01-01 00:00:00.000 -0700", "ACCOUNTADMIN", "", "USERONE, USERTWO")
 	mock.ExpectQuery(`^SHOW RESOURCE MONITORS LIKE 'good_name'$`).WillReturnRows(rows)
 }
 

--- a/pkg/resources/resource_monitor_test.go
+++ b/pkg/resources/resource_monitor_test.go
@@ -25,7 +25,7 @@ func TestResourceMonitorCreate(t *testing.T) {
 
 	in := map[string]interface{}{
 		"name":                       "good_name",
-		"notify_users":               []interface{}{"Snowflake User 1", "Snowflake User 2"},
+		"notify_users":               []interface{}{"USERONE", "USERTWO"},
 		"credit_quota":               100,
 		"notify_triggers":            []interface{}{75, 88},
 		"suspend_triggers":           []interface{}{99},
@@ -38,7 +38,7 @@ func TestResourceMonitorCreate(t *testing.T) {
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`^CREATE RESOURCE MONITOR "good_name" CREDIT_QUOTA=100 NOTIFY_USERS=\('Snowflake User 2', 'Snowflake User 1'\) TRIGGERS ON 99 PERCENT DO SUSPEND ON 105 PERCENT DO SUSPEND_IMMEDIATE ON 88 PERCENT DO NOTIFY ON 75 PERCENT DO NOTIFY$`,
+			`^CREATE RESOURCE MONITOR "good_name" CREDIT_QUOTA=100 NOTIFY_USERS=\('USERTWO', 'USERONE'\) TRIGGERS ON 99 PERCENT DO SUSPEND ON 105 PERCENT DO SUSPEND_IMMEDIATE ON 88 PERCENT DO NOTIFY ON 75 PERCENT DO NOTIFY$`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`^ALTER ACCOUNT SET RESOURCE_MONITOR = "good_name"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 

--- a/pkg/resources/resource_monitor_test.go
+++ b/pkg/resources/resource_monitor_test.go
@@ -25,6 +25,7 @@ func TestResourceMonitorCreate(t *testing.T) {
 
 	in := map[string]interface{}{
 		"name":                       "good_name",
+		"notify_users":               []interface{}{"Snowflake User 1", "Snowflake User 2"},
 		"credit_quota":               100,
 		"notify_triggers":            []interface{}{75, 88},
 		"suspend_triggers":           []interface{}{99},
@@ -37,7 +38,7 @@ func TestResourceMonitorCreate(t *testing.T) {
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`^CREATE RESOURCE MONITOR "good_name" CREDIT_QUOTA=100 TRIGGERS ON 99 PERCENT DO SUSPEND ON 105 PERCENT DO SUSPEND_IMMEDIATE ON 88 PERCENT DO NOTIFY ON 75 PERCENT DO NOTIFY$`,
+			`^CREATE RESOURCE MONITOR "good_name" CREDIT_QUOTA=100 NOTIFY_USERS=\('Snowflake User 1', 'Snowflake User 2'\) TRIGGERS ON 99 PERCENT DO SUSPEND ON 105 PERCENT DO SUSPEND_IMMEDIATE ON 88 PERCENT DO NOTIFY ON 75 PERCENT DO NOTIFY$`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`^ALTER ACCOUNT SET RESOURCE_MONITOR = "good_name"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 

--- a/pkg/resources/resource_monitor_test.go
+++ b/pkg/resources/resource_monitor_test.go
@@ -38,7 +38,7 @@ func TestResourceMonitorCreate(t *testing.T) {
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`^CREATE RESOURCE MONITOR "good_name" CREDIT_QUOTA=100 NOTIFY_USERS=\('Snowflake User 1', 'Snowflake User 2'\) TRIGGERS ON 99 PERCENT DO SUSPEND ON 105 PERCENT DO SUSPEND_IMMEDIATE ON 88 PERCENT DO NOTIFY ON 75 PERCENT DO NOTIFY$`,
+			`^CREATE RESOURCE MONITOR "good_name" CREDIT_QUOTA=100 NOTIFY_USERS=\('Snowflake User 2', 'Snowflake User 1'\) TRIGGERS ON 99 PERCENT DO SUSPEND ON 105 PERCENT DO SUSPEND_IMMEDIATE ON 88 PERCENT DO NOTIFY ON 75 PERCENT DO NOTIFY$`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec(`^ALTER ACCOUNT SET RESOURCE_MONITOR = "good_name"$`).WillReturnResult(sqlmock.NewResult(1, 1))
 

--- a/pkg/snowflake/resource_monitor.go
+++ b/pkg/snowflake/resource_monitor.go
@@ -62,12 +62,12 @@ const (
 func (rb *ResourceMonitorBuilder) Create() *ResourceMonitorCreateBuilder {
 	return &ResourceMonitorCreateBuilder{
 		CreateBuilder{
-			name:             rb.name,
-			entityType:       rb.entityType,
-			stringProperties: make(map[string]string),
-			boolProperties:   make(map[string]bool),
-			intProperties:    make(map[string]int),
-			floatProperties:  make(map[string]float64),
+			name:                 rb.name,
+			entityType:           rb.entityType,
+			stringProperties:     make(map[string]string),
+			boolProperties:       make(map[string]bool),
+			intProperties:        make(map[string]int),
+			floatProperties:      make(map[string]float64),
 			stringListProperties: make(map[string][]string),
 		},
 		make([]trigger, 0),

--- a/pkg/snowflake/resource_monitor.go
+++ b/pkg/snowflake/resource_monitor.go
@@ -144,6 +144,7 @@ type resourceMonitor struct {
 	CreatedOn            sql.NullString `db:"created_on"`
 	Owner                sql.NullString `db:"owner"`
 	Comment              sql.NullString `db:"comment"`
+	NotifyUsers          sql.NullString `db:"notify_users"`
 }
 
 func ScanResourceMonitor(row *sqlx.Row) (*resourceMonitor, error) {

--- a/pkg/snowflake/resource_monitor.go
+++ b/pkg/snowflake/resource_monitor.go
@@ -68,6 +68,7 @@ func (rb *ResourceMonitorBuilder) Create() *ResourceMonitorCreateBuilder {
 			boolProperties:   make(map[string]bool),
 			intProperties:    make(map[string]int),
 			floatProperties:  make(map[string]float64),
+			stringListProperties: make(map[string][]string),
 		},
 		make([]trigger, 0),
 	}
@@ -106,6 +107,10 @@ func (rcb *ResourceMonitorCreateBuilder) Statement() string {
 
 	for k, v := range rcb.floatProperties {
 		sb.WriteString(fmt.Sprintf(` %v=%.2f`, strings.ToUpper(k), v))
+	}
+
+	for k, v := range rcb.stringListProperties {
+		sb.WriteString(fmt.Sprintf(" %s=%s", strings.ToUpper(k), formatStringList(v)))
 	}
 
 	if len(rcb.triggers) > 0 {

--- a/pkg/snowflake/resource_monitor_test.go
+++ b/pkg/snowflake/resource_monitor_test.go
@@ -36,8 +36,9 @@ func TestResourceMonitor(t *testing.T) {
 	cb.SetString("frequency", "YEARLY")
 
 	cb.SetInt("credit_quota", 666)
+	cb.SetStringList("notify_users", []string{"Snowflake User 1", "Snowflake User 2"})
 	q = cb.Statement()
-	r.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666 TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
+	r.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666 NOTIFY_USERS=('Snowflake User 1', 'Snowflake User 2') TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
 }
 
 func TestResourceMonitorSetOnAccount(t *testing.T) {

--- a/pkg/snowflake/resource_monitor_test.go
+++ b/pkg/snowflake/resource_monitor_test.go
@@ -27,18 +27,18 @@ func TestResourceMonitor(t *testing.T) {
 	r.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET CREDIT_QUOTA=66`, q)
 
 	ab = rm.Alter()
-	ab.SetStringList("notify_users", []string{"Snowflake User 1", "Snowflake User 2"})
+	ab.SetStringList("notify_users", []string{"USERONE", "USERTWO"})
 	q = ab.Statement()
-	r.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET NOTIFY_USERS=('Snowflake User 1', 'Snowflake User 2')`, q)
+	r.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET NOTIFY_USERS=('USERONE', 'USERTWO')`, q)
 
 	cb := snowflake.ResourceMonitor("resource_monitor").Create()
 	cb.NotifyAt(80).NotifyAt(90).SuspendAt(95).SuspendImmediatelyAt(100)
 	cb.SetString("frequency", "YEARLY")
 
 	cb.SetInt("credit_quota", 666)
-	cb.SetStringList("notify_users", []string{"Snowflake User 1", "Snowflake User 2"})
+	cb.SetStringList("notify_users", []string{"USERONE", "USERTWO"})
 	q = cb.Statement()
-	r.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666 NOTIFY_USERS=('Snowflake User 1', 'Snowflake User 2') TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
+	r.Equal(`CREATE RESOURCE MONITOR "resource_monitor" FREQUENCY='YEARLY' CREDIT_QUOTA=666 NOTIFY_USERS=('USERONE', 'USERTWO') TRIGGERS ON 80 PERCENT DO NOTIFY ON 90 PERCENT DO NOTIFY ON 95 PERCENT DO SUSPEND ON 100 PERCENT DO SUSPEND_IMMEDIATE`, q)
 }
 
 func TestResourceMonitorSetOnAccount(t *testing.T) {

--- a/pkg/snowflake/resource_monitor_test.go
+++ b/pkg/snowflake/resource_monitor_test.go
@@ -26,6 +26,11 @@ func TestResourceMonitor(t *testing.T) {
 	q = ab.Statement()
 	r.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET CREDIT_QUOTA=66`, q)
 
+	ab = rm.Alter()
+	ab.SetStringList("notify_users", []string{"Snowflake User 1", "Snowflake User 2"})
+	q = ab.Statement()
+	r.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET NOTIFY_USERS=('Snowflake User 1', 'Snowflake User 2')`, q)
+
 	cb := snowflake.ResourceMonitor("resource_monitor").Create()
 	cb.NotifyAt(80).NotifyAt(90).SuspendAt(95).SuspendImmediatelyAt(100)
 	cb.SetString("frequency", "YEARLY")


### PR DESCRIPTION
This PR adds support for managing the `notify_users` attribute on resource monitors via the `snowflake_resource_monitor` Resource. It does not include any changes to the `snowflake_resource_monitors` Data Source.

## Test Plan
- [x] internal tests
- [x] unit tests
- [ ] acceptance tests

All new and existing tests pass, though one new test is a bit special and worth calling out explicitly.

The new test in `pkg/resources/resource_monitor_acceptance_test.go` is particularly tricky, as the users listed must have a verified email address. As far as I know, this verification process may only be completed manually via the Snowflake interface. To circumvent this, that test depends on a new `RESOURCE_MONITOR_NOTIFY_USERS_TEST` environment variable. If the variable is unset, or set to the empty string, the test will be skipped (similar to the `SKIP_*` variable for many other acceptance tests). However, if the variable is set, it is expected to be a comma-delimited list of users that already exist with verified email addresses. Open to suggestions on how this can be improved.

## References
- https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1068
- https://docs.snowflake.com/en/sql-reference/sql/create-resource-monitor.html#optional-parameters