### PR TITLE
feat: Added (missing) API Key to API Integration

### DIFF
--- a/docs/resources/api_integration.md
+++ b/docs/resources/api_integration.md
@@ -35,6 +35,7 @@ resource "snowflake_api_integration" "api_integration" {
 
 - `api_aws_role_arn` (String) ARN of a cloud platform role.
 - `api_blocked_prefixes` (List of String) Lists the endpoints and resources in the HTTPS proxy service that are not allowed to be called from Snowflake.
+- `api_key` (String) The API key (also called a “subscription key”).
 - `azure_ad_application_id` (String) The 'Application (client) id' of the Azure AD app for your remote service.
 - `azure_tenant_id` (String) Specifies the ID for your Office 365 tenant that all Azure API Management instances belong to.
 - `enabled` (Boolean) Specifies whether this API integration is enabled or disabled. If the API integration is disabled, any external function that relies on it will not work.

--- a/pkg/resources/api_integration.go
+++ b/pkg/resources/api_integration.go
@@ -77,6 +77,12 @@ var apiIntegrationSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Description: "Lists the endpoints and resources in the HTTPS proxy service that are not allowed to be called from Snowflake.",
 	},
+	"api_key": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Default:     "",
+		Description: "The API key (also called a “subscription key”).",
+	},
 	"enabled": {
 		Type:        schema.TypeBool,
 		Optional:    true,
@@ -120,6 +126,10 @@ func CreateAPIIntegration(d *schema.ResourceData, meta interface{}) error {
 	// Set optional fields
 	if _, ok := d.GetOk("api_blocked_prefixes"); ok {
 		stmt.SetStringList("API_BLOCKED_PREFIXES", expandStringList(d.Get("api_blocked_prefixes").([]interface{})))
+	}
+
+	if _, ok := d.GetOk("api_key"); ok {
+		stmt.SetString("API_KEY", d.Get("api_key").(string))
 	}
 
 	// Now, set the API provider
@@ -203,6 +213,10 @@ func ReadAPIIntegration(d *schema.ResourceData, meta interface{}) error {
 					return err
 				}
 			}
+		case "API_KEY":
+			if err = d.Set("api_key", v.(string)); err != nil {
+				return err
+			}
 		case "API_AWS_IAM_USER_ARN":
 			if err = d.Set("api_aws_iam_user_arn", v.(string)); err != nil {
 				return err
@@ -248,6 +262,11 @@ func UpdateAPIIntegration(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("api_allowed_prefixes") {
 		runSetStatement = true
 		stmt.SetStringList("API_ALLOWED_PREFIXES", expandStringList(d.Get("api_allowed_prefixes").([]interface{})))
+	}
+
+	if d.HasChange("api_key") {
+		runSetStatement = true
+		stmt.SetString("API_KEY", d.Get("api_key").(string))
 	}
 
 	// We need to UNSET this if we remove all api blocked prefixes.

--- a/pkg/resources/api_integration_acceptance_test.go
+++ b/pkg/resources/api_integration_acceptance_test.go
@@ -30,6 +30,7 @@ func TestAcc_ApiIntegration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("snowflake_api_integration.test_aws_int", "created_on"),
 					resource.TestCheckResourceAttrSet("snowflake_api_integration.test_aws_int", "api_aws_iam_user_arn"),
 					resource.TestCheckResourceAttrSet("snowflake_api_integration.test_aws_int", "api_aws_external_id"),
+					resource.TestCheckResourceAttrSet("snowflake_api_integration.test_aws_int", "api_key"),
 				),
 			},
 			{
@@ -40,6 +41,7 @@ func TestAcc_ApiIntegration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("snowflake_api_integration.test_azure_int", "created_on"),
 					resource.TestCheckResourceAttrSet("snowflake_api_integration.test_azure_int", "azure_multi_tenant_app_name"),
 					resource.TestCheckResourceAttrSet("snowflake_api_integration.test_azure_int", "azure_consent_url"),
+					resource.TestCheckResourceAttrSet("snowflake_api_integration.test_azure_int", "api_key"),
 				),
 			},
 		},
@@ -53,6 +55,7 @@ func apiIntegrationConfigAWS(name string, prefixes []string) string {
 		api_provider = "aws_api_gateway"
 		api_aws_role_arn = "arn:aws:iam::000000000001:/role/test"
 		api_allowed_prefixes = %q
+		api_key = "12345"
 		enabled = true
 	}
 	`, name, prefixes)
@@ -66,6 +69,7 @@ func apiIntegrationConfigAzure(name string, prefixes []string) string {
 		azure_tenant_id = "123456"
 		azure_ad_application_id = "7890"
 		api_allowed_prefixes = %q
+		api_key = "12345"
 		enabled = true
 	}
 	`, name, prefixes)

