### PR TITLE
fix: test modules in acceptance test for warehouse

### DIFF
--- a/pkg/datasources/helpers_test.go
+++ b/pkg/datasources/helpers_test.go
@@ -1,0 +1,13 @@
+package datasources_test
+
+import (
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func providers() map[string]*schema.Provider {
+	p := provider.Provider()
+	return map[string]*schema.Provider{
+		"snowflake": p,
+	}
+}

--- a/pkg/datasources/system_get_aws_sns_iam_policy_acceptance_test.go
+++ b/pkg/datasources/system_get_aws_sns_iam_policy_acceptance_test.go
@@ -3,18 +3,8 @@ package datasources_test
 import (
 	"testing"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-// FIXME refactor to testhelpers.
-func providers() map[string]*schema.Provider {
-	p := provider.Provider()
-	return map[string]*schema.Provider{
-		"snowflake": p,
-	}
-}
 
 func TestAcc_SystemGetAWSSNSIAMPolicy_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{

--- a/pkg/datasources/warehouses_acceptance_test.go
+++ b/pkg/datasources/warehouses_acceptance_test.go
@@ -1,44 +1,44 @@
 package datasources_test
 
 import (
-// "fmt"
-// "strings"
-// "testing"
-//
-// "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-// "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-// func TestAcc_Warehouses(t *testing.T) {
-//	warehouseName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
-//	resource.ParallelTest(t, resource.TestCase{
-//		Providers:    providers(),
-//		CheckDestroy: nil,
-//		Steps: []resource.TestStep{
-//			{
-//				Config: warehouses(warehouseName),
-//				Check: resource.ComposeTestCheckFunc(
-//					resource.TestCheckResourceAttrSet("data.snowflake_warehouses.s", "warehouses.#"),
-//					resource.TestCheckResourceAttrSet("data.snowflake_warehouses.s", "warehouses.0.name"),
-//				),
-//			},
-//		},
-//	})
-//}
+func TestAcc_Warehouses(t *testing.T) {
+	warehouseName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    providers(),
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: warehouses(warehouseName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.snowflake_warehouses.s", "warehouses.#"),
+					resource.TestCheckResourceAttrSet("data.snowflake_warehouses.s", "warehouses.0.name"),
+				),
+			},
+		},
+	})
+}
 
-// func warehouses(warehouseName string) string {
-// 	return fmt.Sprintf(`
-// 	resource snowflake_warehouse "s"{
-// 		name                         = "%v"
-// 		warehouse_size               = "XSMALL"
-// 		initially_suspended          = true
-// 		auto_suspend                 = 60
-// 		max_concurrency_level        = 8
-// 		statement_timeout_in_seconds = 172800
-// 	}
+func warehouses(warehouseName string) string {
+	return fmt.Sprintf(`
+	resource snowflake_warehouse "s"{
+		name                         = "%v"
+		warehouse_size               = "XSMALL"
+		initially_suspended          = true
+		auto_suspend                 = 60
+		max_concurrency_level        = 8
+		statement_timeout_in_seconds = 172800
+	}
 
-// 	data snowflake_warehouses "s" {
-// 		depends_on = [snowflake_warehouse.s]
-// 	}
-// 	`, warehouseName)
-// }
+	data snowflake_warehouses "s" {
+		depends_on = [snowflake_warehouse.s]
+	}
+	`, warehouseName)
+}


### PR DESCRIPTION
This PR fixes tests in datasources.

I don't understand why the acceptance tests for creating warehouse are commented out, and I suspect there is a cause  for this issue https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1343 around here .

