### PR TITLE
fix: wrong usage of testify Equal() function

### DIFF
--- a/pkg/resources/database_grant_test.go
+++ b/pkg/resources/database_grant_test.go
@@ -66,12 +66,12 @@ func TestDatabaseGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 
 	shares := d.Get("shares").(*schema.Set)
 	r.True(shares.Contains("test-share-1"))
 	r.True(shares.Contains("test-share-2"))
-	r.Equal(shares.Len(), 2)
+	r.Equal(2, shares.Len())
 }
 
 func expectReadDatabaseGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/external_table_grant_test.go
+++ b/pkg/resources/external_table_grant_test.go
@@ -69,12 +69,12 @@ func TestExternalTableGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 
 	shares := d.Get("shares").(*schema.Set)
 	r.True(shares.Contains("test-share-1"))
 	r.True(shares.Contains("test-share-2"))
-	r.Equal(shares.Len(), 2)
+	r.Equal(2, shares.Len())
 }
 
 func expectReadExternalTableGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/file_format_grant_test.go
+++ b/pkg/resources/file_format_grant_test.go
@@ -65,7 +65,7 @@ func TestFileFormatGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 }
 
 func expectReadFileFormatGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/function_grant_test.go
+++ b/pkg/resources/function_grant_test.go
@@ -85,12 +85,12 @@ func TestFunctionGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 
 	shares := d.Get("shares").(*schema.Set)
 	r.True(shares.Contains("test-share-1"))
 	r.True(shares.Contains("test-share-2"))
-	r.Equal(shares.Len(), 2)
+	r.Equal(2, shares.Len())
 }
 
 func expectReadFunctionGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/list_expansion_internal_test.go
+++ b/pkg/resources/list_expansion_internal_test.go
@@ -24,5 +24,5 @@ func TestExpandBlankStringList(t *testing.T) {
 	in := []interface{}{}
 	out := expandStringList(in)
 
-	r.Equal(len(out), 0)
+	r.Equal(0, len(out))
 }

--- a/pkg/resources/masking_policy_grant_test.go
+++ b/pkg/resources/masking_policy_grant_test.go
@@ -64,7 +64,7 @@ func TestMaskingPolicyGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 }
 
 func expectReadMaskingPolicyGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/materialized_view_grant_test.go
+++ b/pkg/resources/materialized_view_grant_test.go
@@ -69,12 +69,12 @@ func TestMaterializedViewGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 
 	shares := d.Get("shares").(*schema.Set)
 	r.True(shares.Contains("test-share-1"))
 	r.True(shares.Contains("test-share-2"))
-	r.Equal(shares.Len(), 2)
+	r.Equal(2, shares.Len())
 }
 
 func expectReadMaterializedViewGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/pipe_grant_test.go
+++ b/pkg/resources/pipe_grant_test.go
@@ -65,7 +65,7 @@ func TestPipeGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 }
 
 func expectReadPipeGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/procedure_grant_test.go
+++ b/pkg/resources/procedure_grant_test.go
@@ -85,12 +85,12 @@ func TestProcedureGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 
 	shares := d.Get("shares").(*schema.Set)
 	r.True(shares.Contains("test-share-1"))
 	r.True(shares.Contains("test-share-2"))
-	r.Equal(shares.Len(), 2)
+	r.Equal(2, shares.Len())
 }
 
 func expectReadProcedureGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/row_access_policy_grant_test.go
+++ b/pkg/resources/row_access_policy_grant_test.go
@@ -64,7 +64,7 @@ func TestRowAccessPolicyGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 }
 
 func expectReadRowAccessPolicyGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/schema_grant_test.go
+++ b/pkg/resources/schema_grant_test.go
@@ -78,12 +78,12 @@ func TestSchemaGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 
 	shares := d.Get("shares").(*schema.Set)
 	r.True(shares.Contains("test-share-1"))
 	r.True(shares.Contains("test-share-2"))
-	r.Equal(shares.Len(), 2)
+	r.Equal(2, shares.Len())
 }
 
 func expectReadSchemaGrant(mock sqlmock.Sqlmock, testPriv string) {

--- a/pkg/resources/sequence_grant_test.go
+++ b/pkg/resources/sequence_grant_test.go
@@ -65,7 +65,7 @@ func TestSequenceGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 }
 
 func expectReadSequenceGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/stage_grant_test.go
+++ b/pkg/resources/stage_grant_test.go
@@ -69,7 +69,7 @@ func TestStageGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 }
 
 func expectReadStageGrant(mock sqlmock.Sqlmock, testPriv string) {

--- a/pkg/resources/stream_grant_test.go
+++ b/pkg/resources/stream_grant_test.go
@@ -65,7 +65,7 @@ func TestStreamGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 }
 
 func expectReadStreamGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/table_grant_test.go
+++ b/pkg/resources/table_grant_test.go
@@ -97,12 +97,12 @@ func TestTableGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 
 	shares := d.Get("shares").(*schema.Set)
 	r.True(shares.Contains("test-share-1"))
 	r.True(shares.Contains("test-share-2"))
-	r.Equal(shares.Len(), 2)
+	r.Equal(2, shares.Len())
 }
 
 func expectReadTableGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/tag_grant_test.go
+++ b/pkg/resources/tag_grant_test.go
@@ -64,7 +64,7 @@ func TestTagGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 }
 
 func expectReadTagGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/task_grant_test.go
