### PR TITLE
feat(ci): add some linters and fix codes to pass lint

### DIFF
--- a/.github/workflows/go-fmt.yml
+++ b/.github/workflows/go-fmt.yml
@@ -20,3 +20,22 @@ jobs:
 
       - name: Check Go formatting
         run: if [ "$(gofmt -l . | wc -l)" -gt 0 ]; then exit 1; fi
+
+  golang-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: ./go.mod
+          cache: true
+
+      - run: go mod download
+
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+
+      - name: Run golangci-lint
+        run: golangci-lint run ./... -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,5 +15,5 @@ linters:
     # - unparam
     - exportloopref
     - godot
-    # - gocritic
+    - gocritic
     - misspell

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,3 +17,7 @@ linters:
     - godot
     - gocritic
     - misspell
+    # Errcheck is a program for checking for unchecked errors in go programs.
+    - errcheck
+    # gosimple: Linter for Go source code that specializes in simplifying a code
+    - gosimple

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,14 +10,27 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - gofmt
     - whitespace
-    # - unparam
+    # unparam: Checks Go code for unused constants, variables, functions and types
+    # - unparam  # todo: enabled
     - exportloopref
     - godot
     - gocritic
     - misspell
-    # Errcheck is a program for checking for unchecked errors in go programs.
+    # errcheck: Errcheck is a program for checking for unchecked errors in go programs.
     - errcheck
     # gosimple: Linter for Go source code that specializes in simplifying a code
     - gosimple
+    # govet: Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - govet
+    # ineffassign: Detects when assignments to existing variables are not used
+    - ineffassign
+    # staticcheck: Finds unused struct fields
+    - staticcheck
+    # typecheck: Like the front-end of a Go compiler, parses and type-checks Go code
+    - typecheck
+
+    # not default
+    # gofmt: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
+    - gofmt
+    - gofumpt  # todo

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,4 +33,5 @@ linters:
     # not default
     # gofmt: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
     - gofmt
-    - gofumpt  # todo
+    # gofumpt: Gofumpt checks whether code was gofumpt-ed.
+    - gofumpt

--- a/Makefile
+++ b/Makefile
@@ -102,3 +102,6 @@ check-mod:
 	git diff --exit-code -- go.mod go.sum
 .PHONY: check-mod
 
+.PHONY: fmt
+fmt: ## Run linter and apply formatting autofix
+	golangci-lint run ./... -v --fix

