### PR TITLE
fix: insecure go expression

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,8 @@ linters:
     - staticcheck
     # typecheck: Like the front-end of a Go compiler, parses and type-checks Go code
     - typecheck
+    # Inspects source code for security problems
+    - gosec
 
     # not default
     # unconvert: Remove unnecessary type conversions

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -77,6 +77,7 @@ func TestDSN(t *testing.T) {
 	}
 }
 
+// nolint: gosec
 func TestOAuthDSN(t *testing.T) {
 	type args struct {
 		account          string
@@ -127,6 +128,7 @@ func TestOAuthDSN(t *testing.T) {
 	}
 }
 
+// nolint: gosec
 func TestGetOauthDATA(t *testing.T) {
 	type param struct {
 		refreshToken,
@@ -169,6 +171,7 @@ func TestGetOauthDATA(t *testing.T) {
 	}
 }
 
+// nolint: gosec
 func TestGetOauthResponse(t *testing.T) {
 	type param struct {
 		dataStuff,
@@ -222,6 +225,7 @@ func NewTestClient(fn RoundTripFunc) *http.Client {
 	}
 }
 
+// nolint: gosec
 func TestGetOauthAccessToken(t *testing.T) {
 	type param struct {
 		dataStuff,

--- a/pkg/snowflake/table_constraint.go
+++ b/pkg/snowflake/table_constraint.go
@@ -221,8 +221,8 @@ type tableConstraint struct {
 
 // Show returns the SQL query that will show a table constraint by ID.
 func ShowTableConstraint(name, tableDB, tableSchema, tableName string, db *sql.DB) (*tableConstraint, error) {
-	stmt := fmt.Sprintf(`SELECT * FROM SNOWFLAKE.INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME = '%v' AND TABLE_SCHEMA = '%v' AND TABLE_CATALOG = '%v' AND CONSTRAINT_NAME = '%v'`, tableName, tableSchema, tableDB, name)
-	rows, err := db.Query(stmt)
+	rows, err := db.Query(`SELECT * FROM SNOWFLAKE.INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME = '?' AND TABLE_SCHEMA = '?' AND TABLE_CATALOG = '?' AND CONSTRAINT_NAME = '?'`,
+		tableName, tableSchema, tableDB, name)
 	if err != nil {
 		return nil, err
 	}
@@ -235,5 +235,5 @@ func ShowTableConstraint(name, tableDB, tableSchema, tableName string, db *sql.D
 		log.Printf("[DEBUG] no tableConstraints found for constraint %s", name)
 		return nil, err
 	}
-	return &tableConstraints[0], errors.Wrapf(err, "unable to scan row for %s", stmt)
+	return &tableConstraints[0], errors.Wrapf(err, "unable to scan row")
 }

--- a/pkg/snowflake/tag_association.go
+++ b/pkg/snowflake/tag_association.go
@@ -96,8 +96,8 @@ func ScanTagAssociation(row *sqlx.Row) (*tagAssociation, error) {
 }
 
 func ListTagAssociations(tb *TagAssociationBuilder, db *sql.DB) ([]tagAssociation, error) {
-	stmt := fmt.Sprintf(`SELECT SYSTEM$GET_TAG('"%v"."%v"."%v"', '%v', '%v') TAG_VALUE WHERE TAG_VALUE IS NOT NULL`, tb.databaseName, tb.schemaName, tb.tagName, tb.objectIdentifier, tb.objectType)
-	rows, err := db.Query(stmt)
+	rows, err := db.Query(`SELECT SYSTEM$GET_TAG('"?"."?"."?"', '?', '?') TAG_VALUE WHERE TAG_VALUE IS NOT NULL`,
+		tb.databaseName, tb.schemaName, tb.tagName, tb.objectIdentifier, tb.objectType)
 	if err != nil {
 		return nil, err
 	}
@@ -110,5 +110,5 @@ func ListTagAssociations(tb *TagAssociationBuilder, db *sql.DB) ([]tagAssociatio
 		log.Printf("[DEBUG] no tag associations found for tag %s", tb.tagName)
 		return nil, err
 	}
-	return tagAssociations, errors.Wrapf(err, "unable to scan row for %s", stmt)
+	return tagAssociations, errors.Wrapf(err, "unable to scan row")
 }


### PR DESCRIPTION
This PR fixes insecure go expression.

```
pkg/snowflake/table_constraint.go:224:10: G201: SQL string formatting (gosec)
        stmt := fmt.Sprintf(`SELECT * FROM SNOWFLAKE.INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME = '%v' AND TABLE_SCHEMA = '%v' AND TABLE_CATALOG = '%v' AND CONSTRAINT_NAME = '%v'`, tableName, tableSchema, tableDB, name)
                ^
pkg/snowflake/tag_association.go:99:10: G201: SQL string formatting (gosec)
        stmt := fmt.Sprintf(`SELECT SYSTEM$GET_TAG('"%v"."%v"."%v"', '%v', '%v') TAG_VALUE WHERE TAG_VALUE IS NOT NULL`, tb.databaseName, tb.schemaName, tb.tagName, tb.objectIdentifier, tb.objectType)
```

Refs:
https://securego.io/docs/rules/g201-g202.html
