### PR TITLE
fix(ci): remove unnecessary type conversions by adding lint `unconvert`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,8 @@ linters:
     - typecheck
 
     # not default
+    # unconvert: Remove unnecessary type conversions
+    - unconvert
     # gofmt: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
     - gofmt
     # gofumpt: Gofumpt checks whether code was gofumpt-ed.

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -218,7 +218,7 @@ func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 // NewTestClient returns *http.Client with Transport replaced to avoid making real calls.
 func NewTestClient(fn RoundTripFunc) *http.Client {
 	return &http.Client{
-		Transport: RoundTripFunc(fn),
+		Transport: fn,
 	}
 }
 
@@ -282,7 +282,7 @@ func TestGetOauthAccessToken(t *testing.T) {
 				t.Errorf("Response body was not able to be parsed %v", err)
 			}
 			var result provider.Result
-			unmarshalErr := json.Unmarshal([]byte(got), &result)
+			unmarshalErr := json.Unmarshal(got, &result)
 			if unmarshalErr != nil {
 				return
 			}


### PR DESCRIPTION
This PR adds a new linter called `unconvert` to remove unnecessary type conversions.