--- a/pkg/datasources/current_account.go
+++ b/pkg/datasources/current_account.go
@@ -41,7 +41,6 @@ func CurrentAccount() *schema.Resource {
 func ReadCurrentAccount(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	acc, err := snowflake.ReadCurrentAccount(db)
-
 	if err != nil {
 		log.Println("[DEBUG] current_account failed to decode")
 		d.SetId("")
@@ -58,7 +57,6 @@ func ReadCurrentAccount(d *schema.ResourceData, meta interface{}) error {
 		return regionErr
 	}
 	url, err := acc.AccountURL()
-
 	if err != nil {
 		log.Println("[DEBUG] generating snowflake url failed")
 		d.SetId("")

--- a/pkg/datasources/database_acceptance_test.go
+++ b/pkg/datasources/database_acceptance_test.go
@@ -13,7 +13,6 @@ func TestAcc_Database(t *testing.T) {
 	databaseName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	comment := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	resource.ParallelTest(t, resource.TestCase{
-
 		Providers:    providers(),
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{

--- a/pkg/datasources/databases_acceptance_test.go
+++ b/pkg/datasources/databases_acceptance_test.go
@@ -15,7 +15,6 @@ func TestAcc_Databases(t *testing.T) {
 	databaseName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	comment := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	resource.ParallelTest(t, resource.TestCase{
-
 		Providers:    providers(),
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{

--- a/pkg/datasources/warehouses_acceptance_test.go
+++ b/pkg/datasources/warehouses_acceptance_test.go
@@ -9,7 +9,7 @@ import (
 // "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-//func TestAcc_Warehouses(t *testing.T) {
+// func TestAcc_Warehouses(t *testing.T) {
 //	warehouseName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 //	resource.ParallelTest(t, resource.TestCase{
 //		Providers:    providers(),

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -392,7 +392,7 @@ func DSN(
 		config.Warehouse = warehouse
 	}
 
-	if privateKeyPath != "" {
+	if privateKeyPath != "" { //nolint:gocritic // todo: please fix this to pass gocritic
 		privateKeyBytes, err := ReadPrivateKeyFile(privateKeyPath)
 		if err != nil {
 			return "", errors.Wrap(err, "Private Key file could not be read")

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -502,7 +502,8 @@ func GetOauthAccessToken(
 	endPoint,
 	clientID,
 	clientSecret string,
-	data url.Values) (string, error) {
+	data url.Values,
+) (string, error) {
 	client := &http.Client{}
 	request, err := GetOauthRequest(strings.NewReader(data.Encode()), endPoint, clientID, clientSecret)
 	if err != nil {

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -41,14 +41,26 @@ func TestDSN(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"simple", args{"acct", "user", "pass", false, "region", "role", "", "https", 443, ""},
-			"user:pass@acct.region.snowflakecomputing.com:443?application=terraform-provider-snowflake&ocspFailOpen=true&region=region&role=role&validateDefaultParameters=true", false},
-		{"us-west-2 special case", args{"acct2", "user2", "pass2", false, "us-west-2", "role2", "", "https", 443, ""},
-			"user2:pass2@acct2.snowflakecomputing.com:443?application=terraform-provider-snowflake&ocspFailOpen=true&role=role2&validateDefaultParameters=true", false},
-		{"customhostwregion", args{"acct3", "user3", "pass3", false, "", "role3", "zha123.us-east-1.privatelink.snowflakecomputing.com", "https", 443, ""},
-			"user3:pass3@zha123.us-east-1.privatelink.snowflakecomputing.com:443?account=acct3&application=terraform-provider-snowflake&ocspFailOpen=true&role=role3&validateDefaultParameters=true", false},
-		{"customhostignoreregion", args{"acct4", "user4", "pass4", false, "fakeregion", "role4", "zha1234.us-east-1.privatelink.snowflakecomputing.com", "https", 8443, ""},
-			"user4:pass4@zha1234.us-east-1.privatelink.snowflakecomputing.com:8443?account=acct4&application=terraform-provider-snowflake&ocspFailOpen=true&role=role4&validateDefaultParameters=true", false},
+		{
+			"simple",
+			args{"acct", "user", "pass", false, "region", "role", "", "https", 443, ""},
+			"user:pass@acct.region.snowflakecomputing.com:443?application=terraform-provider-snowflake&ocspFailOpen=true&region=region&role=role&validateDefaultParameters=true", false,
+		},
+		{
+			"us-west-2 special case",
+			args{"acct2", "user2", "pass2", false, "us-west-2", "role2", "", "https", 443, ""},
+			"user2:pass2@acct2.snowflakecomputing.com:443?application=terraform-provider-snowflake&ocspFailOpen=true&role=role2&validateDefaultParameters=true", false,
+		},
+		{
+			"customhostwregion",
+			args{"acct3", "user3", "pass3", false, "", "role3", "zha123.us-east-1.privatelink.snowflakecomputing.com", "https", 443, ""},
+			"user3:pass3@zha123.us-east-1.privatelink.snowflakecomputing.com:443?account=acct3&application=terraform-provider-snowflake&ocspFailOpen=true&role=role3&validateDefaultParameters=true", false,
+		},
+		{
+			"customhostignoreregion",
+			args{"acct4", "user4", "pass4", false, "fakeregion", "role4", "zha1234.us-east-1.privatelink.snowflakecomputing.com", "https", 8443, ""},
+			"user4:pass4@zha1234.us-east-1.privatelink.snowflakecomputing.com:8443?account=acct4&application=terraform-provider-snowflake&ocspFailOpen=true&role=role4&validateDefaultParameters=true", false,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -83,12 +95,21 @@ func TestOAuthDSN(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"simple_oauth", args{"acct", "user", pseudorandomAccessToken, "region", "role", "", "https", 443},
-			"user:@acct.region.snowflakecomputing.com:443?application=terraform-provider-snowflake&authenticator=oauth&ocspFailOpen=true&region=region&role=role&token=ETMsjLOLvQ-C%2FbzGmmdvbEM%2FRSQFFX-a%2BsefbQeQoJqwdFNXZ%2BftBIdwlasApA%2B%2FMItZLNRRW-rYJiEZMvAAdzpGLxaghIoww%2BvDOuIeAFBDUxTAY-I%2BqGbQOXipkNcmzwuAaugjYtlTjPXGjqKw-OSsVacQXzsQyAMnbMyUrbdhRQEETIqTAdMuDqJBeaSj%2BLMsKDXzLd-guSlm-mmv%2B%3D&validateDefaultParameters=true", false},
-		{"oauth_over_password", args{"acct", "user", pseudorandomAccessToken, "region", "role", "", "https", 443},
-			"user:@acct.region.snowflakecomputing.com:443?application=terraform-provider-snowflake&authenticator=oauth&ocspFailOpen=true&region=region&role=role&token=ETMsjLOLvQ-C%2FbzGmmdvbEM%2FRSQFFX-a%2BsefbQeQoJqwdFNXZ%2BftBIdwlasApA%2B%2FMItZLNRRW-rYJiEZMvAAdzpGLxaghIoww%2BvDOuIeAFBDUxTAY-I%2BqGbQOXipkNcmzwuAaugjYtlTjPXGjqKw-OSsVacQXzsQyAMnbMyUrbdhRQEETIqTAdMuDqJBeaSj%2BLMsKDXzLd-guSlm-mmv%2B%3D&validateDefaultParameters=true", false},
-		{"empty_token_no_password_errors_out", args{"acct", "user", "", "region", "role", "", "https", 443},
-			"", true},
+		{
+			"simple_oauth",
+			args{"acct", "user", pseudorandomAccessToken, "region", "role", "", "https", 443},
+			"user:@acct.region.snowflakecomputing.com:443?application=terraform-provider-snowflake&authenticator=oauth&ocspFailOpen=true&region=region&role=role&token=ETMsjLOLvQ-C%2FbzGmmdvbEM%2FRSQFFX-a%2BsefbQeQoJqwdFNXZ%2BftBIdwlasApA%2B%2FMItZLNRRW-rYJiEZMvAAdzpGLxaghIoww%2BvDOuIeAFBDUxTAY-I%2BqGbQOXipkNcmzwuAaugjYtlTjPXGjqKw-OSsVacQXzsQyAMnbMyUrbdhRQEETIqTAdMuDqJBeaSj%2BLMsKDXzLd-guSlm-mmv%2B%3D&validateDefaultParameters=true", false,
+		},
+		{
+			"oauth_over_password",
+			args{"acct", "user", pseudorandomAccessToken, "region", "role", "", "https", 443},
+			"user:@acct.region.snowflakecomputing.com:443?application=terraform-provider-snowflake&authenticator=oauth&ocspFailOpen=true&region=region&role=role&token=ETMsjLOLvQ-C%2FbzGmmdvbEM%2FRSQFFX-a%2BsefbQeQoJqwdFNXZ%2BftBIdwlasApA%2B%2FMItZLNRRW-rYJiEZMvAAdzpGLxaghIoww%2BvDOuIeAFBDUxTAY-I%2BqGbQOXipkNcmzwuAaugjYtlTjPXGjqKw-OSsVacQXzsQyAMnbMyUrbdhRQEETIqTAdMuDqJBeaSj%2BLMsKDXzLd-guSlm-mmv%2B%3D&validateDefaultParameters=true", false,
+		},
+		{
+			"empty_token_no_password_errors_out",
+			args{"acct", "user", "", "region", "role", "", "https", 443},
+			"", true,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -119,12 +140,18 @@ func TestGetOauthDATA(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"simpleData", param{refreshToken, redirectURL},
+		{
+			"simpleData",
+			param{refreshToken, redirectURL},
 			"grant_type=refresh_token&redirect_uri=https%3A%2F%2Flocalhost.com&refresh_token=ETMsDgAAAXdeJNwXABRBRVMvQ0JDL1BLQ1M1UGFwPu1hHM3UoUexZBtXW%2B0cE7KJx2yoUV0ysWu3HKwhJ1v%2FiEa1Np5EdjGDsBqedR15aFb8NstLTWDUoTJPuQNZRJTjJeuxrX%2FJUM3%2FwzcrKt2zDf6QIpkfLXuSlDH4VABeqsaRdl5z6bE9VJVgAUKgZwizwedHAt6pcJgFcQffYZPaY%3D",
-			false},
-		{"errorData", param{"no_refresh_token", redirectURL},
+			false,
+		},
+		{
+			"errorData",
+			param{"no_refresh_token", redirectURL},
 			"grant_type=refresh_token&redirect_uri=https%3A%2F%2Flocalhost.com&refresh_token=no_refresh_token",
-			false},
+			false,
+		},
 	}
 	for _, tt := range cases {
 		tt := tt
@@ -159,9 +186,12 @@ func TestGetOauthResponse(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"simpleContent", param{dataStuff, endpoint, clientid, clientsecret},
+		{
+			"simpleContent",
+			param{dataStuff, endpoint, clientid, clientsecret},
 			"application/x-www-form-urlencoded;charset=UTF-8",
-			false},
+			false,
+		},
 	}
 	for _, tt := range cases {
 		tt := tt
@@ -211,12 +241,18 @@ func TestGetOauthAccessToken(t *testing.T) {
 		wantTok    string
 		wantErr    bool
 	}{
-		{"simpleAccessToken", param{dataStuff, endpoint, clientid, clientsecret},
+		{
+			"simpleAccessToken",
+			param{dataStuff, endpoint, clientid, clientsecret},
 			`{"access_token": "ABCDEFGHIabchefghiJKLMNOPQRjklmnopqrSTUVWXYZstuvwxyz","token_type": "Bearer","expires_in": 600}`,
-			"200", "ABCDEFGHIabchefghiJKLMNOPQRjklmnopqrSTUVWXYZstuvwxyz", false},
-		{"errorAccessToken", param{dataStuff, endpoint, clientid, clientsecret},
+			"200", "ABCDEFGHIabchefghiJKLMNOPQRjklmnopqrSTUVWXYZstuvwxyz", false,
+		},
+		{
+			"errorAccessToken",
+			param{dataStuff, endpoint, clientid, clientsecret},
 			"",
-			"404", "", false},
+			"404", "", false,
+		},
 	}
 	for _, tt := range cases {
 		tt := tt

--- a/pkg/resources/account_grant_test.go
+++ b/pkg/resources/account_grant_test.go
@@ -21,7 +21,7 @@ func TestAccountGrant(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccountGrantCreate(t *testing.T) { //lintignore:AT003
+func TestAccountGrantCreate(t *testing.T) { // lintignore:AT003
 	r := require.New(t)
 
 	in := map[string]interface{}{

--- a/pkg/resources/api_integration_test.go
+++ b/pkg/resources/api_integration_test.go
@@ -89,7 +89,8 @@ func TestAPIIntegrationDelete(t *testing.T) {
 
 func expectReadAPIIntegration(mock sqlmock.Sqlmock) {
 	showRows := sqlmock.NewRows([]string{
-		"name", "type", "category", "enabled", "created_on"},
+		"name", "type", "category", "enabled", "created_on",
+	},
 	).AddRow("test_api_integration", "EXTERNAL_API", "API", true, "now")
 	mock.ExpectQuery(`^SHOW API INTEGRATIONS LIKE 'test_api_integration'$`).WillReturnRows(showRows)
 
@@ -106,7 +107,8 @@ func expectReadAPIIntegration(mock sqlmock.Sqlmock) {
 
 func expectReadGovAPIIntegration(mock sqlmock.Sqlmock) {
 	showRows := sqlmock.NewRows([]string{
-		"name", "type", "category", "enabled", "created_on"},
+		"name", "type", "category", "enabled", "created_on",
+	},
 	).AddRow("test_gov_api_integration", "EXTERNAL_API", "API", true, "now")
 	mock.ExpectQuery(`^SHOW API INTEGRATIONS LIKE 'test_gov_api_integration'$`).WillReturnRows(showRows)
 

--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -260,8 +260,7 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 
 	if opts := database.Options.String; opts != "" {
 		for _, opt := range strings.Split(opts, ", ") {
-			switch opt {
-			case "TRANSIENT":
+			if opt == "TRANSIENT" {
 				err = d.Set("is_transient", true)
 				if err != nil {
 					return err

--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -227,7 +227,6 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 	row := snowflake.QueryRow(db, stmt)
 
 	database, err := snowflake.ScanDatabase(row)
-
 	if err != nil {
 		if err == sql.ErrNoRows {
 			// If not found, mark resource to be removed from statefile during apply or refresh

--- a/pkg/resources/external_function_test.go
+++ b/pkg/resources/external_function_test.go
@@ -114,6 +114,7 @@ func TestExternalFunctionRead(t *testing.T) {
 		r.Equal("CURRENT_TIMESTAMP", testFuncContextHeaders[0])
 	})
 }
+
 func TestExternalFunctionReadReturnTypeVariant(t *testing.T) {
 	r := require.New(t)
 

--- a/pkg/resources/external_oauth_integration.go
+++ b/pkg/resources/external_oauth_integration.go
@@ -28,7 +28,7 @@ var oauthExternalIntegrationSchema = map[string]*schema.Schema{
 		}, true),
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			normalize := func(s string) string {
-				return strings.ToUpper(strings.Replace(s, "-", "", -1))
+				return strings.ToUpper(strings.ReplaceAll(s, "-", ""))
 			}
 			return normalize(old) == normalize(new)
 		},
@@ -58,7 +58,7 @@ var oauthExternalIntegrationSchema = map[string]*schema.Schema{
 		}, true),
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			normalize := func(s string) string {
-				return strings.ToUpper(strings.Replace(s, "-", "", -1))
+				return strings.ToUpper(strings.ReplaceAll(s, "-", ""))
 			}
 			return normalize(old) == normalize(new)
 		},
@@ -108,7 +108,7 @@ var oauthExternalIntegrationSchema = map[string]*schema.Schema{
 		}, true),
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			normalize := func(s string) string {
-				return strings.ToUpper(strings.Replace(s, "-", "", -1))
+				return strings.ToUpper(strings.ReplaceAll(s, "-", ""))
 			}
 			return normalize(old) == normalize(new)
 		},

--- a/pkg/resources/external_oauth_integration_test.go
+++ b/pkg/resources/external_oauth_integration_test.go
@@ -70,7 +70,8 @@ func TestExternalOauthIntegrationDelete(t *testing.T) {
 
 func expectReadExternalOauthIntegration(mock sqlmock.Sqlmock) {
 	showRows := sqlmock.NewRows([]string{
-		"name", "type", "category", "enabled", "comment", "created_on"},
+		"name", "type", "category", "enabled", "comment", "created_on",
+	},
 	).AddRow("test_external_oauth_integration", "EXTERNAL_OAUTH - AZURE", "SECURITY", true, nil, "now")
 	mock.ExpectQuery(`^SHOW SECURITY INTEGRATIONS LIKE 'test_external_oauth_integration'$`).WillReturnRows(showRows)
 

--- a/pkg/resources/file_format_acceptance_test.go
+++ b/pkg/resources/file_format_acceptance_test.go
@@ -187,6 +187,7 @@ func TestAcc_FileFormatXML(t *testing.T) {
 		},
 	})
 }
+
 func fileFormatConfigCSV(n string) string {
 	return fmt.Sprintf(`
 resource "snowflake_database" "test" {

--- a/pkg/resources/file_format_test.go
+++ b/pkg/resources/file_format_test.go
@@ -66,7 +66,8 @@ func TestFileFormatCreateInvalidOptions(t *testing.T) {
 
 func expectReadFileFormat(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
-		"created_on", "name", "database_name", "schema_name", "type", "owner", "comment", "format_options"},
+		"created_on", "name", "database_name", "schema_name", "type", "owner", "comment", "format_options",
+	},
 	).AddRow("2019-12-23 17:20:50.088 +0000", "test_file_format", "test_db", "test_schema", "CSV", "test", "great comment", `{"TYPE":"CSV","RECORD_DELIMITER":"\n","FIELD_DELIMITER":",","FILE_EXTENSION":null,"SKIP_HEADER":0,"DATE_FORMAT":"AUTO","TIME_FORMAT":"AUTO","TIMESTAMP_FORMAT":"AUTO","BINARY_FORMAT":"HEX","ESCAPE":"NONE","ESCAPE_UNENCLOSED_FIELD":"\\","TRIM_SPACE":false,"FIELD_OPTIONALLY_ENCLOSED_BY":"NONE","NULL_IF":["\\N"],"COMPRESSION":"AUTO","ERROR_ON_COLUMN_COUNT_MISMATCH":false,"FIELD_DELIMETER":",","SKIP_BLANK_LINES":false,"REPLACE_INVALID_CHARACTERS":false,"EMPTY_FIELD_AS_NULL":false,"SKIP_BYTE_ORDER_MARK":false,"ENCODING":"UTF8"}`)
 	mock.ExpectQuery(`^SHOW FILE FORMATS LIKE 'test_file_format' IN SCHEMA "test_db"."test_schema"$`).WillReturnRows(rows)
 }

--- a/pkg/resources/function_acceptance_test.go
+++ b/pkg/resources/function_acceptance_test.go
@@ -57,12 +57,12 @@ func TestAcc_Function(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_function.test_funct_java", "arguments.0.type", "NUMBER"),
 
 					// TODO: temporarily remove unit tests to allow for urgent release
-					//resource.TestCheckResourceAttr("snowflake_function.test_funct_python", "name", functName),
-					//resource.TestCheckResourceAttr("snowflake_function.test_funct_python", "comment", "Terraform acceptance test for python"),
-					//resource.TestCheckResourceAttr("snowflake_function.test_funct_python", "statement", expBody5),
-					//resource.TestCheckResourceAttr("snowflake_function.test_funct_python", "arguments.#", "2"),
-					//resource.TestCheckResourceAttr("snowflake_function.test_funct_python", "arguments.0.name", "ARG1"),
-					//resource.TestCheckResourceAttr("snowflake_function.test_funct_python", "arguments.0.type", "NUMBER"),
+					// resource.TestCheckResourceAttr("snowflake_function.test_funct_python", "name", functName),
+					// resource.TestCheckResourceAttr("snowflake_function.test_funct_python", "comment", "Terraform acceptance test for python"),
+					// resource.TestCheckResourceAttr("snowflake_function.test_funct_python", "statement", expBody5),
+					// resource.TestCheckResourceAttr("snowflake_function.test_funct_python", "arguments.#", "2"),
+					// resource.TestCheckResourceAttr("snowflake_function.test_funct_python", "arguments.0.name", "ARG1"),
+					// resource.TestCheckResourceAttr("snowflake_function.test_funct_python", "arguments.0.type", "NUMBER"),
 				),
 			},
 		},

--- a/pkg/resources/function_test.go
+++ b/pkg/resources/function_test.go
@@ -31,7 +31,7 @@ func prepDummyFunctionResource(t *testing.T) *schema.ResourceData {
 		"packages":            []interface{}{"numpy", "pandas"},
 		"handler":             "add_py",
 		"return_type":         "varchar",
-		"statement":           functionBody, //var message = DATA + DATA;return message
+		"statement":           functionBody, // var message = DATA + DATA;return message
 	}
 	d := function(t, "my_db|my_schema|my_funct|VARCHAR-DATE", in)
 	return d

--- a/pkg/resources/integration_grant.go
+++ b/pkg/resources/integration_grant.go
@@ -10,6 +10,7 @@ var validIntegrationPrivileges = NewPrivilegeSet(
 	privilegeUsage,
 	privilegeOwnership,
 )
+
 var integrationGrantSchema = map[string]*schema.Schema{
 	"integration_name": {
 		Type:        schema.TypeString,

--- a/pkg/resources/managed_account.go
+++ b/pkg/resources/managed_account.go
@@ -115,7 +115,7 @@ func CreateManagedAccount(d *schema.ResourceData, meta interface{}) error {
 // wait until the locator is generated.
 func initialReadManagedAccount(d *schema.ResourceData, meta interface{}) error {
 	log.Println("[INFO] sleeping to give the locator a chance to be generated")
-	//lintignore:R018
+	// lintignore:R018
 	time.Sleep(10 * time.Second)
 	return ReadManagedAccount(d, meta)
 }

--- a/pkg/resources/materialized_view_test.go
+++ b/pkg/resources/materialized_view_test.go
@@ -49,6 +49,7 @@ func TestMaterializedViewCreate(t *testing.T) {
 		r.NoError(err)
 	})
 }
+
 func TestMaterializedViewCreateOrReplace(t *testing.T) {
 	r := require.New(t)
 
@@ -80,6 +81,7 @@ func TestMaterializedViewCreateOrReplace(t *testing.T) {
 		r.NoError(err)
 	})
 }
+
 func TestMaterializedViewCreateAmpersand(t *testing.T) {
 	r := require.New(t)
 
@@ -113,7 +115,8 @@ func TestMaterializedViewCreateAmpersand(t *testing.T) {
 
 func expectReadMaterializedView(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
-		"created_on", "name", "reserved", "database_name", "schema_name", "owner", "comment", "text", "is_secure", "is_materialized"},
+		"created_on", "name", "reserved", "database_name", "schema_name", "owner", "comment", "text", "is_secure", "is_materialized",
+	},
 	).AddRow("2019-05-19 16:55:36.530 -0700", "good_name", "", "test_db", "GREAT_SCHEMA", "admin", "great comment", "SELECT * FROM test_db.GREAT_SCHEMA.GREAT_TABLE WHERE account_id = 'bobs-account-id'", true, true)
 	mock.ExpectQuery(`^SHOW MATERIALIZED VIEWS LIKE 'good_name' IN DATABASE "test_db"$`).WillReturnRows(rows)
 }

--- a/pkg/resources/notification_integration_test.go
+++ b/pkg/resources/notification_integration_test.go
@@ -132,7 +132,8 @@ func TestNotificationIntegrationDelete(t *testing.T) {
 
 func expectReadNotificationIntegration(mock sqlmock.Sqlmock, notificationProvider string) {
 	showRows := sqlmock.NewRows([]string{
-		"name", "type", "category", "enabled", "created_on"},
+		"name", "type", "category", "enabled", "created_on",
+	},
 	).AddRow("test_notification_integration", "QUEUE", "NOTIFICATION", true, "now")
 	mock.ExpectQuery(`^SHOW NOTIFICATION INTEGRATIONS LIKE 'test_notification_integration'$`).WillReturnRows(showRows)
 

--- a/pkg/resources/oauth_integration_test.go
+++ b/pkg/resources/oauth_integration_test.go
@@ -66,7 +66,8 @@ func TestOAuthIntegrationDelete(t *testing.T) {
 
 func expectReadOAuthIntegration(mock sqlmock.Sqlmock) {
 	showRows := sqlmock.NewRows([]string{
-		"name", "type", "category", "enabled", "comment", "created_on"},
+		"name", "type", "category", "enabled", "comment", "created_on",
+	},
 	).AddRow("test_oauth_integration", "OAUTH - TABLEAU_DESKTOP", "SECURITY", true, nil, "now")
 	mock.ExpectQuery(`^SHOW SECURITY INTEGRATIONS LIKE 'test_oauth_integration'$`).WillReturnRows(showRows)
 

--- a/pkg/resources/pipe_test.go
+++ b/pkg/resources/pipe_test.go
@@ -68,7 +68,8 @@ func TestPipeRead(t *testing.T) {
 
 func expectReadPipe(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
-		"created_on", "name", "database_name", "schema_name", "definition", "owner", "notification_channel", "comment", "error_integration"},
+		"created_on", "name", "database_name", "schema_name", "definition", "owner", "notification_channel", "comment", "error_integration",
+	},
 	).AddRow("2019-12-23 17:20:50.088 +0000", "test_pipe", "test_db", "test_schema", "test definition", "N", "test", "great comment", "null")
 	mock.ExpectQuery(`^SHOW PIPES LIKE 'test_pipe' IN SCHEMA "test_db"."test_schema"$`).WillReturnRows(rows)
 }

--- a/pkg/resources/procedure_test.go
+++ b/pkg/resources/procedure_test.go
@@ -28,7 +28,7 @@ func prepDummyProcedureResource(t *testing.T) *schema.ResourceData {
 		"language":        "SCALA",
 		"comment":         "mock comment",
 		"return_behavior": "IMMUTABLE",
-		"statement":       procedureBody, //var message = DATA + DATA;return message
+		"statement":       procedureBody, // var message = DATA + DATA;return message
 	}
 	d := procedure(t, "my_db|my_schema|my_proc|VARCHAR-DATE", in)
 	return d

--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -46,7 +46,6 @@ func CreateResource(
 			qb.SetTags(tags.toSnowflakeTagValues())
 		}
 		err := snowflake.Exec(db, qb.Statement())
-
 		if err != nil {
 			return errors.Wrapf(err, "error creating %s", t)
 		}

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -247,9 +247,9 @@ func setDataFromNullStrings(data *schema.ResourceData, ns map[string]sql.NullStr
 	for k, v := range ns {
 		var err error
 		if v.Valid {
-			err = data.Set(k, v.String) //lintignore:R001
+			err = data.Set(k, v.String) // lintignore:R001
 		} else {
-			err = data.Set(k, "") //lintignore:R001
+			err = data.Set(k, "") // lintignore:R001
 		}
 		if err != nil {
 			return err

--- a/pkg/resources/role.go
+++ b/pkg/resources/role.go
@@ -9,23 +9,25 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var roleProperties = []string{"comment"}
-var roleSchema = map[string]*schema.Schema{
-	"name": {
-		Type:     schema.TypeString,
-		Required: true,
-		ValidateFunc: func(val interface{}, key string) ([]string, []error) {
-			additionalCharsToIgnoreValidation := []string{".", " ", ":", "(", ")"}
-			return snowflake.ValidateIdentifier(val, additionalCharsToIgnoreValidation)
+var (
+	roleProperties = []string{"comment"}
+	roleSchema     = map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ValidateFunc: func(val interface{}, key string) ([]string, []error) {
+				additionalCharsToIgnoreValidation := []string{".", " ", ":", "(", ")"}
+				return snowflake.ValidateIdentifier(val, additionalCharsToIgnoreValidation)
+			},
 		},
-	},
-	"comment": {
-		Type:     schema.TypeString,
-		Optional: true,
-		// TODO validation
-	},
-	"tag": tagReferenceSchema,
-}
+		"comment": {
+			Type:     schema.TypeString,
+			Optional: true,
+			// TODO validation
+		},
+		"tag": tagReferenceSchema,
+	}
+)
 
 func Role() *schema.Resource {
 	return &schema.Resource{

--- a/pkg/resources/role_grants_internal_test.go
+++ b/pkg/resources/role_grants_internal_test.go
@@ -52,6 +52,7 @@ func Test_revokeRoleFromRole(t *testing.T) {
 		r.NoError(err)
 	})
 }
+
 func Test_revokeRoleFromUser(t *testing.T) {
 	r := require.New(t)
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {

--- a/pkg/resources/row_access_policy.go
+++ b/pkg/resources/row_access_policy.go
@@ -41,7 +41,7 @@ var rowAccessPolicySchema = map[string]*schema.Schema{
 		Required:    true,
 		ForceNew:    true,
 		Description: "Specifies signature (arguments) for the row access policy (uppercase and sorted to avoid recreation of resource). A signature specifies a set of attributes that must be considered to determine whether the row is accessible. The attribute values come from the database object (e.g. table or view) to be protected by the row access policy.",
-		//Implement DiffSuppressFunc after https://github.com/hashicorp/terraform-plugin-sdk/issues/477 is solved
+		// Implement DiffSuppressFunc after https://github.com/hashicorp/terraform-plugin-sdk/issues/477 is solved
 	},
 	"row_access_expression": {
 		Type:        schema.TypeString,

--- a/pkg/resources/saml_integration.go
+++ b/pkg/resources/saml_integration.go
@@ -45,7 +45,7 @@ var samlIntegrationSchema = map[string]*schema.Schema{
 		}, true),
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			normalize := func(s string) string {
-				return strings.ToUpper(strings.Replace(s, "-", "", -1))
+				return strings.ToUpper(strings.ReplaceAll(s, "-", ""))
 			}
 			return normalize(old) == normalize(new)
 		},

--- a/pkg/resources/saml_integration_test.go
+++ b/pkg/resources/saml_integration_test.go
@@ -70,7 +70,8 @@ func TestSAMLIntegrationDelete(t *testing.T) {
 
 func expectReadSAMLIntegration(mock sqlmock.Sqlmock) {
 	showRows := sqlmock.NewRows([]string{
-		"name", "type", "category", "enabled", "created_on"},
+		"name", "type", "category", "enabled", "created_on",
+	},
 	).AddRow("test_saml_integration", "SAML2", "SECURITY", true, "now")
 	mock.ExpectQuery(`^SHOW SECURITY INTEGRATIONS LIKE 'test_saml_integration'$`).WillReturnRows(showRows)
 

--- a/pkg/resources/schema_test.go
+++ b/pkg/resources/schema_test.go
@@ -67,7 +67,8 @@ func TestSchemaRead(t *testing.T) {
 
 func expectReadSchema(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
-		"created_on", "name", "is_default", "is_current", "database_name", "owner", "comment", "options", "retention_time"},
+		"created_on", "name", "is_default", "is_current", "database_name", "owner", "comment", "options", "retention_time",
+	},
 	).AddRow("2019-05-19 16:55:36.530 -0700", "good_name", "N", "Y", "test_db", "admin", "great comment", "TRANSIENT, MANAGED ACCESS", 1)
 	mock.ExpectQuery(`^SHOW SCHEMAS LIKE 'good_name' IN DATABASE "test_db"$`).WillReturnRows(rows)
 }

--- a/pkg/resources/scim_integration.go
+++ b/pkg/resources/scim_integration.go
@@ -28,7 +28,7 @@ var scimIntegrationSchema = map[string]*schema.Schema{
 		}, true),
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			normalize := func(s string) string {
-				return strings.ToUpper(strings.Replace(s, "-", "", -1))
+				return strings.ToUpper(strings.ReplaceAll(s, "-", ""))
 			}
 			return normalize(old) == normalize(new)
 		},
@@ -42,7 +42,7 @@ var scimIntegrationSchema = map[string]*schema.Schema{
 		}, true),
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			normalize := func(s string) string {
-				return strings.ToUpper(strings.Replace(s, "-", "", -1))
+				return strings.ToUpper(strings.ReplaceAll(s, "-", ""))
 			}
 			return normalize(old) == normalize(new)
 		},

--- a/pkg/resources/scim_integration_test.go
+++ b/pkg/resources/scim_integration_test.go
@@ -68,7 +68,8 @@ func TestSCIMIntegrationDelete(t *testing.T) {
 
 func expectReadSCIMIntegration(mock sqlmock.Sqlmock) {
 	showRows := sqlmock.NewRows([]string{
-		"name", "type", "category", "created_on"},
+		"name", "type", "category", "created_on",
+	},
 	).AddRow("test_scim_integration", "SCIM - AZURE", "SECURITY", "now")
 	mock.ExpectQuery(`^SHOW SECURITY INTEGRATIONS LIKE 'test_scim_integration'$`).WillReturnRows(showRows)
 

--- a/pkg/resources/sequence.go
+++ b/pkg/resources/sequence.go
@@ -151,7 +151,6 @@ func ReadSequence(d *schema.ResourceData, meta interface{}) error {
 	row := snowflake.QueryRow(db, stmt)
 
 	sequence, err := snowflake.ScanSequence(row)
-
 	if err != nil {
 		if err == sql.ErrNoRows {
 			// If not found, mark resource to be removed from statefile during apply or refresh

--- a/pkg/resources/sequence_acceptance_test.go
+++ b/pkg/resources/sequence_acceptance_test.go
@@ -79,6 +79,7 @@ resource "snowflake_sequence" "test_sequence" {
 `
 	return fmt.Sprintf(s, name, name, sequenceName)
 }
+
 func sequenceConfig(name, sequenceName string) string {
 	s := `
 resource "snowflake_database" "test_database" {

--- a/pkg/resources/stage_test.go
+++ b/pkg/resources/stage_test.go
@@ -70,7 +70,8 @@ func TestExternalStageCreate(t *testing.T) {
 
 func expectReadStage(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
-		"parent_property", "property", "property_type", "property_value", "property_default"},
+		"parent_property", "property", "property_type", "property_value", "property_default",
+	},
 	).AddRow("STAGE_LOCATION", "URL", "string", `["s3://load/test/"]`, "").
 		AddRow("STAGE_CREDENTIALS", "AWS_EXTERNAL_ID", "string", "test", "").
 		AddRow("STAGE_FILE_FORMAT", "FORMAT_NAME", "string", "CSV", "").
@@ -80,7 +81,8 @@ func expectReadStage(mock sqlmock.Sqlmock) {
 
 func expectReadStageShow(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
-		"created_on", "name", "database_name", "schema_name", "url", "has_credentials", "has_encryption_key", "owner", "comment", "region", "type", "cloud", "notification_channel", "storage_integration"},
+		"created_on", "name", "database_name", "schema_name", "url", "has_credentials", "has_encryption_key", "owner", "comment", "region", "type", "cloud", "notification_channel", "storage_integration",
+	},
 	).AddRow("2019-12-23 17:20:50.088 +0000", "test_stage", "test_db", "test_schema", "s3://load/test/", "N", "Y", "test", "great comment", "us-east-1", "EXTERNAL", "AWS", "NULL", "NULL")
 	mock.ExpectQuery(`^SHOW STAGES LIKE 'test_stage' IN SCHEMA "test_db"."test_schema"$`).WillReturnRows(rows)
 }

--- a/pkg/resources/storage_integration_test.go
+++ b/pkg/resources/storage_integration_test.go
@@ -103,7 +103,8 @@ func TestStorageIntegrationUpdate(t *testing.T) {
 	d := storageIntegration(t, "test_storage_integration_acl", in)
 
 	showRows := sqlmock.NewRows([]string{
-		"name", "type", "category", "enabled", "created_on"},
+		"name", "type", "category", "enabled", "created_on",
+	},
 	).AddRow("test_storage_integration_acl", "EXTERNAL_STAGE", "STORAGE", true, "now")
 
 	descRows := sqlmock.NewRows([]string{
@@ -136,12 +137,14 @@ func TestStorageIntegrationDelete(t *testing.T) {
 
 func expectReadStorageIntegration(mock sqlmock.Sqlmock) {
 	showRows := sqlmock.NewRows([]string{
-		"name", "type", "category", "enabled", "created_on"},
+		"name", "type", "category", "enabled", "created_on",
+	},
 	).AddRow("test_storage_integration", "EXTERNAL_STAGE", "STORAGE", true, "now")
 	mock.ExpectQuery(`^SHOW STORAGE INTEGRATIONS LIKE 'test_storage_integration'$`).WillReturnRows(showRows)
 
 	descRows := sqlmock.NewRows([]string{
-		"property", "property_type", "property_value", "property_default"}).
+		"property", "property_type", "property_value", "property_default",
+	}).
 		AddRow("ENABLED", "Boolean", true, false).
 		AddRow("STORAGE_PROVIDER", "String", "S3", nil).
 		AddRow("STORAGE_ALLOWED_LOCATIONS", "List", "s3://bucket-a/path-a/,s3://bucket-b/", nil).
@@ -156,12 +159,14 @@ func expectReadStorageIntegration(mock sqlmock.Sqlmock) {
 
 func expectReadStorageIntegrationWithS3GOV(mock sqlmock.Sqlmock) {
 	showRows := sqlmock.NewRows([]string{
-		"name", "type", "category", "enabled", "created_on"},
+		"name", "type", "category", "enabled", "created_on",
+	},
 	).AddRow("test_storage_integration_with_s3gov", "EXTERNAL_STAGE", "STORAGE", true, "now")
 	mock.ExpectQuery(`^SHOW STORAGE INTEGRATIONS LIKE 'test_storage_integration_with_s3gov'$`).WillReturnRows(showRows)
 
 	descRows := sqlmock.NewRows([]string{
-		"property", "property_type", "property_value", "property_default"}).
+		"property", "property_type", "property_value", "property_default",
+	}).
 		AddRow("ENABLED", "Boolean", true, false).
 		AddRow("STORAGE_PROVIDER", "String", "S3GOV", nil).
 		AddRow("STORAGE_ALLOWED_LOCATIONS", "List", "s3://bucket-a/path-a/,s3://bucket-b/", nil).
@@ -176,7 +181,8 @@ func expectReadStorageIntegrationWithS3GOV(mock sqlmock.Sqlmock) {
 
 func expectReadStorageIntegrationEmpty(mock sqlmock.Sqlmock) {
 	noRows := sqlmock.NewRows([]string{
-		"name", "type", "category", "enabled", "created_on"},
+		"name", "type", "category", "enabled", "created_on",
+	},
 	)
 	mock.ExpectQuery(`^SHOW STORAGE INTEGRATIONS.*`).WillReturnRows(noRows)
 }

--- a/pkg/resources/stream.go
+++ b/pkg/resources/stream.go
@@ -164,7 +164,7 @@ func streamOnObjectIDFromString(stringID string) (*streamOnObjectID, error) {
 		return nil, fmt.Errorf("1 line at a time")
 	}
 	if len(lines[0]) != 3 {
-		//return nil, fmt.Errorf("on table format: database_name.schema_name.target_table_name")
+		// return nil, fmt.Errorf("on table format: database_name.schema_name.target_table_name")
 		return nil, fmt.Errorf("invalid format for on_table: %v , expected: <database_name.schema_name.target_table_name>", strings.Join(lines[0], "."))
 	}
 

--- a/pkg/resources/stream.go
+++ b/pkg/resources/stream.go
@@ -191,7 +191,7 @@ func CreateStream(d *schema.ResourceData, meta interface{}) error {
 	onTable, onTableSet := d.GetOk("on_table")
 	onView, onViewSet := d.GetOk("on_view")
 
-	if (onTableSet && onViewSet) || !(onTableSet || onViewSet) {
+	if (onTableSet && onViewSet) || !(onTableSet || onViewSet) { //nolint:gocritic // todo: please fix this to pass gocritic
 		return fmt.Errorf("exactly one of 'on_table' or 'on_view' expected")
 	} else if onTableSet {
 		id, err := streamOnObjectIDFromString(onTable.(string))

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -593,7 +593,7 @@ func ReadTable(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	for key, val := range toSet {
-		err = d.Set(key, val) //lintignore:R001
+		err = d.Set(key, val) // lintignore:R001
 		if err != nil {
 			return err
 		}

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -661,7 +661,7 @@ func UpdateTable(d *schema.ResourceData, meta interface{}) error {
 		for _, cA := range added {
 			var q string
 
-			if cA.identity == nil && cA._default == nil {
+			if cA.identity == nil && cA._default == nil { //nolint:gocritic  // todo: please fix this to pass gocritic
 				q = builder.AddColumn(cA.name, cA.dataType, cA.nullable, nil, nil, cA.comment, cA.maskingPolicy)
 			} else if cA.identity != nil {
 				q = builder.AddColumn(cA.name, cA.dataType, cA.nullable, nil, cA.identity.toSnowflakeColumnIdentity(), cA.comment, cA.maskingPolicy)

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -340,7 +340,7 @@ func (c columns) toSnowflakeColumns() []snowflake.Column {
 type changedColumns []changedColumn
 
 type changedColumn struct {
-	newColumn             column //our new column
+	newColumn             column // our new column
 	changedDataType       bool
 	changedNullConstraint bool
 	dropedDefault         bool
@@ -587,7 +587,7 @@ func ReadTable(d *schema.ResourceData, meta interface{}) error {
 		"comment":    table.Comment.String,
 		"column":     snowflake.NewColumns(tableDescription).Flatten(),
 		"cluster_by": snowflake.ClusterStatementToList(table.ClusterBy.String),
-		//"primary_key":         snowflake.FlattenTablePrimaryKey(pkDescription),
+		// "primary_key":         snowflake.FlattenTablePrimaryKey(pkDescription),
 		"data_retention_days": table.RetentionTime.Int32,
 		"change_tracking":     (table.ChangeTracking.String == "ON"),
 	}
@@ -723,7 +723,7 @@ func UpdateTable(d *schema.ResourceData, meta interface{}) error {
 		oldpk := getPrimaryKey(opk)
 
 		if len(oldpk.keys) > 0 || len(newpk.keys) == 0 {
-			//drop our pk if there was an old primary key, or pk has been removed
+			// drop our pk if there was an old primary key, or pk has been removed
 			q := builder.DropPrimaryKey()
 			err := snowflake.Exec(db, q)
 			if err != nil {

--- a/pkg/resources/table_constraint.go
+++ b/pkg/resources/table_constraint.go
@@ -288,7 +288,7 @@ func CreateTableConstraint(d *schema.ResourceData, meta interface{}) error {
 
 // ReadTableConstraint implements schema.ReadFunc.
 func ReadTableConstraint(d *schema.ResourceData, meta interface{}) error {
-	//commenting this out since it requires an active warehouse to be set which may not be intuitive.
+	// commenting this out since it requires an active warehouse to be set which may not be intuitive.
 	// also it takes a while for the database to reflect changes. Would likely need to add a validation
 	// step like in tag association. People don't like waiting 40 minutes for Terraform to run.
 

--- a/pkg/resources/tag_association.go
+++ b/pkg/resources/tag_association.go
@@ -125,7 +125,6 @@ func CreateTagAssociation(d *schema.ResourceData, meta interface{}) error {
 
 		err = resource.RetryContext(context.Background(), d.Timeout(schema.TimeoutCreate)-time.Minute, func() *resource.RetryError {
 			resp, err := snowflake.ListTagAssociations(builder, db)
-
 			if err != nil {
 				return resource.NonRetryableError(fmt.Errorf("error: %s", err))
 			}

--- a/pkg/resources/tag_association.go
+++ b/pkg/resources/tag_association.go
@@ -173,7 +173,7 @@ func ReadTagAssociation(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 	if err != nil {
-		//return err
+		// return err
 		return errors.Wrap(err, "error listing tag associations")
 	}
 

--- a/pkg/resources/tag_masking_policy_association.go
+++ b/pkg/resources/tag_masking_policy_association.go
@@ -128,7 +128,6 @@ func CreateTagMaskingPolicyAssociation(d *schema.ResourceData, meta interface{})
 	q := builder.AddMaskingPolicy()
 
 	err := snowflake.Exec(db, q)
-
 	if err != nil {
 		return errors.Wrapf(err, "error attaching masking policy %v to tag %v", mpName, tagName)
 	}

--- a/pkg/resources/tag_masking_policy_association_test.go
+++ b/pkg/resources/tag_masking_policy_association_test.go
@@ -2,9 +2,8 @@ package resources_test
 
 import (
 	"database/sql"
-	"testing"
-
 	"regexp"
+	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider"
@@ -88,7 +87,8 @@ func TestTagMaskingPolicyAssociationRead(t *testing.T) {
 
 func expectReadTestTagMaskingPolicyAssociation(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
-		"POLICY_DB", "POLICY_SCHEMA", "POLICY_NAME", "POLICY_KIND", "REF_DATABASE_NAME", "REF_SCHEMA_NAME", "REF_ENTITY_NAME", "REF_ENTITY_DOMAIN"},
+		"POLICY_DB", "POLICY_SCHEMA", "POLICY_NAME", "POLICY_KIND", "REF_DATABASE_NAME", "REF_SCHEMA_NAME", "REF_ENTITY_NAME", "REF_ENTITY_DOMAIN",
+	},
 	).AddRow("mp_db", "mp_schema", "mp_name", "MASKING", "tag_db", "tag_schema", "tag_name", "TAG")
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * from table ("tag_db".information_schema.policy_references(ref_entity_name => '"tag_db"."tag_schema"."tag_name"', ref_entity_domain => 'TAG')) where policy_db='mp_db' and policy_schema='mp_schema' and policy_name='mp_name'`)).WillReturnRows(rows)
 }

--- a/pkg/resources/tag_test.go
+++ b/pkg/resources/tag_test.go
@@ -116,7 +116,8 @@ func TestTagRead(t *testing.T) {
 
 func expectReadTag(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
-		"created_on", "name", "database_name", "schema_name", "owner", "comment", "allowed_values"},
+		"created_on", "name", "database_name", "schema_name", "owner", "comment", "allowed_values",
+	},
 	).AddRow("2019-05-19 16:55:36.530 -0700", "good_name", "test_db", "test_schema", "admin", "great comment", "'al1','al2'")
 	mock.ExpectQuery(`^SHOW TAGS LIKE 'good_name' IN SCHEMA "test_db"."test_schema"$`).WillReturnRows(rows)
 }

--- a/pkg/resources/task.go
+++ b/pkg/resources/task.go
@@ -342,7 +342,7 @@ func ReadTask(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		for key, value := range fieldParameters {
-			//lintignore:R001
+			// lintignore:R001
 			err = d.Set(key, value)
 			if err != nil {
 				return err
@@ -523,7 +523,7 @@ func UpdateTask(d *schema.ResourceData, meta interface{}) error {
 		warehouse := d.Get("warehouse")
 
 		if warehouse == "" && newSize != "" {
-			var q = builder.SwitchManagedWithInitialSize(newSize.(string))
+			q := builder.SwitchManagedWithInitialSize(newSize.(string))
 			err := snowflake.Exec(db, q)
 			if err != nil {
 				return errors.Wrapf(err, "error updating user_task_managed_initial_warehouse_size on task %v", d.Id())

--- a/pkg/resources/task_acceptance_test.go
+++ b/pkg/resources/task_acceptance_test.go
@@ -362,7 +362,6 @@ resource "snowflake_task" "solo_task" {
 	{{- end }}
 }
 	`)
-
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/pkg/resources/user.go
+++ b/pkg/resources/user.go
@@ -36,7 +36,8 @@ var userSchema = map[string]*schema.Schema{
 	"name": {
 		Type:        schema.TypeString,
 		Required:    true,
-		Description: "Name of the user. Note that if you do not supply login_name this will be used as login_name. [doc](https://docs.snowflake.net/manuals/sql-reference/sql/create-user.html#required-parameters)"},
+		Description: "Name of the user. Note that if you do not supply login_name this will be used as login_name. [doc](https://docs.snowflake.net/manuals/sql-reference/sql/create-user.html#required-parameters)",
+	},
 	"login_name": {
 		Type:        schema.TypeString,
 		Optional:    true,

--- a/pkg/resources/user_grant.go
+++ b/pkg/resources/user_grant.go
@@ -10,6 +10,7 @@ var validUserPrivileges = NewPrivilegeSet(
 	privilegeMonitor,
 	privilegeOwnership,
 )
+
 var userGrantSchema = map[string]*schema.Schema{
 	"user_name": {
 		Type:        schema.TypeString,

--- a/pkg/resources/user_public_keys.go
+++ b/pkg/resources/user_public_keys.go
@@ -168,6 +168,7 @@ func updateUserPublicKeys(db *sql.DB, name string, prop string, value string) er
 	stmt := fmt.Sprintf(`ALTER USER "%s" SET %s = '%s'`, name, prop, value)
 	return snowflake.Exec(db, stmt)
 }
+
 func unsetUserPublicKeys(db *sql.DB, name string, prop string) error {
 	stmt := fmt.Sprintf(`ALTER USER "%s" UNSET %s`, name, prop)
 	return snowflake.Exec(db, stmt)

--- a/pkg/resources/view_test.go
+++ b/pkg/resources/view_test.go
@@ -45,6 +45,7 @@ func TestViewCreate(t *testing.T) {
 		r.NoError(err)
 	})
 }
+
 func TestViewCreateOrReplace(t *testing.T) {
 	r := require.New(t)
 
@@ -70,6 +71,7 @@ func TestViewCreateOrReplace(t *testing.T) {
 		r.NoError(err)
 	})
 }
+
 func TestViewCreateAmpersand(t *testing.T) {
 	r := require.New(t)
 
@@ -97,7 +99,8 @@ func TestViewCreateAmpersand(t *testing.T) {
 
 func expectReadView(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
-		"created_on", "name", "reserved", "database_name", "schema_name", "owner", "comment", "text", "is_secure", "is_materialized"},
+		"created_on", "name", "reserved", "database_name", "schema_name", "owner", "comment", "text", "is_secure", "is_materialized",
+	},
 	).AddRow("2019-05-19 16:55:36.530 -0700", "good_name", "", "test_db", "test_schema", "admin", "great comment", "SELECT * FROM test_db.GREAT_SCHEMA.GREAT_TABLE WHERE account_id = 'bobs-account-id'", true, false)
 	mock.ExpectQuery(`^SHOW VIEWS LIKE 'good_name' IN SCHEMA "test_db"."test_schema"$`).WillReturnRows(rows)
 }

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -44,7 +44,7 @@ var warehouseSchema = map[string]*schema.Schema{
 		}, true),
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			normalize := func(s string) string {
-				return strings.ToUpper(strings.Replace(s, "-", "", -1))
+				return strings.ToUpper(strings.ReplaceAll(s, "-", ""))
 			}
 			return normalize(old) == normalize(new)
 		},

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -255,7 +255,7 @@ func ReadWarehouse(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		key := strings.ToLower(param.Key)
-		//lintignore:R001
+		// lintignore:R001
 		err = d.Set(key, value)
 		if err != nil {
 			return err

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -154,7 +154,7 @@ func Warehouse() *schema.Resource {
 
 // CreateWarehouse implements schema.CreateFunc.
 func CreateWarehouse(d *schema.ResourceData, meta interface{}) error {
-	props := append(warehouseProperties, warehouseCreateProperties...)
+	props := append(warehouseProperties, warehouseCreateProperties...) //nolint:gocritic // todo: please fix this to pass gocritic
 	return CreateResource(
 		"warehouse",
 		props,

--- a/pkg/resources/warehouse_grant.go
+++ b/pkg/resources/warehouse_grant.go
@@ -13,6 +13,7 @@ var validWarehousePrivileges = NewPrivilegeSet(
 	privilegeOwnership,
 	privilegeUsage,
 )
+
 var warehouseGrantSchema = map[string]*schema.Schema{
 	"warehouse_name": {
 		Type:        schema.TypeString,

--- a/pkg/snowflake/errors.go
+++ b/pkg/snowflake/errors.go
@@ -13,6 +13,6 @@ var (
 
 func IsResourceNotExistOrNotAuthorized(errorString string, resourceType string) bool {
 	regexStr := fmt.Sprintf("SQL compilation error:%s '.*' does not exist or not authorized.", resourceType)
-	var userNotExistOrNotAuthorizedRegEx, _ = regexp.Compile(regexStr)
+	userNotExistOrNotAuthorizedRegEx, _ := regexp.Compile(regexStr)
 	return userNotExistOrNotAuthorizedRegEx.MatchString(strings.ReplaceAll(errorString, "\n", ""))
 }

--- a/pkg/snowflake/escaping.go
+++ b/pkg/snowflake/escaping.go
@@ -9,21 +9,21 @@ import (
 // EscapeString will escape only the ' character. Would prefer a more robust OSS solution, but this should
 // prevent some dumb errors for now.
 func EscapeString(in string) string {
-	out := strings.Replace(in, `\`, `\\`, -1)
-	out = strings.Replace(out, `'`, `\'`, -1)
+	out := strings.ReplaceAll(in, `\`, `\\`)
+	out = strings.ReplaceAll(out, `'`, `\'`)
 	return out
 }
 
 // UnescapeString reverses EscapeString.
 func UnescapeString(in string) string {
-	out := strings.Replace(in, `\\`, `\`, -1)
-	out = strings.Replace(out, `\'`, `'`, -1)
+	out := strings.ReplaceAll(in, `\\`, `\`)
+	out = strings.ReplaceAll(out, `\'`, `'`)
 	return out
 }
 
 // EscapeSnowflakeString will escape single quotes with the SQL native double single quote.
 func EscapeSnowflakeString(in string) string {
-	out := strings.Replace(in, `'`, `''`, -1)
+	out := strings.ReplaceAll(in, `'`, `''`)
 	return fmt.Sprintf(`'%v'`, out)
 }
 
@@ -31,7 +31,7 @@ func EscapeSnowflakeString(in string) string {
 func UnescapeSnowflakeString(in string) string {
 	out := strings.TrimPrefix(in, `'`)
 	out = strings.TrimSuffix(out, `'`)
-	out = strings.Replace(out, `''`, `'`, -1)
+	out = strings.ReplaceAll(out, `''`, `'`)
 	return out
 }
 

--- a/pkg/snowflake/escaping.go
+++ b/pkg/snowflake/escaping.go
@@ -42,7 +42,7 @@ func AddressEscape(in ...string) string {
 
 	for i, n := range in {
 		if quoteCheck.MatchString(n) {
-			address[i] = fmt.Sprintf(`"%s"`, strings.Replace(n, `"`, `\"`, -1))
+			address[i] = fmt.Sprintf(`"%s"`, strings.ReplaceAll(n, `"`, `\"`))
 		} else {
 			address[i] = n
 		}

--- a/pkg/snowflake/external_table.go
+++ b/pkg/snowflake/external_table.go
@@ -60,34 +60,42 @@ func (tb *ExternalTableBuilder) WithColumns(c []map[string]string) *ExternalTabl
 	tb.columns = c
 	return tb
 }
+
 func (tb *ExternalTableBuilder) WithPartitionBys(c []string) *ExternalTableBuilder {
 	tb.partitionBys = c
 	return tb
 }
+
 func (tb *ExternalTableBuilder) WithLocation(c string) *ExternalTableBuilder {
 	tb.location = c
 	return tb
 }
+
 func (tb *ExternalTableBuilder) WithRefreshOnCreate(c bool) *ExternalTableBuilder {
 	tb.refreshOnCreate = c
 	return tb
 }
+
 func (tb *ExternalTableBuilder) WithAutoRefresh(c bool) *ExternalTableBuilder {
 	tb.autoRefresh = c
 	return tb
 }
+
 func (tb *ExternalTableBuilder) WithPattern(c string) *ExternalTableBuilder {
 	tb.pattern = c
 	return tb
 }
+
 func (tb *ExternalTableBuilder) WithFileFormat(c string) *ExternalTableBuilder {
 	tb.fileFormat = c
 	return tb
 }
+
 func (tb *ExternalTableBuilder) WithCopyGrants(c bool) *ExternalTableBuilder {
 	tb.copyGrants = c
 	return tb
 }
+
 func (tb *ExternalTableBuilder) WithAwsSNSTopic(c string) *ExternalTableBuilder {
 	tb.awsSNSTopic = c
 	return tb

--- a/pkg/snowflake/file_format.go
+++ b/pkg/snowflake/file_format.go
@@ -344,14 +344,15 @@ func (ffb *FileFormatBuilder) Create() string {
 	}
 
 	// set boolean values
-	if ffb.formatType == "CSV" {
+	switch ffb.formatType {
+	case "CSV":
 		q.WriteString(fmt.Sprintf(` SKIP_BLANK_LINES = %v`, ffb.skipBlankLines))
 		q.WriteString(fmt.Sprintf(` TRIM_SPACE = %v`, ffb.trimSpace))
 		q.WriteString(fmt.Sprintf(` ERROR_ON_COLUMN_COUNT_MISMATCH = %v`, ffb.errorOnColumnCountMismatch))
 		q.WriteString(fmt.Sprintf(` REPLACE_INVALID_CHARACTERS = %v`, ffb.replaceInvalidCharacters))
 		q.WriteString(fmt.Sprintf(` EMPTY_FIELD_AS_NULL = %v`, ffb.emptyFieldAsNull))
 		q.WriteString(fmt.Sprintf(` SKIP_BYTE_ORDER_MARK = %v`, ffb.skipByteOrderMark))
-	} else if ffb.formatType == "JSON" {
+	case "JSON":
 		q.WriteString(fmt.Sprintf(` TRIM_SPACE = %v`, ffb.trimSpace))
 		q.WriteString(fmt.Sprintf(` ENABLE_OCTAL = %v`, ffb.enableOctal))
 		q.WriteString(fmt.Sprintf(` ALLOW_DUPLICATE = %v`, ffb.allowDuplicate))
@@ -360,12 +361,12 @@ func (ffb *FileFormatBuilder) Create() string {
 		q.WriteString(fmt.Sprintf(` REPLACE_INVALID_CHARACTERS = %v`, ffb.replaceInvalidCharacters))
 		q.WriteString(fmt.Sprintf(` IGNORE_UTF8_ERRORS = %v`, ffb.ignoreUTF8Errors))
 		q.WriteString(fmt.Sprintf(` SKIP_BYTE_ORDER_MARK = %v`, ffb.skipByteOrderMark))
-	} else if ffb.formatType == "AVRO" || ffb.formatType == "ORC" {
+	case "AVRO", "ORC":
 		q.WriteString(fmt.Sprintf(` TRIM_SPACE = %v`, ffb.trimSpace))
-	} else if ffb.formatType == "PARQUET" {
+	case "PARQUET":
 		q.WriteString(fmt.Sprintf(` BINARY_AS_TEXT = %v`, ffb.binaryAsText))
 		q.WriteString(fmt.Sprintf(` TRIM_SPACE = %v`, ffb.trimSpace))
-	} else if ffb.formatType == "XML" {
+	case "XML":
 		q.WriteString(fmt.Sprintf(` IGNORE_UTF8_ERRORS = %v`, ffb.ignoreUTF8Errors))
 		q.WriteString(fmt.Sprintf(` PRESERVE_SPACE = %v`, ffb.preserveSpace))
 		q.WriteString(fmt.Sprintf(` STRIP_OUTER_ELEMENT = %v`, ffb.stripOuterElement))

--- a/pkg/snowflake/function_test.go
+++ b/pkg/snowflake/function_test.go
@@ -39,7 +39,7 @@ func getJavaFuction(withArgs bool) *FunctionBuilder {
 const pythonfunc = `def add_py(i):` + "\n " +
 	` return i+1`
 
-func getPythonFuction(withArgs bool) *FunctionBuilder {
+func getPythonFunction(withArgs bool) *FunctionBuilder {
 	s := Function("test_db", "test_schema", "test_func", []string{})
 	s.WithReturnType("int")
 	s.WithStatement(pythonfunc)
@@ -140,7 +140,7 @@ func TestFunctionCreateWithJavaFunctionWithTargetPath(t *testing.T) {
 
 func TestFunctionCreateWithPythonFunction(t *testing.T) {
 	r := require.New(t)
-	s := getPythonFuction(true)
+	s := getPythonFunction(true)
 	s.WithComment("this is cool func!")
 	s.WithLanguage("PYTHON")
 	s.WithRuntimeVersion("3.8")
@@ -155,7 +155,7 @@ func TestFunctionCreateWithPythonFunction(t *testing.T) {
 
 func TestFunctionCreateWithPythonFunctionWithPackages(t *testing.T) {
 	r := require.New(t)
-	s := getPythonFuction(true)
+	s := getPythonFunction(true)
 
 	pkgs := []string{"numpy", "pandas"}
 
@@ -176,7 +176,7 @@ func TestFunctionCreateWithPythonFunctionWithPackages(t *testing.T) {
 
 func TestFunctionCreateWithPythonFunctionWithImports(t *testing.T) {
 	r := require.New(t)
-	s := getPythonFuction(true)
+	s := getPythonFunction(true)
 	s.WithComment("this is cool func!")
 	s.WithLanguage("PYTHON")
 	s.WithRuntimeVersion("3.8")
@@ -194,7 +194,7 @@ func TestFunctionCreateWithPythonFunctionWithImports(t *testing.T) {
 
 func TestFunctionCreateWithPythonFunctionWithTargetPath(t *testing.T) {
 	r := require.New(t)
-	s := getPythonFuction(true)
+	s := getPythonFunction(true)
 	s.WithComment("this is cool func!")
 	s.WithLanguage("PYTHON")
 	s.WithRuntimeVersion("3.8")

--- a/pkg/snowflake/function_test.go
+++ b/pkg/snowflake/function_test.go
@@ -13,7 +13,8 @@ func getJavaScriptFuction(withArgs bool) *FunctionBuilder {
 	if withArgs {
 		s.WithArgs([]map[string]string{
 			{"name": "user", "type": "varchar"},
-			{"name": "eventdt", "type": "date"}})
+			{"name": "eventdt", "type": "date"},
+		})
 	}
 	return s
 }
@@ -31,7 +32,8 @@ func getJavaFuction(withArgs bool) *FunctionBuilder {
 	if withArgs {
 		s.WithArgs([]map[string]string{
 			{"name": "user", "type": "varchar"},
-			{"name": "count", "type": "number"}})
+			{"name": "count", "type": "number"},
+		})
 	}
 	return s
 }
@@ -45,7 +47,8 @@ func getPythonFunction(withArgs bool) *FunctionBuilder {
 	s.WithStatement(pythonfunc)
 	if withArgs {
 		s.WithArgs([]map[string]string{
-			{"name": "arg", "type": "int"}})
+			{"name": "arg", "type": "int"},
+		})
 	}
 	return s
 }

--- a/pkg/snowflake/future_grant.go
+++ b/pkg/snowflake/future_grant.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 )
 
-type futureGrantType string
-type futureGrantTarget string
+type (
+	futureGrantType   string
+	futureGrantTarget string
+)
 
 const (
 	futureSchemaType           futureGrantType = "SCHEMA"

--- a/pkg/snowflake/grant.go
+++ b/pkg/snowflake/grant.go
@@ -352,7 +352,7 @@ func (gb *CurrentGrantBuilder) Share(n string) GrantExecutable {
 // Grant returns the SQL that will grant privileges on the grant to the grantee.
 func (ge *CurrentGrantExecutable) Grant(p string, w bool) string {
 	var template string
-	if p == `OWNERSHIP` {
+	if p == `OWNERSHIP` { //nolint:gocritic // todo: please fix this
 		template = `GRANT %v ON %v %v TO %v "%v" COPY CURRENT GRANTS`
 	} else if w {
 		template = `GRANT %v ON %v %v TO %v "%v" WITH GRANT OPTION`

--- a/pkg/snowflake/network_policy.go
+++ b/pkg/snowflake/network_policy.go
@@ -52,10 +52,10 @@ func NetworkPolicy(name string) *NetworkPolicyBuilder {
 func (npb *NetworkPolicyBuilder) Create() string {
 	createSQL := fmt.Sprintf(`CREATE NETWORK POLICY "%v" ALLOWED_IP_LIST=%v`, npb.name, npb.allowedIPList)
 	if npb.blockedIPList != "" {
-		createSQL = createSQL + fmt.Sprintf(" BLOCKED_IP_LIST=%v", npb.blockedIPList)
+		createSQL += fmt.Sprintf(" BLOCKED_IP_LIST=%v", npb.blockedIPList)
 	}
 	if npb.comment != "" {
-		createSQL = createSQL + fmt.Sprintf(` COMMENT="%v"`, npb.comment)
+		createSQL += fmt.Sprintf(` COMMENT="%v"`, npb.comment)
 	}
 
 	return createSQL

--- a/pkg/snowflake/parser.go
+++ b/pkg/snowflake/parser.go
@@ -156,7 +156,7 @@ func (e *ViewSelectStatementExtractor) consumeComment() {
 			break
 		}
 
-		if escaped {
+		if escaped { //nolint:gocritic // todo: please fix this to pass gocritic
 			escaped = false
 		} else if e.input[e.pos+found] == '\\' {
 			escaped = true

--- a/pkg/snowflake/procedure_test.go
+++ b/pkg/snowflake/procedure_test.go
@@ -14,7 +14,8 @@ func getProcedure(withArgs bool) *ProcedureBuilder {
 	if withArgs {
 		s.WithArgs([]map[string]string{
 			{"name": "user", "type": "varchar"},
-			{"name": "eventdt", "type": "date"}})
+			{"name": "eventdt", "type": "date"},
+		})
 	}
 	return s
 }

--- a/pkg/snowflake/table.go
+++ b/pkg/snowflake/table.go
@@ -200,7 +200,7 @@ func FlattenTablePrimaryKey(pkds []primaryKeyDescription) []interface{} {
 		num2, _ := strconv.Atoi(pkds[j].KeySequence.String)
 		return num1 < num2
 	})
-	//sort our keys on the key sequence
+	// sort our keys on the key sequence
 
 	flat := map[string]interface{}{}
 	var keys []string
@@ -208,7 +208,7 @@ func FlattenTablePrimaryKey(pkds []primaryKeyDescription) []interface{} {
 	var nameSet bool
 
 	for _, pk := range pkds {
-		//set as empty string, sys_constraint means it was an unnnamed constraint
+		// set as empty string, sys_constraint means it was an unnnamed constraint
 		if strings.Contains(pk.ConstraintName.String, "SYS_CONSTRAINT") && !nameSet {
 			name = ""
 			nameSet = true
@@ -390,7 +390,7 @@ func (tb *TableBuilder) UnsetTag(tag TagValue) string {
 
 // Function to get clustering definition.
 func (tb *TableBuilder) GetClusterKeyString() string {
-	return JoinStringList(tb.clusterBy[:], ", ")
+	return JoinStringList(tb.clusterBy, ", ")
 }
 
 func (tb *TableBuilder) GetTagValueString() string {
@@ -409,7 +409,7 @@ func (tb *TableBuilder) GetTagValueString() string {
 }
 
 func JoinStringList(instrings []string, delimiter string) string {
-	return fmt.Sprint(strings.Join(instrings[:], delimiter))
+	return fmt.Sprint(strings.Join(instrings, delimiter))
 }
 
 func quoteStringList(instrings []string) []string {
@@ -427,7 +427,7 @@ func (tb *TableBuilder) getCreateStatementBody() string {
 	colDef := tb.columns.getColumnDefinitions(true, true)
 
 	if len(tb.primaryKey.keys) > 0 {
-		colDef = strings.TrimSuffix(colDef, ")") //strip trailing
+		colDef = strings.TrimSuffix(colDef, ")") // strip trailing
 		q.WriteString(colDef)
 		if tb.primaryKey.name != "" {
 			q.WriteString(fmt.Sprintf(` ,CONSTRAINT "%v" PRIMARY KEY(%v)`, tb.primaryKey.name, JoinStringList(quoteStringList(tb.primaryKey.keys), ",")))
@@ -503,7 +503,7 @@ func (tb *TableBuilder) Create() string {
 	}
 
 	if tb.clusterBy != nil {
-		//add optional clustering statement
+		// add optional clustering statement
 		q.WriteString(fmt.Sprintf(` CLUSTER BY LINEAR(%v)`, tb.GetClusterKeyString()))
 	}
 

--- a/pkg/snowflake/task.go
+++ b/pkg/snowflake/task.go
@@ -145,10 +145,8 @@ func (tb *TaskBuilder) Create() string {
 
 	if tb.warehouse != "" {
 		q.WriteString(fmt.Sprintf(` WAREHOUSE = "%v"`, EscapeString(tb.warehouse)))
-	} else {
-		if tb.userTaskManagedInitialWarehouseSize != "" {
-			q.WriteString(fmt.Sprintf(` USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = '%v'`, EscapeString(tb.userTaskManagedInitialWarehouseSize)))
-		}
+	} else if tb.userTaskManagedInitialWarehouseSize != "" {
+		q.WriteString(fmt.Sprintf(` USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = '%v'`, EscapeString(tb.userTaskManagedInitialWarehouseSize)))
 	}
 
 	if tb.schedule != "" {

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -138,7 +138,7 @@ func ParseAndFormatFullyQualifiedObectID(s string) string {
 }
 
 func ParseFullyQualifiedObjectID(s string) (dbName, schemaName, objectName string) {
-	parsedString := strings.Replace(s, "\"", "", -1)
+	parsedString := strings.ReplaceAll(s, "\"", "")
 
 	var parts []string
 	if strings.Contains(parsedString, "|") {

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -95,7 +95,7 @@ func ValidateIsNotAccountLocator(i interface{}, k string) (s []string, errors []
 
 func ValidateFullyQualifiedObjectID(i interface{}, k string) (s []string, errors []error) {
 	v, _ := i.(string)
-	if strings.Contains(v, ".") {
+	if strings.Contains(v, ".") { //nolint:gocritic // todo: please fix this
 		tagArray := strings.Split(v, ".")
 		if len(tagArray) != 3 {
 			errors = append(errors, fmt.Errorf("%v, is not a valid id. If using period delimiter, three parts must be specified <db_name>.<schema_name>.<object_name>", v))


### PR DESCRIPTION
This PR adds some linters with golangci-lint to enhance the quality of the code.
I manually modified a couple of lines, but there remained some ignored lines; those are annotated with `todo` comments.

Additionally, this PR adds github actions workflow for golangci-lint.

Examples:
- string.replace with -1 to string.replaceAll
- if-else chain to be switch statements