### PR TITLE
Feat golangci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,3 +35,5 @@ linters:
     - gofmt
     # gofumpt: Gofumpt checks whether code was gofumpt-ed.
     - gofumpt
+    # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers
+    - thelper

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,3 +39,5 @@ linters:
     - thelper
     # wastedassign: wastedassign finds wasted assignment statements.
     - wastedassign
+    # whitespace: Tool for detection of leading and trailing whitespace
+    - whitespace

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,3 +37,5 @@ linters:
     - gofumpt
     # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers
     - thelper
+    # wastedassign: wastedassign finds wasted assignment statements.
+    - wastedassign


### PR DESCRIPTION
This PR adds three lint rules called thelper, wastedassign and whitespace, which were already fixed in my earlier PR. I recommend adding these to maintain code quality.