+++ b/pkg/resources/task_grant_test.go
@@ -65,7 +65,7 @@ func TestTaskGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 }
 
 func expectReadTaskGrant(mock sqlmock.Sqlmock) {

--- a/pkg/resources/task_internal_test.go
+++ b/pkg/resources/task_internal_test.go
@@ -12,7 +12,7 @@ func TestStringFromTaskID(t *testing.T) {
 	task := taskID{DatabaseName: "test_db", SchemaName: "test_schema", TaskName: "test_task"}
 	id, err := task.String()
 	r.NoError(err)
-	r.Equal(id, "test_db|test_schema|test_task")
+	r.Equal("test_db|test_schema|test_task", id)
 }
 
 func TestTaskIDFromString(t *testing.T) {

--- a/pkg/resources/view_grant_test.go
+++ b/pkg/resources/view_grant_test.go
@@ -69,12 +69,12 @@ func TestViewGrantRead(t *testing.T) {
 	roles := d.Get("roles").(*schema.Set)
 	r.True(roles.Contains("test-role-1"))
 	r.True(roles.Contains("test-role-2"))
-	r.Equal(roles.Len(), 2)
+	r.Equal(2, roles.Len())
 
 	shares := d.Get("shares").(*schema.Set)
 	r.True(shares.Contains("test-share-1"))
 	r.True(shares.Contains("test-share-2"))
-	r.Equal(shares.Len(), 2)
+	r.Equal(2, shares.Len())
 }
 
 func expectReadViewGrant(mock sqlmock.Sqlmock) {

--- a/pkg/snowflake/database_test.go
+++ b/pkg/snowflake/database_test.go
@@ -132,13 +132,15 @@ func TestListDatabases(t *testing.T) {
 func TestEnableReplicationAccounts(t *testing.T) {
 	r := require.New(t)
 	db := snowflake.Database("good_name")
-	r.Equal(db.EnableReplicationAccounts("good_name", "account1"), `ALTER DATABASE "good_name" ENABLE REPLICATION TO ACCOUNTS account1`)
+	expected := `ALTER DATABASE "good_name" ENABLE REPLICATION TO ACCOUNTS account1`
+	r.Equal(expected, db.EnableReplicationAccounts("good_name", "account1"))
 }
 
 func TestDisableReplicationAccounts(t *testing.T) {
 	r := require.New(t)
 	db := snowflake.Database("good_name")
-	r.Equal(db.DisableReplicationAccounts("good_name", "account1"), `ALTER DATABASE "good_name" DISABLE REPLICATION TO ACCOUNTS account1`)
+	expected := `ALTER DATABASE "good_name" DISABLE REPLICATION TO ACCOUNTS account1`
+	r.Equal(expected, db.DisableReplicationAccounts("good_name", "account1"))
 }
 
 func TestGetRemovedAccountsFromReplicationConfiguration(t *testing.T) {
@@ -148,5 +150,5 @@ func TestGetRemovedAccountsFromReplicationConfiguration(t *testing.T) {
 	oldAccounts := []interface{}{"acc1", "acc2", "acc3"}
 	newAccounts := []interface{}{"acc1", "acc2"}
 
-	r.Equal(db.GetRemovedAccountsFromReplicationConfiguration(oldAccounts, newAccounts), []interface{}{"acc3"})
+	r.Equal([]interface{}{"acc3"}, db.GetRemovedAccountsFromReplicationConfiguration(oldAccounts, newAccounts))
 }

--- a/pkg/snowflake/external_function_test.go
+++ b/pkg/snowflake/external_function_test.go
@@ -17,10 +17,11 @@ func TestExternalFunctionCreate(t *testing.T) {
 	s.WithAPIIntegration("test_api_integration_01")
 	s.WithURLOfProxyAndResource("https://123456.execute-api.us-west-2.amazonaws.com/prod/test_func")
 
-	r.Equal(s.QualifiedName(), `"test_db"."test_schema"."test_function"`)
-	r.Equal(s.QualifiedNameWithArgTypes(), `"test_db"."test_schema"."test_function" (varchar)`)
+	r.Equal(`"test_db"."test_schema"."test_function"`, s.QualifiedName())
+	r.Equal(`"test_db"."test_schema"."test_function" (varchar)`, s.QualifiedNameWithArgTypes())
 
-	r.Equal(s.Create(), `CREATE EXTERNAL FUNCTION "test_db"."test_schema"."test_function" (data varchar) RETURNS varchar NULL RETURNS NULL ON NULL INPUT IMMUTABLE API_INTEGRATION = 'test_api_integration_01' AS 'https://123456.execute-api.us-west-2.amazonaws.com/prod/test_func'`)
+	expected := `CREATE EXTERNAL FUNCTION "test_db"."test_schema"."test_function" (data varchar) RETURNS varchar NULL RETURNS NULL ON NULL INPUT IMMUTABLE API_INTEGRATION = 'test_api_integration_01' AS 'https://123456.execute-api.us-west-2.amazonaws.com/prod/test_func'`
+	r.Equal(expected, s.Create())
 }
 
 func TestExternalFunctionDrop(t *testing.T) {
@@ -28,15 +29,15 @@ func TestExternalFunctionDrop(t *testing.T) {
 
 	// Without arg
 	s := ExternalFunction("test_function", "test_db", "test_schema")
-	r.Equal(s.Drop(), `DROP FUNCTION "test_db"."test_schema"."test_function" ()`)
+	r.Equal(`DROP FUNCTION "test_db"."test_schema"."test_function" ()`, s.Drop())
 
 	// With arg
 	s = ExternalFunction("test_function", "test_db", "test_schema").WithArgTypes("varchar")
-	r.Equal(s.Drop(), `DROP FUNCTION "test_db"."test_schema"."test_function" (varchar)`)
+	r.Equal(`DROP FUNCTION "test_db"."test_schema"."test_function" (varchar)`, s.Drop())
 }
 
 func TestExternalFunctionShow(t *testing.T) {
 	r := require.New(t)
 	s := ExternalFunction("test_function", "test_db", "test_schema")
-	r.Equal(s.Show(), `SHOW EXTERNAL FUNCTIONS LIKE 'test_function' IN SCHEMA "test_db"."test_schema"`)
+	r.Equal(`SHOW EXTERNAL FUNCTIONS LIKE 'test_function' IN SCHEMA "test_db"."test_schema"`, s.Show())
 }

--- a/pkg/snowflake/external_table_test.go
+++ b/pkg/snowflake/external_table_test.go
@@ -13,29 +13,30 @@ func TestExternalTableCreate(t *testing.T) {
 	s.WithLocation("location")
 	s.WithPattern("pattern")
 	s.WithFileFormat("TYPE = CSV FIELD_DELIMITER = '|'")
-	r.Equal(s.QualifiedName(), `"test_db"."test_schema"."test_table"`)
+	r.Equal(`"test_db"."test_schema"."test_table"`, s.QualifiedName())
 
-	r.Equal(s.Create(), `CREATE EXTERNAL TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT AS expression1, "column2" VARCHAR AS expression2) WITH LOCATION = location REFRESH_ON_CREATE = false AUTO_REFRESH = false PATTERN = 'pattern' FILE_FORMAT = ( TYPE = CSV FIELD_DELIMITER = '|' )`)
+	r.Equal(`CREATE EXTERNAL TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT AS expression1, "column2" VARCHAR AS expression2) WITH LOCATION = location REFRESH_ON_CREATE = false AUTO_REFRESH = false PATTERN = 'pattern' FILE_FORMAT = ( TYPE = CSV FIELD_DELIMITER = '|' )`, s.Create())
 
 	s.WithComment("Test Comment")
-	r.Equal(s.Create(), `CREATE EXTERNAL TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT AS expression1, "column2" VARCHAR AS expression2) WITH LOCATION = location REFRESH_ON_CREATE = false AUTO_REFRESH = false PATTERN = 'pattern' FILE_FORMAT = ( TYPE = CSV FIELD_DELIMITER = '|' ) COMMENT = 'Test Comment'`)
+	r.Equal(`CREATE EXTERNAL TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT AS expression1, "column2" VARCHAR AS expression2) WITH LOCATION = location REFRESH_ON_CREATE = false AUTO_REFRESH = false PATTERN = 'pattern' FILE_FORMAT = ( TYPE = CSV FIELD_DELIMITER = '|' ) COMMENT = 'Test Comment'`, s.Create())
 }
 
 func TestExternalTableUpdate(t *testing.T) {
 	r := require.New(t)
 	s := ExternalTable("test_table", "test_db", "test_schema")
 	s.WithTags([]TagValue{{Name: "tag1", Value: "value1", Schema: "test_schema", Database: "test_db"}})
-	r.Equal(s.Update(), `ALTER EXTERNAL TABLE "test_db"."test_schema"."test_table" TAG "test_db"."test_schema"."tag1" = "value1"`)
+	expected := `ALTER EXTERNAL TABLE "test_db"."test_schema"."test_table" TAG "test_db"."test_schema"."tag1" = "value1"`
+	r.Equal(expected, s.Update())
 }
 
 func TestExternalTableDrop(t *testing.T) {
 	r := require.New(t)
 	s := ExternalTable("test_table", "test_db", "test_schema")
-	r.Equal(s.Drop(), `DROP EXTERNAL TABLE "test_db"."test_schema"."test_table"`)
+	r.Equal(`DROP EXTERNAL TABLE "test_db"."test_schema"."test_table"`, s.Drop())
 }
 
 func TestExternalTableShow(t *testing.T) {
 	r := require.New(t)
 	s := ExternalTable("test_table", "test_db", "test_schema")
-	r.Equal(s.Show(), `SHOW EXTERNAL TABLES LIKE 'test_table' IN SCHEMA "test_db"."test_schema"`)
+	r.Equal(`SHOW EXTERNAL TABLES LIKE 'test_table' IN SCHEMA "test_db"."test_schema"`, s.Show())
 }

--- a/pkg/snowflake/file_format_test.go
+++ b/pkg/snowflake/file_format_test.go
@@ -9,7 +9,7 @@ import (
 func TestFileFormatCreateCSV(t *testing.T) {
 	r := require.New(t)
 	f := FileFormat("test_file_format", "test_db", "test_schema")
-	r.Equal(f.QualifiedName(), `"test_db"."test_schema"."test_file_format"`)
+	r.Equal(`"test_db"."test_schema"."test_file_format"`, f.QualifiedName())
 
 	f.WithFormatType("CSV")
 	f.WithCompression("AUTO")
@@ -40,7 +40,7 @@ func TestFileFormatCreateCSV(t *testing.T) {
 func TestFileFormatCreateJSON(t *testing.T) {
 	r := require.New(t)
 	f := FileFormat("test_file_format_json", "test_db", "test_schema")
-	r.Equal(f.QualifiedName(), `"test_db"."test_schema"."test_file_format_json"`)
+	r.Equal(`"test_db"."test_schema"."test_file_format_json"`, f.QualifiedName())
 
 	f.WithFormatType("JSON")
 	f.WithCompression("AUTO")

--- a/pkg/snowflake/function_test.go
+++ b/pkg/snowflake/function_test.go
@@ -219,7 +219,7 @@ func TestFunctionDrop(t *testing.T) {
 	// Without arg
 	s := getJavaScriptFuction(false)
 	stmnt, _ := s.Drop()
-	r.Equal(stmnt, `DROP FUNCTION "test_db"."test_schema"."test_func"()`)
+	r.Equal(`DROP FUNCTION "test_db"."test_schema"."test_func"()`, stmnt)
 
 	// With arg
 	ss := getJavaScriptFuction(true)
@@ -231,7 +231,7 @@ func TestFunctionShow(t *testing.T) {
 	r := require.New(t)
 	s := getJavaScriptFuction(false)
 	stmnt := s.Show()
-	r.Equal(stmnt, `SHOW USER FUNCTIONS LIKE 'test_func' IN SCHEMA "test_db"."test_schema"`)
+	r.Equal(`SHOW USER FUNCTIONS LIKE 'test_func' IN SCHEMA "test_db"."test_schema"`, stmnt)
 }
 
 func TestFunctionRename(t *testing.T) {

--- a/pkg/snowflake/future_grant_test.go
+++ b/pkg/snowflake/future_grant_test.go
@@ -10,7 +10,7 @@ import (
 func TestFutureSchemaGrant(t *testing.T) {
 	r := require.New(t)
 	fvg := snowflake.FutureSchemaGrant("test_db")
-	r.Equal(fvg.Name(), "test_db")
+	r.Equal("test_db", fvg.Name())
 
 	s := fvg.Show()
 	r.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)
@@ -25,7 +25,7 @@ func TestFutureSchemaGrant(t *testing.T) {
 func TestFutureTableGrant(t *testing.T) {
 	r := require.New(t)
 	fvg := snowflake.FutureTableGrant("test_db", "PUBLIC")
-	r.Equal(fvg.Name(), "PUBLIC")
+	r.Equal("PUBLIC", fvg.Name())
 
 	s := fvg.Show()
 	r.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
@@ -38,7 +38,7 @@ func TestFutureTableGrant(t *testing.T) {
 
 	b := require.New(t)
 	fvgd := snowflake.FutureTableGrant("test_db", "")
-	b.Equal(fvgd.Name(), "test_db")
+	b.Equal("test_db", fvgd.Name())
 
 	s = fvgd.Show()
 	b.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)
@@ -53,7 +53,7 @@ func TestFutureTableGrant(t *testing.T) {
 func TestFutureMaterializedViewGrant(t *testing.T) {
 	r := require.New(t)
 	fvg := snowflake.FutureMaterializedViewGrant("test_db", "PUBLIC")
-	r.Equal(fvg.Name(), "PUBLIC")
+	r.Equal("PUBLIC", fvg.Name())
 
 	s := fvg.Show()
 	r.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
@@ -66,7 +66,7 @@ func TestFutureMaterializedViewGrant(t *testing.T) {
 
 	b := require.New(t)
 	fvgd := snowflake.FutureMaterializedViewGrant("test_db", "")
-	b.Equal(fvgd.Name(), "test_db")
+	b.Equal("test_db", fvgd.Name())
 
 	s = fvgd.Show()
 	b.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)
@@ -81,7 +81,7 @@ func TestFutureMaterializedViewGrant(t *testing.T) {
 func TestFutureViewGrant(t *testing.T) {
 	r := require.New(t)
 	fvg := snowflake.FutureViewGrant("test_db", "PUBLIC")
-	r.Equal(fvg.Name(), "PUBLIC")
+	r.Equal("PUBLIC", fvg.Name())
 
 	s := fvg.Show()
 	r.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
@@ -94,7 +94,7 @@ func TestFutureViewGrant(t *testing.T) {
 
 	b := require.New(t)
 	fvgd := snowflake.FutureViewGrant("test_db", "")
-	b.Equal(fvgd.Name(), "test_db")
+	b.Equal("test_db", fvgd.Name())
 
 	s = fvgd.Show()
 	b.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)
@@ -109,7 +109,7 @@ func TestFutureViewGrant(t *testing.T) {
 func TestFutureStageGrant(t *testing.T) {
 	r := require.New(t)
 	fvg := snowflake.FutureStageGrant("test_db", "PUBLIC")
-	r.Equal(fvg.Name(), "PUBLIC")
+	r.Equal("PUBLIC", fvg.Name())
 
 	s := fvg.Show()
 	r.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
@@ -122,7 +122,7 @@ func TestFutureStageGrant(t *testing.T) {
 
 	b := require.New(t)
 	fvgd := snowflake.FutureStageGrant("test_db", "")
-	b.Equal(fvgd.Name(), "test_db")
+	b.Equal("test_db", fvgd.Name())
 
 	s = fvgd.Show()
 	b.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)
@@ -152,7 +152,7 @@ func TestShowFutureGrantsInSchema(t *testing.T) {
 func TestFutureExternalTableGrant(t *testing.T) {
 	r := require.New(t)
 	fvg := snowflake.FutureExternalTableGrant("test_db", "PUBLIC")
-	r.Equal(fvg.Name(), "PUBLIC")
+	r.Equal("PUBLIC", fvg.Name())
 
 	s := fvg.Show()
 	r.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
@@ -165,7 +165,7 @@ func TestFutureExternalTableGrant(t *testing.T) {
 
 	b := require.New(t)
 	fvgd := snowflake.FutureExternalTableGrant("test_db", "")
-	b.Equal(fvgd.Name(), "test_db")
+	b.Equal("test_db", fvgd.Name())
 
 	s = fvgd.Show()
 	b.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)
@@ -180,7 +180,7 @@ func TestFutureExternalTableGrant(t *testing.T) {
 func TestFutureFileFormatGrant(t *testing.T) {
 	r := require.New(t)
 	fvg := snowflake.FutureFileFormatGrant("test_db", "PUBLIC")
-	r.Equal(fvg.Name(), "PUBLIC")
+	r.Equal("PUBLIC", fvg.Name())
 
 	s := fvg.Show()
 	r.Equal(`SHOW FUTURE GRANTS IN SCHEMA "test_db"."PUBLIC"`, s)
@@ -193,7 +193,7 @@ func TestFutureFileFormatGrant(t *testing.T) {
 
 	b := require.New(t)
 	fvgd := snowflake.FutureFileFormatGrant("test_db", "")
-	b.Equal(fvgd.Name(), "test_db")
+	b.Equal("test_db", fvgd.Name())
 
 	s = fvgd.Show()
 	b.Equal(`SHOW FUTURE GRANTS IN DATABASE "test_db"`, s)

--- a/pkg/snowflake/grant_test.go
+++ b/pkg/snowflake/grant_test.go
@@ -10,7 +10,7 @@ import (
 func TestDatabaseGrant(t *testing.T) {
 	r := require.New(t)
 	dg := snowflake.DatabaseGrant("testDB")
-	r.Equal(dg.Name(), "testDB")
+	r.Equal("testDB", dg.Name())
 
 	s := dg.Show()
 	r.Equal(`SHOW GRANTS ON DATABASE "testDB"`, s)
@@ -37,7 +37,7 @@ func TestDatabaseGrant(t *testing.T) {
 func TestSchemaGrant(t *testing.T) {
 	r := require.New(t)
 	sg := snowflake.SchemaGrant("test_db", "testSchema")
-	r.Equal(sg.Name(), "testSchema")
+	r.Equal("testSchema", sg.Name())
 
 	s := sg.Show()
 	r.Equal(`SHOW GRANTS ON SCHEMA "test_db"."testSchema"`, s)
@@ -64,7 +64,7 @@ func TestSchemaGrant(t *testing.T) {
 func TestViewGrant(t *testing.T) {
 	r := require.New(t)
 	vg := snowflake.ViewGrant("test_db", "PUBLIC", "testView")
-	r.Equal(vg.Name(), "testView")
+	r.Equal("testView", vg.Name())
 
 	s := vg.Show()
 	r.Equal(`SHOW GRANTS ON VIEW "test_db"."PUBLIC"."testView"`, s)
@@ -91,7 +91,7 @@ func TestViewGrant(t *testing.T) {
 func TestMaterializedViewGrant(t *testing.T) {
 	r := require.New(t)
 	vg := snowflake.MaterializedViewGrant("test_db", "PUBLIC", "testMaterializedView")
-	r.Equal(vg.Name(), "testMaterializedView")
+	r.Equal("testMaterializedView", vg.Name())
 
 	s := vg.Show()
 	r.Equal(`SHOW GRANTS ON MATERIALIZED VIEW "test_db"."PUBLIC"."testMaterializedView"`, s)
@@ -118,7 +118,7 @@ func TestMaterializedViewGrant(t *testing.T) {
 func TestExternalTableGrant(t *testing.T) {
 	r := require.New(t)
 	vg := snowflake.ExternalTableGrant("test_db", "PUBLIC", "testExternalTable")
-	r.Equal(vg.Name(), "testExternalTable")
+	r.Equal("testExternalTable", vg.Name())
 
 	s := vg.Show()
 	r.Equal(`SHOW GRANTS ON EXTERNAL TABLE "test_db"."PUBLIC"."testExternalTable"`, s)
@@ -145,7 +145,7 @@ func TestExternalTableGrant(t *testing.T) {
 func TestFileFormatGrant(t *testing.T) {
 	r := require.New(t)
 	vg := snowflake.FileFormatGrant("test_db", "PUBLIC", "testFileFormat")
-	r.Equal(vg.Name(), "testFileFormat")
+	r.Equal("testFileFormat", vg.Name())
 
 	s := vg.Show()
 	r.Equal(`SHOW GRANTS ON FILE FORMAT "test_db"."PUBLIC"."testFileFormat"`, s)
@@ -172,7 +172,7 @@ func TestFileFormatGrant(t *testing.T) {
 func TestFunctionGrant(t *testing.T) {
 	r := require.New(t)
 	vg := snowflake.FunctionGrant("test_db", "PUBLIC", "testFunction", []string{"ARRAY", "STRING"})
-	r.Equal(vg.Name(), "testFunction")
+	r.Equal("testFunction", vg.Name())
 
 	s := vg.Show()
 	r.Equal(`SHOW GRANTS ON FUNCTION "test_db"."PUBLIC"."testFunction"(ARRAY, STRING)`, s)
@@ -199,7 +199,7 @@ func TestFunctionGrant(t *testing.T) {
 func TestProcedureGrant(t *testing.T) {
 	r := require.New(t)
 	vg := snowflake.ProcedureGrant("test_db", "PUBLIC", "testProcedure", []string{"ARRAY", "STRING"})
-	r.Equal(vg.Name(), "testProcedure")
+	r.Equal("testProcedure", vg.Name())
 
 	s := vg.Show()
 	r.Equal(`SHOW GRANTS ON PROCEDURE "test_db"."PUBLIC"."testProcedure"(ARRAY, STRING)`, s)
@@ -226,7 +226,7 @@ func TestProcedureGrant(t *testing.T) {
 func TestWarehouseGrant(t *testing.T) {
 	r := require.New(t)
 	wg := snowflake.WarehouseGrant("test_warehouse")
-	r.Equal(wg.Name(), "test_warehouse")
+	r.Equal("test_warehouse", wg.Name())
 
 	s := wg.Show()
 	r.Equal(`SHOW GRANTS ON WAREHOUSE "test_warehouse"`, s)
@@ -248,7 +248,7 @@ func TestWarehouseGrant(t *testing.T) {
 func TestAccountGrant(t *testing.T) {
 	r := require.New(t)
 	wg := snowflake.AccountGrant()
-	r.Equal(wg.Name(), "")
+	r.Equal("", wg.Name())
 
 	// There's an extra space after "ACCOUNT"
 	//  because accounts don't have names
@@ -269,7 +269,7 @@ func TestAccountGrant(t *testing.T) {
 func TestIntegrationGrant(t *testing.T) {
 	r := require.New(t)
 	wg := snowflake.IntegrationGrant("test_integration")
-	r.Equal(wg.Name(), "test_integration")
+	r.Equal("test_integration", wg.Name())
 
 	s := wg.Show()
 	r.Equal(`SHOW GRANTS ON INTEGRATION "test_integration"`, s)
@@ -290,7 +290,7 @@ func TestIntegrationGrant(t *testing.T) {
 func TestResourceMonitorGrant(t *testing.T) {
 	r := require.New(t)
 	wg := snowflake.ResourceMonitorGrant("test_monitor")
-	r.Equal(wg.Name(), "test_monitor")
+	r.Equal("test_monitor", wg.Name())
 
 	s := wg.Show()
 	r.Equal(`SHOW GRANTS ON RESOURCE MONITOR "test_monitor"`, s)
@@ -311,7 +311,7 @@ func TestResourceMonitorGrant(t *testing.T) {
 func TestMaskingPolicyGrant(t *testing.T) {
 	r := require.New(t)
 	mg := snowflake.MaskingPolicyGrant("test_db", "PUBLIC", "testMaskingPolicy")
-	r.Equal(mg.Name(), "testMaskingPolicy")
+	r.Equal("testMaskingPolicy", mg.Name())
 
 	s := mg.Show()
 	r.Equal(`SHOW GRANTS ON MASKING POLICY "test_db"."PUBLIC"."testMaskingPolicy"`, s)

--- a/pkg/snowflake/pipe_test.go
+++ b/pkg/snowflake/pipe_test.go
@@ -9,46 +9,46 @@ import (
 func TestPipeCreate(t *testing.T) {
 	r := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
-	r.Equal(s.QualifiedName(), `"test_db"."test_schema"."test_pipe"`)
+	r.Equal(`"test_db"."test_schema"."test_pipe"`, s.QualifiedName())
 
-	r.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe"`)
+	r.Equal(`CREATE PIPE "test_db"."test_schema"."test_pipe"`, s.Create())
 
 	s.WithAutoIngest()
-	r.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE`)
+	r.Equal(`CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE`, s.Create())
 
 	s.WithComment("Yeehaw")
-	r.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE COMMENT = 'Yeehaw'`)
+	r.Equal(`CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE COMMENT = 'Yeehaw'`, s.Create())
 
 	s.WithCopyStatement("test copy statement ")
-	r.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE COMMENT = 'Yeehaw' AS test copy statement `)
+	r.Equal(`CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE COMMENT = 'Yeehaw' AS test copy statement `, s.Create())
 
 	s.WithAwsSnsTopicArn("arn:aws:sns:us-east-1:1234567890123456:mytopic")
-	r.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE AWS_SNS_TOPIC = 'arn:aws:sns:us-east-1:1234567890123456:mytopic' COMMENT = 'Yeehaw' AS test copy statement `)
+	r.Equal(`CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE AWS_SNS_TOPIC = 'arn:aws:sns:us-east-1:1234567890123456:mytopic' COMMENT = 'Yeehaw' AS test copy statement `, s.Create())
 
 	s.WithIntegration("myintegration")
-	r.Equal(s.Create(), `CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE INTEGRATION = 'myintegration' AWS_SNS_TOPIC = 'arn:aws:sns:us-east-1:1234567890123456:mytopic' COMMENT = 'Yeehaw' AS test copy statement `)
+	r.Equal(`CREATE PIPE "test_db"."test_schema"."test_pipe" AUTO_INGEST = TRUE INTEGRATION = 'myintegration' AWS_SNS_TOPIC = 'arn:aws:sns:us-east-1:1234567890123456:mytopic' COMMENT = 'Yeehaw' AS test copy statement `, s.Create())
 }
 
 func TestPipeChangeComment(t *testing.T) {
 	r := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
-	r.Equal(s.ChangeComment("worst pipe ever"), `ALTER PIPE "test_db"."test_schema"."test_pipe" SET COMMENT = 'worst pipe ever'`)
+	r.Equal(`ALTER PIPE "test_db"."test_schema"."test_pipe" SET COMMENT = 'worst pipe ever'`, s.ChangeComment("worst pipe ever"))
 }
 
 func TestPipeRemoveComment(t *testing.T) {
 	r := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
-	r.Equal(s.RemoveComment(), `ALTER PIPE "test_db"."test_schema"."test_pipe" UNSET COMMENT`)
+	r.Equal(`ALTER PIPE "test_db"."test_schema"."test_pipe" UNSET COMMENT`, s.RemoveComment())
 }
 
 func TestPipeDrop(t *testing.T) {
 	r := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
-	r.Equal(s.Drop(), `DROP PIPE "test_db"."test_schema"."test_pipe"`)
+	r.Equal(`DROP PIPE "test_db"."test_schema"."test_pipe"`, s.Drop())
 }
 
 func TestPipeShow(t *testing.T) {
 	r := require.New(t)
 	s := Pipe("test_pipe", "test_db", "test_schema")
-	r.Equal(s.Show(), `SHOW PIPES LIKE 'test_pipe' IN SCHEMA "test_db"."test_schema"`)
+	r.Equal(`SHOW PIPES LIKE 'test_pipe' IN SCHEMA "test_db"."test_schema"`, s.Show())
 }

--- a/pkg/snowflake/procedure_test.go
+++ b/pkg/snowflake/procedure_test.go
@@ -62,7 +62,7 @@ func TestProcedureDrop(t *testing.T) {
 	// Without arg
 	s := getProcedure(false)
 	stmnt, _ := s.Drop()
-	r.Equal(stmnt, `DROP PROCEDURE "test_db"."test_schema"."test_proc"()`)
+	r.Equal(`DROP PROCEDURE "test_db"."test_schema"."test_proc"()`, stmnt)
 
 	// With arg
 	ss := getProcedure(true)
@@ -74,7 +74,7 @@ func TestProcedureShow(t *testing.T) {
 	r := require.New(t)
 	s := getProcedure(false)
 	stmnt := s.Show()
-	r.Equal(stmnt, `SHOW PROCEDURES LIKE 'test_proc' IN SCHEMA "test_db"."test_schema"`)
+	r.Equal(`SHOW PROCEDURES LIKE 'test_proc' IN SCHEMA "test_db"."test_schema"`, stmnt)
 }
 
 func TestProcedureRename(t *testing.T) {

--- a/pkg/snowflake/schema_test.go
+++ b/pkg/snowflake/schema_test.go
@@ -9,21 +9,21 @@ import (
 func TestSchemaCreate(t *testing.T) {
 	r := require.New(t)
 	s := Schema("test")
-	r.Equal(s.QualifiedName(), `"test"`)
+	r.Equal(`"test"`, s.QualifiedName())
 
 	s.WithDB("db")
-	r.Equal(s.QualifiedName(), `"db"."test"`)
+	r.Equal(`"db"."test"`, s.QualifiedName())
 
-	r.Equal(s.Create(), `CREATE SCHEMA "db"."test"`)
+	r.Equal(`CREATE SCHEMA "db"."test"`, s.Create())
 
 	s.Transient()
-	r.Equal(s.Create(), `CREATE TRANSIENT SCHEMA "db"."test"`)
+	r.Equal(`CREATE TRANSIENT SCHEMA "db"."test"`, s.Create())
 
 	s.Managed()
-	r.Equal(s.Create(), `CREATE TRANSIENT SCHEMA "db"."test" WITH MANAGED ACCESS`)
+	r.Equal(`CREATE TRANSIENT SCHEMA "db"."test" WITH MANAGED ACCESS`, s.Create())
 
 	s.WithDataRetentionDays(7)
-	r.Equal(s.Create(), `CREATE TRANSIENT SCHEMA "db"."test" WITH MANAGED ACCESS DATA_RETENTION_TIME_IN_DAYS = 7`)
+	r.Equal(`CREATE TRANSIENT SCHEMA "db"."test" WITH MANAGED ACCESS DATA_RETENTION_TIME_IN_DAYS = 7`, s.Create())
 
 	s.WithComment("Yee'haw")
 	r.Equal(`CREATE TRANSIENT SCHEMA "db"."test" WITH MANAGED ACCESS DATA_RETENTION_TIME_IN_DAYS = 7 COMMENT = 'Yee\'haw'`, s.Create())
@@ -32,13 +32,13 @@ func TestSchemaCreate(t *testing.T) {
 func TestSchemaRename(t *testing.T) {
 	r := require.New(t)
 	s := Schema("test")
-	r.Equal(s.Rename("bob"), `ALTER SCHEMA "test" RENAME TO "bob"`)
+	r.Equal(`ALTER SCHEMA "test" RENAME TO "bob"`, s.Rename("bob"))
 }
 
 func TestSchemaSwap(t *testing.T) {
 	r := require.New(t)
 	s := Schema("test")
-	r.Equal(s.Swap("bob"), `ALTER SCHEMA "test" SWAP WITH "bob"`)
+	r.Equal(`ALTER SCHEMA "test" SWAP WITH "bob"`, s.Swap("bob"))
 }
 
 func TestSchemaChangeComment(t *testing.T) {
@@ -50,56 +50,56 @@ func TestSchemaChangeComment(t *testing.T) {
 func TestSchemaRemoveComment(t *testing.T) {
 	r := require.New(t)
 	s := Schema("test")
-	r.Equal(s.RemoveComment(), `ALTER SCHEMA "test" UNSET COMMENT`)
+	r.Equal(`ALTER SCHEMA "test" UNSET COMMENT`, s.RemoveComment())
 }
 
 func TestSchemaChangeDataRetentionDays(t *testing.T) {
 	r := require.New(t)
 	s := Schema("test")
-	r.Equal(s.ChangeDataRetentionDays(22), `ALTER SCHEMA "test" SET DATA_RETENTION_TIME_IN_DAYS = 22`)
+	r.Equal(`ALTER SCHEMA "test" SET DATA_RETENTION_TIME_IN_DAYS = 22`, s.ChangeDataRetentionDays(22))
 }
 
 func TestSchemaRemoveDataRetentionDays(t *testing.T) {
 	r := require.New(t)
 	s := Schema("test")
-	r.Equal(s.RemoveDataRetentionDays(), `ALTER SCHEMA "test" UNSET DATA_RETENTION_TIME_IN_DAYS`)
+	r.Equal(`ALTER SCHEMA "test" UNSET DATA_RETENTION_TIME_IN_DAYS`, s.RemoveDataRetentionDays())
 }
 
 func TestSchemaManage(t *testing.T) {
 	r := require.New(t)
 	s := Schema("test")
-	r.Equal(s.Manage(), `ALTER SCHEMA "test" ENABLE MANAGED ACCESS`)
+	r.Equal(`ALTER SCHEMA "test" ENABLE MANAGED ACCESS`, s.Manage())
 }
 
 func TestSchemaUnmanage(t *testing.T) {
 	r := require.New(t)
 	s := Schema("test")
-	r.Equal(s.Unmanage(), `ALTER SCHEMA "test" DISABLE MANAGED ACCESS`)
+	r.Equal(`ALTER SCHEMA "test" DISABLE MANAGED ACCESS`, s.Unmanage())
 }
 
 func TestSchemaDrop(t *testing.T) {
 	r := require.New(t)
 	s := Schema("test")
-	r.Equal(s.Drop(), `DROP SCHEMA "test"`)
+	r.Equal(`DROP SCHEMA "test"`, s.Drop())
 }
 
 func TestSchemaUndrop(t *testing.T) {
 	r := require.New(t)
 	s := Schema("test")
-	r.Equal(s.Undrop(), `UNDROP SCHEMA "test"`)
+	r.Equal(`UNDROP SCHEMA "test"`, s.Undrop())
 }
 
 func TestSchemaUse(t *testing.T) {
 	r := require.New(t)
 	s := Schema("test")
-	r.Equal(s.Use(), `USE SCHEMA "test"`)
+	r.Equal(`USE SCHEMA "test"`, s.Use())
 }
 
 func TestSchemaShow(t *testing.T) {
 	r := require.New(t)
 	s := Schema("test")
-	r.Equal(s.Show(), `SHOW SCHEMAS LIKE 'test'`)
+	r.Equal(`SHOW SCHEMAS LIKE 'test'`, s.Show())
 
 	s.WithDB("db")
-	r.Equal(s.Show(), `SHOW SCHEMAS LIKE 'test' IN DATABASE "db"`)
+	r.Equal(`SHOW SCHEMAS LIKE 'test' IN DATABASE "db"`, s.Show())
 }

--- a/pkg/snowflake/stage_test.go
+++ b/pkg/snowflake/stage_test.go
@@ -9,27 +9,27 @@ import (
 func TestStageCreate(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.QualifiedName(), `"test_db"."test_schema"."test_stage"`)
+	r.Equal(`"test_db"."test_schema"."test_stage"`, s.QualifiedName())
 
-	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage"`)
+	r.Equal(`CREATE STAGE "test_db"."test_schema"."test_stage"`, s.Create())
 
 	s.WithCredentials("aws_role='arn:aws:iam::001234567890:role/mysnowflakerole'")
-	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole')`)
+	r.Equal(`CREATE STAGE "test_db"."test_schema"."test_stage" CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole')`, s.Create())
 
 	s.WithEncryption("type='AWS_SSE_KMS' kms_key_id = 'aws/key'")
-	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`)
+	r.Equal(`CREATE STAGE "test_db"."test_schema"."test_stage" CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`, s.Create())
 
 	s.WithURL("s3://load/encrypted_files/")
-	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`)
+	r.Equal(`CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`, s.Create())
 
 	s.WithFileFormat("format_name=my_csv_format")
-	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format)`)
+	r.Equal(`CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format)`, s.Create())
 
 	s.WithCopyOptions("on_error='skip_file'")
-	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file')`)
+	r.Equal(`CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file')`, s.Create())
 
 	s.WithDirectory("ENABLE=TRUE")
-	r.Equal(s.Create(), `CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file') DIRECTORY = (ENABLE=TRUE)`)
+	r.Equal(`CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file') DIRECTORY = (ENABLE=TRUE)`, s.Create())
 
 	s.WithComment("Yee'haw")
 	r.Equal(`CREATE STAGE "test_db"."test_schema"."test_stage" URL = 's3://load/encrypted_files/' CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole') ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key') FILE_FORMAT = (format_name=my_csv_format) COPY_OPTIONS = (on_error='skip_file') DIRECTORY = (ENABLE=TRUE) COMMENT = 'Yee\'haw'`, s.Create())
@@ -41,77 +41,77 @@ func TestStageCreate(t *testing.T) {
 func TestStageRename(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.Rename("test_stage2"), `ALTER STAGE "test_db"."test_schema"."test_stage" RENAME TO "test_stage2"`)
+	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" RENAME TO "test_stage2"`, s.Rename("test_stage2"))
 }
 
 func TestStageChangeComment(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.ChangeComment("worst stage ever"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET COMMENT = 'worst stage ever'`)
+	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET COMMENT = 'worst stage ever'`, s.ChangeComment("worst stage ever"))
 }
 
 func TestStageChangeURL(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.ChangeURL("s3://load/test/"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET URL = 's3://load/test/'`)
+	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET URL = 's3://load/test/'`, s.ChangeURL("s3://load/test/"))
 }
 
 func TestStageChangeFileFormat(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.ChangeFileFormat("format_name=my_csv_format"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET FILE_FORMAT = (format_name=my_csv_format)`)
+	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET FILE_FORMAT = (format_name=my_csv_format)`, s.ChangeFileFormat("format_name=my_csv_format"))
 }
 
 func TestStageChangeFileFormatToEmptyList(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.ChangeFileFormat("TYPE = parquet NULL_IF = [] COMPRESSION = none"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET FILE_FORMAT = (TYPE = parquet NULL_IF = () COMPRESSION = none)`)
+	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET FILE_FORMAT = (TYPE = parquet NULL_IF = () COMPRESSION = none)`, s.ChangeFileFormat("TYPE = parquet NULL_IF = [] COMPRESSION = none"))
 }
 
 func TestStageChangeEncryption(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.ChangeEncryption("type='AWS_SSE_KMS' kms_key_id = 'aws/key'"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`)
+	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`, s.ChangeEncryption("type='AWS_SSE_KMS' kms_key_id = 'aws/key'"))
 }
 
 func TestStageChangeCredentials(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.ChangeCredentials("aws_role='arn:aws:iam::001234567890:role/mysnowflakerole'"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole')`)
+	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole')`, s.ChangeCredentials("aws_role='arn:aws:iam::001234567890:role/mysnowflakerole'"))
 }
 
 func TestStageChangeStorageIntegration(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.ChangeStorageIntegration("MY_INTEGRATION"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET STORAGE_INTEGRATION = "MY_INTEGRATION"`)
+	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET STORAGE_INTEGRATION = "MY_INTEGRATION"`, s.ChangeStorageIntegration("MY_INTEGRATION"))
 }
 
 func TestStageChangeCopyOptions(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.ChangeCopyOptions("on_error='skip_file'"), `ALTER STAGE "test_db"."test_schema"."test_stage" SET COPY_OPTIONS = (on_error='skip_file')`)
+	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET COPY_OPTIONS = (on_error='skip_file')`, s.ChangeCopyOptions("on_error='skip_file'"))
 }
 
 func TestStageDrop(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.Drop(), `DROP STAGE "test_db"."test_schema"."test_stage"`)
+	r.Equal(`DROP STAGE "test_db"."test_schema"."test_stage"`, s.Drop())
 }
 
 func TestStageUndrop(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.Undrop(), `UNDROP STAGE "test_db"."test_schema"."test_stage"`)
+	r.Equal(`UNDROP STAGE "test_db"."test_schema"."test_stage"`, s.Undrop())
 }
 
 func TestStageDescribe(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.Describe(), `DESCRIBE STAGE "test_db"."test_schema"."test_stage"`)
+	r.Equal(`DESCRIBE STAGE "test_db"."test_schema"."test_stage"`, s.Describe())
 }
 
 func TestStageShow(t *testing.T) {
 	r := require.New(t)
 	s := Stage("test_stage", "test_db", "test_schema")
-	r.Equal(s.Show(), `SHOW STAGES LIKE 'test_stage' IN SCHEMA "test_db"."test_schema"`)
+	r.Equal(`SHOW STAGES LIKE 'test_stage' IN SCHEMA "test_db"."test_schema"`, s.Show())
 }

--- a/pkg/snowflake/stream_test.go
+++ b/pkg/snowflake/stream_test.go
@@ -11,44 +11,44 @@ func TestStreamCreate(t *testing.T) {
 	s := Stream("test_stream", "test_db", "test_schema")
 
 	s.WithOnTable("test_db", "test_schema", "test_target_table")
-	r.Equal(s.Create(), `CREATE STREAM "test_db"."test_schema"."test_stream" ON TABLE "test_db"."test_schema"."test_target_table" APPEND_ONLY = false INSERT_ONLY = false SHOW_INITIAL_ROWS = false`)
+	r.Equal(`CREATE STREAM "test_db"."test_schema"."test_stream" ON TABLE "test_db"."test_schema"."test_target_table" APPEND_ONLY = false INSERT_ONLY = false SHOW_INITIAL_ROWS = false`, s.Create())
 
 	s.WithComment("Test Comment")
-	r.Equal(s.Create(), `CREATE STREAM "test_db"."test_schema"."test_stream" ON TABLE "test_db"."test_schema"."test_target_table" COMMENT = 'Test Comment' APPEND_ONLY = false INSERT_ONLY = false SHOW_INITIAL_ROWS = false`)
+	r.Equal(`CREATE STREAM "test_db"."test_schema"."test_stream" ON TABLE "test_db"."test_schema"."test_target_table" COMMENT = 'Test Comment' APPEND_ONLY = false INSERT_ONLY = false SHOW_INITIAL_ROWS = false`, s.Create())
 
 	s.WithShowInitialRows(true)
-	r.Equal(s.Create(), `CREATE STREAM "test_db"."test_schema"."test_stream" ON TABLE "test_db"."test_schema"."test_target_table" COMMENT = 'Test Comment' APPEND_ONLY = false INSERT_ONLY = false SHOW_INITIAL_ROWS = true`)
+	r.Equal(`CREATE STREAM "test_db"."test_schema"."test_stream" ON TABLE "test_db"."test_schema"."test_target_table" COMMENT = 'Test Comment' APPEND_ONLY = false INSERT_ONLY = false SHOW_INITIAL_ROWS = true`, s.Create())
 
 	s.WithAppendOnly(true)
-	r.Equal(s.Create(), `CREATE STREAM "test_db"."test_schema"."test_stream" ON TABLE "test_db"."test_schema"."test_target_table" COMMENT = 'Test Comment' APPEND_ONLY = true INSERT_ONLY = false SHOW_INITIAL_ROWS = true`)
+	r.Equal(`CREATE STREAM "test_db"."test_schema"."test_stream" ON TABLE "test_db"."test_schema"."test_target_table" COMMENT = 'Test Comment' APPEND_ONLY = true INSERT_ONLY = false SHOW_INITIAL_ROWS = true`, s.Create())
 
 	s.WithInsertOnly(true)
-	r.Equal(s.Create(), `CREATE STREAM "test_db"."test_schema"."test_stream" ON TABLE "test_db"."test_schema"."test_target_table" COMMENT = 'Test Comment' APPEND_ONLY = true INSERT_ONLY = true SHOW_INITIAL_ROWS = true`)
+	r.Equal(`CREATE STREAM "test_db"."test_schema"."test_stream" ON TABLE "test_db"."test_schema"."test_target_table" COMMENT = 'Test Comment' APPEND_ONLY = true INSERT_ONLY = true SHOW_INITIAL_ROWS = true`, s.Create())
 
 	s.WithExternalTable(true)
-	r.Equal(s.Create(), `CREATE STREAM "test_db"."test_schema"."test_stream" ON EXTERNAL TABLE "test_db"."test_schema"."test_target_table" COMMENT = 'Test Comment' APPEND_ONLY = true INSERT_ONLY = true SHOW_INITIAL_ROWS = true`)
+	r.Equal(`CREATE STREAM "test_db"."test_schema"."test_stream" ON EXTERNAL TABLE "test_db"."test_schema"."test_target_table" COMMENT = 'Test Comment' APPEND_ONLY = true INSERT_ONLY = true SHOW_INITIAL_ROWS = true`, s.Create())
 }
 
 func TestStreamChangeComment(t *testing.T) {
 	r := require.New(t)
 	s := Stream("test_stream", "test_db", "test_schema")
-	r.Equal(s.ChangeComment("new stream comment"), `ALTER STREAM "test_db"."test_schema"."test_stream" SET COMMENT = 'new stream comment'`)
+	r.Equal(`ALTER STREAM "test_db"."test_schema"."test_stream" SET COMMENT = 'new stream comment'`, s.ChangeComment("new stream comment"))
 }
 
 func TestStreamRemoveComment(t *testing.T) {
 	r := require.New(t)
 	s := Stream("test_stream", "test_db", "test_schema")
-	r.Equal(s.RemoveComment(), `ALTER STREAM "test_db"."test_schema"."test_stream" UNSET COMMENT`)
+	r.Equal(`ALTER STREAM "test_db"."test_schema"."test_stream" UNSET COMMENT`, s.RemoveComment())
 }
 
 func TestStreamDrop(t *testing.T) {
 	r := require.New(t)
 	s := Stream("test_stream", "test_db", "test_schema")
-	r.Equal(s.Drop(), `DROP STREAM "test_db"."test_schema"."test_stream"`)
+	r.Equal(`DROP STREAM "test_db"."test_schema"."test_stream"`, s.Drop())
 }
 
 func TestStreamShow(t *testing.T) {
 	r := require.New(t)
 	s := Stream("test_stream", "test_db", "test_schema")
-	r.Equal(s.Show(), `SHOW STREAMS LIKE 'test_stream' IN SCHEMA "test_db"."test_schema"`)
+	r.Equal(`SHOW STREAMS LIKE 'test_stream' IN SCHEMA "test_db"."test_schema"`, s.Show())
 }

--- a/pkg/snowflake/system_generate_scim_access_token_test.go
+++ b/pkg/snowflake/system_generate_scim_access_token_test.go
@@ -10,5 +10,5 @@ func TestSystemGenerateSCIMAccessToken(t *testing.T) {
 	r := require.New(t)
 	sb := SystemGenerateSCIMAccessToken("AAD_PROVISIONING")
 
-	r.Equal(sb.Select(), `SELECT SYSTEM$GENERATE_SCIM_ACCESS_TOKEN('AAD_PROVISIONING') AS "TOKEN"`)
+	r.Equal(`SELECT SYSTEM$GENERATE_SCIM_ACCESS_TOKEN('AAD_PROVISIONING') AS "TOKEN"`, sb.Select())
 }

--- a/pkg/snowflake/system_get_aws_sns_iam_policy_test.go
+++ b/pkg/snowflake/system_get_aws_sns_iam_policy_test.go
@@ -10,5 +10,5 @@ func TestSystemGetAWSSNSIAMPolicy(t *testing.T) {
 	r := require.New(t)
 	sb := SystemGetAWSSNSIAMPolicy("arn:aws:sns:us-east-1:1234567890123456:mytopic")
 
-	r.Equal(sb.Select(), `SELECT SYSTEM$GET_AWS_SNS_IAM_POLICY('arn:aws:sns:us-east-1:1234567890123456:mytopic') AS "policy"`)
+	r.Equal(`SELECT SYSTEM$GET_AWS_SNS_IAM_POLICY('arn:aws:sns:us-east-1:1234567890123456:mytopic') AS "policy"`, sb.Select())
 }

--- a/pkg/snowflake/system_get_privatelink_config_test.go
+++ b/pkg/snowflake/system_get_privatelink_config_test.go
@@ -10,7 +10,7 @@ func TestSystemGetPrivateLinkConfigQuery(t *testing.T) {
 	r := require.New(t)
 	sb := SystemGetPrivateLinkConfigQuery()
 
-	r.Equal(sb, `SELECT SYSTEM$GET_PRIVATELINK_CONFIG() AS "config"`)
+	r.Equal(`SELECT SYSTEM$GET_PRIVATELINK_CONFIG() AS "config"`, sb)
 }
 
 func TestSystemGetPrivateLinkGetStructuredConfigAws(t *testing.T) {

--- a/pkg/snowflake/system_get_snowflake_platform_info_test.go
+++ b/pkg/snowflake/system_get_snowflake_platform_info_test.go
@@ -10,7 +10,7 @@ func TestSystemGetSnowflakePlatformInfoQuery(t *testing.T) {
 	r := require.New(t)
 	sb := SystemGetSnowflakePlatformInfoQuery()
 
-	r.Equal(sb, `SELECT SYSTEM$GET_SNOWFLAKE_PLATFORM_INFO() AS "INFO"`)
+	r.Equal(`SELECT SYSTEM$GET_SNOWFLAKE_PLATFORM_INFO() AS "INFO"`, sb)
 }
 
 func TestSystemGetSnowflakePlatformInfoGetStructuredConfigAws(t *testing.T) {

--- a/pkg/snowflake/table_test.go
+++ b/pkg/snowflake/table_test.go
@@ -64,27 +64,27 @@ func TestTableCreate(t *testing.T) {
 		},
 	}
 
-	r.Equal(s.QualifiedName(), `"test_db"."test_schema"."test_table"`)
+	r.Equal(`"test_db"."test_schema"."test_table"`, s.QualifiedName())
 
 	r.Equal(`CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL DEFAULT "test_db"."test_schema"."test_seq".NEXTVAL COMMENT '', "column4" VARCHAR NOT NULL DEFAULT 'test default''s' COMMENT '', "column5" TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP() COMMENT '', "column6" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '') DATA_RETENTION_TIME_IN_DAYS = 0 CHANGE_TRACKING = false`, s.Create())
 
 	s.WithComment("Test Comment")
-	r.Equal(s.Create(), `CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL DEFAULT "test_db"."test_schema"."test_seq".NEXTVAL COMMENT '', "column4" VARCHAR NOT NULL DEFAULT 'test default''s' COMMENT '', "column5" TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP() COMMENT '', "column6" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '') COMMENT = 'Test Comment' DATA_RETENTION_TIME_IN_DAYS = 0 CHANGE_TRACKING = false`)
+	r.Equal(`CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL DEFAULT "test_db"."test_schema"."test_seq".NEXTVAL COMMENT '', "column4" VARCHAR NOT NULL DEFAULT 'test default''s' COMMENT '', "column5" TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP() COMMENT '', "column6" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '') COMMENT = 'Test Comment' DATA_RETENTION_TIME_IN_DAYS = 0 CHANGE_TRACKING = false`, s.Create())
 
 	s.WithClustering([]string{"column1"})
-	r.Equal(s.Create(), `CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL DEFAULT "test_db"."test_schema"."test_seq".NEXTVAL COMMENT '', "column4" VARCHAR NOT NULL DEFAULT 'test default''s' COMMENT '', "column5" TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP() COMMENT '', "column6" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '') COMMENT = 'Test Comment' CLUSTER BY LINEAR(column1) DATA_RETENTION_TIME_IN_DAYS = 0 CHANGE_TRACKING = false`)
+	r.Equal(`CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL DEFAULT "test_db"."test_schema"."test_seq".NEXTVAL COMMENT '', "column4" VARCHAR NOT NULL DEFAULT 'test default''s' COMMENT '', "column5" TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP() COMMENT '', "column6" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '') COMMENT = 'Test Comment' CLUSTER BY LINEAR(column1) DATA_RETENTION_TIME_IN_DAYS = 0 CHANGE_TRACKING = false`, s.Create())
 
 	s.WithPrimaryKey(PrimaryKey{name: "MY_KEY", keys: []string{"column1"}})
-	r.Equal(s.Create(), `CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL DEFAULT "test_db"."test_schema"."test_seq".NEXTVAL COMMENT '', "column4" VARCHAR NOT NULL DEFAULT 'test default''s' COMMENT '', "column5" TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP() COMMENT '', "column6" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '' ,CONSTRAINT "MY_KEY" PRIMARY KEY("column1")) COMMENT = 'Test Comment' CLUSTER BY LINEAR(column1) DATA_RETENTION_TIME_IN_DAYS = 0 CHANGE_TRACKING = false`)
+	r.Equal(`CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL DEFAULT "test_db"."test_schema"."test_seq".NEXTVAL COMMENT '', "column4" VARCHAR NOT NULL DEFAULT 'test default''s' COMMENT '', "column5" TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP() COMMENT '', "column6" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '' ,CONSTRAINT "MY_KEY" PRIMARY KEY("column1")) COMMENT = 'Test Comment' CLUSTER BY LINEAR(column1) DATA_RETENTION_TIME_IN_DAYS = 0 CHANGE_TRACKING = false`, s.Create())
 
 	s.WithDataRetentionTimeInDays(10)
-	r.Equal(s.Create(), `CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL DEFAULT "test_db"."test_schema"."test_seq".NEXTVAL COMMENT '', "column4" VARCHAR NOT NULL DEFAULT 'test default''s' COMMENT '', "column5" TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP() COMMENT '', "column6" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '' ,CONSTRAINT "MY_KEY" PRIMARY KEY("column1")) COMMENT = 'Test Comment' CLUSTER BY LINEAR(column1) DATA_RETENTION_TIME_IN_DAYS = 10 CHANGE_TRACKING = false`)
+	r.Equal(`CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL DEFAULT "test_db"."test_schema"."test_seq".NEXTVAL COMMENT '', "column4" VARCHAR NOT NULL DEFAULT 'test default''s' COMMENT '', "column5" TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP() COMMENT '', "column6" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '' ,CONSTRAINT "MY_KEY" PRIMARY KEY("column1")) COMMENT = 'Test Comment' CLUSTER BY LINEAR(column1) DATA_RETENTION_TIME_IN_DAYS = 10 CHANGE_TRACKING = false`, s.Create())
 
 	s.WithChangeTracking(true)
-	r.Equal(s.Create(), `CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL DEFAULT "test_db"."test_schema"."test_seq".NEXTVAL COMMENT '', "column4" VARCHAR NOT NULL DEFAULT 'test default''s' COMMENT '', "column5" TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP() COMMENT '', "column6" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '' ,CONSTRAINT "MY_KEY" PRIMARY KEY("column1")) COMMENT = 'Test Comment' CLUSTER BY LINEAR(column1) DATA_RETENTION_TIME_IN_DAYS = 10 CHANGE_TRACKING = true`)
+	r.Equal(`CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL DEFAULT "test_db"."test_schema"."test_seq".NEXTVAL COMMENT '', "column4" VARCHAR NOT NULL DEFAULT 'test default''s' COMMENT '', "column5" TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP() COMMENT '', "column6" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '' ,CONSTRAINT "MY_KEY" PRIMARY KEY("column1")) COMMENT = 'Test Comment' CLUSTER BY LINEAR(column1) DATA_RETENTION_TIME_IN_DAYS = 10 CHANGE_TRACKING = true`, s.Create())
 
 	s.WithTags(tags)
-	r.Equal(s.Create(), `CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL DEFAULT "test_db"."test_schema"."test_seq".NEXTVAL COMMENT '', "column4" VARCHAR NOT NULL DEFAULT 'test default''s' COMMENT '', "column5" TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP() COMMENT '', "column6" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '' ,CONSTRAINT "MY_KEY" PRIMARY KEY("column1")) COMMENT = 'Test Comment' CLUSTER BY LINEAR(column1) DATA_RETENTION_TIME_IN_DAYS = 10 CHANGE_TRACKING = true WITH TAG ("test_db"."test_schema"."tag" = "value", "test_db"."test_schema"."tag2" = "value2")`)
+	r.Equal(`CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL DEFAULT "test_db"."test_schema"."test_seq".NEXTVAL COMMENT '', "column4" VARCHAR NOT NULL DEFAULT 'test default''s' COMMENT '', "column5" TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP() COMMENT '', "column6" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '' ,CONSTRAINT "MY_KEY" PRIMARY KEY("column1")) COMMENT = 'Test Comment' CLUSTER BY LINEAR(column1) DATA_RETENTION_TIME_IN_DAYS = 10 CHANGE_TRACKING = true WITH TAG ("test_db"."test_schema"."tag" = "value", "test_db"."test_schema"."tag2" = "value2")`, s.Create())
 }
 
 func TestTableCreateIdentity(t *testing.T) {
@@ -117,7 +117,7 @@ func TestTableCreateIdentity(t *testing.T) {
 	}
 
 	s.WithColumns(Columns(cols))
-	r.Equal(s.QualifiedName(), `"test_db"."test_schema"."test_table"`)
+	r.Equal(`"test_db"."test_schema"."test_table"`, s.QualifiedName())
 
 	r.Equal(`CREATE TABLE "test_db"."test_schema"."test_table" ("column1" OBJECT COMMENT '', "column2" VARCHAR COMMENT 'only populated when data is available', "column3" NUMBER(38,0) NOT NULL IDENTITY(2, 5) COMMENT '', "column4" VARCHAR WITH MASKING POLICY TEST_MP COMMENT '') DATA_RETENTION_TIME_IN_DAYS = 0 CHANGE_TRACKING = false`, s.Create())
 }
@@ -125,155 +125,155 @@ func TestTableCreateIdentity(t *testing.T) {
 func TestTableChangeComment(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.ChangeComment("new table comment"), `ALTER TABLE "test_db"."test_schema"."test_table" SET COMMENT = 'new table comment'`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" SET COMMENT = 'new table comment'`, s.ChangeComment("new table comment"))
 }
 
 func TestTableRemoveComment(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.RemoveComment(), `ALTER TABLE "test_db"."test_schema"."test_table" UNSET COMMENT`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" UNSET COMMENT`, s.RemoveComment())
 }
 
 func TestTableAddColumn(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.AddColumn("new_column", "VARIANT", true, nil, nil, "", ""), `ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" VARIANT COMMENT ''`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" VARIANT COMMENT ''`, s.AddColumn("new_column", "VARIANT", true, nil, nil, "", ""))
 }
 
 func TestTableAddColumnWithComment(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.AddColumn("new_column", "VARIANT", true, nil, nil, "some comment", ""), `ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" VARIANT COMMENT 'some comment'`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" VARIANT COMMENT 'some comment'`, s.AddColumn("new_column", "VARIANT", true, nil, nil, "some comment", ""))
 }
 
 func TestTableAddColumnWithDefault(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.AddColumn("new_column", "NUMBER(38,0)", true, NewColumnDefaultWithConstant("1"), nil, "", ""), `ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" NUMBER(38,0) DEFAULT 1 COMMENT ''`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" NUMBER(38,0) DEFAULT 1 COMMENT ''`, s.AddColumn("new_column", "NUMBER(38,0)", true, NewColumnDefaultWithConstant("1"), nil, "", ""))
 }
 
 func TestTableAddColumnWithIdentity(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.AddColumn("new_column", "NUMBER(38,0)", true, nil, &ColumnIdentity{1, 4}, "", ""), `ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" NUMBER(38,0) IDENTITY(1, 4) COMMENT ''`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" NUMBER(38,0) IDENTITY(1, 4) COMMENT ''`, s.AddColumn("new_column", "NUMBER(38,0)", true, nil, &ColumnIdentity{1, 4}, "", ""))
 }
 
 func TestTableAddColumnWithMaskingPolicy(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.AddColumn("new_column", "NUMBER(38,0)", true, nil, &ColumnIdentity{1, 4}, "", "TEST_MP"), `ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" NUMBER(38,0) IDENTITY(1, 4) WITH MASKING POLICY TEST_MP COMMENT ''`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" NUMBER(38,0) IDENTITY(1, 4) WITH MASKING POLICY TEST_MP COMMENT ''`, s.AddColumn("new_column", "NUMBER(38,0)", true, nil, &ColumnIdentity{1, 4}, "", "TEST_MP"))
 }
 
 func TestTableDropColumn(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.DropColumn("old_column"), `ALTER TABLE "test_db"."test_schema"."test_table" DROP COLUMN "old_column"`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" DROP COLUMN "old_column"`, s.DropColumn("old_column"))
 }
 
 func TestTableChangeColumnType(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.ChangeColumnType("old_column", "BIGINT"), `ALTER TABLE "test_db"."test_schema"."test_table" MODIFY COLUMN "old_column" BIGINT`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" MODIFY COLUMN "old_column" BIGINT`, s.ChangeColumnType("old_column", "BIGINT"))
 }
 
 func TestTableChangeColumnComment(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.ChangeColumnComment("old_column", "some comment"), `ALTER TABLE "test_db"."test_schema"."test_table" MODIFY COLUMN "old_column" COMMENT 'some comment'`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" MODIFY COLUMN "old_column" COMMENT 'some comment'`, s.ChangeColumnComment("old_column", "some comment"))
 }
 
 func TestTableChangeColumnMaskingPolicy(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.ChangeColumnMaskingPolicy("old_column", "TEST_MP"), `ALTER TABLE "test_db"."test_schema"."test_table" MODIFY COLUMN "old_column" SET MASKING POLICY TEST_MP`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" MODIFY COLUMN "old_column" SET MASKING POLICY TEST_MP`, s.ChangeColumnMaskingPolicy("old_column", "TEST_MP"))
 }
 
 func TestTableDropColumnDefault(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.DropColumnDefault("old_column"), `ALTER TABLE "test_db"."test_schema"."test_table" MODIFY COLUMN "old_column" DROP DEFAULT`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" MODIFY COLUMN "old_column" DROP DEFAULT`, s.DropColumnDefault("old_column"))
 }
 
 func TestTableChangeClusterBy(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.ChangeClusterBy("column2, column3"), `ALTER TABLE "test_db"."test_schema"."test_table" CLUSTER BY LINEAR(column2, column3)`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" CLUSTER BY LINEAR(column2, column3)`, s.ChangeClusterBy("column2, column3"))
 }
 
 func TestTableChangeDataRetention(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.ChangeDataRetention(5), `ALTER TABLE "test_db"."test_schema"."test_table" SET DATA_RETENTION_TIME_IN_DAYS = 5`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" SET DATA_RETENTION_TIME_IN_DAYS = 5`, s.ChangeDataRetention(5))
 }
 
 func TestTableChangeChangeTracking(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.ChangeChangeTracking(true), `ALTER TABLE "test_db"."test_schema"."test_table" SET CHANGE_TRACKING = true`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" SET CHANGE_TRACKING = true`, s.ChangeChangeTracking(true))
 }
 
 func TestTableDropClusterBy(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.DropClustering(), `ALTER TABLE "test_db"."test_schema"."test_table" DROP CLUSTERING KEY`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" DROP CLUSTERING KEY`, s.DropClustering())
 }
 
 func TestTableDrop(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.Drop(), `DROP TABLE "test_db"."test_schema"."test_table"`)
+	r.Equal(`DROP TABLE "test_db"."test_schema"."test_table"`, s.Drop())
 }
 
 func TestTableShow(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.Show(), `SHOW TABLES LIKE 'test_table' IN SCHEMA "test_db"."test_schema"`)
+	r.Equal(`SHOW TABLES LIKE 'test_table' IN SCHEMA "test_db"."test_schema"`, s.Show())
 }
 
 func TestTableShowPrimaryKeys(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.ShowPrimaryKeys(), `SHOW PRIMARY KEYS IN TABLE "test_db"."test_schema"."test_table"`)
+	r.Equal(`SHOW PRIMARY KEYS IN TABLE "test_db"."test_schema"."test_table"`, s.ShowPrimaryKeys())
 }
 
 func TestTableDropPrimaryKeys(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.DropPrimaryKey(), `ALTER TABLE "test_db"."test_schema"."test_table" DROP PRIMARY KEY`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" DROP PRIMARY KEY`, s.DropPrimaryKey())
 }
 
 func TestTableChangePrimaryKeysWithConstraintName(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.ChangePrimaryKey(PrimaryKey{name: "MY_KEY", keys: []string{"column1", "column2"}}), `ALTER TABLE "test_db"."test_schema"."test_table" ADD CONSTRAINT "MY_KEY" PRIMARY KEY("column1", "column2")`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD CONSTRAINT "MY_KEY" PRIMARY KEY("column1", "column2")`, s.ChangePrimaryKey(PrimaryKey{name: "MY_KEY", keys: []string{"column1", "column2"}}))
 }
 
 func TestTableChangePrimaryKeysWithoutConstraintName(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.ChangePrimaryKey(PrimaryKey{name: "", keys: []string{"column1", "column2"}}), `ALTER TABLE "test_db"."test_schema"."test_table" ADD PRIMARY KEY("column1", "column2")`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD PRIMARY KEY("column1", "column2")`, s.ChangePrimaryKey(PrimaryKey{name: "", keys: []string{"column1", "column2"}}))
 }
 
 func TestTableAddTag(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.AddTag(TagValue{Name: "tag", Schema: "test_schema", Database: "test_db", Value: "value"}), `ALTER TABLE "test_db"."test_schema"."test_table" SET TAG "test_db"."test_schema"."tag" = "value"`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" SET TAG "test_db"."test_schema"."tag" = "value"`, s.AddTag(TagValue{Name: "tag", Schema: "test_schema", Database: "test_db", Value: "value"}))
 }
 
 func TestTableChangeTag(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.ChangeTag(TagValue{Name: "tag", Schema: "test_schema", Database: "test_db", Value: "value"}), `ALTER TABLE "test_db"."test_schema"."test_table" SET TAG "test_db"."test_schema"."tag" = "value"`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" SET TAG "test_db"."test_schema"."tag" = "value"`, s.ChangeTag(TagValue{Name: "tag", Schema: "test_schema", Database: "test_db", Value: "value"}))
 }
 
 func TestTableUnsetTag(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table", "test_db", "test_schema")
-	r.Equal(s.UnsetTag(TagValue{Name: "tag", Schema: "test_schema", Database: "test_db"}), `ALTER TABLE "test_db"."test_schema"."test_table" UNSET TAG "test_db"."test_schema"."tag"`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" UNSET TAG "test_db"."test_schema"."tag"`, s.UnsetTag(TagValue{Name: "tag", Schema: "test_schema", Database: "test_db"}))
 }
 
 func TestTableRename(t *testing.T) {
 	r := require.New(t)
 	s := Table("test_table1", "test_db", "test_schema")
-	r.Equal(s.Rename("test_table2"), `ALTER TABLE "test_db"."test_schema"."test_table1" RENAME TO "test_db"."test_schema"."test_table2"`)
+	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table1" RENAME TO "test_db"."test_schema"."test_table2"`, s.Rename("test_table2"))
 }

--- a/pkg/snowflake/tag_test.go
+++ b/pkg/snowflake/tag_test.go
@@ -9,15 +9,15 @@ import (
 func TestTagCreate(t *testing.T) {
 	r := require.New(t)
 	o := Tag("test")
-	r.Equal(o.QualifiedName(), `"test"`)
+	r.Equal(`"test"`, o.QualifiedName())
 
 	o.WithDB("db")
-	r.Equal(o.QualifiedName(), `"db"."test"`)
+	r.Equal(`"db"."test"`, o.QualifiedName())
 
 	o.WithSchema("schema")
-	r.Equal(o.QualifiedName(), `"db"."schema"."test"`)
+	r.Equal(`"db"."schema"."test"`, o.QualifiedName())
 
-	r.Equal(o.Create(), `CREATE TAG "db"."schema"."test"`)
+	r.Equal(`CREATE TAG "db"."schema"."test"`, o.Create())
 
 	allowedValues := []string{"marketing", "finance"}
 	o.WithAllowedValues(allowedValues)
@@ -29,7 +29,7 @@ func TestTagCreate(t *testing.T) {
 func TestTagRename(t *testing.T) {
 	r := require.New(t)
 	o := Tag("test")
-	r.Equal(o.Rename("bob"), `ALTER TAG "test" RENAME TO "bob"`)
+	r.Equal(`ALTER TAG "test" RENAME TO "bob"`, o.Rename("bob"))
 }
 
 func TestTagChangeComment(t *testing.T) {
@@ -41,65 +41,65 @@ func TestTagChangeComment(t *testing.T) {
 func TestTagRemoveComment(t *testing.T) {
 	r := require.New(t)
 	o := Tag("test")
-	r.Equal(o.RemoveComment(), `ALTER TAG "test" UNSET COMMENT`)
+	r.Equal(`ALTER TAG "test" UNSET COMMENT`, o.RemoveComment())
 }
 
 func TestTagAddAllowedValues(t *testing.T) {
 	r := require.New(t)
 	o := Tag("test")
 	avs := []string{"foo", "bar"}
-	r.Equal(o.AddAllowedValues(avs), `ALTER TAG "test" ADD ALLOWED_VALUES 'foo', 'bar'`)
+	r.Equal(`ALTER TAG "test" ADD ALLOWED_VALUES 'foo', 'bar'`, o.AddAllowedValues(avs))
 }
 
 func TestTagDropAllowedValues(t *testing.T) {
 	r := require.New(t)
 	o := Tag("test")
 	avs := []string{"foo"}
-	r.Equal(o.DropAllowedValues(avs), `ALTER TAG "test" DROP ALLOWED_VALUES 'foo'`)
+	r.Equal(`ALTER TAG "test" DROP ALLOWED_VALUES 'foo'`, o.DropAllowedValues(avs))
 }
 
 func TestTagRemoveAllowedValues(t *testing.T) {
 	r := require.New(t)
 	o := Tag("test")
-	r.Equal(o.RemoveAllowedValues(), `ALTER TAG "test" UNSET ALLOWED_VALUES`)
+	r.Equal(`ALTER TAG "test" UNSET ALLOWED_VALUES`, o.RemoveAllowedValues())
 }
 
 func TestTagDrop(t *testing.T) {
 	r := require.New(t)
 	o := Tag("test")
-	r.Equal(o.Drop(), `DROP TAG "test"`)
+	r.Equal(`DROP TAG "test"`, o.Drop())
 }
 
 func TestTagUndrop(t *testing.T) {
 	r := require.New(t)
 	o := Tag("test")
-	r.Equal(o.Undrop(), `UNDROP TAG "test"`)
+	r.Equal(`UNDROP TAG "test"`, o.Undrop())
 }
 
 func TestTagShow(t *testing.T) {
 	r := require.New(t)
 	o := Tag("test")
-	r.Equal(o.Show(), `SHOW TAGS LIKE 'test'`)
+	r.Equal(`SHOW TAGS LIKE 'test'`, o.Show())
 
 	o.WithDB("db")
-	r.Equal(o.Show(), `SHOW TAGS LIKE 'test' IN DATABASE "db"`)
+	r.Equal(`SHOW TAGS LIKE 'test' IN DATABASE "db"`, o.Show())
 
 	o.WithSchema("schema")
-	r.Equal(o.Show(), `SHOW TAGS LIKE 'test' IN SCHEMA "db"."schema"`)
+	r.Equal(`SHOW TAGS LIKE 'test' IN SCHEMA "db"."schema"`, o.Show())
 }
 
 func TestTagShowAttachedPolicy(t *testing.T) {
 	r := require.New(t)
 	o := Tag("test")
-	r.Equal(o.Show(), `SHOW TAGS LIKE 'test'`)
+	r.Equal(`SHOW TAGS LIKE 'test'`, o.Show())
 
 	o.WithDB("db")
-	r.Equal(o.Show(), `SHOW TAGS LIKE 'test' IN DATABASE "db"`)
+	r.Equal(`SHOW TAGS LIKE 'test' IN DATABASE "db"`, o.Show())
 
 	o.WithSchema("schema")
-	r.Equal(o.Show(), `SHOW TAGS LIKE 'test' IN SCHEMA "db"."schema"`)
+	r.Equal(`SHOW TAGS LIKE 'test' IN SCHEMA "db"."schema"`, o.Show())
 
 	mP := MaskingPolicy("policy", "db2", "schema2")
 	o.WithMaskingPolicy(mP)
-	r.Equal(o.ShowAttachedPolicy(), `SELECT * from table ("db".information_schema.policy_references(ref_entity_name => '"db"."schema"."test"', ref_entity_domain => 'TAG')) where policy_db='db2' and policy_schema='schema2' and policy_name='policy'`)
+	r.Equal(`SELECT * from table ("db".information_schema.policy_references(ref_entity_name => '"db"."schema"."test"', ref_entity_domain => 'TAG')) where policy_db='db2' and policy_schema='schema2' and policy_name='policy'`, o.ShowAttachedPolicy())
 }

--- a/pkg/snowflake/task_test.go
+++ b/pkg/snowflake/task_test.go
@@ -9,166 +9,166 @@ import (
 func TestTaskCreate(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.QualifiedName(), `"test_db"."test_schema"."test_task"`)
+	r.Equal(`"test_db"."test_schema"."test_task"`, st.QualifiedName())
 
 	st.WithWarehouse("test_wh")
-	r.Equal(st.Create(), `CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh"`)
+	r.Equal(`CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh"`, st.Create())
 
 	st.WithSchedule("USING CRON 0 9-17 * * SUN America/Los_Angeles")
-	r.Equal(st.Create(), `CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles'`)
+	r.Equal(`CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles'`, st.Create())
 
 	st.WithSessionParameters(map[string]interface{}{"TIMESTAMP_INPUT_FORMAT": "YYYY-MM-DD HH24"})
-	r.Equal(st.Create(), `CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24"`)
+	r.Equal(`CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24"`, st.Create())
 
 	st.WithComment("test comment")
-	r.Equal(st.Create(), `CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment'`)
+	r.Equal(`CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment'`, st.Create())
 
 	st.WithTimeout(12)
-	r.Equal(st.Create(), `CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment' USER_TASK_TIMEOUT_MS = 12`)
+	r.Equal(`CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment' USER_TASK_TIMEOUT_MS = 12`, st.Create())
 
 	st.WithAfter([]string{"other_task"})
-	r.Equal(st.Create(), `CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment' USER_TASK_TIMEOUT_MS = 12 AFTER "test_db"."test_schema"."other_task"`)
+	r.Equal(`CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment' USER_TASK_TIMEOUT_MS = 12 AFTER "test_db"."test_schema"."other_task"`, st.Create())
 
 	st.WithCondition("SYSTEM$STREAM_HAS_DATA('MYSTREAM')")
-	r.Equal(st.Create(), `CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment' USER_TASK_TIMEOUT_MS = 12 AFTER "test_db"."test_schema"."other_task" WHEN SYSTEM$STREAM_HAS_DATA('MYSTREAM')`)
+	r.Equal(`CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment' USER_TASK_TIMEOUT_MS = 12 AFTER "test_db"."test_schema"."other_task" WHEN SYSTEM$STREAM_HAS_DATA('MYSTREAM')`, st.Create())
 
 	st.WithStatement("SELECT * FROM table WHERE column = 'name'")
-	r.Equal(st.Create(), `CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment' USER_TASK_TIMEOUT_MS = 12 AFTER "test_db"."test_schema"."other_task" WHEN SYSTEM$STREAM_HAS_DATA('MYSTREAM') AS SELECT * FROM table WHERE column = 'name'`)
+	r.Equal(`CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment' USER_TASK_TIMEOUT_MS = 12 AFTER "test_db"."test_schema"."other_task" WHEN SYSTEM$STREAM_HAS_DATA('MYSTREAM') AS SELECT * FROM table WHERE column = 'name'`, st.Create())
 
 	st.WithAllowOverlappingExecution(true)
-	r.Equal(st.Create(), `CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment' ALLOW_OVERLAPPING_EXECUTION = TRUE USER_TASK_TIMEOUT_MS = 12 AFTER "test_db"."test_schema"."other_task" WHEN SYSTEM$STREAM_HAS_DATA('MYSTREAM') AS SELECT * FROM table WHERE column = 'name'`)
+	r.Equal(`CREATE TASK "test_db"."test_schema"."test_task" WAREHOUSE = "test_wh" SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles' TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24" COMMENT = 'test comment' ALLOW_OVERLAPPING_EXECUTION = TRUE USER_TASK_TIMEOUT_MS = 12 AFTER "test_db"."test_schema"."other_task" WHEN SYSTEM$STREAM_HAS_DATA('MYSTREAM') AS SELECT * FROM table WHERE column = 'name'`, st.Create())
 }
 
 func TestChangeWarehouse(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.ChangeWarehouse("much_wh"), `ALTER TASK "test_db"."test_schema"."test_task" SET WAREHOUSE = "much_wh"`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET WAREHOUSE = "much_wh"`, st.ChangeWarehouse("much_wh"))
 }
 
 func TestSwitchWarehouseToManaged(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.SwitchWarehouseToManaged(), `ALTER TASK "test_db"."test_schema"."test_task" SET WAREHOUSE = null`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET WAREHOUSE = null`, st.SwitchWarehouseToManaged())
 }
 
 func TestSwitchManagedWithInitialSize(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.SwitchManagedWithInitialSize("SMALL"), `ALTER TASK "test_db"."test_schema"."test_task" SET USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = 'SMALL'`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = 'SMALL'`, st.SwitchManagedWithInitialSize("SMALL"))
 }
 
 func TestChangeSchedule(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.ChangeSchedule("USING CRON 0 9-17 * * SUN America/New_York"), `ALTER TASK "test_db"."test_schema"."test_task" SET SCHEDULE = 'USING CRON 0 9-17 * * SUN America/New_York'`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET SCHEDULE = 'USING CRON 0 9-17 * * SUN America/New_York'`, st.ChangeSchedule("USING CRON 0 9-17 * * SUN America/New_York"))
 }
 
 func TestRemoveSchedule(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.RemoveSchedule(), `ALTER TASK "test_db"."test_schema"."test_task" UNSET SCHEDULE`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" UNSET SCHEDULE`, st.RemoveSchedule())
 }
 
 func TestChangeTimeout(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.ChangeTimeout(100), `ALTER TASK "test_db"."test_schema"."test_task" SET USER_TASK_TIMEOUT_MS = 100`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET USER_TASK_TIMEOUT_MS = 100`, st.ChangeTimeout(100))
 }
 
 func TestRemoveTimeout(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.RemoveTimeout(), `ALTER TASK "test_db"."test_schema"."test_task" UNSET USER_TASK_TIMEOUT_MS`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" UNSET USER_TASK_TIMEOUT_MS`, st.RemoveTimeout())
 }
 
 func TestChangeComment(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.ChangeComment("much comment wow"), `ALTER TASK "test_db"."test_schema"."test_task" SET COMMENT = 'much comment wow'`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET COMMENT = 'much comment wow'`, st.ChangeComment("much comment wow"))
 }
 
 func TestRemoveComment(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.RemoveComment(), `ALTER TASK "test_db"."test_schema"."test_task" UNSET COMMENT`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" UNSET COMMENT`, st.RemoveComment())
 }
 
 func TestAddAfter(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.AddAfter([]string{"other_task"}), `ALTER TASK "test_db"."test_schema"."test_task" ADD AFTER "test_db"."test_schema"."other_task"`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" ADD AFTER "test_db"."test_schema"."other_task"`, st.AddAfter([]string{"other_task"}))
 }
 
 func TestRemoveAfter(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.RemoveAfter([]string{"first_me_task"}), `ALTER TASK "test_db"."test_schema"."test_task" REMOVE AFTER "test_db"."test_schema"."first_me_task"`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" REMOVE AFTER "test_db"."test_schema"."first_me_task"`, st.RemoveAfter([]string{"first_me_task"}))
 }
 
 func TestAddSessionParameters(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
 	params := map[string]interface{}{"TIMESTAMP_INPUT_FORMAT": "YYYY-MM-DD HH24", "CLIENT_TIMESTAMP_TYPE_MAPPING": "TIMESTAMP_LTZ"}
-	r.Equal(st.AddSessionParameters(params), `ALTER TASK "test_db"."test_schema"."test_task" SET CLIENT_TIMESTAMP_TYPE_MAPPING = "TIMESTAMP_LTZ", TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24"`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET CLIENT_TIMESTAMP_TYPE_MAPPING = "TIMESTAMP_LTZ", TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24"`, st.AddSessionParameters(params))
 }
 
 func TestRemoveSessionParameters(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
 	params := map[string]interface{}{"TIMESTAMP_INPUT_FORMAT": "YYYY-MM-DD HH24", "CLIENT_TIMESTAMP_TYPE_MAPPING": "TIMESTAMP_LTZ"}
-	r.Equal(st.RemoveSessionParameters(params), `ALTER TASK "test_db"."test_schema"."test_task" UNSET CLIENT_TIMESTAMP_TYPE_MAPPING, TIMESTAMP_INPUT_FORMAT`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" UNSET CLIENT_TIMESTAMP_TYPE_MAPPING, TIMESTAMP_INPUT_FORMAT`, st.RemoveSessionParameters(params))
 }
 
 func TestChangeCondition(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.ChangeCondition("TRUE = TRUE"), `ALTER TASK "test_db"."test_schema"."test_task" MODIFY WHEN TRUE = TRUE`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" MODIFY WHEN TRUE = TRUE`, st.ChangeCondition("TRUE = TRUE"))
 }
 
 func TestChangeSqlStatement(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.ChangeSQLStatement("SELECT * FROM table"), `ALTER TASK "test_db"."test_schema"."test_task" MODIFY AS SELECT * FROM table`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" MODIFY AS SELECT * FROM table`, st.ChangeSQLStatement("SELECT * FROM table"))
 }
 
 func TestSuspend(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.Suspend(), `ALTER TASK "test_db"."test_schema"."test_task" SUSPEND`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SUSPEND`, st.Suspend())
 }
 
 func TestResume(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.Resume(), `ALTER TASK "test_db"."test_schema"."test_task" RESUME`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" RESUME`, st.Resume())
 }
 
 func TestShowParameters(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.ShowParameters(), `SHOW PARAMETERS IN TASK "test_db"."test_schema"."test_task"`)
+	r.Equal(`SHOW PARAMETERS IN TASK "test_db"."test_schema"."test_task"`, st.ShowParameters())
 }
 
 func TestDrop(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.Drop(), `DROP TASK "test_db"."test_schema"."test_task"`)
+	r.Equal(`DROP TASK "test_db"."test_schema"."test_task"`, st.Drop())
 }
 
 func TestDescribe(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.Describe(), `DESCRIBE TASK "test_db"."test_schema"."test_task"`)
+	r.Equal(`DESCRIBE TASK "test_db"."test_schema"."test_task"`, st.Describe())
 }
 
 func TestShow(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.Show(), `SHOW TASKS LIKE 'test_task' IN SCHEMA "test_db"."test_schema"`)
+	r.Equal(`SHOW TASKS LIKE 'test_task' IN SCHEMA "test_db"."test_schema"`, st.Show())
 }
 
 func TestSetAllowOverlappingExecution(t *testing.T) {
 	r := require.New(t)
 	st := Task("test_task", "test_db", "test_schema")
-	r.Equal(st.SetAllowOverlappingExecutionParameter(), `ALTER TASK "test_db"."test_schema"."test_task" SET ALLOW_OVERLAPPING_EXECUTION = TRUE`)
+	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET ALLOW_OVERLAPPING_EXECUTION = TRUE`, st.SetAllowOverlappingExecutionParameter())
 }

--- a/pkg/snowflake/view_test.go
+++ b/pkg/snowflake/view_test.go
@@ -18,7 +18,7 @@ func TestView(t *testing.T) {
 	r.False(v.secure)
 	qn, err := v.QualifiedName()
 	r.NoError(err)
-	r.Equal(qn, fmt.Sprintf(`"%v"."%v"."%v"`, db, schema, view))
+	r.Equal(fmt.Sprintf(`"%v"."%v"."%v"`, db, schema, view), qn)
 
 	v.WithSecure()
 	r.True(v.secure)
@@ -59,7 +59,7 @@ func TestView(t *testing.T) {
 	v.WithDB("mydb")
 	qn, err = v.QualifiedName()
 	r.NoError(err)
-	r.Equal(qn, `"mydb"."some_schema"."test"`)
+	r.Equal(`"mydb"."some_schema"."test"`, qn)
 
 	q, err = v.Create()
 	r.NoError(err)
@@ -82,7 +82,7 @@ func TestQualifiedName(t *testing.T) {
 	v := View("view").WithDB("db").WithSchema("schema")
 	qn, err := v.QualifiedName()
 	r.NoError(err)
-	r.Equal(qn, `"db"."schema"."view"`)
+	r.Equal(`"db"."schema"."view"`, qn)
 }
 
 func TestRename(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR fixes the wrong usages of testify package.

Function arguments of `Equal()`  from the `testify` package should be first `expected` and second `actual` values. The actual values are often the function's return to be tested. However, many tests with `Equal()` in this repo are incorrect.


The definition is as follows:

```
func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
	if h, ok := a.t.(tHelper); ok {
		h.Helper()
	}
	Equal(a.t, expected, actual, msgAndArgs...)
}
```

https://pkg.go.dev/github.com/stretchr/testify/require#Assertions.Equal

This leads to showing the unexpected verbose output when the test fails.