### PR TITLE
Remove double quotes from external table column definition

### DIFF
--- a/pkg/snowflake/external_table.go
+++ b/pkg/snowflake/external_table.go
@@ -130,7 +130,7 @@ func (tb *ExternalTableBuilder) Create() string {
 	q.WriteString(` (`)
 	columnDefinitions := []string{}
 	for _, columnDefinition := range tb.columns {
-		columnDefinitions = append(columnDefinitions, fmt.Sprintf(`"%v" %v AS %v`, EscapeString(columnDefinition["name"]), EscapeString(columnDefinition["type"]), columnDefinition["as"]))
+		columnDefinitions = append(columnDefinitions, fmt.Sprintf(`%v %v AS %v`, EscapeString(columnDefinition["name"]), EscapeString(columnDefinition["type"]), columnDefinition["as"]))
 	}
 	q.WriteString(strings.Join(columnDefinitions, ", "))
 	q.WriteString(`)`)


### PR DESCRIPTION
this is inconsistent with the partition_by field, for example, this generated SQL:

``` sql
CREATE EXTERNAL TABLE "x"."y"."z" ("partition_date" date AS '2020-01-01')) PARTITION BY ( partition_date ) WITH LOCATION ...
```

it throws an error because `"partition_date"` is not the same as `partition_date`