--- a/pkg/resources/api_integration_test.go
+++ b/pkg/resources/api_integration_test.go
@@ -26,6 +26,7 @@ func TestAPIIntegrationCreate(t *testing.T) {
 		"api_allowed_prefixes": []interface{}{"https://123456.execute-api.us-west-2.amazonaws.com/prod/"},
 		"api_provider":         "aws_api_gateway",
 		"api_aws_role_arn":     "arn:aws:iam::000000000001:/role/test",
+		"api_key":              "12345",
 	}
 
 	in2 := map[string]interface{}{
@@ -33,6 +34,7 @@ func TestAPIIntegrationCreate(t *testing.T) {
 		"api_allowed_prefixes": []interface{}{"https://123456.execute-api.us-gov-west-1.amazonaws.com/prod/"},
 		"api_provider":         "aws_gov_api_gateway",
 		"api_aws_role_arn":     "arn:aws:iam::000000000001:/role/test",
+		"api_key":              "12345",
 	}
 
 	d := schema.TestResourceDataRaw(t, resources.APIIntegration().Schema, in)
@@ -43,7 +45,7 @@ func TestAPIIntegrationCreate(t *testing.T) {
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`^CREATE API INTEGRATION "test_api_integration" API_PROVIDER=aws_api_gateway API_AWS_ROLE_ARN='arn:aws:iam::000000000001:/role/test' API_ALLOWED_PREFIXES=\('https://123456.execute-api.us-west-2.amazonaws.com/prod/'\) ENABLED=true$`,
+			`^CREATE API INTEGRATION "test_api_integration" API_PROVIDER=aws_api_gateway API_AWS_ROLE_ARN='arn:aws:iam::000000000001:/role/test' API_KEY='12345' API_ALLOWED_PREFIXES=\('https://123456.execute-api.us-west-2.amazonaws.com/prod/'\) ENABLED=true$`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadAPIIntegration(mock)
 
@@ -53,7 +55,7 @@ func TestAPIIntegrationCreate(t *testing.T) {
 
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
-			`^CREATE API INTEGRATION "test_gov_api_integration" API_PROVIDER=aws_gov_api_gateway API_AWS_ROLE_ARN='arn:aws:iam::000000000001:/role/test' API_ALLOWED_PREFIXES=\('https://123456.execute-api.us-gov-west-1.amazonaws.com/prod/'\) ENABLED=true$`,
+			`^CREATE API INTEGRATION "test_gov_api_integration" API_PROVIDER=aws_gov_api_gateway API_AWS_ROLE_ARN='arn:aws:iam::000000000001:/role/test' API_KEY='12345' API_ALLOWED_PREFIXES=\('https://123456.execute-api.us-gov-west-1.amazonaws.com/prod/'\) ENABLED=true$`,
 		).WillReturnResult(sqlmock.NewResult(1, 1))
 		expectReadGovAPIIntegration(mock)
 
@@ -97,6 +99,7 @@ func expectReadAPIIntegration(mock sqlmock.Sqlmock) {
 	descRows := sqlmock.NewRows([]string{
 		"property", "property_type", "property_value", "property_default",
 	}).AddRow("ENABLED", "Boolean", true, false).
+		AddRow("API_KEY", "String", "12345", nil).
 		AddRow("API_ALLOWED_PREFIXES", "List", "https://123456.execute-api.us-west-2.amazonaws.com/prod/,https://123456.execute-api.us-west-2.amazonaws.com/staging/", nil).
 		AddRow("API_AWS_IAM_USER_ARN", "String", "arn:aws:iam::000000000000:/user/test", nil).
 		AddRow("API_AWS_ROLE_ARN", "String", "arn:aws:iam::000000000001:/role/test", nil).
@@ -115,6 +118,7 @@ func expectReadGovAPIIntegration(mock sqlmock.Sqlmock) {
 	descRows := sqlmock.NewRows([]string{
 		"property", "property_type", "property_value", "property_default",
 	}).AddRow("ENABLED", "Boolean", true, false).
+		AddRow("API_KEY", "String", "12345", nil).
 		AddRow("API_ALLOWED_PREFIXES", "List", "https://123456.execute-api.us-gov-west-1.amazonaws.com/prod/,https://123456.execute-api.us-gov-west-1.amazonaws.com/staging/", nil).
 		AddRow("API_AWS_IAM_USER_ARN", "String", "arn:aws:iam::000000000000:/user/test", nil).
 		AddRow("API_AWS_ROLE_ARN", "String", "arn:aws:iam::000000000001:/role/test", nil).


### PR DESCRIPTION
Added (missing) API Key property to the API Integration

## Test Plan
* [x] acceptance tests
* [x] unit tests

## References
* https://docs.snowflake.com/en/sql-reference/sql/create-api-integration.html 