### PR TITLE
fix: preallocate slice

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,8 @@ linters:
     # not default
     # unconvert: Remove unnecessary type conversions
     - unconvert
+    # Finds slice declarations that could potentially be pre-allocated
+    - prealloc
     # gofmt: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
     - gofmt
     # gofumpt: Gofumpt checks whether code was gofumpt-ed.

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -285,7 +285,7 @@ func extractTriggerInts(s sql.NullString) ([]int, error) {
 		return []int{}, nil
 	}
 	ints := strings.Split(s.String, ",")
-	var out []int
+	out := make([]int, 0, len(ints))
 	for _, i := range ints {
 		myInt, err := strconv.Atoi(i[:len(i)-1])
 		if err != nil {

--- a/pkg/resources/table_constraint.go
+++ b/pkg/resources/table_constraint.go
@@ -214,7 +214,7 @@ func CreateTableConstraint(d *schema.ResourceData, meta interface{}) error {
 	builder := snowflake.TableConstraint(name, constraintType, formattedTableID)
 
 	cc := d.Get("columns").([]interface{})
-	var columns []string
+	columns := make([]string, 0, len(cc))
 	for _, c := range cc {
 		columns = append(columns, c.(string))
 	}
@@ -343,7 +343,7 @@ func DeleteTableConstraint(d *schema.ResourceData, meta interface{}) error {
 	formattedTableID := snowflakeValidation.ParseAndFormatFullyQualifiedObectID(tc.tableID)
 	builder := snowflake.TableConstraint(tc.name, tc.constraintType, formattedTableID)
 	cc := d.Get("columns").([]interface{})
-	var columns []string
+	columns := make([]string, 0, len(cc))
 	for _, c := range cc {
 		columns = append(columns, c.(string))
 	}

--- a/pkg/snowflake/failover_group.go
+++ b/pkg/snowflake/failover_group.go
@@ -275,7 +275,7 @@ func ShowDatabasesInFailoverGroup(name string, db *sql.DB) ([]string, error) {
 		return nil, nil
 	}
 
-	var result []string
+	result := make([]string, 0, len(failoverGroupAllowedDatabase))
 	for _, v := range failoverGroupAllowedDatabase {
 		result = append(result, v.Name.String)
 	}
@@ -302,7 +302,7 @@ func ShowSharesInFailoverGroup(name string, db *sql.DB) ([]string, error) {
 		return nil, nil
 	}
 
-	var result []string
+	result := make([]string, 0, len(failoverGroupAllowedShares))
 	for _, v := range failoverGroupAllowedShares {
 		result = append(result, v.Name.String)
 	}

--- a/pkg/snowflake/table.go
+++ b/pkg/snowflake/table.go
@@ -203,7 +203,7 @@ func FlattenTablePrimaryKey(pkds []primaryKeyDescription) []interface{} {
 	// sort our keys on the key sequence
 
 	flat := map[string]interface{}{}
-	var keys []string
+	keys := make([]string, 0, len(pkds))
 	var name string
 	var nameSet bool
 
@@ -413,7 +413,7 @@ func JoinStringList(instrings []string, delimiter string) string {
 }
 
 func quoteStringList(instrings []string) []string {
-	var clean []string
+	clean := make([]string, 0, len(instrings))
 	for _, word := range instrings {
 		quoted := fmt.Sprintf(`"%s"`, word)
 		clean = append(clean, quoted)
@@ -452,9 +452,9 @@ func ClusterStatementToList(clusterStatement string) []string {
 	cleanStatement := strings.TrimSuffix(strings.Replace(clusterStatement, "LINEAR(", "", 1), ")")
 	// remove cluster statement and trailing parenthesis
 
-	var clean []string
-
-	for _, s := range strings.Split(cleanStatement, ",") {
+	spCleanStatement := strings.Split(cleanStatement, ",")
+	clean := make([]string, 0, len(spCleanStatement))
+	for _, s := range spCleanStatement {
 		clean = append(clean, strings.TrimSpace(s))
 	}
 

--- a/pkg/snowflake/task.go
+++ b/pkg/snowflake/task.go
@@ -412,7 +412,7 @@ func (t *task) GetPredecessors() ([]string, error) {
 	}
 
 	// Since 2022_03, Snowflake returns this as a JSON array (even empty)
-	var predecessorNames []string
+	var predecessorNames []string // nolint: prealloc  //todo: fixme
 	if err := json.Unmarshal([]byte(*t.Predecessors), &predecessorNames); err == nil {
 		for i, predecessorName := range predecessorNames {
 			formattedName := predecessorName[strings.LastIndex(predecessorName, ".")+1:]
@@ -502,7 +502,7 @@ func GetRootTasks(name string, databaseName string, schemaName string, db *sql.D
 		return []*task{t}, nil
 	}
 
-	var tasks []*task
+	tasks := make([]*task, 0, len(predecessors))
 	// get the root tasks for each predecessor and append them all together
 	for _, predecessor := range predecessors {
 		predecessorTasks, err := GetRootTasks(predecessor, databaseName, schemaName, db)


### PR DESCRIPTION
This PR fixes go slice preallocation, and adds `prealloc` lint rule.