### PR TITLE
feat(ci): add depguard in golangci to avoid importing unacceptable packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,11 @@ run:
 linters-settings:
   misspell:
     locale: US
+  depguard:
+    include-go-root: true
+    packages:
+      - github.com/pkg/error
+      - io/ioutil
 
 linters:
   disable-all: true
@@ -31,6 +36,8 @@ linters:
     - typecheck
 
     # not default
+    # depguard: Go linter that checks if package imports are in a list of acceptable packages
+    - depguard
     # unconvert: Remove unnecessary type conversions
     - unconvert
     # gofmt: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification


### PR DESCRIPTION
This PR adds a new linter rule called `depguard` which checks whether the packages imported in this project are acceptable. This PR should be merged after my earlier PRs because this PR does not modify any codes.

I want not to use `github.com/pkg/error` and `io/ioutil` anymore because they are deprecated.

All of `github.com/pkg/error` will be removed in the PR: https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/1360 .