### PR TITLE
fix: File Format Update Grants

### DIFF
--- a/pkg/resources/file_format_grant.go
+++ b/pkg/resources/file_format_grant.go
@@ -75,7 +75,7 @@ func FileFormatGrant() *TerraformGrantResource {
 			Create: CreateFileFormatGrant,
 			Read:   ReadFileFormatGrant,
 			Delete: DeleteFileFormatGrant,
-			Update: UpdateFileFormat,
+			Update: UpdateFileFormatGrant,
 
 			Schema: fileFormatGrantSchema,
 			Importer: &schema.ResourceImporter{


### PR DESCRIPTION
This fixes the update call of file format grants:
Update of file format grants are getting error "4 fields allowed" due to the fact that the Update call for File Format Grants is (incorrectly) pointing to the Update call of File Format not File Format Grants

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
* [x] unit tests