### PR TITLE
fix: stop file format failure when does not exist

### DIFF
--- a/.github/workflows/team-jira-issues.yml
+++ b/.github/workflows/team-jira-issues.yml
@@ -31,10 +31,7 @@ jobs:
                 "labels": ["${{ secrets.JIRA_LABEL }}"],
                 "customfield_11401": {"id": "${{ secrets.JIRA_AREA }}"},
                 "customfield_10008": "${{ secrets.JIRA_EPIC }}",
-                "assignee": {
-                    "name": {
-                        "id": "${{ secrets.JIRA_ASSIGNEE }}"
-                }
+                "assignee": {"id": "${{ secrets.JIRA_ASSIGNEE }}"}
               }
             }
           }'

--- a/.github/workflows/team-jira-issues.yml
+++ b/.github/workflows/team-jira-issues.yml
@@ -31,6 +31,10 @@ jobs:
                 "labels": ["${{ secrets.JIRA_LABEL }}"],
                 "customfield_11401": {"id": "${{ secrets.JIRA_AREA }}"},
                 "customfield_10008": "${{ secrets.JIRA_EPIC }}",
-                "assignee": {"name": null}
+                "assignee": {
+                    "name": {
+                        "id": "${{ secrets.JIRA_ASSIGNEE }}"
+                }
+              }
             }
           }'

--- a/pkg/resources/file_format.go
+++ b/pkg/resources/file_format.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -538,6 +539,12 @@ func ReadFileFormat(d *schema.ResourceData, meta interface{}) error {
 	row := snowflake.QueryRow(db, ff)
 
 	f, err := snowflake.ScanFileFormatShow(row)
+	if err == sql.ErrNoRows {
+		// If not found, mark resource to be removed from statefile during apply or refresh
+		log.Printf("[DEBUG] file_format (%s) not found", d.Id())
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/resources/file_format_test.go
+++ b/pkg/resources/file_format_test.go
@@ -7,6 +7,7 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake"
 	. "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/require"
@@ -70,4 +71,31 @@ func expectReadFileFormat(mock sqlmock.Sqlmock) {
 	},
 	).AddRow("2019-12-23 17:20:50.088 +0000", "test_file_format", "test_db", "test_schema", "CSV", "test", "great comment", `{"TYPE":"CSV","RECORD_DELIMITER":"\n","FIELD_DELIMITER":",","FILE_EXTENSION":null,"SKIP_HEADER":0,"DATE_FORMAT":"AUTO","TIME_FORMAT":"AUTO","TIMESTAMP_FORMAT":"AUTO","BINARY_FORMAT":"HEX","ESCAPE":"NONE","ESCAPE_UNENCLOSED_FIELD":"\\","TRIM_SPACE":false,"FIELD_OPTIONALLY_ENCLOSED_BY":"NONE","NULL_IF":["\\N"],"COMPRESSION":"AUTO","ERROR_ON_COLUMN_COUNT_MISMATCH":false,"FIELD_DELIMETER":",","SKIP_BLANK_LINES":false,"REPLACE_INVALID_CHARACTERS":false,"EMPTY_FIELD_AS_NULL":false,"SKIP_BYTE_ORDER_MARK":false,"ENCODING":"UTF8"}`)
 	mock.ExpectQuery(`^SHOW FILE FORMATS LIKE 'test_file_format' IN SCHEMA "test_db"."test_schema"$`).WillReturnRows(rows)
+}
+
+
+func TestFileFormatWhenMissing(t *testing.T) {
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"name":                           "test_file_format",
+		"database":                       "test_db",
+		"schema":                         "test_schema",
+		"format_type":                    "CSV",
+		"null_if":                        []interface{}{"NULL"},
+		"error_on_column_count_mismatch": true,
+		"comment":                        "great comment",
+	}
+	d := schema.TestResourceDataRaw(t, resources.FileFormat().Schema, in)
+	d.SetId("test_db|test_schema|test_file_format")
+
+	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		// Test when resource is not found, checking if state will be empty
+		r.NotEmpty(d.State())
+		q := snowflake.FileFormat("test_file_format", "test_db", "test_schema").Show()
+		mock.ExpectQuery(q).WillReturnError(sql.ErrNoRows)
+		err := resources.ReadFileFormat(d, db)
+		r.Empty(d.State())
+		r.Nil(err)
+	})
 }


### PR DESCRIPTION
If a file format has been created vis the provider and the is subsequently deleted manually the plan refresh fails rather than removing the resource from the plan and recreating

## Test Plan
* [*] acceptance tests executed
* [* ] unit test added

## References
Fixes #1395
* 