### PR TITLE
fix: Go syntax to add revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,9 @@ linters:
     - whitespace
     # unparam: Checks Go code for unused constants, variables, functions and types
     # - unparam  # todo: enabled
+    # checks for pointers to enclosing loop variables
     - exportloopref
+    # Check if comments end in a period
     - godot
     - gocritic
     - misspell
@@ -61,3 +63,5 @@ linters:
     - goimports
     # Finds slice declarations with non-zero initial length
     - makezero
+    # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint
+    - revive

--- a/pkg/datasources/functions.go
+++ b/pkg/datasources/functions.go
@@ -65,14 +65,14 @@ func Functions() *schema.Resource {
 	}
 }
 
-// todo: fix this. ListFunctions isn't using the right struct right now and also the signature of this doesn't support all the features it could for example, database and schema should be optional, and you could also list by account.
+// todo: fix this. ListUserFunctions isn't using the right struct right now and also the signature of this doesn't support all the features it could for example, database and schema should be optional, and you could also list by account.
 func ReadFunctions(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	databaseName := d.Get("database").(string)
 	schemaName := d.Get("schema").(string)
 
 	d.SetId("functions")
-	currentFunctions, err := snowflake.ListFunctions(databaseName, schemaName, db)
+	currentFunctions, err := snowflake.ListUserFunctions(databaseName, schemaName, db)
 	if err != nil {
 		log.Printf("[DEBUG] error listing functions: %v", err)
 		return nil

--- a/pkg/datasources/system_generate_scim_access_token.go
+++ b/pkg/datasources/system_generate_scim_access_token.go
@@ -34,7 +34,7 @@ func ReadSystemGenerateSCIMAccessToken(d *schema.ResourceData, meta interface{})
 	db := meta.(*sql.DB)
 	integrationName := d.Get("integration_name").(string)
 
-	sel := snowflake.SystemGenerateSCIMAccessToken(integrationName).Select()
+	sel := snowflake.NewSystemGenerateSCIMAccessTokenBuilder(integrationName).Select()
 	row := snowflake.QueryRow(db, sel)
 	accessToken, err := snowflake.ScanSCIMAccessToken(row)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/datasources/system_get_aws_sns_iam_policy.go
+++ b/pkg/datasources/system_get_aws_sns_iam_policy.go
@@ -35,7 +35,7 @@ func ReadSystemGetAWSSNSIAMPolicy(d *schema.ResourceData, meta interface{}) erro
 	db := meta.(*sql.DB)
 	awsSNSTopicArn := d.Get("aws_sns_topic_arn").(string)
 
-	sel := snowflake.SystemGetAWSSNSIAMPolicy(awsSNSTopicArn).Select()
+	sel := snowflake.NewSystemGetAWSSNSIAMPolicyBuilder(awsSNSTopicArn).Select()
 	row := snowflake.QueryRow(db, sel)
 	policy, err := snowflake.ScanAWSSNSIAMPolicy(row)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -506,7 +506,7 @@ func GetOauthAccessToken(
 	client := &http.Client{}
 	request, err := GetOauthRequest(strings.NewReader(data.Encode()), endPoint, clientID, clientSecret)
 	if err != nil {
-		return "", fmt.Errorf("Oauth request returned an error:")
+		return "", fmt.Errorf("oauth request returned an error")
 	}
 
 	var result Result

--- a/pkg/resources/api_integration.go
+++ b/pkg/resources/api_integration.go
@@ -116,7 +116,7 @@ func CreateAPIIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	name := d.Get("name").(string)
 
-	stmt := snowflake.APIIntegration(name).Create()
+	stmt := snowflake.NewAPIIntegrationBuilder(name).Create()
 
 	// Set required fields
 	stmt.SetBool(`ENABLED`, d.Get("enabled").(bool))
@@ -151,7 +151,7 @@ func ReadAPIIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.APIIntegration(id).Show()
+	stmt := snowflake.NewAPIIntegrationBuilder(id).Show()
 	row := snowflake.QueryRow(db, stmt)
 
 	// Some properties can come from the SHOW INTEGRATION call
@@ -162,9 +162,8 @@ func ReadAPIIntegration(d *schema.ResourceData, meta interface{}) error {
 		if err.Error() == snowflake.ErrNoRowInRS {
 			d.SetId("")
 			return nil
-		} else {
-			return fmt.Errorf("could not show api integration: %w", err)
 		}
+		return fmt.Errorf("could not show api integration: %w", err)
 	}
 
 	// Note: category must be API or something is broken
@@ -188,7 +187,7 @@ func ReadAPIIntegration(d *schema.ResourceData, meta interface{}) error {
 	// We need to grab them in a loop
 	var k, pType string
 	var v, unused interface{}
-	stmt = snowflake.APIIntegration(id).Describe()
+	stmt = snowflake.NewAPIIntegrationBuilder(id).Describe()
 	rows, err := db.Query(stmt)
 	if err != nil {
 		return fmt.Errorf("could not describe api integration: %w", err)
@@ -244,7 +243,7 @@ func UpdateAPIIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.APIIntegration(id).Alter()
+	stmt := snowflake.NewAPIIntegrationBuilder(id).Alter()
 
 	var runSetStatement bool
 
@@ -308,7 +307,7 @@ func UpdateAPIIntegration(d *schema.ResourceData, meta interface{}) error {
 
 // DeleteAPIIntegration implements schema.DeleteFunc.
 func DeleteAPIIntegration(d *schema.ResourceData, meta interface{}) error {
-	return DeleteResource("", snowflake.APIIntegration)(d, meta)
+	return DeleteResource("", snowflake.NewAPIIntegrationBuilder)(d, meta)
 }
 
 func setAPIProviderSettings(data *schema.ResourceData, stmt snowflake.SettingBuilder) error {

--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -124,7 +124,7 @@ func CreateDatabase(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	name := d.Get("name").(string)
-	builder := snowflake.Database(name)
+	builder := snowflake.NewDatabaseBuilder(name)
 
 	// Set optionals
 	if v, ok := d.GetOk("comment"); ok {
@@ -221,7 +221,7 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	name := d.Id()
 
-	stmt := snowflake.Database(name).Show()
+	stmt := snowflake.NewDatabaseBuilder(name).Show()
 	row := snowflake.QueryRow(db, stmt)
 
 	database, err := snowflake.ScanDatabase(row)
@@ -267,7 +267,7 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 
 func UpdateDatabase(d *schema.ResourceData, meta interface{}) error {
 	dbName := d.Id()
-	builder := snowflake.Database(dbName)
+	builder := snowflake.NewDatabaseBuilder(dbName)
 	db := meta.(*sql.DB)
 
 	// If replication configuration changes, need to update accounts that have permission to replicate database
@@ -340,7 +340,7 @@ func DeleteDatabase(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	name := d.Id()
 
-	q := snowflake.Database(name).Drop()
+	q := snowflake.NewDatabaseBuilder(name).Drop()
 	if err := snowflake.Exec(db, q); err != nil {
 		return fmt.Errorf("error deleting database %v err = %w", d.Id(), err)
 	}

--- a/pkg/resources/external_oauth_integration.go
+++ b/pkg/resources/external_oauth_integration.go
@@ -149,7 +149,7 @@ func CreateExternalOauthIntegration(d *schema.ResourceData, meta interface{}) er
 	db := meta.(*sql.DB)
 	name := d.Get("name").(string)
 
-	stmt := snowflake.ExternalOauthIntegration(name).Create()
+	stmt := snowflake.NewExternalOauthIntegrationBuilder(name).Create()
 
 	// Set required fields
 	stmt.SetRaw(`TYPE=EXTERNAL_OAUTH`)
@@ -202,7 +202,7 @@ func ReadExternalOauthIntegration(d *schema.ResourceData, meta interface{}) erro
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.ExternalOauthIntegration(id).Show()
+	stmt := snowflake.NewExternalOauthIntegrationBuilder(id).Show()
 	row := snowflake.QueryRow(db, stmt)
 
 	// Some properties can come from the SHOW INTEGRATION call
@@ -241,7 +241,7 @@ func ReadExternalOauthIntegration(d *schema.ResourceData, meta interface{}) erro
 	// We need to grab them in a loop
 	var k, pType string
 	var v, unused interface{}
-	stmt = snowflake.ExternalOauthIntegration(id).Describe()
+	stmt = snowflake.NewExternalOauthIntegrationBuilder(id).Describe()
 	rows, err := db.Query(stmt)
 	if err != nil {
 		return fmt.Errorf("could not describe security integration err = %w", err)
@@ -339,7 +339,7 @@ func UpdateExternalOauthIntegration(d *schema.ResourceData, meta interface{}) er
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.ExternalOauthIntegration(id).Alter()
+	stmt := snowflake.NewExternalOauthIntegrationBuilder(id).Alter()
 
 	var runSetStatement bool
 
@@ -411,5 +411,5 @@ func UpdateExternalOauthIntegration(d *schema.ResourceData, meta interface{}) er
 
 // DeleteExternalOauthIntegration implements schema.DeleteFunc.
 func DeleteExternalOauthIntegration(d *schema.ResourceData, meta interface{}) error {
-	return DeleteResource("", snowflake.ExternalOauthIntegration)(d, meta)
+	return DeleteResource("", snowflake.NewExternalOauthIntegrationBuilder)(d, meta)
 }

--- a/pkg/resources/external_table.go
+++ b/pkg/resources/external_table.go
@@ -206,7 +206,7 @@ func CreateExternalTable(d *schema.ResourceData, meta interface{}) error {
 		}
 		columns = append(columns, columnDef)
 	}
-	builder := snowflake.ExternalTable(name, database, dbSchema)
+	builder := snowflake.NewExternalTableBuilder(name, database, dbSchema)
 	builder.WithColumns(columns)
 	builder.WithFileFormat(d.Get("file_format").(string))
 	builder.WithLocation(d.Get("location").(string))
@@ -269,7 +269,7 @@ func ReadExternalTable(d *schema.ResourceData, meta interface{}) error {
 	schema := externalTableID.SchemaName
 	name := externalTableID.ExternalTableName
 
-	stmt := snowflake.ExternalTable(name, dbName, schema).Show()
+	stmt := snowflake.NewExternalTableBuilder(name, dbName, schema).Show()
 	row := snowflake.QueryRow(db, stmt)
 	externalTable, err := snowflake.ScanExternalTable(row)
 	if err != nil {
@@ -277,9 +277,8 @@ func ReadExternalTable(d *schema.ResourceData, meta interface{}) error {
 			log.Printf("[DEBUG] external table (%s) not found", d.Id())
 			d.SetId("")
 			return nil
-		} else {
-			return err
 		}
+		return err
 	}
 
 	if err := d.Set("name", externalTable.ExternalTableName.String); err != nil {
@@ -300,7 +299,7 @@ func UpdateExternalTable(d *schema.ResourceData, meta interface{}) error {
 	dbSchema := d.Get("schema").(string)
 	name := d.Get("name").(string)
 
-	builder := snowflake.ExternalTable(name, database, dbSchema)
+	builder := snowflake.NewExternalTableBuilder(name, database, dbSchema)
 
 	if d.HasChange("tag") {
 		v := d.Get("tag")
@@ -339,7 +338,7 @@ func DeleteExternalTable(d *schema.ResourceData, meta interface{}) error {
 	schema := externalTableID.SchemaName
 	externalTableName := externalTableID.ExternalTableName
 
-	q := snowflake.ExternalTable(externalTableName, dbName, schema).Drop()
+	q := snowflake.NewExternalTableBuilder(externalTableName, dbName, schema).Drop()
 	if err := snowflake.Exec(db, q); err != nil {
 		return fmt.Errorf("error deleting pipe %v err = %w", d.Id(), err)
 	}

--- a/pkg/resources/external_table_grant.go
+++ b/pkg/resources/external_table_grant.go
@@ -108,13 +108,13 @@ func CreateExternalTableGrant(d *schema.ResourceData, meta interface{}) error {
 	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (externalTableName == "") && !futureExternalTables {
-		return errors.New("external_table_name must be set unless on_future is true.")
+		return errors.New("external_table_name must be set unless on_future is true")
 	}
 	if (externalTableName != "") && futureExternalTables {
-		return errors.New("external_table_name must be empty if on_future is true.")
+		return errors.New("external_table_name must be empty if on_future is true")
 	}
 	if (schemaName == "") && !futureExternalTables {
-		return errors.New("schema_name must be set when on_future is false.")
+		return errors.New("schema_name must be set when on_future is false")
 	}
 
 	var builder snowflake.GrantBuilder

--- a/pkg/resources/failover_group.go
+++ b/pkg/resources/failover_group.go
@@ -151,7 +151,7 @@ func CreateFailoverGroup(d *schema.ResourceData, meta interface{}) error {
 
 	// getting required attributes
 	name := d.Get("name").(string)
-	builder := snowflake.FailoverGroup(name)
+	builder := snowflake.NewFailoverGroupBuilder(name)
 
 	// if from_replica is set, then we are creating a failover group from an existing replica
 	if v, ok := d.GetOk("from_replica"); ok {
@@ -403,7 +403,7 @@ func ReadFailoverGroup(d *schema.ResourceData, meta interface{}) error {
 func UpdateFailoverGroup(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	name := d.Id()
-	builder := snowflake.FailoverGroup(name)
+	builder := snowflake.NewFailoverGroupBuilder(name)
 
 	if d.HasChange("object_types") {
 		_, new := d.GetChange("object_types")
@@ -585,7 +585,7 @@ func UpdateFailoverGroup(d *schema.ResourceData, meta interface{}) error {
 func DeleteFailoverGroup(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	name := d.Id()
-	builder := snowflake.FailoverGroup(name)
+	builder := snowflake.NewFailoverGroupBuilder(name)
 	stmt := builder.Drop()
 	if err := snowflake.Exec(db, stmt); err != nil {
 		return fmt.Errorf("error deleting file format %v err = %w", d.Id(), err)

--- a/pkg/resources/file_format_grant.go
+++ b/pkg/resources/file_format_grant.go
@@ -101,10 +101,10 @@ func CreateFileFormatGrant(d *schema.ResourceData, meta interface{}) error {
 	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (fileFormatName == "") && !futureFileFormats {
-		return errors.New("file_format_name must be set unless on_future is true.")
+		return errors.New("file_format_name must be set unless on_future is true")
 	}
 	if (fileFormatName != "") && futureFileFormats {
-		return errors.New("file_format_name must be empty if on_future is true.")
+		return errors.New("file_format_name must be empty if on_future is true")
 	}
 
 	var builder snowflake.GrantBuilder

--- a/pkg/resources/function.go
+++ b/pkg/resources/function.go
@@ -463,7 +463,7 @@ func DeleteFunction(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	builder := snowflake.Function(
+	builder := snowflake.NewFunctionBuilder(
 		pID.DatabaseName,
 		pID.SchemaName,
 		pID.FunctionName,

--- a/pkg/resources/function.go
+++ b/pkg/resources/function.go
@@ -164,7 +164,7 @@ func CreateFunction(d *schema.ResourceData, meta interface{}) error {
 	s := d.Get("statement").(string)
 	ret := d.Get("return_type").(string)
 
-	builder := snowflake.Function(database, schema, name, []string{}).WithStatement(s).WithReturnType(ret)
+	builder := snowflake.NewFunctionBuilder(database, schema, name, []string{}).WithStatement(s).WithReturnType(ret)
 
 	// Set optionals, args
 	if _, ok := d.GetOk("arguments"); ok {
@@ -258,7 +258,7 @@ func ReadFunction(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	funct := snowflake.Function(
+	funct := snowflake.NewFunctionBuilder(
 		functionID.DatabaseName,
 		functionID.SchemaName,
 		functionID.FunctionName,
@@ -405,7 +405,7 @@ func UpdateFunction(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	builder := snowflake.Function(
+	builder := snowflake.NewFunctionBuilder(
 		pID.DatabaseName,
 		pID.SchemaName,
 		pID.FunctionName,

--- a/pkg/resources/function_grant.go
+++ b/pkg/resources/function_grant.go
@@ -134,7 +134,7 @@ func CreateFunctionGrant(d *schema.ResourceData, meta interface{}) error {
 		if ret, ok := d.GetOk("return_type"); ok {
 			returnType = strings.ToUpper(ret.(string))
 		} else {
-			return errors.New("return_type must be set when specifying function_name.")
+			return errors.New("return_type must be set when specifying function_name")
 		}
 	}
 	dbName := d.Get("database_name").(string)
@@ -146,10 +146,10 @@ func CreateFunctionGrant(d *schema.ResourceData, meta interface{}) error {
 	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (functionName == "") && !futureFunctions {
-		return errors.New("function_name must be set unless on_future is true.")
+		return errors.New("function_name must be set unless on_future is true")
 	}
 	if (functionName != "") && futureFunctions {
-		return errors.New("function_name must be empty if on_future is true.")
+		return errors.New("function_name must be empty if on_future is true")
 	}
 
 	if functionName != "" {

--- a/pkg/resources/managed_account.go
+++ b/pkg/resources/managed_account.go
@@ -106,7 +106,7 @@ func CreateManagedAccount(d *schema.ResourceData, meta interface{}) error {
 		"this does not seem to be used",
 		managedAccountProperties,
 		managedAccountSchema,
-		snowflake.ManagedAccount,
+		snowflake.NewManagedAccountBuilder,
 		initialReadManagedAccount,
 	)(d, meta)
 }
@@ -126,7 +126,7 @@ func ReadManagedAccount(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.ManagedAccount(id).Show()
+	stmt := snowflake.NewManagedAccountBuilder(id).Show()
 	row := snowflake.QueryRow(db, stmt)
 	a, err := snowflake.ScanManagedAccount(row)
 
@@ -179,5 +179,5 @@ func ReadManagedAccount(d *schema.ResourceData, meta interface{}) error {
 
 // DeleteManagedAccount implements schema.DeleteFunc.
 func DeleteManagedAccount(d *schema.ResourceData, meta interface{}) error {
-	return DeleteResource("this does not seem to be used", snowflake.ManagedAccount)(d, meta)
+	return DeleteResource("this does not seem to be used", snowflake.NewManagedAccountBuilder)(d, meta)
 }

--- a/pkg/resources/managed_account_test.go
+++ b/pkg/resources/managed_account_test.go
@@ -47,7 +47,7 @@ func TestManagedAccountRead(t *testing.T) {
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
-		q := snowflake.ManagedAccount(d.Id()).Show()
+		q := snowflake.NewManagedAccountBuilder(d.Id()).Show()
 		mock.ExpectQuery(q).WillReturnError(sql.ErrNoRows)
 		err := resources.ReadManagedAccount(d, db)
 

--- a/pkg/resources/materialized_view.go
+++ b/pkg/resources/materialized_view.go
@@ -137,7 +137,7 @@ func CreateMaterializedView(d *schema.ResourceData, meta interface{}) error {
 	warehouse := d.Get("warehouse").(string)
 	s := d.Get("statement").(string)
 
-	builder := snowflake.MaterializedView(name).WithDB(database).WithSchema(schema).WithWarehouse(warehouse).WithStatement(s)
+	builder := snowflake.NewMaterializedViewBuilder(name).WithDB(database).WithSchema(schema).WithWarehouse(warehouse).WithStatement(s)
 
 	// Set optionals
 	if v, ok := d.GetOk("or_replace"); ok && v.(bool) {
@@ -189,7 +189,7 @@ func ReadMaterializedView(d *schema.ResourceData, meta interface{}) error {
 	schema := materializedViewID.SchemaName
 	view := materializedViewID.ViewName
 
-	q := snowflake.MaterializedView(view).WithDB(dbName).WithSchema(schema).Show()
+	q := snowflake.NewMaterializedViewBuilder(view).WithDB(dbName).WithSchema(schema).Show()
 	row := snowflake.QueryRow(db, q)
 	v, err := snowflake.ScanMaterializedView(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -244,7 +244,7 @@ func UpdateMaterializedView(d *schema.ResourceData, meta interface{}) error {
 	schema := mvid.SchemaName
 	view := mvid.ViewName
 
-	builder := snowflake.MaterializedView(view).WithDB(dbName).WithSchema(schema)
+	builder := snowflake.NewMaterializedViewBuilder(view).WithDB(dbName).WithSchema(schema)
 
 	db := meta.(*sql.DB)
 	if d.HasChange("name") {
@@ -317,7 +317,7 @@ func DeleteMaterializedView(d *schema.ResourceData, meta interface{}) error {
 	schema := materializedViewID.SchemaName
 	view := materializedViewID.ViewName
 
-	q := snowflake.MaterializedView(view).WithDB(dbName).WithSchema(schema).Drop()
+	q := snowflake.NewMaterializedViewBuilder(view).WithDB(dbName).WithSchema(schema).Drop()
 	if err := snowflake.Exec(db, q); err != nil {
 		return fmt.Errorf("error deleting materialized view %v err = %w", d.Id(), err)
 	}

--- a/pkg/resources/materialized_view_grant.go
+++ b/pkg/resources/materialized_view_grant.go
@@ -114,14 +114,14 @@ func CreateMaterializedViewGrant(d *schema.ResourceData, meta interface{}) error
 	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (schemaName == "") && !futureMaterializedViews {
-		return errors.New("schema_name must be set unless on_future is true.")
+		return errors.New("schema_name must be set unless on_future is true")
 	}
 
 	if (materializedViewName == "") && !futureMaterializedViews {
-		return errors.New("materialized_view_name must be set unless on_future is true.")
+		return errors.New("materialized_view_name must be set unless on_future is true")
 	}
 	if (materializedViewName != "") && futureMaterializedViews {
-		return errors.New("materialized_view_name must be empty if on_future is true.")
+		return errors.New("materialized_view_name must be empty if on_future is true")
 	}
 
 	var builder snowflake.GrantBuilder

--- a/pkg/resources/materialized_view_test.go
+++ b/pkg/resources/materialized_view_test.go
@@ -135,7 +135,7 @@ func TestMaterializedViewRead(t *testing.T) {
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
-		q := snowflake.MaterializedView("good_name").WithDB("test_db").WithSchema("test_schema").Show()
+		q := snowflake.NewMaterializedViewBuilder("good_name").WithDB("test_db").WithSchema("test_schema").Show()
 		mock.ExpectQuery(q).WillReturnError(sql.ErrNoRows)
 		err := resources.ReadMaterializedView(d, db)
 		r.Empty(d.State())

--- a/pkg/resources/network_policy.go
+++ b/pkg/resources/network_policy.go
@@ -109,7 +109,7 @@ func ReadNetworkPolicy(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	var s *snowflake.NetworkPolicyStruct = nil
+	var s *snowflake.NetworkPolicyStruct
 	for _, value := range allPolicies {
 		if value.Name.String == policyName {
 			s = value

--- a/pkg/resources/network_policy_attachment.go
+++ b/pkg/resources/network_policy_attachment.go
@@ -277,7 +277,7 @@ func unsetOnUser(user string, data *schema.ResourceData, meta interface{}) error
 func ensureUserAlterPrivileges(users []string, meta interface{}) error {
 	db := meta.(*sql.DB)
 	for _, user := range users {
-		userDescSQL := snowflake.User(user).Describe()
+		userDescSQL := snowflake.NewUser(user).Describe()
 		if err := snowflake.Exec(db, userDescSQL); err != nil {
 			return fmt.Errorf("error altering network policy of user %v", user)
 		}

--- a/pkg/resources/network_policy_attachment.go
+++ b/pkg/resources/network_policy_attachment.go
@@ -277,7 +277,7 @@ func unsetOnUser(user string, data *schema.ResourceData, meta interface{}) error
 func ensureUserAlterPrivileges(users []string, meta interface{}) error {
 	db := meta.(*sql.DB)
 	for _, user := range users {
-		userDescSQL := snowflake.NewUser(user).Describe()
+		userDescSQL := snowflake.NewUserBuilder(user).Describe()
 		if err := snowflake.Exec(db, userDescSQL); err != nil {
 			return fmt.Errorf("error altering network policy of user %v", user)
 		}

--- a/pkg/resources/notification_integration.go
+++ b/pkg/resources/notification_integration.go
@@ -138,7 +138,7 @@ func CreateNotificationIntegration(d *schema.ResourceData, meta interface{}) err
 	db := meta.(*sql.DB)
 	name := d.Get("name").(string)
 
-	stmt := snowflake.NotificationIntegration(name).Create()
+	stmt := snowflake.NewNotificationIntegrationBuilder(name).Create()
 
 	// Set required fields
 	stmt.SetString(`TYPE`, d.Get("type").(string))
@@ -193,7 +193,7 @@ func ReadNotificationIntegration(d *schema.ResourceData, meta interface{}) error
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.NotificationIntegration(d.Id()).Show()
+	stmt := snowflake.NewNotificationIntegrationBuilder(d.Id()).Show()
 	row := snowflake.QueryRow(db, stmt)
 
 	// Some properties can come from the SHOW INTEGRATION call
@@ -232,7 +232,7 @@ func ReadNotificationIntegration(d *schema.ResourceData, meta interface{}) error
 	// We need to grab them in a loop
 	var k, pType string
 	var v, n interface{}
-	stmt = snowflake.NotificationIntegration(d.Id()).Describe()
+	stmt = snowflake.NewNotificationIntegrationBuilder(d.Id()).Describe()
 	rows, err := db.Query(stmt)
 	if err != nil {
 		return fmt.Errorf("could not describe notification integration: %w", err)
@@ -314,7 +314,7 @@ func UpdateNotificationIntegration(d *schema.ResourceData, meta interface{}) err
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.NotificationIntegration(id).Alter()
+	stmt := snowflake.NewNotificationIntegrationBuilder(id).Alter()
 
 	// This is required in case the only change is to UNSET STORAGE_ALLOWED_LOCATIONS.
 	// Not sure if there is a more elegant way of determining this
@@ -391,5 +391,5 @@ func UpdateNotificationIntegration(d *schema.ResourceData, meta interface{}) err
 
 // DeleteNotificationIntegration implements schema.DeleteFunc.
 func DeleteNotificationIntegration(d *schema.ResourceData, meta interface{}) error {
-	return DeleteResource("", snowflake.NotificationIntegration)(d, meta)
+	return DeleteResource("", snowflake.NewNotificationIntegrationBuilder)(d, meta)
 }

--- a/pkg/resources/oauth_integration.go
+++ b/pkg/resources/oauth_integration.go
@@ -94,7 +94,7 @@ func CreateOAuthIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	name := d.Get("name").(string)
 
-	stmt := snowflake.OAuthIntegration(name).Create()
+	stmt := snowflake.NewOAuthIntegrationBuilder(name).Create()
 
 	// Set required fields
 	stmt.SetRaw(`TYPE=OAUTH`)
@@ -137,7 +137,7 @@ func ReadOAuthIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.OAuthIntegration(id).Show()
+	stmt := snowflake.NewOAuthIntegrationBuilder(id).Show()
 	row := snowflake.QueryRow(db, stmt)
 
 	// Some properties can come from the SHOW INTEGRATION call
@@ -176,7 +176,7 @@ func ReadOAuthIntegration(d *schema.ResourceData, meta interface{}) error {
 	// We need to grab them in a loop
 	var k, pType string
 	var v, unused interface{}
-	stmt = snowflake.OAuthIntegration(id).Describe()
+	stmt = snowflake.NewOAuthIntegrationBuilder(id).Describe()
 	rows, err := db.Query(stmt)
 	if err != nil {
 		return fmt.Errorf("could not describe security integration err = %w", err)
@@ -258,7 +258,7 @@ func UpdateOAuthIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.OAuthIntegration(id).Alter()
+	stmt := snowflake.NewOAuthIntegrationBuilder(id).Alter()
 
 	var runSetStatement bool
 
@@ -313,5 +313,5 @@ func UpdateOAuthIntegration(d *schema.ResourceData, meta interface{}) error {
 
 // DeleteOAuthIntegration implements schema.DeleteFunc.
 func DeleteOAuthIntegration(d *schema.ResourceData, meta interface{}) error {
-	return DeleteResource("", snowflake.OAuthIntegration)(d, meta)
+	return DeleteResource("", snowflake.NewOAuthIntegrationBuilder)(d, meta)
 }

--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -158,7 +158,7 @@ func CreatePipe(d *schema.ResourceData, meta interface{}) error {
 	schema := d.Get("schema").(string)
 	name := d.Get("name").(string)
 
-	builder := snowflake.Pipe(name, database, schema)
+	builder := snowflake.NewPipeBuilder(name, database, schema)
 
 	// Set optionals
 	if v, ok := d.GetOk("copy_statement"); ok {
@@ -217,7 +217,7 @@ func ReadPipe(d *schema.ResourceData, meta interface{}) error {
 	schema := pipeID.SchemaName
 	name := pipeID.PipeName
 
-	sq := snowflake.Pipe(name, dbName, schema).Show()
+	sq := snowflake.NewPipeBuilder(name, dbName, schema).Show()
 	row := snowflake.QueryRow(db, sq)
 	pipe, err := snowflake.ScanPipe(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -290,7 +290,7 @@ func UpdatePipe(d *schema.ResourceData, meta interface{}) error {
 	schema := pipeID.SchemaName
 	pipe := pipeID.PipeName
 
-	builder := snowflake.Pipe(pipe, dbName, schema)
+	builder := snowflake.NewPipeBuilder(pipe, dbName, schema)
 
 	db := meta.(*sql.DB)
 	if d.HasChange("comment") {
@@ -328,7 +328,7 @@ func DeletePipe(d *schema.ResourceData, meta interface{}) error {
 	schema := pipeID.SchemaName
 	pipe := pipeID.PipeName
 
-	q := snowflake.Pipe(pipe, dbName, schema).Drop()
+	q := snowflake.NewPipeBuilder(pipe, dbName, schema).Drop()
 
 	if err := snowflake.Exec(db, q); err != nil {
 		return fmt.Errorf("error deleting pipe %v err = %w", d.Id(), err)

--- a/pkg/resources/pipe_grant.go
+++ b/pkg/resources/pipe_grant.go
@@ -101,10 +101,10 @@ func CreatePipeGrant(d *schema.ResourceData, meta interface{}) error {
 	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (pipeName == "") && !futurePipes {
-		return errors.New("pipe_name must be set unless on_future is true.")
+		return errors.New("pipe_name must be set unless on_future is true")
 	}
 	if (pipeName != "") && futurePipes {
-		return errors.New("pipe_name must be empty if on_future is true.")
+		return errors.New("pipe_name must be empty if on_future is true")
 	}
 
 	var builder snowflake.GrantBuilder

--- a/pkg/resources/pipe_test.go
+++ b/pkg/resources/pipe_test.go
@@ -58,7 +58,7 @@ func TestPipeRead(t *testing.T) {
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
-		q := snowflake.Pipe("test_pipe", "test_db", "test_schema").Show()
+		q := snowflake.NewPipeBuilder("test_pipe", "test_db", "test_schema").Show()
 		mock.ExpectQuery(q).WillReturnError(sql.ErrNoRows)
 		err := resources.ReadPipe(d, db)
 		r.Empty(d.State())

--- a/pkg/resources/procedure.go
+++ b/pkg/resources/procedure.go
@@ -162,7 +162,7 @@ func CreateProcedure(d *schema.ResourceData, meta interface{}) error {
 	s := d.Get("statement").(string)
 	ret := d.Get("return_type").(string)
 
-	builder := snowflake.Procedure(database, schema, name, []string{}).WithStatement(s).WithReturnType(ret)
+	builder := snowflake.NewProcedureBuilder(database, schema, name, []string{}).WithStatement(s).WithReturnType(ret)
 
 	// Set optionals, args
 	if _, ok := d.GetOk("arguments"); ok {
@@ -229,7 +229,7 @@ func ReadProcedure(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	proc := snowflake.Procedure(
+	proc := snowflake.NewProcedureBuilder(
 		procedureID.DatabaseName,
 		procedureID.SchemaName,
 		procedureID.ProcedureName,
@@ -351,7 +351,7 @@ func UpdateProcedure(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	builder := snowflake.Procedure(
+	builder := snowflake.NewProcedureBuilder(
 		pID.DatabaseName,
 		pID.SchemaName,
 		pID.ProcedureName,
@@ -420,7 +420,7 @@ func DeleteProcedure(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	builder := snowflake.Procedure(
+	builder := snowflake.NewProcedureBuilder(
 		pID.DatabaseName,
 		pID.SchemaName,
 		pID.ProcedureName,

--- a/pkg/resources/procedure_grant.go
+++ b/pkg/resources/procedure_grant.go
@@ -134,7 +134,7 @@ func CreateProcedureGrant(d *schema.ResourceData, meta interface{}) error {
 		if ret, ok := d.GetOk("return_type"); ok {
 			returnType = strings.ToUpper(ret.(string))
 		} else {
-			return errors.New("return_type must be set when specifying procedure_name.")
+			return errors.New("return_type must be set when specifying procedure_name")
 		}
 	}
 	dbName := d.Get("database_name").(string)
@@ -146,10 +146,10 @@ func CreateProcedureGrant(d *schema.ResourceData, meta interface{}) error {
 	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (procedureName == "") && !futureProcedures {
-		return errors.New("procedure_name must be set unless on_future is true.")
+		return errors.New("procedure_name must be set unless on_future is true")
 	}
 	if (procedureName != "") && futureProcedures {
-		return errors.New("procedure_name must be empty if on_future is true.")
+		return errors.New("procedure_name must be empty if on_future is true")
 	}
 
 	if procedureName != "" {

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -116,7 +116,7 @@ func CreateResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	name := d.Get("name").(string)
 
-	cb := snowflake.ResourceMonitor(name).Create()
+	cb := snowflake.NewResourceMonitorBuilder(name).Create()
 	// Set optionals
 	if v, ok := d.GetOk("notify_users"); ok {
 		cb.SetStringList("notify_users", expandStringList(v.(*schema.Set).List()))
@@ -178,7 +178,7 @@ func CreateResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 // ReadResourceMonitor implements schema.ReadFunc.
 func ReadResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
-	stmt := snowflake.ResourceMonitor(d.Id()).Show()
+	stmt := snowflake.NewResourceMonitorBuilder(d.Id()).Show()
 
 	row := snowflake.QueryRow(db, stmt)
 
@@ -291,7 +291,7 @@ func extractTriggerInts(s sql.NullString) ([]int, error) {
 func DeleteResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 
-	stmt := snowflake.ResourceMonitor(d.Id()).Drop()
+	stmt := snowflake.NewResourceMonitorBuilder(d.Id()).Drop()
 	if err := snowflake.Exec(db, stmt); err != nil {
 		return fmt.Errorf("error deleting resource monitor %v err = %w", d.Id(), err)
 	}

--- a/pkg/resources/resource_monitor_test.go
+++ b/pkg/resources/resource_monitor_test.go
@@ -89,7 +89,7 @@ func TestResourceMonitorRead(t *testing.T) {
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
-		q := snowflake.ResourceMonitor(d.Id()).Show()
+		q := snowflake.NewResourceMonitorBuilder(d.Id()).Show()
 		mock.ExpectQuery(q).WillReturnError(sql.ErrNoRows)
 		err := resources.ReadResourceMonitor(d, db)
 		r.Empty(d.State())

--- a/pkg/resources/role.go
+++ b/pkg/resources/role.go
@@ -45,7 +45,7 @@ func Role() *schema.Resource {
 }
 
 func CreateRole(d *schema.ResourceData, meta interface{}) error {
-	return CreateResource("role", roleProperties, roleSchema, snowflake.Role, ReadRole)(d, meta)
+	return CreateResource("role", roleProperties, roleSchema, snowflake.NewRoleBuilder, ReadRole)(d, meta)
 }
 
 func ReadRole(d *schema.ResourceData, meta interface{}) error {
@@ -76,9 +76,9 @@ func ReadRole(d *schema.ResourceData, meta interface{}) error {
 }
 
 func UpdateRole(d *schema.ResourceData, meta interface{}) error {
-	return UpdateResource("role", roleProperties, roleSchema, snowflake.Role, ReadRole)(d, meta)
+	return UpdateResource("role", roleProperties, roleSchema, snowflake.NewRoleBuilder, ReadRole)(d, meta)
 }
 
 func DeleteRole(d *schema.ResourceData, meta interface{}) error {
-	return DeleteResource("role", snowflake.Role)(d, meta)
+	return DeleteResource("role", snowflake.NewRoleBuilder)(d, meta)
 }

--- a/pkg/resources/role_ownership_grant.go
+++ b/pkg/resources/role_ownership_grant.go
@@ -72,7 +72,7 @@ func CreateRoleOwnershipGrant(d *schema.ResourceData, meta interface{}) error {
 	toRoleName := d.Get("to_role_name").(string)
 	currentGrants := d.Get("current_grants").(string)
 
-	g := snowflake.RoleOwnershipGrant(onRoleName, currentGrants)
+	g := snowflake.NewRoleOwnershipGrantBuilder(onRoleName, currentGrants)
 	if err := snowflake.Exec(db, g.Role(toRoleName).Grant()); err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func UpdateRoleOwnershipGrant(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(fmt.Sprintf(`%s|%s|%s`, onRoleName, toRoleName, currentGrants))
 
-	g := snowflake.RoleOwnershipGrant(onRoleName, currentGrants)
+	g := snowflake.NewRoleOwnershipGrantBuilder(onRoleName, currentGrants)
 	if err := snowflake.Exec(db, g.Role(toRoleName).Grant()); err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func DeleteRoleOwnershipGrant(d *schema.ResourceData, meta interface{}) error {
 	currentGrants := d.Get("current_grants").(string)
 	reversionRole := d.Get("revert_ownership_to_role_name").(string)
 
-	g := snowflake.RoleOwnershipGrant(onRoleName, currentGrants)
+	g := snowflake.NewRoleOwnershipGrantBuilder(onRoleName, currentGrants)
 	if err := snowflake.Exec(db, g.Role(reversionRole).Revoke()); err != nil {
 		return err
 	}

--- a/pkg/resources/saml_integration.go
+++ b/pkg/resources/saml_integration.go
@@ -157,7 +157,7 @@ func CreateSAMLIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	name := d.Get("name").(string)
 
-	stmt := snowflake.SamlIntegration(name).Create()
+	stmt := snowflake.NewSamlIntegrationBuilder(name).Create()
 
 	// Set required fields
 	stmt.SetRaw(`TYPE=SAML2`)
@@ -222,7 +222,7 @@ func ReadSAMLIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.SamlIntegration(id).Show()
+	stmt := snowflake.NewSamlIntegrationBuilder(id).Show()
 	row := snowflake.QueryRow(db, stmt)
 
 	// Some properties can come from the SHOW INTEGRATION call
@@ -258,7 +258,7 @@ func ReadSAMLIntegration(d *schema.ResourceData, meta interface{}) error {
 	// We need to grab them in a loop
 	var k, pType string
 	var v, unused interface{}
-	stmt = snowflake.SamlIntegration(id).Describe()
+	stmt = snowflake.NewSamlIntegrationBuilder(id).Describe()
 	rows, err := db.Query(stmt)
 	if err != nil {
 		return fmt.Errorf("could not describe security integration err = %w", err)
@@ -386,7 +386,7 @@ func UpdateSAMLIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.SamlIntegration(id).Alter()
+	stmt := snowflake.NewSamlIntegrationBuilder(id).Alter()
 
 	var runSetStatement bool
 
@@ -471,5 +471,5 @@ func UpdateSAMLIntegration(d *schema.ResourceData, meta interface{}) error {
 
 // DeleteSAMLIntegration implements schema.DeleteFunc.
 func DeleteSAMLIntegration(d *schema.ResourceData, meta interface{}) error {
-	return DeleteResource("", snowflake.SamlIntegration)(d, meta)
+	return DeleteResource("", snowflake.NewSamlIntegrationBuilder)(d, meta)
 }

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -124,7 +124,7 @@ func CreateSchema(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	database := d.Get("database").(string)
 
-	builder := snowflake.Schema(name).WithDB(database)
+	builder := snowflake.NewSchemaBuilder(name).WithDB(database)
 
 	// Set optionals
 	if v, ok := d.GetOk("comment"); ok {
@@ -177,7 +177,7 @@ func ReadSchema(d *schema.ResourceData, meta interface{}) error {
 	dbName := schemaID.DatabaseName
 	schema := schemaID.SchemaName
 
-	q := snowflake.Schema(schema).WithDB(dbName).Show()
+	q := snowflake.NewSchemaBuilder(schema).WithDB(dbName).Show()
 	row := snowflake.QueryRow(db, q)
 
 	s, err := snowflake.ScanSchema(row)
@@ -257,7 +257,7 @@ func UpdateSchema(d *schema.ResourceData, meta interface{}) error {
 	dbName := sid.DatabaseName
 	schema := sid.SchemaName
 
-	builder := snowflake.Schema(schema).WithDB(dbName)
+	builder := snowflake.NewSchemaBuilder(schema).WithDB(dbName)
 
 	db := meta.(*sql.DB)
 	if d.HasChange("name") {
@@ -328,7 +328,7 @@ func DeleteSchema(d *schema.ResourceData, meta interface{}) error {
 	dbName := schemaID.DatabaseName
 	schema := schemaID.SchemaName
 
-	q := snowflake.Schema(schema).WithDB(dbName).Drop()
+	q := snowflake.NewSchemaBuilder(schema).WithDB(dbName).Drop()
 	if err := snowflake.Exec(db, q); err != nil {
 		return fmt.Errorf("error deleting schema %v err = %w", d.Id(), err)
 	}

--- a/pkg/resources/schema_grant.go
+++ b/pkg/resources/schema_grant.go
@@ -121,7 +121,7 @@ func CreateSchemaGrant(d *schema.ResourceData, meta interface{}) error {
 	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (schemaName == "") && !onFuture {
-		return errors.New("schema_name must be set unless on_future is true.")
+		return errors.New("schema_name must be set unless on_future is true")
 	}
 
 	var builder snowflake.GrantBuilder

--- a/pkg/resources/schema_test.go
+++ b/pkg/resources/schema_test.go
@@ -57,7 +57,7 @@ func TestSchemaRead(t *testing.T) {
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
-		q := snowflake.Schema("good_name").WithDB("test_db").Show()
+		q := snowflake.NewSchemaBuilder("good_name").WithDB("test_db").Show()
 		mock.ExpectQuery(q).WillReturnError(sql.ErrNoRows)
 		err := resources.ReadSchema(d, db)
 		r.Empty(d.State())

--- a/pkg/resources/scim_integration.go
+++ b/pkg/resources/scim_integration.go
@@ -78,7 +78,7 @@ func CreateSCIMIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	name := d.Get("name").(string)
 
-	stmt := snowflake.ScimIntegration(name).Create()
+	stmt := snowflake.NewSCIMIntegrationBuilder(name).Create()
 
 	// Set required fields
 	stmt.SetRaw(`TYPE=SCIM`)
@@ -104,7 +104,7 @@ func ReadSCIMIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.ScimIntegration(id).Show()
+	stmt := snowflake.NewSCIMIntegrationBuilder(id).Show()
 	row := snowflake.QueryRow(db, stmt)
 
 	// Some properties can come from the SHOW INTEGRATION call
@@ -135,7 +135,7 @@ func ReadSCIMIntegration(d *schema.ResourceData, meta interface{}) error {
 	// We need to grab them in a loop
 	var k, pType string
 	var v, unused interface{}
-	stmt = snowflake.ScimIntegration(id).Describe()
+	stmt = snowflake.NewSCIMIntegrationBuilder(id).Describe()
 	rows, err := db.Query(stmt)
 	if err != nil {
 		return fmt.Errorf("could not describe security integration")
@@ -167,7 +167,7 @@ func UpdateSCIMIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.ScimIntegration(id).Alter()
+	stmt := snowflake.NewSCIMIntegrationBuilder(id).Alter()
 
 	var runSetStatement bool
 
@@ -205,5 +205,5 @@ func UpdateSCIMIntegration(d *schema.ResourceData, meta interface{}) error {
 
 // DeleteSCIMIntegration implements schema.DeleteFunc.
 func DeleteSCIMIntegration(d *schema.ResourceData, meta interface{}) error {
-	return DeleteResource("", snowflake.ScimIntegration)(d, meta)
+	return DeleteResource("", snowflake.NewSCIMIntegrationBuilder)(d, meta)
 }

--- a/pkg/resources/sequence.go
+++ b/pkg/resources/sequence.go
@@ -103,7 +103,7 @@ func CreateSequence(d *schema.ResourceData, meta interface{}) error {
 	schema := d.Get("schema").(string)
 	name := d.Get("name").(string)
 
-	sq := snowflake.Sequence(name, database, schema)
+	sq := snowflake.NewSequenceBuilder(name, database, schema)
 
 	if i, ok := d.GetOk("increment"); ok {
 		sq.WithIncrement(i.(int))
@@ -144,7 +144,7 @@ func ReadSequence(d *schema.ResourceData, meta interface{}) error {
 	schema := sequenceID.SchemaName
 	name := sequenceID.SequenceName
 
-	seq := snowflake.Sequence(name, database, schema)
+	seq := snowflake.NewSequenceBuilder(name, database, schema)
 	stmt := seq.Show()
 	row := snowflake.QueryRow(db, stmt)
 
@@ -211,7 +211,7 @@ func UpdateSequence(d *schema.ResourceData, meta interface{}) error {
 	schema := sequenceID.SchemaName
 	name := sequenceID.SequenceName
 
-	sq := snowflake.Sequence(name, database, schema)
+	sq := snowflake.NewSequenceBuilder(name, database, schema)
 	stmt := sq.Show()
 	row := snowflake.QueryRow(db, stmt)
 
@@ -261,7 +261,7 @@ func DeleteSequence(d *schema.ResourceData, meta interface{}) error {
 	schema := sequenceID.SchemaName
 	name := sequenceID.SequenceName
 
-	stmt := snowflake.Sequence(name, database, schema).Drop()
+	stmt := snowflake.NewSequenceBuilder(name, database, schema).Drop()
 	if err := snowflake.Exec(db, stmt); err != nil {
 		return fmt.Errorf("error dropping sequence %s err = %w", name, err)
 	}

--- a/pkg/resources/sequence_grant.go
+++ b/pkg/resources/sequence_grant.go
@@ -101,10 +101,10 @@ func CreateSequenceGrant(d *schema.ResourceData, meta interface{}) error {
 	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (sequenceName == "") && !futureSequences {
-		return errors.New("sequence_name must be set unless on_future is true.")
+		return errors.New("sequence_name must be set unless on_future is true")
 	}
 	if (sequenceName != "") && futureSequences {
-		return errors.New("sequence_name must be empty if on_future is true.")
+		return errors.New("sequence_name must be empty if on_future is true")
 	}
 
 	var builder snowflake.GrantBuilder

--- a/pkg/resources/share.go
+++ b/pkg/resources/share.go
@@ -64,7 +64,7 @@ func CreateShare(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	name := d.Get("name").(string)
 
-	builder := snowflake.Share(name).Create()
+	builder := snowflake.NewShareBuilder(name).Create()
 	builder.SetString("COMMENT", d.Get("comment").(string))
 
 	if err := snowflake.Exec(db, builder.Statement()); err != nil {
@@ -94,7 +94,7 @@ func setAccounts(d *schema.ResourceData, meta interface{}) error {
 	// thing working.
 	// 1. Create new temporary DB
 	tempName := fmt.Sprintf("TEMP_%v_%d", name, time.Now().Unix())
-	tempDB := snowflake.Database(tempName)
+	tempDB := snowflake.NewDatabaseBuilder(tempName)
 	if err := snowflake.Exec(db, tempDB.Create()); err != nil {
 		return fmt.Errorf("error creating temporary DB %v err = %w", tempName, err)
 	}
@@ -152,7 +152,7 @@ func ReadShare(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.Share(id).Show()
+	stmt := snowflake.NewShareBuilder(id).Show()
 	row := snowflake.QueryRow(db, stmt)
 
 	s, err := snowflake.ScanShare(row)
@@ -188,12 +188,12 @@ func UpdateShare(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	return UpdateResource("this does not seem to be used", shareProperties, shareSchema, snowflake.Share, ReadShare)(d, meta)
+	return UpdateResource("this does not seem to be used", shareProperties, shareSchema, snowflake.NewShareBuilder, ReadShare)(d, meta)
 }
 
 // DeleteShare implements schema.DeleteFunc.
 func DeleteShare(d *schema.ResourceData, meta interface{}) error {
-	return DeleteResource("this does not seem to be used", snowflake.Share)(d, meta)
+	return DeleteResource("this does not seem to be used", snowflake.NewShareBuilder)(d, meta)
 }
 
 // StripAccountFromName removes the account prefix from a resource (e.g. a share)

--- a/pkg/resources/share_test.go
+++ b/pkg/resources/share_test.go
@@ -86,7 +86,7 @@ func TestShareRead(t *testing.T) {
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
-		q := snowflake.Share(d.Id()).Show()
+		q := snowflake.NewShareBuilder(d.Id()).Show()
 		mock.ExpectQuery(q).WillReturnError(sql.ErrNoRows)
 		err := resources.ReadShare(d, db)
 		r.Empty(d.State())

--- a/pkg/resources/snowflake_sweeper_test.go
+++ b/pkg/resources/snowflake_sweeper_test.go
@@ -122,7 +122,7 @@ func getUsersSweeper(name string) *resource.Sweeper {
 				log.Printf("[DEBUG] Testing if user %s starts with tst-terraform", user.Name.String)
 				if strings.HasPrefix(user.Name.String, "tst-terraform") {
 					log.Printf("[DEBUG] deleting user %s", user.Name.String)
-					stmt := snowflake.NewUser(user.Name.String).Drop()
+					stmt := snowflake.NewUserBuilder(user.Name.String).Drop()
 					if err := snowflake.Exec(db, stmt); err != nil {
 						return fmt.Errorf("Error deleting user %q %w", user.Name.String, err)
 					}

--- a/pkg/resources/snowflake_sweeper_test.go
+++ b/pkg/resources/snowflake_sweeper_test.go
@@ -34,7 +34,7 @@ func getWarehousesSweeper(name string) *resource.Sweeper {
 				log.Printf("[DEBUG] Testing if warehouse %s starts with tst-terraform", wh.Name)
 				if strings.HasPrefix(wh.Name, "tst-terraform") {
 					log.Printf("[DEBUG] deleting warehouse %s", wh.Name)
-					whBuilder := snowflake.Warehouse(name).Builder
+					whBuilder := snowflake.NewWarehouseBuilder(name).Builder
 					stmt := whBuilder.Drop()
 					if err := snowflake.Exec(db, stmt); err != nil {
 						return fmt.Errorf("Error deleting warehouse %q %w", wh.Name, err)
@@ -64,7 +64,7 @@ func getDatabaseSweepers(name string) *resource.Sweeper {
 				log.Printf("[DEBUG] Testing if database %s starts with tst-terraform", database.DBName.String)
 				if strings.HasPrefix(database.DBName.String, "tst-terraform") {
 					log.Printf("[DEBUG] deleting database %s", database.DBName.String)
-					stmt := snowflake.Database(database.DBName.String).Drop()
+					stmt := snowflake.NewDatabaseBuilder(database.DBName.String).Drop()
 					if err := snowflake.Exec(db, stmt); err != nil {
 						return fmt.Errorf("Error deleting database %q %w", database.DBName.String, err)
 					}
@@ -93,7 +93,7 @@ func getRolesSweeper(name string) *resource.Sweeper {
 				log.Printf("[DEBUG] Testing if role %s starts with tst-terraform", role.Name.String)
 				if strings.HasPrefix(role.Name.String, "tst-terraform") {
 					log.Printf("[DEBUG] deleting role %s", role.Name.String)
-					stmt := snowflake.Role(role.Name.String).Drop()
+					stmt := snowflake.NewRoleBuilder(role.Name.String).Drop()
 					if err := snowflake.Exec(db, stmt); err != nil {
 						return fmt.Errorf("Error deleting role %q %w", role.Name.String, err)
 					}
@@ -122,7 +122,7 @@ func getUsersSweeper(name string) *resource.Sweeper {
 				log.Printf("[DEBUG] Testing if user %s starts with tst-terraform", user.Name.String)
 				if strings.HasPrefix(user.Name.String, "tst-terraform") {
 					log.Printf("[DEBUG] deleting user %s", user.Name.String)
-					stmt := snowflake.User(user.Name.String).Drop()
+					stmt := snowflake.NewUser(user.Name.String).Drop()
 					if err := snowflake.Exec(db, stmt); err != nil {
 						return fmt.Errorf("Error deleting user %q %w", user.Name.String, err)
 					}

--- a/pkg/resources/stage.go
+++ b/pkg/resources/stage.go
@@ -159,7 +159,7 @@ func CreateStage(d *schema.ResourceData, meta interface{}) error {
 	database := d.Get("database").(string)
 	schema := d.Get("schema").(string)
 
-	builder := snowflake.Stage(name, database, schema)
+	builder := snowflake.NewStageBuilder(name, database, schema)
 
 	// Set optionals
 	if v, ok := d.GetOk("url"); ok {
@@ -232,7 +232,7 @@ func ReadStage(d *schema.ResourceData, meta interface{}) error {
 	schema := stageID.SchemaName
 	stage := stageID.StageName
 
-	q := snowflake.Stage(stage, dbName, schema).Describe()
+	q := snowflake.NewStageBuilder(stage, dbName, schema).Describe()
 	stageDesc, err := snowflake.DescStage(db, q)
 	if errors.Is(err, sql.ErrNoRows) {
 		// If not found, mark resource to be removed from statefile during apply or refresh
@@ -251,7 +251,7 @@ func ReadStage(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	sq := snowflake.Stage(stage, dbName, schema).Show()
+	sq := snowflake.NewStageBuilder(stage, dbName, schema).Show()
 	row := snowflake.QueryRow(db, sq)
 
 	s, err := snowflake.ScanStageShow(row)
@@ -317,7 +317,7 @@ func UpdateStage(d *schema.ResourceData, meta interface{}) error {
 	schema := stageID.SchemaName
 	stage := stageID.StageName
 
-	builder := snowflake.Stage(stage, dbName, schema)
+	builder := snowflake.NewStageBuilder(stage, dbName, schema)
 
 	db := meta.(*sql.DB)
 	if d.HasChange("url") {
@@ -393,7 +393,7 @@ func DeleteStage(d *schema.ResourceData, meta interface{}) error {
 	schema := stageID.SchemaName
 	stage := stageID.StageName
 
-	q := snowflake.Stage(stage, dbName, schema).Drop()
+	q := snowflake.NewStageBuilder(stage, dbName, schema).Drop()
 	if err := snowflake.Exec(db, q); err != nil {
 		return fmt.Errorf("error deleting stage %v err = %w", d.Id(), err)
 	}

--- a/pkg/resources/stage_test.go
+++ b/pkg/resources/stage_test.go
@@ -100,7 +100,7 @@ func TestStageRead(t *testing.T) {
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
-		q := snowflake.Stage("test_stage", "test_db", "test_schema").Describe()
+		q := snowflake.NewStageBuilder("test_stage", "test_db", "test_schema").Describe()
 		mock.ExpectQuery(q).WillReturnError(sql.ErrNoRows)
 		err := resources.ReadStage(d, db)
 		r.Empty(d.State())

--- a/pkg/resources/storage_integration.go
+++ b/pkg/resources/storage_integration.go
@@ -123,7 +123,7 @@ func CreateStorageIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	name := d.Get("name").(string)
 
-	stmt := snowflake.StorageIntegration(name).Create()
+	stmt := snowflake.NewStorageIntegrationBuilder(name).Create()
 
 	// Set required fields
 	stmt.SetString(`TYPE`, d.Get("type").(string))
@@ -162,7 +162,7 @@ func ReadStorageIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.StorageIntegration(d.Id()).Show()
+	stmt := snowflake.NewStorageIntegrationBuilder(d.Id()).Show()
 	row := snowflake.QueryRow(db, stmt)
 
 	// Some properties can come from the SHOW INTEGRATION call
@@ -203,7 +203,7 @@ func ReadStorageIntegration(d *schema.ResourceData, meta interface{}) error {
 	// We need to grab them in a loop
 	var k, pType string
 	var v, unused interface{}
-	stmt = snowflake.StorageIntegration(d.Id()).Describe()
+	stmt = snowflake.NewStorageIntegrationBuilder(d.Id()).Describe()
 	rows, err := db.Query(stmt)
 	if err != nil {
 		return fmt.Errorf("could not describe storage integration: %w", err)
@@ -279,7 +279,7 @@ func UpdateStorageIntegration(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
-	stmt := snowflake.StorageIntegration(id).Alter()
+	stmt := snowflake.NewStorageIntegrationBuilder(id).Alter()
 
 	// This is required in case the only change is to UNSET STORAGE_ALLOWED_LOCATIONS.
 	// Not sure if there is a more elegant way of determining this
@@ -361,7 +361,7 @@ func UpdateStorageIntegration(d *schema.ResourceData, meta interface{}) error {
 
 // DeleteStorageIntegration implements schema.DeleteFunc.
 func DeleteStorageIntegration(d *schema.ResourceData, meta interface{}) error {
-	return DeleteResource("", snowflake.StorageIntegration)(d, meta)
+	return DeleteResource("", snowflake.NewStorageIntegrationBuilder)(d, meta)
 }
 
 func setStorageProviderSettings(data *schema.ResourceData, stmt snowflake.SettingBuilder) error {

--- a/pkg/resources/stream.go
+++ b/pkg/resources/stream.go
@@ -198,7 +198,7 @@ func CreateStream(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		tq := snowflake.Table(id.Name, id.DatabaseName, id.SchemaName).Show()
+		tq := snowflake.NewTableBuilder(id.Name, id.DatabaseName, id.SchemaName).Show()
 		tableRow := snowflake.QueryRow(db, tq)
 
 		t, err := snowflake.ScanTable(tableRow)
@@ -214,7 +214,7 @@ func CreateStream(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		tq := snowflake.View(id.Name).WithDB(id.DatabaseName).WithSchema(id.SchemaName).Show()
+		tq := snowflake.NewViewBuilder(id.Name).WithDB(id.DatabaseName).WithSchema(id.SchemaName).Show()
 		viewRow := snowflake.QueryRow(db, tq)
 
 		t, err := snowflake.ScanView(viewRow)

--- a/pkg/resources/stream_grant.go
+++ b/pkg/resources/stream_grant.go
@@ -101,10 +101,10 @@ func CreateStreamGrant(d *schema.ResourceData, meta interface{}) error {
 	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (streamName == "") && !futureStreams {
-		return errors.New("stream_name must be set unless on_future is true.")
+		return errors.New("stream_name must be set unless on_future is true")
 	}
 	if (streamName != "") && futureStreams {
-		return errors.New("stream_name must be empty if on_future is true.")
+		return errors.New("stream_name must be empty if on_future is true")
 	}
 
 	var builder snowflake.GrantBuilder

--- a/pkg/resources/table_constraint.go
+++ b/pkg/resources/table_constraint.go
@@ -210,7 +210,7 @@ func CreateTableConstraint(d *schema.ResourceData, meta interface{}) error {
 	tableID := d.Get("table_id").(string)
 
 	formattedTableID := snowflakeValidation.ParseAndFormatFullyQualifiedObectID(tableID)
-	builder := snowflake.TableConstraint(name, constraintType, formattedTableID)
+	builder := snowflake.NewTableConstraintBuilder(name, constraintType, formattedTableID)
 
 	cc := d.Get("columns").([]interface{})
 	columns := make([]string, 0, len(cc))
@@ -312,7 +312,7 @@ func UpdateTableConstraint(d *schema.ResourceData, meta interface{}) error {
 	tc.parse(d.Id())
 	formattedTableID := snowflakeValidation.ParseAndFormatFullyQualifiedObectID(tc.tableID)
 
-	builder := snowflake.TableConstraint(tc.name, tc.constraintType, formattedTableID)
+	builder := snowflake.NewTableConstraintBuilder(tc.name, tc.constraintType, formattedTableID)
 
 	/* "unsupported feature comment error message"
 	if d.HasChange("comment") {
@@ -340,7 +340,7 @@ func DeleteTableConstraint(d *schema.ResourceData, meta interface{}) error {
 	tc := tableConstraintID{}
 	tc.parse(d.Id())
 	formattedTableID := snowflakeValidation.ParseAndFormatFullyQualifiedObectID(tc.tableID)
-	builder := snowflake.TableConstraint(tc.name, tc.constraintType, formattedTableID)
+	builder := snowflake.NewTableConstraintBuilder(tc.name, tc.constraintType, formattedTableID)
 	cc := d.Get("columns").([]interface{})
 	columns := make([]string, 0, len(cc))
 	for _, c := range cc {

--- a/pkg/resources/table_grant.go
+++ b/pkg/resources/table_grant.go
@@ -122,11 +122,11 @@ func CreateTableGrant(d *schema.ResourceData, meta interface{}) error {
 	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (schemaName == "") && !onFuture {
-		return errors.New("schema_name must be set unless on_future is true.")
+		return errors.New("schema_name must be set unless on_future is true")
 	}
 
 	if (tableName == "") && !onFuture {
-		return errors.New("table_name must be set unless on_future is true.")
+		return errors.New("table_name must be set unless on_future is true")
 	}
 
 	var builder snowflake.GrantBuilder

--- a/pkg/resources/table_test.go
+++ b/pkg/resources/table_test.go
@@ -128,7 +128,7 @@ func TestTableRead(t *testing.T) {
 
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
-		q := snowflake.Table("good_name", "database_name", "schema_name").Show()
+		q := snowflake.NewTableBuilder("good_name", "database_name", "schema_name").Show()
 		mock.ExpectQuery(q).WillReturnError(sql.ErrNoRows)
 		err2 := resources.ReadTable(d, db)
 		r.Empty(d.State())

--- a/pkg/resources/tag_association.go
+++ b/pkg/resources/tag_association.go
@@ -111,7 +111,7 @@ func CreateTagAssociation(d *schema.ResourceData, meta interface{}) error {
 	tagValue := d.Get("tag_value").(string)
 	objectIdentifier := d.Get("object_identifier").([]interface{})[0].(map[string]interface{})
 	fullyQualifierObjectIdentifier := tagAssociationFullyQualifiedIdentifier(objectIdentifier, objectType)
-	builder := snowflake.TagAssociation(tagID).WithObjectIdentifier(fullyQualifierObjectIdentifier).WithObjectType(objectType).WithTagValue(tagValue)
+	builder := snowflake.NewTagAssociationBuilder(tagID).WithObjectIdentifier(fullyQualifierObjectIdentifier).WithObjectType(objectType).WithTagValue(tagValue)
 
 	q := builder.Create()
 	if err := snowflake.Exec(db, q); err != nil {
@@ -159,7 +159,7 @@ func ReadTagAssociation(d *schema.ResourceData, meta interface{}) error {
 	objectType := d.Get("object_type").(string)
 	objectIdentifier := d.Get("object_identifier").([]interface{})[0].(map[string]interface{})
 	fullyQualifierObjectIdentifier := tagAssociationFullyQualifiedIdentifier(objectIdentifier, objectType)
-	q := snowflake.TagAssociation(tagID).WithObjectIdentifier(fullyQualifierObjectIdentifier).WithObjectType(objectType).Show()
+	q := snowflake.NewTagAssociationBuilder(tagID).WithObjectIdentifier(fullyQualifierObjectIdentifier).WithObjectType(objectType).Show()
 	row := snowflake.QueryRow(db, q)
 
 	ta, err := snowflake.ScanTagAssociation(row)
@@ -188,7 +188,7 @@ func UpdateTagAssociation(d *schema.ResourceData, meta interface{}) error {
 	objectType := d.Get("object_type").(string)
 	objectIdentifier := d.Get("object_identifier").([]interface{})[0].(map[string]interface{})
 	fullyQualifierObjectIdentifier := tagAssociationFullyQualifiedIdentifier(objectIdentifier, objectType)
-	builder := snowflake.TagAssociation(tagID).WithObjectIdentifier(fullyQualifierObjectIdentifier).WithObjectType(objectType)
+	builder := snowflake.NewTagAssociationBuilder(tagID).WithObjectIdentifier(fullyQualifierObjectIdentifier).WithObjectType(objectType)
 
 	if d.HasChange("skip_validation") {
 		old, new := d.GetChange("skip_validation")
@@ -220,7 +220,7 @@ func DeleteTagAssociation(d *schema.ResourceData, meta interface{}) error {
 	objectType := d.Get("object_type").(string)
 	objectIdentifier := d.Get("object_identifier").([]interface{})[0].(map[string]interface{})
 	fullyQualifierObjectIdentifier := tagAssociationFullyQualifiedIdentifier(objectIdentifier, objectType)
-	q := snowflake.TagAssociation(tagID).WithObjectIdentifier(fullyQualifierObjectIdentifier).WithObjectType(objectType).Drop()
+	q := snowflake.NewTagAssociationBuilder(tagID).WithObjectIdentifier(fullyQualifierObjectIdentifier).WithObjectType(objectType).Drop()
 
 	if err := snowflake.Exec(db, q); err != nil {
 		log.Printf("[DEBUG] error is %v", err.Error())
@@ -247,18 +247,17 @@ func tagAssociationFullyQualifiedIdentifier(objectIdentifier map[string]interfac
 
 		*/
 		return snowflakeValidation.FormatFullyQualifiedObjectID("", objectDatabase, objectSchema) // db_name.schema_name
-	} else {
-		objectName := objectIdentifier["name"].(string)
-		objectSchema := ""
-		obs := objectIdentifier["schema"]
-		if obs != nil {
-			objectSchema = obs.(string)
-		}
-		objectDatabase := ""
-		obd := objectIdentifier["database"]
-		if obd != nil {
-			objectDatabase = obd.(string)
-		}
-		return snowflakeValidation.FormatFullyQualifiedObjectID(objectDatabase, objectSchema, objectName)
 	}
+	objectName := objectIdentifier["name"].(string)
+	objectSchema := ""
+	obs := objectIdentifier["schema"]
+	if obs != nil {
+		objectSchema = obs.(string)
+	}
+	objectDatabase := ""
+	obd := objectIdentifier["database"]
+	if obd != nil {
+		objectDatabase = obd.(string)
+	}
+	return snowflakeValidation.FormatFullyQualifiedObjectID(objectDatabase, objectSchema, objectName)
 }

--- a/pkg/resources/tag_masking_policy_association.go
+++ b/pkg/resources/tag_masking_policy_association.go
@@ -122,7 +122,7 @@ func CreateTagMaskingPolicyAssociation(d *schema.ResourceData, meta interface{})
 	mpName := mpIDStruct.MaskingPolicyName
 
 	mP := snowflake.MaskingPolicy(mpName, mpDB, mpSchema)
-	builder := snowflake.Tag(tagName).WithDB(tagDB).WithSchema(tagSchema).WithMaskingPolicy(mP)
+	builder := snowflake.NewTagBuilder(tagName).WithDB(tagDB).WithSchema(tagSchema).WithMaskingPolicy(mP)
 
 	q := builder.AddMaskingPolicy()
 
@@ -163,7 +163,7 @@ func ReadTagMaskingPolicyAssociation(d *schema.ResourceData, meta interface{}) e
 	mpName := attachementID.MaskingPolicyName
 
 	mP := snowflake.MaskingPolicy(mpName, mpDBName, mpSchameName)
-	builder := snowflake.Tag(tagName).WithDB(tagDBName).WithSchema(tagSchemaName).WithMaskingPolicy(mP)
+	builder := snowflake.NewTagBuilder(tagName).WithDB(tagDBName).WithSchema(tagSchemaName).WithMaskingPolicy(mP)
 
 	row := snowflake.QueryRow(db, builder.ShowAttachedPolicy())
 	t, err := snowflake.ScanTagPolicy(row)
@@ -228,7 +228,7 @@ func DeleteTagMaskingPolicyAssociation(d *schema.ResourceData, meta interface{})
 
 	mP := snowflake.MaskingPolicy(mpName, mpDBName, mpSchameName)
 
-	builder := snowflake.Tag(tagName).WithDB(tagDBName).WithSchema(tagSchemaName).WithMaskingPolicy(mP)
+	builder := snowflake.NewTagBuilder(tagName).WithDB(tagDBName).WithSchema(tagSchemaName).WithMaskingPolicy(mP)
 
 	if err := snowflake.Exec(db, builder.RemoveMaskingPolicy()); err != nil {
 		return fmt.Errorf("error unattaching masking policy for %v err = %w", d.Id(), err)

--- a/pkg/resources/tag_masking_policy_association_test.go
+++ b/pkg/resources/tag_masking_policy_association_test.go
@@ -76,7 +76,7 @@ func TestTagMaskingPolicyAssociationRead(t *testing.T) {
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
 		mP := snowflake.MaskingPolicy("mp_name", "mp_db", "mp_schema")
-		q := snowflake.Tag("tag_name").WithDB("tag_db").WithSchema("tag_schema").WithMaskingPolicy(mP).ShowAttachedPolicy()
+		q := snowflake.NewTagBuilder("tag_name").WithDB("tag_db").WithSchema("tag_schema").WithMaskingPolicy(mP).ShowAttachedPolicy()
 		mock.ExpectQuery(regexp.QuoteMeta(q)).WillReturnError(sql.ErrNoRows)
 		err := resources.ReadTagMaskingPolicyAssociation(d, db)
 

--- a/pkg/resources/tag_test.go
+++ b/pkg/resources/tag_test.go
@@ -106,7 +106,7 @@ func TestTagRead(t *testing.T) {
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
-		q := snowflake.Tag("good_name").WithDB("test_db").WithSchema("test_schema").Show()
+		q := snowflake.NewTagBuilder("good_name").WithDB("test_db").WithSchema("test_schema").Show()
 		mock.ExpectQuery(q).WillReturnError(sql.ErrNoRows)
 		err := resources.ReadTag(d, db)
 		r.Empty(d.State())

--- a/pkg/resources/task.go
+++ b/pkg/resources/task.go
@@ -200,7 +200,7 @@ func ReadTask(d *schema.ResourceData, meta interface{}) error {
 	schema := taskID.SchemaName
 	name := taskID.TaskName
 
-	builder := snowflake.Task(name, database, schema)
+	builder := snowflake.NewTaskBuilder(name, database, schema)
 	q := builder.Show()
 	row := snowflake.QueryRow(db, q)
 	t, err := snowflake.ScanTask(row)
@@ -352,7 +352,7 @@ func CreateTask(d *schema.ResourceData, meta interface{}) error {
 	sql := d.Get("sql_statement").(string)
 	enabled := d.Get("enabled").(bool)
 
-	builder := snowflake.Task(name, database, schema)
+	builder := snowflake.NewTaskBuilder(name, database, schema)
 	builder.WithStatement(sql)
 
 	// Set optionals
@@ -459,7 +459,7 @@ func UpdateTask(d *schema.ResourceData, meta interface{}) error {
 	database := taskID.DatabaseName
 	schema := taskID.SchemaName
 	name := taskID.TaskName
-	builder := snowflake.Task(name, database, schema)
+	builder := snowflake.NewTaskBuilder(name, database, schema)
 
 	rootTasks, err := snowflake.GetRootTasks(name, database, schema, db)
 	if err != nil {
@@ -757,7 +757,7 @@ func DeleteTask(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	q := snowflake.Task(name, database, schema).Drop()
+	q := snowflake.NewTaskBuilder(name, database, schema).Drop()
 	if err := snowflake.Exec(db, q); err != nil {
 		return fmt.Errorf("error deleting task %v err = %w", d.Id(), err)
 	}

--- a/pkg/resources/task_grant.go
+++ b/pkg/resources/task_grant.go
@@ -102,10 +102,10 @@ func CreateTaskGrant(d *schema.ResourceData, meta interface{}) error {
 	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (taskName == "") && !futureTasks {
-		return errors.New("task_name must be set unless on_future is true.")
+		return errors.New("task_name must be set unless on_future is true")
 	}
 	if (taskName != "") && futureTasks {
-		return errors.New("task_name must be empty if on_future is true.")
+		return errors.New("task_name must be empty if on_future is true")
 	}
 
 	var builder snowflake.GrantBuilder

--- a/pkg/resources/user.go
+++ b/pkg/resources/user.go
@@ -156,7 +156,7 @@ func User() *schema.Resource {
 }
 
 func CreateUser(d *schema.ResourceData, meta interface{}) error {
-	return CreateResource("user", userProperties, userSchema, snowflake.User, ReadUser)(d, meta)
+	return CreateResource("user", userProperties, userSchema, snowflake.NewUserBuilder, ReadUser)(d, meta)
 }
 
 func ReadUser(d *schema.ResourceData, meta interface{}) error {
@@ -165,7 +165,7 @@ func ReadUser(d *schema.ResourceData, meta interface{}) error {
 
 	// We use User.Describe instead of User.Show because the "SHOW USERS ..." command
 	// requires the "MANAGE GRANTS" global privilege
-	stmt := snowflake.User(id).Describe()
+	stmt := snowflake.NewUserBuilder(id).Describe()
 	rows, err := snowflake.Query(db, stmt)
 
 	if err != nil && snowflake.IsResourceNotExistOrNotAuthorized(err.Error(), "User") {
@@ -253,9 +253,9 @@ func ReadUser(d *schema.ResourceData, meta interface{}) error {
 }
 
 func UpdateUser(d *schema.ResourceData, meta interface{}) error {
-	return UpdateResource("user", userProperties, userSchema, snowflake.User, ReadUser)(d, meta)
+	return UpdateResource("user", userProperties, userSchema, snowflake.NewUserBuilder, ReadUser)(d, meta)
 }
 
 func DeleteUser(d *schema.ResourceData, meta interface{}) error {
-	return DeleteResource("user", snowflake.User)(d, meta)
+	return DeleteResource("user", snowflake.NewUserBuilder)(d, meta)
 }

--- a/pkg/resources/user_ownership_grant.go
+++ b/pkg/resources/user_ownership_grant.go
@@ -68,7 +68,7 @@ func CreateUserOwnershipGrant(d *schema.ResourceData, meta interface{}) error {
 	role := d.Get("to_role_name").(string)
 	currentGrants := d.Get("current_grants").(string)
 
-	g := snowflake.UserOwnershipGrant(user, currentGrants)
+	g := snowflake.NewUserOwnershipGrantBuilder(user, currentGrants)
 	err := snowflake.Exec(db, g.Role(role).Grant())
 	if err != nil {
 		return err
@@ -133,7 +133,7 @@ func UpdateUserOwnershipGrant(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(fmt.Sprintf(`%s|%s|%s`, user, role, currentGrants))
 
-	g := snowflake.UserOwnershipGrant(user, currentGrants)
+	g := snowflake.NewUserOwnershipGrantBuilder(user, currentGrants)
 	err := snowflake.Exec(db, g.Role(role).Grant())
 	if err != nil {
 		return err
@@ -148,7 +148,7 @@ func DeleteUserOwnershipGrant(d *schema.ResourceData, meta interface{}) error {
 	currentGrants := d.Get("current_grants").(string)
 	reversionRole := d.Get("revert_ownership_to_role_name").(string)
 
-	g := snowflake.UserOwnershipGrant(user, currentGrants)
+	g := snowflake.NewUserOwnershipGrantBuilder(user, currentGrants)
 	err := snowflake.Exec(db, g.Role(reversionRole).Revoke())
 	if err != nil {
 		return err

--- a/pkg/resources/user_public_keys.go
+++ b/pkg/resources/user_public_keys.go
@@ -61,7 +61,7 @@ func UserPublicKeys() *schema.Resource {
 
 func checkUserExists(db *sql.DB, name string) (bool, error) {
 	// First check if user exists
-	stmt := snowflake.User(name).Describe()
+	stmt := snowflake.NewUserBuilder(name).Describe()
 	_, err := snowflake.Query(db, stmt)
 	if errors.Is(err, sql.ErrNoRows) {
 		log.Printf("[DEBUG] user (%s) not found", name)

--- a/pkg/resources/user_test.go
+++ b/pkg/resources/user_test.go
@@ -110,8 +110,8 @@ func TestUserRead(t *testing.T) {
 
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
-		q := snowflake.User(d.Id()).Describe()
-		mock.ExpectQuery(q).WillReturnError(fmt.Errorf("SQL compilation error:User '%s' does not exist or not authorized.", name))
+		q := snowflake.NewUserBuilder(d.Id()).Describe()
+		mock.ExpectQuery(q).WillReturnError(fmt.Errorf("SQL compilation error:User '%s' does not exist or not authorized", name))
 		err2 := resources.ReadUser(d, db)
 		r.Empty(d.State())
 		r.Nil(err2)

--- a/pkg/resources/view_grant.go
+++ b/pkg/resources/view_grant.go
@@ -117,14 +117,13 @@ func CreateViewGrant(d *schema.ResourceData, meta interface{}) error {
 	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
 	if (schemaName == "") && !futureViews {
-		return errors.New("schema_name must be set unless on_future is true.")
+		return errors.New("schema_name must be set unless on_future is true")
 	}
-
 	if (viewName == "") && !futureViews {
-		return errors.New("view_name must be set unless on_future is true.")
+		return errors.New("view_name must be set unless on_future is true")
 	}
 	if (viewName != "") && futureViews {
-		return errors.New("view_name must be empty if on_future is true.")
+		return errors.New("view_name must be empty if on_future is true")
 	}
 
 	var builder snowflake.GrantBuilder

--- a/pkg/resources/view_test.go
+++ b/pkg/resources/view_test.go
@@ -145,7 +145,7 @@ func TestViewRead(t *testing.T) {
 	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
-		q := snowflake.View("good_name").WithDB("test_db").WithSchema("test_schema").Show()
+		q := snowflake.NewViewBuilder("good_name").WithDB("test_db").WithSchema("test_schema").Show()
 		fmt.Println(q)
 		mock.ExpectQuery(q).WillReturnError(sql.ErrNoRows)
 		err := resources.ReadView(d, db)

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -169,7 +169,7 @@ func CreateWarehouse(d *schema.ResourceData, meta interface{}) error {
 		props,
 		warehouseSchema,
 		func(name string) *snowflake.Builder {
-			return snowflake.Warehouse(name).Builder
+			return snowflake.NewWarehouseBuilder(name).Builder
 		},
 		ReadWarehouse,
 	)(d, meta)
@@ -178,7 +178,7 @@ func CreateWarehouse(d *schema.ResourceData, meta interface{}) error {
 // ReadWarehouse implements schema.ReadFunc.
 func ReadWarehouse(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
-	warehouseBuilder := snowflake.Warehouse(d.Id())
+	warehouseBuilder := snowflake.NewWarehouseBuilder(d.Id())
 	stmt := warehouseBuilder.Show()
 
 	row := snowflake.QueryRow(db, stmt)
@@ -293,7 +293,7 @@ func UpdateWarehouse(d *schema.ResourceData, meta interface{}) error {
 		warehouseProperties,
 		warehouseSchema,
 		func(name string) *snowflake.Builder {
-			return snowflake.Warehouse(name).Builder
+			return snowflake.NewWarehouseBuilder(name).Builder
 		},
 		ReadWarehouse,
 	)(d, meta)
@@ -303,7 +303,7 @@ func UpdateWarehouse(d *schema.ResourceData, meta interface{}) error {
 func DeleteWarehouse(d *schema.ResourceData, meta interface{}) error {
 	return DeleteResource(
 		"warehouse", func(name string) *snowflake.Builder {
-			return snowflake.Warehouse(name).Builder
+			return snowflake.NewWarehouseBuilder(name).Builder
 		},
 	)(d, meta)
 }

--- a/pkg/resources/warehouse_test.go
+++ b/pkg/resources/warehouse_test.go
@@ -60,7 +60,7 @@ func TestWarehouseRead(t *testing.T) {
 
 		// Test when resource is not found, checking if state will be empty
 		r.NotEmpty(d.State())
-		q := snowflake.Warehouse(d.Id()).Show()
+		q := snowflake.NewWarehouseBuilder(d.Id()).Show()
 		mock.ExpectQuery(q).WillReturnError(sql.ErrNoRows)
 		err2 := resources.ReadWarehouse(d, db)
 		r.Empty(d.State())

--- a/pkg/snowflake/api_integration.go
+++ b/pkg/snowflake/api_integration.go
@@ -16,14 +16,14 @@ import (
 //   - DESCRIBE INTEGRATION
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/sql-reference/ddl-user-security.html#api-integrations)
-func APIIntegration(name string) *Builder {
+func NewAPIIntegrationBuilder(name string) *Builder {
 	return &Builder{
 		entityType: APIIntegrationType,
 		name:       name,
 	}
 }
 
-type apiIntegration struct {
+type APIIntegration struct {
 	Name            sql.NullString `db:"name"`
 	Category        sql.NullString `db:"category"`
 	IntegrationType sql.NullString `db:"type"`
@@ -31,8 +31,8 @@ type apiIntegration struct {
 	Enabled         sql.NullBool   `db:"enabled"`
 }
 
-func ScanAPIIntegration(row *sqlx.Row) (*apiIntegration, error) {
-	r := &apiIntegration{}
+func ScanAPIIntegration(row *sqlx.Row) (*APIIntegration, error) {
+	r := &APIIntegration{}
 	err := row.StructScan(r)
 	return r, err
 }

--- a/pkg/snowflake/api_integration_test.go
+++ b/pkg/snowflake/api_integration_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAPIIntegration(t *testing.T) {
 	r := require.New(t)
-	builder := snowflake.APIIntegration("aws_api")
+	builder := snowflake.NewAPIIntegrationBuilder("aws_api")
 	r.NotNil(builder)
 
 	q := builder.Show()

--- a/pkg/snowflake/current_account.go
+++ b/pkg/snowflake/current_account.go
@@ -39,23 +39,23 @@ func SelectCurrentAccount() string {
 	return `SELECT CURRENT_ACCOUNT() AS "account", CURRENT_REGION() AS "region";`
 }
 
-type account struct {
+type Account struct {
 	Account string `db:"account"`
 	Region  string `db:"region"`
 }
 
-func ScanCurrentAccount(row *sqlx.Row) (*account, error) {
-	acc := &account{}
+func ScanCurrentAccount(row *sqlx.Row) (*Account, error) {
+	acc := &Account{}
 	err := row.StructScan(acc)
 	return acc, err
 }
 
-func ReadCurrentAccount(db *sql.DB) (*account, error) {
+func ReadCurrentAccount(db *sql.DB) (*Account, error) {
 	row := QueryRow(db, SelectCurrentAccount())
 	return ScanCurrentAccount(row)
 }
 
-func (acc *account) AccountURL() (string, error) {
+func (acc *Account) AccountURL() (string, error) {
 	if regionID, ok := regionMapping[strings.ToLower(acc.Region)]; ok {
 		accountID := acc.Account
 		if len(regionID) > 0 {

--- a/pkg/snowflake/database.go
+++ b/pkg/snowflake/database.go
@@ -83,7 +83,7 @@ func (db *DatabaseBuilder) UnsetTag(tag TagValue) string {
 //   - SHOW DATABASE
 //
 // [Snowflake Reference](https://docs.snowflake.net/manuals/sql-reference/ddl-database.html#database-management)
-func Database(name string) *DatabaseBuilder {
+func NewDatabaseBuilder(name string) *DatabaseBuilder {
 	return &DatabaseBuilder{
 		name: name,
 	}
@@ -251,7 +251,7 @@ func (db *DatabaseBuilder) GetRemovedAccountsFromReplicationConfiguration(oldAcc
 	return removedAccounts
 }
 
-type database struct {
+type Database struct {
 	CreatedOn     sql.NullString `db:"created_on"`
 	DBName        sql.NullString `db:"name"`
 	IsDefault     sql.NullString `db:"is_default"`
@@ -263,13 +263,13 @@ type database struct {
 	RetentionTime sql.NullString `db:"retention_time"`
 }
 
-func ScanDatabase(row *sqlx.Row) (*database, error) {
-	d := &database{}
+func ScanDatabase(row *sqlx.Row) (*Database, error) {
+	d := &Database{}
 	e := row.StructScan(d)
 	return d, e
 }
 
-func ListDatabases(sdb *sqlx.DB) ([]database, error) {
+func ListDatabases(sdb *sqlx.DB) ([]Database, error) {
 	stmt := "SHOW DATABASES"
 	rows, err := sdb.Queryx(stmt)
 	if err != nil {
@@ -277,7 +277,7 @@ func ListDatabases(sdb *sqlx.DB) ([]database, error) {
 	}
 	defer rows.Close()
 
-	dbs := []database{}
+	dbs := []Database{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no databases found")
@@ -288,7 +288,7 @@ func ListDatabases(sdb *sqlx.DB) ([]database, error) {
 	return dbs, nil
 }
 
-func ListDatabase(sdb *sqlx.DB, databaseName string) (*database, error) {
+func ListDatabase(sdb *sqlx.DB, databaseName string) (*Database, error) {
 	stmt := fmt.Sprintf("SHOW DATABASES LIKE '%s'", databaseName)
 	rows, err := sdb.Queryx(stmt)
 	if err != nil {
@@ -296,7 +296,7 @@ func ListDatabase(sdb *sqlx.DB, databaseName string) (*database, error) {
 	}
 	defer rows.Close()
 
-	dbs := []database{}
+	dbs := []Database{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) || len(dbs) == 0 {
 			log.Println("[DEBUG] no databases found")
@@ -304,7 +304,7 @@ func ListDatabase(sdb *sqlx.DB, databaseName string) (*database, error) {
 		}
 		return nil, fmt.Errorf("unable to scan row for %s err = %w", stmt, err)
 	}
-	db := &database{}
+	db := &Database{}
 	for _, d := range dbs {
 		d := d
 		if d.DBName.String == databaseName {

--- a/pkg/snowflake/database_test.go
+++ b/pkg/snowflake/database_test.go
@@ -12,13 +12,13 @@ import (
 
 func TestQualifiedNameDatabase(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("test")
+	db := snowflake.NewDatabaseBuilder("test")
 	r.Equal(`"test"`, db.QualifiedName())
 }
 
 func TestCreateDatabase(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("test")
+	db := snowflake.NewDatabaseBuilder("test")
 
 	r.Equal(`CREATE DATABASE "test"`, db.Create())
 
@@ -56,63 +56,63 @@ func TestDatabaseCreateFromReplica(t *testing.T) {
 
 func TestDatabaseRename(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("db1")
+	db := snowflake.NewDatabaseBuilder("db1")
 
 	r.Equal(`ALTER DATABASE "db1" RENAME TO "db2"`, db.Rename("db2"))
 }
 
 func TestDatabaseSwap(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("test")
+	db := snowflake.NewDatabaseBuilder("test")
 	r.Equal(`ALTER DATABASE "test" SWAP WITH "target"`, db.Swap("target"))
 }
 
 func TestDatabaseChangeComment(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("test")
+	db := snowflake.NewDatabaseBuilder("test")
 	r.Equal(`ALTER DATABASE "test" SET COMMENT = 'test\' db'`, db.ChangeComment("test' db"))
 }
 
 func TestDatabaseRemoveComment(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("test")
+	db := snowflake.NewDatabaseBuilder("test")
 	r.Equal(`ALTER DATABASE "test" UNSET COMMENT`, db.RemoveComment())
 }
 
 func TestDatabaseChangeDataRetentionDays(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("test")
+	db := snowflake.NewDatabaseBuilder("test")
 	r.Equal(`ALTER DATABASE "test" SET DATA_RETENTION_TIME_IN_DAYS = 22`, db.ChangeDataRetentionDays(22))
 }
 
 func TestDatabaseRemoveDataRetentionDays(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("test")
+	db := snowflake.NewDatabaseBuilder("test")
 	r.Equal(`ALTER DATABASE "test" UNSET DATA_RETENTION_TIME_IN_DAYS`, db.RemoveDataRetentionDays())
 }
 
 func TestDatabaseDrop(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("db1")
+	db := snowflake.NewDatabaseBuilder("db1")
 
 	r.Equal(`DROP DATABASE "db1"`, db.Drop())
 }
 
 func TestDatabaseUndrop(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("test")
+	db := snowflake.NewDatabaseBuilder("test")
 	r.Equal(`UNDROP DATABASE "test"`, db.Undrop())
 }
 
 func TestDatabaseUse(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("test")
+	db := snowflake.NewDatabaseBuilder("test")
 	r.Equal(`USE DATABASE "test"`, db.Use())
 }
 
 func TestDatabaseShow(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("db1")
+	db := snowflake.NewDatabaseBuilder("db1")
 
 	r.Equal("SHOW DATABASES LIKE 'db1'", db.Show())
 }
@@ -131,21 +131,21 @@ func TestListDatabases(t *testing.T) {
 
 func TestEnableReplicationAccounts(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("good_name")
+	db := snowflake.NewDatabaseBuilder("good_name")
 	expected := `ALTER DATABASE "good_name" ENABLE REPLICATION TO ACCOUNTS account1`
 	r.Equal(expected, db.EnableReplicationAccounts("good_name", "account1"))
 }
 
 func TestDisableReplicationAccounts(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("good_name")
+	db := snowflake.NewDatabaseBuilder("good_name")
 	expected := `ALTER DATABASE "good_name" DISABLE REPLICATION TO ACCOUNTS account1`
 	r.Equal(expected, db.DisableReplicationAccounts("good_name", "account1"))
 }
 
 func TestGetRemovedAccountsFromReplicationConfiguration(t *testing.T) {
 	r := require.New(t)
-	db := snowflake.Database("good_name")
+	db := snowflake.NewDatabaseBuilder("good_name")
 
 	oldAccounts := []interface{}{"acc1", "acc2", "acc3"}
 	newAccounts := []interface{}{"acc1", "acc2"}

--- a/pkg/snowflake/errors.go
+++ b/pkg/snowflake/errors.go
@@ -12,7 +12,7 @@ var (
 )
 
 func IsResourceNotExistOrNotAuthorized(errorString string, resourceType string) bool {
-	regexStr := fmt.Sprintf("SQL compilation error:%s '.*' does not exist or not authorized.", resourceType)
+	regexStr := fmt.Sprintf("SQL compilation error:%s '.*' does not exist or not authorized", resourceType)
 	userNotExistOrNotAuthorizedRegEx, _ := regexp.Compile(regexStr)
 	return userNotExistOrNotAuthorizedRegEx.MatchString(strings.ReplaceAll(errorString, "\n", ""))
 }

--- a/pkg/snowflake/external_function.go
+++ b/pkg/snowflake/external_function.go
@@ -137,7 +137,7 @@ func (fb *ExternalFunctionBuilder) WithComment(c string) *ExternalFunctionBuilde
 	return fb
 }
 
-// ExternalFunction returns a pointer to a Builder that abstracts the DDL operations for an external function.
+// NewExternalFunctionBuilder returns a pointer to a Builder that abstracts the DDL operations for an external function.
 //
 // Supported DDL operations are:
 //   - CREATE EXTERNAL FUNCTION
@@ -147,7 +147,7 @@ func (fb *ExternalFunctionBuilder) WithComment(c string) *ExternalFunctionBuilde
 //   - DESCRIBE FUNCTION
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/sql-reference/ddl-udf.html#external-function-management)
-func ExternalFunction(name, db, schema string) *ExternalFunctionBuilder {
+func NewExternalFunctionBuilder(name, db, schema string) *ExternalFunctionBuilder {
 	return &ExternalFunctionBuilder{
 		name:              name,
 		db:                db,
@@ -232,7 +232,7 @@ func (fb *ExternalFunctionBuilder) Describe() string {
 	return fmt.Sprintf(`DESCRIBE FUNCTION %s`, fb.QualifiedNameWithArgTypes())
 }
 
-type externalFunction struct {
+type ExternalFunction struct {
 	CreatedOn            sql.NullString `db:"created_on"`
 	ExternalFunctionName sql.NullString `db:"name"`
 	DatabaseName         sql.NullString `db:"catalog_name"`
@@ -243,22 +243,22 @@ type externalFunction struct {
 }
 
 // ScanExternalFunction.
-func ScanExternalFunction(row *sqlx.Row) (*externalFunction, error) {
-	f := &externalFunction{}
+func ScanExternalFunction(row *sqlx.Row) (*ExternalFunction, error) {
+	f := &ExternalFunction{}
 	e := row.StructScan(f)
 	return f, e
 }
 
-type externalFunctionDescription struct {
+type ExternalFunctionDescription struct {
 	Property sql.NullString `db:"property"`
 	Value    sql.NullString `db:"value"`
 }
 
 // ScanExternalFunctionDescription.
-func ScanExternalFunctionDescription(rows *sqlx.Rows) ([]externalFunctionDescription, error) {
-	efds := []externalFunctionDescription{}
+func ScanExternalFunctionDescription(rows *sqlx.Rows) ([]ExternalFunctionDescription, error) {
+	efds := []ExternalFunctionDescription{}
 	for rows.Next() {
-		efd := externalFunctionDescription{}
+		efd := ExternalFunctionDescription{}
 		err := rows.StructScan(&efd)
 		if err != nil {
 			return nil, err
@@ -268,7 +268,7 @@ func ScanExternalFunctionDescription(rows *sqlx.Rows) ([]externalFunctionDescrip
 	return efds, rows.Err()
 }
 
-func ListExternalFunctions(databaseName string, schemaName string, db *sql.DB) ([]externalFunction, error) {
+func ListExternalFunctions(databaseName string, schemaName string, db *sql.DB) ([]ExternalFunction, error) {
 	stmt := fmt.Sprintf(`SHOW EXTERNAL FUNCTIONS IN SCHEMA "%s"."%v"`, databaseName, schemaName)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -276,7 +276,7 @@ func ListExternalFunctions(databaseName string, schemaName string, db *sql.DB) (
 	}
 	defer rows.Close()
 
-	dbs := []externalFunction{}
+	dbs := []ExternalFunction{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no external functions found")

--- a/pkg/snowflake/external_function_test.go
+++ b/pkg/snowflake/external_function_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestExternalFunctionCreate(t *testing.T) {
 	r := require.New(t)
-	s := ExternalFunction("test_function", "test_db", "test_schema")
+	s := NewExternalFunctionBuilder("test_function", "test_db", "test_schema")
 	s.WithArgs([]map[string]string{{"name": "data", "type": "varchar"}})
 	s.WithArgTypes("varchar")
 	s.WithReturnType("varchar")
@@ -28,16 +28,16 @@ func TestExternalFunctionDrop(t *testing.T) {
 	r := require.New(t)
 
 	// Without arg
-	s := ExternalFunction("test_function", "test_db", "test_schema")
+	s := NewExternalFunctionBuilder("test_function", "test_db", "test_schema")
 	r.Equal(`DROP FUNCTION "test_db"."test_schema"."test_function" ()`, s.Drop())
 
 	// With arg
-	s = ExternalFunction("test_function", "test_db", "test_schema").WithArgTypes("varchar")
+	s = NewExternalFunctionBuilder("test_function", "test_db", "test_schema").WithArgTypes("varchar")
 	r.Equal(`DROP FUNCTION "test_db"."test_schema"."test_function" (varchar)`, s.Drop())
 }
 
 func TestExternalFunctionShow(t *testing.T) {
 	r := require.New(t)
-	s := ExternalFunction("test_function", "test_db", "test_schema")
+	s := NewExternalFunctionBuilder("test_function", "test_db", "test_schema")
 	r.Equal(`SHOW EXTERNAL FUNCTIONS LIKE 'test_function' IN SCHEMA "test_db"."test_schema"`, s.Show())
 }

--- a/pkg/snowflake/external_oauth_integration.go
+++ b/pkg/snowflake/external_oauth_integration.go
@@ -7,7 +7,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// ExternalOauthIntegration returns a pointer to a Builder that abstracts the DDL operations for an api integration.
+// NewExternalOauthIntegrationBuilder returns a pointer to a Builder that abstracts the DDL operations for an api integration.
 //
 // Supported DDL operations are:
 //   - CREATE SECURITY INTEGRATION
@@ -17,14 +17,14 @@ import (
 //   - DESCRIBE INTEGRATION
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/sql-reference/ddl-user-security.html#security-integrations)
-func ExternalOauthIntegration(name string) *Builder {
+func NewExternalOauthIntegrationBuilder(name string) *Builder {
 	return &Builder{
 		entityType: SecurityIntegrationType,
 		name:       name,
 	}
 }
 
-type externalOauthIntegration struct {
+type ExternalOauthIntegration struct {
 	Name            sql.NullString `db:"name"`
 	Category        sql.NullString `db:"category"`
 	IntegrationType sql.NullString `db:"type"`
@@ -33,8 +33,8 @@ type externalOauthIntegration struct {
 	CreatedOn       sql.NullString `db:"created_on"`
 }
 
-func ScanExternalOauthIntegration(row *sqlx.Row) (*externalOauthIntegration, error) {
-	r := &externalOauthIntegration{}
+func ScanExternalOauthIntegration(row *sqlx.Row) (*ExternalOauthIntegration, error) {
+	r := &ExternalOauthIntegration{}
 	if err := row.StructScan(r); err != nil {
 		return r, fmt.Errorf("error scanning struct err = %w", err)
 	}

--- a/pkg/snowflake/external_oauth_integration_test.go
+++ b/pkg/snowflake/external_oauth_integration_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestExternalOauthIntegration(t *testing.T) {
 	r := require.New(t)
-	builder := snowflake.ExternalOauthIntegration("azure")
+	builder := snowflake.NewExternalOauthIntegrationBuilder("azure")
 	r.NotNil(builder)
 
 	q := builder.Show()

--- a/pkg/snowflake/external_table.go
+++ b/pkg/snowflake/external_table.go
@@ -114,7 +114,7 @@ func (tb *ExternalTableBuilder) WithTags(tags []TagValue) *ExternalTableBuilder 
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/sql-reference/sql/create-external-table.html)
 
-func ExternalTable(name, db, schema string) *ExternalTableBuilder {
+func NewExternalTableBuilder(name, db, schema string) *ExternalTableBuilder {
 	return &ExternalTableBuilder{
 		name:   name,
 		db:     db,
@@ -207,7 +207,7 @@ func (tb *ExternalTableBuilder) GetTagValueString() string {
 	return strings.TrimSuffix(q.String(), ", ")
 }
 
-type externalTable struct {
+type ExternalTable struct {
 	CreatedOn         sql.NullString `db:"created_on"`
 	ExternalTableName sql.NullString `db:"name"`
 	DatabaseName      sql.NullString `db:"database_name"`
@@ -216,13 +216,13 @@ type externalTable struct {
 	Owner             sql.NullString `db:"owner"`
 }
 
-func ScanExternalTable(row *sqlx.Row) (*externalTable, error) {
-	t := &externalTable{}
+func ScanExternalTable(row *sqlx.Row) (*ExternalTable, error) {
+	t := &ExternalTable{}
 	e := row.StructScan(t)
 	return t, e
 }
 
-func ListExternalTables(databaseName string, schemaName string, db *sql.DB) ([]externalTable, error) {
+func ListExternalTables(databaseName string, schemaName string, db *sql.DB) ([]ExternalTable, error) {
 	stmt := fmt.Sprintf(`SHOW EXTERNAL TABLES IN SCHEMA "%s"."%v"`, databaseName, schemaName)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -230,7 +230,7 @@ func ListExternalTables(databaseName string, schemaName string, db *sql.DB) ([]e
 	}
 	defer rows.Close()
 
-	dbs := []externalTable{}
+	dbs := []ExternalTable{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no external tables found")

--- a/pkg/snowflake/external_table_test.go
+++ b/pkg/snowflake/external_table_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestExternalTableCreate(t *testing.T) {
 	r := require.New(t)
-	s := ExternalTable("test_table", "test_db", "test_schema")
+	s := NewExternalTableBuilder("test_table", "test_db", "test_schema")
 	s.WithColumns([]map[string]string{{"name": "column1", "type": "OBJECT", "as": "expression1"}, {"name": "column2", "type": "VARCHAR", "as": "expression2"}})
 	s.WithLocation("location")
 	s.WithPattern("pattern")
@@ -23,7 +23,7 @@ func TestExternalTableCreate(t *testing.T) {
 
 func TestExternalTableUpdate(t *testing.T) {
 	r := require.New(t)
-	s := ExternalTable("test_table", "test_db", "test_schema")
+	s := NewExternalTableBuilder("test_table", "test_db", "test_schema")
 	s.WithTags([]TagValue{{Name: "tag1", Value: "value1", Schema: "test_schema", Database: "test_db"}})
 	expected := `ALTER EXTERNAL TABLE "test_db"."test_schema"."test_table" TAG "test_db"."test_schema"."tag1" = "value1"`
 	r.Equal(expected, s.Update())
@@ -31,12 +31,12 @@ func TestExternalTableUpdate(t *testing.T) {
 
 func TestExternalTableDrop(t *testing.T) {
 	r := require.New(t)
-	s := ExternalTable("test_table", "test_db", "test_schema")
+	s := NewExternalTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`DROP EXTERNAL TABLE "test_db"."test_schema"."test_table"`, s.Drop())
 }
 
 func TestExternalTableShow(t *testing.T) {
 	r := require.New(t)
-	s := ExternalTable("test_table", "test_db", "test_schema")
+	s := NewExternalTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`SHOW EXTERNAL TABLES LIKE 'test_table' IN SCHEMA "test_db"."test_schema"`, s.Show())
 }

--- a/pkg/snowflake/failover_group.go
+++ b/pkg/snowflake/failover_group.go
@@ -75,7 +75,7 @@ func (b *FailoverGroupBuilder) WithReplicationScheduleTimeZone(replicationSchedu
 }
 
 // CreateFailoverGroup returns a pointer to a Builder that abstracts the DDL operations for a failover group.
-func FailoverGroup(name string) *FailoverGroupBuilder {
+func NewFailoverGroupBuilder(name string) *FailoverGroupBuilder {
 	return &FailoverGroupBuilder{
 		name: name,
 	}
@@ -222,7 +222,7 @@ func (b *FailoverGroupBuilder) Show() string {
 }
 
 // ListFailoverGroups returns a list of all failover groups in the account.
-func ListFailoverGroups(db *sql.DB, accountLocator string) ([]failoverGroup, error) {
+func ListFailoverGroups(db *sql.DB, accountLocator string) ([]FailoverGroup, error) {
 	stmt := fmt.Sprintf("SHOW FAILOVER GROUPS IN ACCOUNT %s", accountLocator)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -230,7 +230,7 @@ func ListFailoverGroups(db *sql.DB, accountLocator string) ([]failoverGroup, err
 	}
 	defer rows.Close()
 
-	v := []failoverGroup{}
+	v := []FailoverGroup{}
 	err = sqlx.StructScan(rows, &v)
 	if errors.Is(err, sql.ErrNoRows) {
 		log.Println("[DEBUG] no failover groups found")
@@ -239,7 +239,7 @@ func ListFailoverGroups(db *sql.DB, accountLocator string) ([]failoverGroup, err
 	return v, fmt.Errorf("unable to scan row for %s err = %w", stmt, err)
 }
 
-type failoverGroup struct {
+type FailoverGroup struct {
 	RegionGroup             sql.NullString `db:"region_group"`
 	SnowflakeRegion         sql.NullString `db:"snowflake_region"`
 	CreatedOn               sql.NullString `db:"created_on"`

--- a/pkg/snowflake/file_format.go
+++ b/pkg/snowflake/file_format.go
@@ -561,7 +561,7 @@ func (ffb *FileFormatBuilder) Show() string {
 	return fmt.Sprintf(`SHOW FILE FORMATS LIKE '%v' IN SCHEMA "%v"."%v"`, ffb.name, ffb.db, ffb.schema)
 }
 
-type fileFormatShow struct {
+type FileFormatShow struct {
 	CreatedOn      sql.NullString `db:"created_on"`
 	FileFormatName sql.NullString `db:"name"`
 	DatabaseName   sql.NullString `db:"database_name"`
@@ -572,7 +572,7 @@ type fileFormatShow struct {
 	FormatOptions  sql.NullString `db:"format_options"`
 }
 
-type fileFormatOptions struct {
+type FileFormatOptions struct {
 	Type                       string   `json:"TYPE"`
 	Compression                string   `json:"COMPRESSION,omitempty"`
 	RecordDelimiter            string   `json:"RECORD_DELIMITER,omitempty"`
@@ -606,19 +606,19 @@ type fileFormatOptions struct {
 	DisableAutoConvert         bool     `json:"DISABLE_AUTO_CONVERT,omitempty"`
 }
 
-func ScanFileFormatShow(row *sqlx.Row) (*fileFormatShow, error) {
-	r := &fileFormatShow{}
+func ScanFileFormatShow(row *sqlx.Row) (*FileFormatShow, error) {
+	r := &FileFormatShow{}
 	err := row.StructScan(r)
 	return r, err
 }
 
-func ParseFormatOptions(fileOptions string) (*fileFormatOptions, error) {
-	ff := &fileFormatOptions{}
+func ParseFormatOptions(fileOptions string) (*FileFormatOptions, error) {
+	ff := &FileFormatOptions{}
 	err := json.Unmarshal([]byte(fileOptions), ff)
 	return ff, err
 }
 
-func ListFileFormats(databaseName string, schemaName string, db *sql.DB) ([]fileFormatShow, error) {
+func ListFileFormats(databaseName string, schemaName string, db *sql.DB) ([]FileFormatShow, error) {
 	stmt := fmt.Sprintf(`SHOW FILE FORMATS IN SCHEMA "%s"."%v"`, databaseName, schemaName)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -626,7 +626,7 @@ func ListFileFormats(databaseName string, schemaName string, db *sql.DB) ([]file
 	}
 	defer rows.Close()
 
-	dbs := []fileFormatShow{}
+	dbs := []FileFormatShow{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no file formats found")

--- a/pkg/snowflake/function.go
+++ b/pkg/snowflake/function.go
@@ -144,7 +144,7 @@ func (pb *FunctionBuilder) ArgTypes() []string {
 //   - DESCRIBE
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/sql-reference/user-defined-functions.html)
-func Function(db, schema, name string, argTypes []string) *FunctionBuilder {
+func NewFunctionBuilder(db, schema, name string, argTypes []string) *FunctionBuilder {
 	return &FunctionBuilder{
 		name:          name,
 		db:            db,
@@ -285,7 +285,7 @@ func (pb *FunctionBuilder) Drop() (string, error) {
 	return fmt.Sprintf(`DROP FUNCTION %v`, qn), nil
 }
 
-type function struct {
+type Function struct {
 	Comment sql.NullString `db:"description"`
 	// Snowflake returns is_secure in the show function output, but it is irrelevant
 	Name         sql.NullString `db:"name"`
@@ -317,10 +317,10 @@ func ScanFunctionDescription(rows *sqlx.Rows) ([]functionDescription, error) {
 
 // SHOW FUNCTION can return more than one item because of function names overloading
 // https://docs.snowflake.com/en/sql-reference/sql/show-functions.html
-func ScanFunctions(rows *sqlx.Rows) ([]*function, error) {
-	var pcs []*function
+func ScanFunctions(rows *sqlx.Rows) ([]*Function, error) {
+	var pcs []*Function
 	for rows.Next() {
-		r := &function{}
+		r := &Function{}
 		err := rows.StructScan(r)
 		if err != nil {
 			return nil, err

--- a/pkg/snowflake/function.go
+++ b/pkg/snowflake/function.go
@@ -242,8 +242,8 @@ func (pb *FunctionBuilder) Rename(newName string) (string, error) {
 }
 
 // ChangeComment returns the SQL query that will update the comment on the function.
-func (vb *FunctionBuilder) ChangeComment(c string) (string, error) {
-	qn, err := vb.QualifiedName()
+func (pb *FunctionBuilder) ChangeComment(c string) (string, error) {
+	qn, err := pb.QualifiedName()
 	if err != nil {
 		return "", err
 	}
@@ -252,8 +252,8 @@ func (vb *FunctionBuilder) ChangeComment(c string) (string, error) {
 }
 
 // RemoveComment returns the SQL query that will remove the comment on the function.
-func (vb *FunctionBuilder) RemoveComment() (string, error) {
-	qn, err := vb.QualifiedName()
+func (pb *FunctionBuilder) RemoveComment() (string, error) {
+	qn, err := pb.QualifiedName()
 	if err != nil {
 		return "", err
 	}
@@ -295,17 +295,17 @@ type Function struct {
 	Arguments    sql.NullString `db:"arguments"`
 }
 
-type functionDescription struct {
+type FunctionDescription struct {
 	Property sql.NullString `db:"property"`
 	Value    sql.NullString `db:"value"`
 }
 
 // ScanFunctionDescription reads through the rows with property and value columns
 // and returns a slice of functionDescription structs.
-func ScanFunctionDescription(rows *sqlx.Rows) ([]functionDescription, error) {
-	pdsl := []functionDescription{}
+func ScanFunctionDescription(rows *sqlx.Rows) ([]FunctionDescription, error) {
+	pdsl := []FunctionDescription{}
 	for rows.Next() {
-		pd := functionDescription{}
+		pd := FunctionDescription{}
 		err := rows.StructScan(&pd)
 		if err != nil {
 			return nil, err
@@ -330,14 +330,14 @@ func ScanFunctions(rows *sqlx.Rows) ([]*Function, error) {
 	return pcs, rows.Err()
 }
 
-type listFunctions struct {
+type UserFunctions struct {
 	Name        sql.NullString `db:"name"`
 	Arguments   sql.NullString `db:"arguments"`
 	Description sql.NullString `db:"description"`
 	Language    sql.NullString `db:"language"`
 }
 
-func ListFunctions(databaseName string, schemaName string, db *sql.DB) ([]listFunctions, error) {
+func ListUserFunctions(databaseName string, schemaName string, db *sql.DB) ([]UserFunctions, error) {
 	stmt := fmt.Sprintf(`SHOW USER FUNCTIONS IN SCHEMA "%v"."%v"`, databaseName, schemaName)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -345,7 +345,7 @@ func ListFunctions(databaseName string, schemaName string, db *sql.DB) ([]listFu
 	}
 	defer rows.Close()
 
-	dbs := []listFunctions{}
+	dbs := []UserFunctions{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no functions found")

--- a/pkg/snowflake/function_test.go
+++ b/pkg/snowflake/function_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func getJavaScriptFuction(withArgs bool) *FunctionBuilder {
-	s := Function("test_db", "test_schema", "test_func", []string{})
+	s := NewFunctionBuilder("test_db", "test_schema", "test_func", []string{})
 	s.WithStatement(`var message = "Hi"` + "\n" + `return message`)
 	s.WithReturnType("varchar")
 	if withArgs {
@@ -26,7 +26,7 @@ const javafunc = `class CoolFunc {` + "\n" +
 	`}`
 
 func getJavaFuction(withArgs bool) *FunctionBuilder {
-	s := Function("test_db", "test_schema", "test_func", []string{})
+	s := NewFunctionBuilder("test_db", "test_schema", "test_func", []string{})
 	s.WithReturnType("varchar")
 	s.WithStatement(javafunc)
 	if withArgs {
@@ -42,7 +42,7 @@ const pythonfunc = `def add_py(i):` + "\n " +
 	` return i+1`
 
 func getPythonFunction(withArgs bool) *FunctionBuilder {
-	s := Function("test_db", "test_schema", "test_func", []string{})
+	s := NewFunctionBuilder("test_db", "test_schema", "test_func", []string{})
 	s.WithReturnType("int")
 	s.WithStatement(pythonfunc)
 	if withArgs {

--- a/pkg/snowflake/future_grant.go
+++ b/pkg/snowflake/future_grant.go
@@ -228,7 +228,7 @@ func (fgb *FutureGrantBuilder) Role(n string) GrantExecutable {
 }
 
 // Share is not implemented because future objects cannot be granted to shares.
-func (gb *FutureGrantBuilder) Share(n string) GrantExecutable {
+func (fgb *FutureGrantBuilder) Share(n string) GrantExecutable {
 	return nil
 }
 

--- a/pkg/snowflake/generic.go
+++ b/pkg/snowflake/generic.go
@@ -105,8 +105,8 @@ func (ab *AlterPropertiesBuilder) SetRaw(rawStatement string) {
 	ab.rawStatement = sb.String()
 }
 
-func (b *AlterPropertiesBuilder) SetTags(tags []TagValue) {
-	b.tags = tags
+func (ab *AlterPropertiesBuilder) SetTags(tags []TagValue) {
+	ab.tags = tags
 }
 
 func (ab *AlterPropertiesBuilder) GetTagValueString() string {

--- a/pkg/snowflake/managed_account.go
+++ b/pkg/snowflake/managed_account.go
@@ -6,7 +6,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// ManagedAccount returns a pointer to a Builder that abstracts the DDL
+// NewManagedAccountBuilder returns a pointer to a Builder that abstracts the DDL
 // operations for a reader account.
 //
 // Supported DDL operations are:
@@ -15,14 +15,14 @@ import (
 //   - SHOW MANAGED ACCOUNTS
 //
 // [Snowflake Reference](https://docs.snowflake.net/manuals/user-guide/data-sharing-reader-create.html)
-func ManagedAccount(name string) *Builder {
+func NewManagedAccountBuilder(name string) *Builder {
 	return &Builder{
 		entityType: ManagedAccountType,
 		name:       name,
 	}
 }
 
-type managedAccount struct {
+type ManagedAccount struct {
 	Name      sql.NullString `db:"name"`
 	Cloud     sql.NullString `db:"cloud"`
 	Region    sql.NullString `db:"region"`
@@ -33,8 +33,8 @@ type managedAccount struct {
 	IsReader  bool           `db:"is_reader"`
 }
 
-func ScanManagedAccount(row *sqlx.Row) (*managedAccount, error) {
-	a := &managedAccount{}
+func ScanManagedAccount(row *sqlx.Row) (*ManagedAccount, error) {
+	a := &ManagedAccount{}
 	e := row.StructScan(a)
 	return a, e
 }

--- a/pkg/snowflake/managed_account_test.go
+++ b/pkg/snowflake/managed_account_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestManagedAccount(t *testing.T) {
 	r := require.New(t)
-	u := snowflake.ManagedAccount("managedaccount1")
+	u := snowflake.NewManagedAccountBuilder("managedaccount1")
 	r.NotNil(u)
 
 	q := u.Show()

--- a/pkg/snowflake/materialized_view.go
+++ b/pkg/snowflake/materialized_view.go
@@ -118,7 +118,7 @@ func (vb *MaterializedViewBuilder) UnsetTag(tag TagValue) string {
 //   - DESCRIBE MATERIALIZED VIEW
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/sql-reference/ddl-table.html#materialized-view-management)
-func MaterializedView(name string) *MaterializedViewBuilder {
+func NewMaterializedViewBuilder(name string) *MaterializedViewBuilder {
 	return &MaterializedViewBuilder{
 		name: name,
 	}
@@ -200,7 +200,7 @@ func (vb *MaterializedViewBuilder) Drop() string {
 	return fmt.Sprintf(`DROP MATERIALIZED VIEW %v`, vb.QualifiedName())
 }
 
-type materializedView struct {
+type MaterializedView struct {
 	Comment       sql.NullString `db:"comment"`
 	IsSecure      bool           `db:"is_secure"`
 	Name          sql.NullString `db:"name"`
@@ -210,13 +210,13 @@ type materializedView struct {
 	WarehouseName sql.NullString `db:"warehouse_name"`
 }
 
-func ScanMaterializedView(row *sqlx.Row) (*materializedView, error) {
-	r := &materializedView{}
+func ScanMaterializedView(row *sqlx.Row) (*MaterializedView, error) {
+	r := &MaterializedView{}
 	err := row.StructScan(r)
 	return r, err
 }
 
-func ListMaterializedViews(databaseName string, schemaName string, db *sql.DB) ([]materializedView, error) {
+func ListMaterializedViews(databaseName string, schemaName string, db *sql.DB) ([]MaterializedView, error) {
 	stmt := fmt.Sprintf(`SHOW MATERIALIZED VIEWS IN SCHEMA "%s"."%v"`, databaseName, schemaName)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -224,7 +224,7 @@ func ListMaterializedViews(databaseName string, schemaName string, db *sql.DB) (
 	}
 	defer rows.Close()
 
-	dbs := []materializedView{}
+	dbs := []MaterializedView{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no materialized views found")

--- a/pkg/snowflake/notification_integration.go
+++ b/pkg/snowflake/notification_integration.go
@@ -16,14 +16,14 @@ import (
 //   - DESCRIBE INTEGRATION
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/sql-reference/ddl-user-security.html#notification-integrations)
-func NotificationIntegration(name string) *Builder {
+func NewNotificationIntegrationBuilder(name string) *Builder {
 	return &Builder{
 		entityType: NotificationIntegrationType,
 		name:       name,
 	}
 }
 
-type notificationIntegration struct {
+type NotificationIntegration struct {
 	Name      sql.NullString `db:"name"`
 	Category  sql.NullString `db:"category"`
 	Type      sql.NullString `db:"type"`
@@ -31,8 +31,8 @@ type notificationIntegration struct {
 	Enabled   sql.NullBool   `db:"enabled"`
 }
 
-func ScanNotificationIntegration(row *sqlx.Row) (*notificationIntegration, error) {
-	r := &notificationIntegration{}
+func ScanNotificationIntegration(row *sqlx.Row) (*NotificationIntegration, error) {
+	r := &NotificationIntegration{}
 	err := row.StructScan(r)
 	return r, err
 }

--- a/pkg/snowflake/notification_integration_test.go
+++ b/pkg/snowflake/notification_integration_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNotificationIntegration_Azure(t *testing.T) {
 	r := require.New(t)
-	builder := snowflake.NotificationIntegration("azure")
+	builder := snowflake.NewNotificationIntegrationBuilder("azure")
 	r.NotNil(builder)
 
 	q := builder.Show()
@@ -28,7 +28,7 @@ func TestNotificationIntegration_Azure(t *testing.T) {
 
 func TestNotificationIntegration_AWS(t *testing.T) {
 	r := require.New(t)
-	builder := snowflake.NotificationIntegration("aws_sqs")
+	builder := snowflake.NewNotificationIntegrationBuilder("aws_sqs")
 	r.NotNil(builder)
 
 	q := builder.Show()
@@ -48,7 +48,7 @@ func TestNotificationIntegration_AWS(t *testing.T) {
 
 func TestNotificationIntegration_AWS_SNS(t *testing.T) {
 	r := require.New(t)
-	builder := snowflake.NotificationIntegration("aws_sns")
+	builder := snowflake.NewNotificationIntegrationBuilder("aws_sns")
 	r.NotNil(builder)
 
 	q := builder.Show()

--- a/pkg/snowflake/oauth_integration.go
+++ b/pkg/snowflake/oauth_integration.go
@@ -19,14 +19,14 @@ import (
 //   - DESCRIBE INTEGRATION
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/sql-reference/ddl-user-security.html#security-integrations)
-func OAuthIntegration(name string) *Builder {
+func NewOAuthIntegrationBuilder(name string) *Builder {
 	return &Builder{
 		entityType: SecurityIntegrationType,
 		name:       name,
 	}
 }
 
-type oauthIntegration struct {
+type OauthIntegration struct {
 	Name            sql.NullString `db:"name"`
 	Category        sql.NullString `db:"category"`
 	IntegrationType sql.NullString `db:"type"`
@@ -35,15 +35,15 @@ type oauthIntegration struct {
 	CreatedOn       sql.NullString `db:"created_on"`
 }
 
-func ScanOAuthIntegration(row *sqlx.Row) (*oauthIntegration, error) {
-	r := &oauthIntegration{}
+func ScanOAuthIntegration(row *sqlx.Row) (*OauthIntegration, error) {
+	r := &OauthIntegration{}
 	if err := row.StructScan(r); err != nil {
 		return nil, fmt.Errorf("error scanning struct err = %w", err)
 	}
 	return r, nil
 }
 
-func ListIntegrations(db *sql.DB) ([]oauthIntegration, error) {
+func ListIntegrations(db *sql.DB) ([]OauthIntegration, error) {
 	stmt := "SHOW INTEGRATIONS"
 	rows, err := db.Query(stmt)
 	if err != nil {
@@ -52,7 +52,7 @@ func ListIntegrations(db *sql.DB) ([]oauthIntegration, error) {
 
 	defer rows.Close()
 
-	r := []oauthIntegration{}
+	r := []OauthIntegration{}
 	if err := sqlx.StructScan(rows, &r); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no integrations found")
@@ -64,6 +64,6 @@ func ListIntegrations(db *sql.DB) ([]oauthIntegration, error) {
 }
 
 func DropIntegration(db *sql.DB, name string) error {
-	stmt := OAuthIntegration(name).Drop()
+	stmt := NewOAuthIntegrationBuilder(name).Drop()
 	return Exec(db, stmt)
 }

--- a/pkg/snowflake/oauth_integration_test.go
+++ b/pkg/snowflake/oauth_integration_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestOAuthIntegration(t *testing.T) {
 	r := require.New(t)
-	builder := snowflake.OAuthIntegration("tableau_desktop")
+	builder := snowflake.NewOAuthIntegrationBuilder("tableau_desktop")
 	r.NotNil(builder)
 
 	q := builder.Show()

--- a/pkg/snowflake/parser.go
+++ b/pkg/snowflake/parser.go
@@ -96,7 +96,7 @@ func (e *ViewSelectStatementExtractor) consumeToken(t string) bool {
 		if e.pos+i > len(e.input) || !strings.EqualFold(string(r), string(e.input[e.pos+i])) {
 			break
 		}
-		found += 1
+		found++
 	}
 
 	if found == len(t) {
@@ -112,7 +112,7 @@ func (e *ViewSelectStatementExtractor) consumeSpace() {
 		if e.pos+found > len(e.input)-1 || !unicode.IsSpace(e.input[e.pos+found]) {
 			break
 		}
-		found += 1
+		found++
 	}
 	e.pos += found
 }
@@ -127,7 +127,7 @@ func (e *ViewSelectStatementExtractor) consumeNonSpace() {
 		if e.pos+found > len(e.input)-1 || unicode.IsSpace(e.input[e.pos+found]) {
 			break
 		}
-		found += 1
+		found++
 	}
 	e.pos += found
 }
@@ -163,7 +163,7 @@ func (e *ViewSelectStatementExtractor) consumeComment() {
 		} else if e.input[e.pos+found] == '\'' {
 			break
 		}
-		found += 1
+		found++
 	}
 	e.pos += found
 
@@ -181,7 +181,7 @@ func (e *ViewSelectStatementExtractor) consumeClusterBy() {
 		if e.pos+found > len(e.input)-1 || e.input[e.pos+found-1] == ')' {
 			break
 		}
-		found += 1
+		found++
 	}
 	e.pos += found
 }

--- a/pkg/snowflake/pipe.go
+++ b/pkg/snowflake/pipe.go
@@ -89,7 +89,7 @@ func (pb *PipeBuilder) WithErrorIntegration(s string) *PipeBuilder {
 //   - SHOW PIPE
 //
 // [Snowflake Reference](https://docs.snowflake.net/manuals/sql-reference/ddl-pipe.html#pipe-management)
-func Pipe(name, db, schema string) *PipeBuilder {
+func NewPipeBuilder(name, db, schema string) *PipeBuilder {
 	return &PipeBuilder{
 		name:   name,
 		db:     db,
@@ -160,7 +160,7 @@ func (pb *PipeBuilder) Show() string {
 	return fmt.Sprintf(`SHOW PIPES LIKE '%v' IN SCHEMA "%v"."%v"`, pb.name, pb.db, pb.schema)
 }
 
-type pipe struct {
+type Pipe struct {
 	Createdon           string         `db:"created_on"`
 	Name                string         `db:"name"`
 	DatabaseName        string         `db:"database_name"`
@@ -173,13 +173,13 @@ type pipe struct {
 	ErrorIntegration    sql.NullString `db:"error_integration"`
 }
 
-func ScanPipe(row *sqlx.Row) (*pipe, error) {
-	p := &pipe{}
+func ScanPipe(row *sqlx.Row) (*Pipe, error) {
+	p := &Pipe{}
 	e := row.StructScan(p)
 	return p, e
 }
 
-func ListPipes(databaseName string, schemaName string, db *sql.DB) ([]pipe, error) {
+func ListPipes(databaseName string, schemaName string, db *sql.DB) ([]Pipe, error) {
 	stmt := fmt.Sprintf(`SHOW PIPES IN SCHEMA "%s"."%v"`, databaseName, schemaName)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -187,7 +187,7 @@ func ListPipes(databaseName string, schemaName string, db *sql.DB) ([]pipe, erro
 	}
 	defer rows.Close()
 
-	dbs := []pipe{}
+	dbs := []Pipe{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no pipes found")

--- a/pkg/snowflake/pipe_test.go
+++ b/pkg/snowflake/pipe_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestPipeCreate(t *testing.T) {
 	r := require.New(t)
-	s := Pipe("test_pipe", "test_db", "test_schema")
+	s := NewPipeBuilder("test_pipe", "test_db", "test_schema")
 	r.Equal(`"test_db"."test_schema"."test_pipe"`, s.QualifiedName())
 
 	r.Equal(`CREATE PIPE "test_db"."test_schema"."test_pipe"`, s.Create())
@@ -31,24 +31,24 @@ func TestPipeCreate(t *testing.T) {
 
 func TestPipeChangeComment(t *testing.T) {
 	r := require.New(t)
-	s := Pipe("test_pipe", "test_db", "test_schema")
+	s := NewPipeBuilder("test_pipe", "test_db", "test_schema")
 	r.Equal(`ALTER PIPE "test_db"."test_schema"."test_pipe" SET COMMENT = 'worst pipe ever'`, s.ChangeComment("worst pipe ever"))
 }
 
 func TestPipeRemoveComment(t *testing.T) {
 	r := require.New(t)
-	s := Pipe("test_pipe", "test_db", "test_schema")
+	s := NewPipeBuilder("test_pipe", "test_db", "test_schema")
 	r.Equal(`ALTER PIPE "test_db"."test_schema"."test_pipe" UNSET COMMENT`, s.RemoveComment())
 }
 
 func TestPipeDrop(t *testing.T) {
 	r := require.New(t)
-	s := Pipe("test_pipe", "test_db", "test_schema")
+	s := NewPipeBuilder("test_pipe", "test_db", "test_schema")
 	r.Equal(`DROP PIPE "test_db"."test_schema"."test_pipe"`, s.Drop())
 }
 
 func TestPipeShow(t *testing.T) {
 	r := require.New(t)
-	s := Pipe("test_pipe", "test_db", "test_schema")
+	s := NewPipeBuilder("test_pipe", "test_db", "test_schema")
 	r.Equal(`SHOW PIPES LIKE 'test_pipe' IN SCHEMA "test_db"."test_schema"`, s.Show())
 }

--- a/pkg/snowflake/procedure.go
+++ b/pkg/snowflake/procedure.go
@@ -116,7 +116,7 @@ func (pb *ProcedureBuilder) ArgTypes() []string {
 //   - DESCRIBE
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/sql-reference/stored-procedures.html)
-func Procedure(db, schema, name string, argTypes []string) *ProcedureBuilder {
+func NewProcedureBuilder(db, schema, name string, argTypes []string) *ProcedureBuilder {
 	return &ProcedureBuilder{
 		name:          name,
 		db:            db,
@@ -180,8 +180,8 @@ func (pb *ProcedureBuilder) Rename(newName string) (string, error) {
 }
 
 // ChangeComment returns the SQL query that will update the comment on the procedure.
-func (vb *ProcedureBuilder) ChangeComment(c string) (string, error) {
-	qn, err := vb.QualifiedName()
+func (pb *ProcedureBuilder) ChangeComment(c string) (string, error) {
+	qn, err := pb.QualifiedName()
 	if err != nil {
 		return "", err
 	}
@@ -190,8 +190,8 @@ func (vb *ProcedureBuilder) ChangeComment(c string) (string, error) {
 }
 
 // RemoveComment returns the SQL query that will remove the comment on the procedure.
-func (vb *ProcedureBuilder) RemoveComment() (string, error) {
-	qn, err := vb.QualifiedName()
+func (pb *ProcedureBuilder) RemoveComment() (string, error) {
+	qn, err := pb.QualifiedName()
 	if err != nil {
 		return "", err
 	}
@@ -199,8 +199,8 @@ func (vb *ProcedureBuilder) RemoveComment() (string, error) {
 }
 
 // ChangeExecuteAs returns the SQL query that will update the call mode on the procedure.
-func (vb *ProcedureBuilder) ChangeExecuteAs(c string) (string, error) {
-	qn, err := vb.QualifiedName()
+func (pb *ProcedureBuilder) ChangeExecuteAs(c string) (string, error) {
+	qn, err := pb.QualifiedName()
 	if err != nil {
 		return "", err
 	}
@@ -232,7 +232,7 @@ func (pb *ProcedureBuilder) Drop() (string, error) {
 	return fmt.Sprintf(`DROP PROCEDURE %v`, qn), nil
 }
 
-type procedure struct {
+type Procedure struct {
 	Comment sql.NullString `db:"description"`
 	// Snowflake returns is_secure in the show procedure output, but it is irrelevant
 	Name         sql.NullString `db:"name"`
@@ -242,17 +242,17 @@ type procedure struct {
 	Arguments    sql.NullString `db:"arguments"`
 }
 
-type procedureDescription struct {
+type ProcedureDescription struct {
 	Property sql.NullString `db:"property"`
 	Value    sql.NullString `db:"value"`
 }
 
 // ScanProcedureDescription reads through the rows with property and value columns
 // and returns a slice of procedureDescription structs.
-func ScanProcedureDescription(rows *sqlx.Rows) ([]procedureDescription, error) {
-	pdsl := []procedureDescription{}
+func ScanProcedureDescription(rows *sqlx.Rows) ([]ProcedureDescription, error) {
+	pdsl := []ProcedureDescription{}
 	for rows.Next() {
-		pd := procedureDescription{}
+		pd := ProcedureDescription{}
 		err := rows.StructScan(&pd)
 		if err != nil {
 			return nil, err
@@ -264,10 +264,10 @@ func ScanProcedureDescription(rows *sqlx.Rows) ([]procedureDescription, error) {
 
 // SHOW PROCEDURE can return more than one item because of procedure names overloading
 // https://docs.snowflake.com/en/sql-reference/sql/show-procedures.html
-func ScanProcedures(rows *sqlx.Rows) ([]*procedure, error) {
-	var pcs []*procedure
+func ScanProcedures(rows *sqlx.Rows) ([]*Procedure, error) {
+	var pcs []*Procedure
 	for rows.Next() {
-		r := &procedure{}
+		r := &Procedure{}
 		err := rows.StructScan(r)
 		if err != nil {
 			return nil, err
@@ -277,7 +277,7 @@ func ScanProcedures(rows *sqlx.Rows) ([]*procedure, error) {
 	return pcs, rows.Err()
 }
 
-func ListProcedures(databaseName string, schemaName string, db *sql.DB) ([]procedure, error) {
+func ListProcedures(databaseName string, schemaName string, db *sql.DB) ([]Procedure, error) {
 	stmt := fmt.Sprintf(`SHOW PROCEDURES IN SCHEMA "%s"."%v"`, databaseName, schemaName)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -285,7 +285,7 @@ func ListProcedures(databaseName string, schemaName string, db *sql.DB) ([]proce
 	}
 	defer rows.Close()
 
-	dbs := []procedure{}
+	dbs := []Procedure{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no procedures found")

--- a/pkg/snowflake/procedure_test.go
+++ b/pkg/snowflake/procedure_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func getProcedure(withArgs bool) *ProcedureBuilder {
-	s := Procedure("test_db", "test_schema", "test_proc", []string{})
+	s := NewProcedureBuilder("test_db", "test_schema", "test_proc", []string{})
 	s.WithStatement(`var message = "Hi"` + "\n" + `return message`)
 	s.WithReturnType("varchar")
 	s.WithExecuteAs("CALLER")

--- a/pkg/snowflake/replication.go
+++ b/pkg/snowflake/replication.go
@@ -20,13 +20,13 @@ type ReplicationBuilder struct {
 }
 
 // DatabaseFromDatabase returns a pointer to a builder that can create a database from a source database.
-func Replication(database string) *ReplicationBuilder {
+func NewReplicationBuilder(database string) *ReplicationBuilder {
 	return &ReplicationBuilder{
 		database: database,
 	}
 }
 
-type replication struct {
+type Replication struct {
 	Region           sql.NullString `db:"snowflake_region"`
 	CreatedOn        sql.NullString `db:"created_on"`
 	AccountName      sql.NullString `db:"account_name"`
@@ -40,9 +40,9 @@ type replication struct {
 	AccountLocator   sql.NullString `db:"account_locator"`
 }
 
-func ScanReplication(rows *sqlx.Rows, accName string) (*replication, error) {
+func ScanReplication(rows *sqlx.Rows, accName string) (*Replication, error) {
 	for rows.Next() {
-		r := &replication{}
+		r := &Replication{}
 		err := rows.StructScan(r)
 		if r.AccountName.String == accName {
 			return r, err

--- a/pkg/snowflake/resource_monitor.go
+++ b/pkg/snowflake/resource_monitor.go
@@ -24,7 +24,7 @@ type ResourceMonitorBuilder struct {
 //   - SHOW RESOURCE MONITOR
 //
 // [Snowflake Reference](https://docs.snowflake.net/manuals/user-guide/resource-monitors.html#ddl-for-resource-monitors)
-func ResourceMonitor(name string) *ResourceMonitorBuilder {
+func NewResourceMonitorBuilder(name string) *ResourceMonitorBuilder {
 	return &ResourceMonitorBuilder{
 		Builder{
 			entityType: ResourceMonitorType,
@@ -134,7 +134,7 @@ func (rcb *ResourceMonitorCreateBuilder) SetOnWarehouse(warehouse string) string
 	return fmt.Sprintf(`ALTER WAREHOUSE "%v" SET RESOURCE_MONITOR = "%v"`, warehouse, rcb.name)
 }
 
-type resourceMonitor struct {
+type ResourceMonitor struct {
 	Name                 sql.NullString `db:"name"`
 	CreditQuota          sql.NullString `db:"credit_quota"`
 	UsedCredits          sql.NullString `db:"used_credits"`
@@ -152,13 +152,13 @@ type resourceMonitor struct {
 	NotifyUsers          sql.NullString `db:"notify_users"`
 }
 
-func ScanResourceMonitor(row *sqlx.Row) (*resourceMonitor, error) {
-	rm := &resourceMonitor{}
+func ScanResourceMonitor(row *sqlx.Row) (*ResourceMonitor, error) {
+	rm := &ResourceMonitor{}
 	err := row.StructScan(rm)
 	return rm, err
 }
 
-func ListResourceMonitors(db *sql.DB) ([]resourceMonitor, error) {
+func ListResourceMonitors(db *sql.DB) ([]ResourceMonitor, error) {
 	stmt := "SHOW RESOURCE MONITORS"
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -166,7 +166,7 @@ func ListResourceMonitors(db *sql.DB) ([]resourceMonitor, error) {
 	}
 	defer rows.Close()
 
-	dbs := []resourceMonitor{}
+	dbs := []ResourceMonitor{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no resource monitors found")

--- a/pkg/snowflake/resource_monitor_test.go
+++ b/pkg/snowflake/resource_monitor_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestResourceMonitor(t *testing.T) {
 	r := require.New(t)
-	rm := snowflake.ResourceMonitor("resource_monitor")
+	rm := snowflake.NewResourceMonitorBuilder("resource_monitor")
 	r.NotNil(rm)
 
 	q := rm.Show()
@@ -31,7 +31,7 @@ func TestResourceMonitor(t *testing.T) {
 	q = ab.Statement()
 	r.Equal(`ALTER RESOURCE MONITOR "resource_monitor" SET NOTIFY_USERS=('USERONE', 'USERTWO')`, q)
 
-	cb := snowflake.ResourceMonitor("resource_monitor").Create()
+	cb := snowflake.NewResourceMonitorBuilder("resource_monitor").Create()
 	cb.NotifyAt(80).NotifyAt(90).SuspendAt(95).SuspendImmediatelyAt(100)
 	cb.SetString("frequency", "YEARLY")
 
@@ -43,7 +43,7 @@ func TestResourceMonitor(t *testing.T) {
 
 func TestResourceMonitorSetOnAccount(t *testing.T) {
 	r := require.New(t)
-	s := snowflake.ResourceMonitor("test_resource_monitor")
+	s := snowflake.NewResourceMonitorBuilder("test_resource_monitor")
 	r.NotNil(s)
 
 	q := s.Create().SetOnAccount()
@@ -52,7 +52,7 @@ func TestResourceMonitorSetOnAccount(t *testing.T) {
 
 func TestResourceMonitorSetOnWarehouse(t *testing.T) {
 	r := require.New(t)
-	s := snowflake.ResourceMonitor("test_resource_monitor")
+	s := snowflake.NewResourceMonitorBuilder("test_resource_monitor")
 	r.NotNil(s)
 
 	q := s.Create().SetOnWarehouse("test_warehouse")

--- a/pkg/snowflake/role.go
+++ b/pkg/snowflake/role.go
@@ -10,26 +10,26 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func Role(name string) *Builder {
+func NewRoleBuilder(name string) *Builder {
 	return &Builder{
 		entityType: RoleType,
 		name:       name,
 	}
 }
 
-type role struct {
+type Role struct {
 	Name    sql.NullString `db:"name"`
 	Comment sql.NullString `db:"comment"`
 	Owner   sql.NullString `db:"owner"`
 }
 
-func ScanRole(row *sqlx.Row) (*role, error) {
-	r := &role{}
+func ScanRole(row *sqlx.Row) (*Role, error) {
+	r := &Role{}
 	err := row.StructScan(r)
 	return r, err
 }
 
-func ListRoles(db *sql.DB, rolePattern string) ([]*role, error) {
+func ListRoles(db *sql.DB, rolePattern string) ([]*Role, error) {
 	stmt := strings.Builder{}
 	stmt.WriteString("SHOW ROLES")
 	if rolePattern != "" {
@@ -41,7 +41,7 @@ func ListRoles(db *sql.DB, rolePattern string) ([]*role, error) {
 	}
 	defer rows.Close()
 
-	roles := []*role{}
+	roles := []*Role{}
 	if err := sqlx.StructScan(rows, &roles); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no roles found")

--- a/pkg/snowflake/role_ownership_grant.go
+++ b/pkg/snowflake/role_ownership_grant.go
@@ -19,7 +19,7 @@ type RoleOwnershipGrantExecutable struct {
 	currentGrants string
 }
 
-func RoleOwnershipGrant(role string, currentGrants string) *RoleOwnershipGrantBuilder {
+func NewRoleOwnershipGrantBuilder(role string, currentGrants string) *RoleOwnershipGrantBuilder {
 	return &RoleOwnershipGrantBuilder{role: role, currentGrants: currentGrants}
 }
 
@@ -40,7 +40,7 @@ func (gr *RoleOwnershipGrantExecutable) Revoke() string {
 	return fmt.Sprintf(`GRANT OWNERSHIP ON %s "%s" TO ROLE "%s" %s CURRENT GRANTS`, gr.granteeType, gr.grantee, gr.role, gr.currentGrants) // nolint: gosec
 }
 
-type roleOwnershipGrant struct {
+type RoleOwnershipGrant struct {
 	CreatedOn       sql.NullString `db:"created_on"`
 	Name            sql.NullString `db:"name"`
 	IsDefault       sql.NullString `db:"is_default"`
@@ -53,8 +53,8 @@ type roleOwnershipGrant struct {
 	Comment         sql.NullString `db:"comment"`
 }
 
-func ScanRoleOwnershipGrant(row *sqlx.Row) (*roleOwnershipGrant, error) {
-	rog := &roleOwnershipGrant{}
+func ScanRoleOwnershipGrant(row *sqlx.Row) (*RoleOwnershipGrant, error) {
+	rog := &RoleOwnershipGrant{}
 	err := row.StructScan(rog)
 	return rog, err
 }

--- a/pkg/snowflake/role_ownership_grant_test.go
+++ b/pkg/snowflake/role_ownership_grant_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestRoleOwnershipGrantQuery(t *testing.T) {
 	r := require.New(t)
-	copy := snowflake.RoleOwnershipGrant("role1", "COPY")
-	revoke := snowflake.RoleOwnershipGrant("role1", "REVOKE")
+	copy := snowflake.NewRoleOwnershipGrantBuilder("role1", "COPY")
+	revoke := snowflake.NewRoleOwnershipGrantBuilder("role1", "REVOKE")
 
 	g1 := copy.Role("role2").Grant()
 	r.Equal(`GRANT OWNERSHIP ON ROLE "role1" TO ROLE "role2" COPY CURRENT GRANTS`, g1)

--- a/pkg/snowflake/saml_integration.go
+++ b/pkg/snowflake/saml_integration.go
@@ -17,14 +17,14 @@ import (
 //   - DESCRIBE INTEGRATION
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/sql-reference/ddl-user-security.html#security-integrations)
-func SamlIntegration(name string) *Builder {
+func NewSamlIntegrationBuilder(name string) *Builder {
 	return &Builder{
 		entityType: SecurityIntegrationType,
 		name:       name,
 	}
 }
 
-type samlIntegration struct {
+type SamlIntegration struct {
 	Name            sql.NullString `db:"name"`
 	Category        sql.NullString `db:"category"`
 	IntegrationType sql.NullString `db:"type"`
@@ -32,8 +32,8 @@ type samlIntegration struct {
 	Enabled         sql.NullBool   `db:"enabled"`
 }
 
-func ScanSamlIntegration(row *sqlx.Row) (*samlIntegration, error) {
-	r := &samlIntegration{}
+func ScanSamlIntegration(row *sqlx.Row) (*SamlIntegration, error) {
+	r := &SamlIntegration{}
 	if err := row.StructScan(r); err != nil {
 		return r, fmt.Errorf("error scanning struct err = %w", err)
 	}

--- a/pkg/snowflake/saml_integration_test.go
+++ b/pkg/snowflake/saml_integration_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSamlIntegration(t *testing.T) {
 	r := require.New(t)
-	builder := snowflake.SamlIntegration("test_saml_integration")
+	builder := snowflake.NewSamlIntegrationBuilder("test_saml_integration")
 	r.NotNil(builder)
 
 	q := builder.Show()

--- a/pkg/snowflake/schema.go
+++ b/pkg/snowflake/schema.go
@@ -88,7 +88,7 @@ func (sb *SchemaBuilder) UnsetTag(tag TagValue) string {
 	return fmt.Sprintf(`ALTER SCHEMA %s UNSET TAG "%v"."%v"."%v"`, sb.QualifiedName(), tag.Database, tag.Schema, tag.Name)
 }
 
-// Schema returns a pointer to a Builder that abstracts the DDL operations for a schema.
+// NewSchemaBuilder returns a pointer to a Builder that abstracts the DDL operations for a schema.
 //
 // Supported DDL operations are:
 //   - CREATE SCHEMA
@@ -99,7 +99,7 @@ func (sb *SchemaBuilder) UnsetTag(tag TagValue) string {
 //   - SHOW SCHEMAS
 //
 // [Snowflake Reference](https://docs.snowflake.net/manuals/sql-reference/ddl-database.html#schema-management)
-func Schema(name string) *SchemaBuilder {
+func NewSchemaBuilder(name string) *SchemaBuilder {
 	return &SchemaBuilder{
 		name: name,
 	}
@@ -204,7 +204,7 @@ func (sb *SchemaBuilder) Show() string {
 	return q.String()
 }
 
-type schema struct {
+type Schema struct {
 	Name          sql.NullString `db:"name"`
 	DatabaseName  sql.NullString `db:"database_name"`
 	Comment       sql.NullString `db:"comment"`
@@ -212,13 +212,13 @@ type schema struct {
 	RetentionTime sql.NullString `db:"retention_time"`
 }
 
-func ScanSchema(row *sqlx.Row) (*schema, error) {
-	r := &schema{}
+func ScanSchema(row *sqlx.Row) (*Schema, error) {
+	r := &Schema{}
 	err := row.StructScan(r)
 	return r, err
 }
 
-func ListSchemas(databaseName string, db *sql.DB) ([]schema, error) {
+func ListSchemas(databaseName string, db *sql.DB) ([]Schema, error) {
 	stmt := fmt.Sprintf(`SHOW SCHEMAS IN DATABASE "%v"`, databaseName)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -226,7 +226,7 @@ func ListSchemas(databaseName string, db *sql.DB) ([]schema, error) {
 	}
 	defer rows.Close()
 
-	dbs := []schema{}
+	dbs := []Schema{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no schemas found")

--- a/pkg/snowflake/schema_test.go
+++ b/pkg/snowflake/schema_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestSchemaCreate(t *testing.T) {
 	r := require.New(t)
-	s := Schema("test")
+	s := NewSchemaBuilder("test")
 	r.Equal(`"test"`, s.QualifiedName())
 
 	s.WithDB("db")
@@ -31,73 +31,73 @@ func TestSchemaCreate(t *testing.T) {
 
 func TestSchemaRename(t *testing.T) {
 	r := require.New(t)
-	s := Schema("test")
+	s := NewSchemaBuilder("test")
 	r.Equal(`ALTER SCHEMA "test" RENAME TO "bob"`, s.Rename("bob"))
 }
 
 func TestSchemaSwap(t *testing.T) {
 	r := require.New(t)
-	s := Schema("test")
+	s := NewSchemaBuilder("test")
 	r.Equal(`ALTER SCHEMA "test" SWAP WITH "bob"`, s.Swap("bob"))
 }
 
 func TestSchemaChangeComment(t *testing.T) {
 	r := require.New(t)
-	s := Schema("test")
+	s := NewSchemaBuilder("test")
 	r.Equal(`ALTER SCHEMA "test" SET COMMENT = 'worst\' schema ever'`, s.ChangeComment("worst' schema ever"))
 }
 
 func TestSchemaRemoveComment(t *testing.T) {
 	r := require.New(t)
-	s := Schema("test")
+	s := NewSchemaBuilder("test")
 	r.Equal(`ALTER SCHEMA "test" UNSET COMMENT`, s.RemoveComment())
 }
 
 func TestSchemaChangeDataRetentionDays(t *testing.T) {
 	r := require.New(t)
-	s := Schema("test")
+	s := NewSchemaBuilder("test")
 	r.Equal(`ALTER SCHEMA "test" SET DATA_RETENTION_TIME_IN_DAYS = 22`, s.ChangeDataRetentionDays(22))
 }
 
 func TestSchemaRemoveDataRetentionDays(t *testing.T) {
 	r := require.New(t)
-	s := Schema("test")
+	s := NewSchemaBuilder("test")
 	r.Equal(`ALTER SCHEMA "test" UNSET DATA_RETENTION_TIME_IN_DAYS`, s.RemoveDataRetentionDays())
 }
 
 func TestSchemaManage(t *testing.T) {
 	r := require.New(t)
-	s := Schema("test")
+	s := NewSchemaBuilder("test")
 	r.Equal(`ALTER SCHEMA "test" ENABLE MANAGED ACCESS`, s.Manage())
 }
 
 func TestSchemaUnmanage(t *testing.T) {
 	r := require.New(t)
-	s := Schema("test")
+	s := NewSchemaBuilder("test")
 	r.Equal(`ALTER SCHEMA "test" DISABLE MANAGED ACCESS`, s.Unmanage())
 }
 
 func TestSchemaDrop(t *testing.T) {
 	r := require.New(t)
-	s := Schema("test")
+	s := NewSchemaBuilder("test")
 	r.Equal(`DROP SCHEMA "test"`, s.Drop())
 }
 
 func TestSchemaUndrop(t *testing.T) {
 	r := require.New(t)
-	s := Schema("test")
+	s := NewSchemaBuilder("test")
 	r.Equal(`UNDROP SCHEMA "test"`, s.Undrop())
 }
 
 func TestSchemaUse(t *testing.T) {
 	r := require.New(t)
-	s := Schema("test")
+	s := NewSchemaBuilder("test")
 	r.Equal(`USE SCHEMA "test"`, s.Use())
 }
 
 func TestSchemaShow(t *testing.T) {
 	r := require.New(t)
-	s := Schema("test")
+	s := NewSchemaBuilder("test")
 	r.Equal(`SHOW SCHEMAS LIKE 'test'`, s.Show())
 
 	s.WithDB("db")

--- a/pkg/snowflake/scim_integration.go
+++ b/pkg/snowflake/scim_integration.go
@@ -7,7 +7,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// ScimIntegration returns a pointer to a Builder that abstracts the DDL operations for an api integration.
+// NewSCIMIntegrationBuilder returns a pointer to a Builder that abstracts the DDL operations for an api integration.
 //
 // Supported DDL operations are:
 //   - CREATE SECURITY INTEGRATION
@@ -17,22 +17,22 @@ import (
 //   - DESCRIBE INTEGRATION
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/sql-reference/ddl-user-security.html#security-integrations)
-func ScimIntegration(name string) *Builder {
+func NewSCIMIntegrationBuilder(name string) *Builder {
 	return &Builder{
 		entityType: SecurityIntegrationType,
 		name:       name,
 	}
 }
 
-type scimIntegration struct {
+type SCIMIntegration struct {
 	Name            sql.NullString `db:"name"`
 	Category        sql.NullString `db:"category"`
 	IntegrationType sql.NullString `db:"type"`
 	CreatedOn       sql.NullString `db:"created_on"`
 }
 
-func ScanScimIntegration(row *sqlx.Row) (*scimIntegration, error) {
-	r := &scimIntegration{}
+func ScanScimIntegration(row *sqlx.Row) (*SCIMIntegration, error) {
+	r := &SCIMIntegration{}
 	if err := row.StructScan(r); err != nil {
 		return r, fmt.Errorf("error scanning struct err = %w", err)
 	}

--- a/pkg/snowflake/scim_integration_test.go
+++ b/pkg/snowflake/scim_integration_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestScimIntegration(t *testing.T) {
 	r := require.New(t)
-	builder := snowflake.ScimIntegration("aad_provisioning")
+	builder := snowflake.NewSCIMIntegrationBuilder("aad_provisioning")
 	r.NotNil(builder)
 
 	q := builder.Show()

--- a/pkg/snowflake/sequence.go
+++ b/pkg/snowflake/sequence.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Sequence returns a pointer to a Builder for a sequence.
-func Sequence(name, db, schema string) *SequenceBuilder {
+func NewSequenceBuilder(name, db, schema string) *SequenceBuilder {
 	return &SequenceBuilder{
 		name:      name,
 		db:        db,
@@ -21,7 +21,7 @@ func Sequence(name, db, schema string) *SequenceBuilder {
 	}
 }
 
-type sequence struct {
+type Sequence struct {
 	Name       sql.NullString `db:"name"`
 	DBName     sql.NullString `db:"database_name"`
 	SchemaName sql.NullString `db:"schema_name"`
@@ -89,13 +89,13 @@ func (sb *SequenceBuilder) Address() string {
 	return AddressEscape(sb.db, sb.schema, sb.name)
 }
 
-func ScanSequence(row *sqlx.Row) (*sequence, error) {
-	d := &sequence{}
+func ScanSequence(row *sqlx.Row) (*Sequence, error) {
+	d := &Sequence{}
 	e := row.StructScan(d)
 	return d, e
 }
 
-func ListSequences(databaseName string, schemaName string, db *sql.DB) ([]sequence, error) {
+func ListSequences(databaseName string, schemaName string, db *sql.DB) ([]Sequence, error) {
 	stmt := fmt.Sprintf(`SHOW SEQUENCES IN SCHEMA "%s"."%v"`, databaseName, schemaName)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -103,7 +103,7 @@ func ListSequences(databaseName string, schemaName string, db *sql.DB) ([]sequen
 	}
 	defer rows.Close()
 
-	dbs := []sequence{}
+	dbs := []Sequence{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no sequences found")

--- a/pkg/snowflake/sequence_test.go
+++ b/pkg/snowflake/sequence_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestSequenceCreate(t *testing.T) {
 	r := require.New(t)
-	s := Sequence("test_sequence", "test_db", "test_schema")
+	s := NewSequenceBuilder("test_sequence", "test_db", "test_schema")
 
 	r.Equal(`"test_db"."test_schema"."test_sequence"`, s.QualifiedName())
 
@@ -24,12 +24,12 @@ func TestSequenceCreate(t *testing.T) {
 
 func TestSequenceDrop(t *testing.T) {
 	r := require.New(t)
-	s := Sequence("test_sequence", "test_db", "test_schema")
+	s := NewSequenceBuilder("test_sequence", "test_db", "test_schema")
 	r.Equal(`DROP SEQUENCE "test_db"."test_schema"."test_sequence"`, s.Drop())
 }
 
 func TestSequenceShow(t *testing.T) {
 	r := require.New(t)
-	s := Sequence("test_sequence", "test_db", "test_schema")
+	s := NewSequenceBuilder("test_sequence", "test_db", "test_schema")
 	r.Equal(`SHOW SEQUENCES LIKE 'test_sequence' IN SCHEMA "test_db"."test_schema"`, s.Show())
 }

--- a/pkg/snowflake/share.go
+++ b/pkg/snowflake/share.go
@@ -16,21 +16,21 @@ import (
 //   - DESCRIBE SHARE
 //
 // [Snowflake Reference](https://docs.snowflake.net/manuals/sql-reference/ddl-database.html#share-management)
-func Share(name string) *Builder {
+func NewShareBuilder(name string) *Builder {
 	return &Builder{
 		entityType: ShareType,
 		name:       name,
 	}
 }
 
-type share struct {
+type Share struct {
 	Name    sql.NullString `db:"name"`
 	To      sql.NullString `db:"to"`
 	Comment sql.NullString `db:"comment"`
 }
 
-func ScanShare(row *sqlx.Row) (*share, error) {
-	r := &share{}
+func ScanShare(row *sqlx.Row) (*Share, error) {
+	r := &Share{}
 	err := row.StructScan(r)
 	return r, err
 }

--- a/pkg/snowflake/share_test.go
+++ b/pkg/snowflake/share_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestShare(t *testing.T) {
 	r := require.New(t)
-	s := snowflake.Share("share1")
+	s := snowflake.NewShareBuilder("share1")
 	r.NotNil(s)
 
 	q := s.Show()

--- a/pkg/snowflake/stage_test.go
+++ b/pkg/snowflake/stage_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestStageCreate(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`"test_db"."test_schema"."test_stage"`, s.QualifiedName())
 
 	r.Equal(`CREATE STAGE "test_db"."test_schema"."test_stage"`, s.Create())
@@ -40,78 +40,78 @@ func TestStageCreate(t *testing.T) {
 
 func TestStageRename(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" RENAME TO "test_stage2"`, s.Rename("test_stage2"))
 }
 
 func TestStageChangeComment(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET COMMENT = 'worst stage ever'`, s.ChangeComment("worst stage ever"))
 }
 
 func TestStageChangeURL(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET URL = 's3://load/test/'`, s.ChangeURL("s3://load/test/"))
 }
 
 func TestStageChangeFileFormat(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET FILE_FORMAT = (format_name=my_csv_format)`, s.ChangeFileFormat("format_name=my_csv_format"))
 }
 
 func TestStageChangeFileFormatToEmptyList(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET FILE_FORMAT = (TYPE = parquet NULL_IF = () COMPRESSION = none)`, s.ChangeFileFormat("TYPE = parquet NULL_IF = [] COMPRESSION = none"))
 }
 
 func TestStageChangeEncryption(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET ENCRYPTION = (type='AWS_SSE_KMS' kms_key_id = 'aws/key')`, s.ChangeEncryption("type='AWS_SSE_KMS' kms_key_id = 'aws/key'"))
 }
 
 func TestStageChangeCredentials(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET CREDENTIALS = (aws_role='arn:aws:iam::001234567890:role/mysnowflakerole')`, s.ChangeCredentials("aws_role='arn:aws:iam::001234567890:role/mysnowflakerole'"))
 }
 
 func TestStageChangeStorageIntegration(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET STORAGE_INTEGRATION = "MY_INTEGRATION"`, s.ChangeStorageIntegration("MY_INTEGRATION"))
 }
 
 func TestStageChangeCopyOptions(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`ALTER STAGE "test_db"."test_schema"."test_stage" SET COPY_OPTIONS = (on_error='skip_file')`, s.ChangeCopyOptions("on_error='skip_file'"))
 }
 
 func TestStageDrop(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`DROP STAGE "test_db"."test_schema"."test_stage"`, s.Drop())
 }
 
 func TestStageUndrop(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`UNDROP STAGE "test_db"."test_schema"."test_stage"`, s.Undrop())
 }
 
 func TestStageDescribe(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`DESCRIBE STAGE "test_db"."test_schema"."test_stage"`, s.Describe())
 }
 
 func TestStageShow(t *testing.T) {
 	r := require.New(t)
-	s := Stage("test_stage", "test_db", "test_schema")
+	s := NewStageBuilder("test_stage", "test_db", "test_schema")
 	r.Equal(`SHOW STAGES LIKE 'test_stage' IN SCHEMA "test_db"."test_schema"`, s.Show())
 }

--- a/pkg/snowflake/storage_integration.go
+++ b/pkg/snowflake/storage_integration.go
@@ -19,14 +19,14 @@ import (
 //   - DESCRIBE INTEGRATION
 //
 // [Snowflake Reference](https://docs.snowflake.net/manuals/sql-reference/ddl-user-security.html#storage-integrations)
-func StorageIntegration(name string) *Builder {
+func NewStorageIntegrationBuilder(name string) *Builder {
 	return &Builder{
 		entityType: StorageIntegrationType,
 		name:       name,
 	}
 }
 
-type storageIntegration struct {
+type StorageIntegration struct {
 	Name            sql.NullString `db:"name"`
 	Category        sql.NullString `db:"category"`
 	IntegrationType sql.NullString `db:"type"`
@@ -35,13 +35,13 @@ type storageIntegration struct {
 	Comment         sql.NullString `db:"comment"`
 }
 
-func ScanStorageIntegration(row *sqlx.Row) (*storageIntegration, error) {
-	r := &storageIntegration{}
+func ScanStorageIntegration(row *sqlx.Row) (*StorageIntegration, error) {
+	r := &StorageIntegration{}
 	err := row.StructScan(r)
 	return r, err
 }
 
-func ListStorageIntegrations(db *sql.DB) ([]storageIntegration, error) {
+func ListStorageIntegrations(db *sql.DB) ([]StorageIntegration, error) {
 	stmt := "SHOW STORAGE INTEGRATIONS"
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -49,7 +49,7 @@ func ListStorageIntegrations(db *sql.DB) ([]storageIntegration, error) {
 	}
 	defer rows.Close()
 
-	dbs := []storageIntegration{}
+	dbs := []StorageIntegration{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no resource monitors found")

--- a/pkg/snowflake/storage_integration_test.go
+++ b/pkg/snowflake/storage_integration_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestStorageIntegration(t *testing.T) {
 	r := require.New(t)
-	builder := snowflake.StorageIntegration("aws")
+	builder := snowflake.NewStorageIntegrationBuilder("aws")
 	r.NotNil(builder)
 
 	q := builder.Show()

--- a/pkg/snowflake/stream.go
+++ b/pkg/snowflake/stream.go
@@ -147,7 +147,7 @@ func (sb *StreamBuilder) Show() string {
 	return fmt.Sprintf(`SHOW STREAMS LIKE '%v' IN SCHEMA "%v"."%v"`, sb.name, sb.db, sb.schema)
 }
 
-type descStreamRow struct {
+type DescStreamRow struct {
 	CreatedOn       sql.NullString `db:"created_on"`
 	StreamName      sql.NullString `db:"name"`
 	DatabaseName    sql.NullString `db:"database_name"`
@@ -162,13 +162,13 @@ type descStreamRow struct {
 	Mode            sql.NullString `db:"mode"`
 }
 
-func ScanStream(row *sqlx.Row) (*descStreamRow, error) {
-	t := &descStreamRow{}
+func ScanStream(row *sqlx.Row) (*DescStreamRow, error) {
+	t := &DescStreamRow{}
 	e := row.StructScan(t)
 	return t, e
 }
 
-func ListStreams(databaseName string, schemaName string, db *sql.DB) ([]descStreamRow, error) {
+func ListStreams(databaseName string, schemaName string, db *sql.DB) ([]DescStreamRow, error) {
 	stmt := fmt.Sprintf(`SHOW STREAMS IN SCHEMA "%s"."%v"`, databaseName, schemaName)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -176,7 +176,7 @@ func ListStreams(databaseName string, schemaName string, db *sql.DB) ([]descStre
 	}
 	defer rows.Close()
 
-	dbs := []descStreamRow{}
+	dbs := []DescStreamRow{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no stages found")

--- a/pkg/snowflake/system_generate_scim_access_token.go
+++ b/pkg/snowflake/system_generate_scim_access_token.go
@@ -12,7 +12,7 @@ type SystemGenerateSCIMAccessTokenBuilder struct {
 }
 
 // SystemGenerateSCIMAccessToken returns a pointer to a builder that abstracts calling the the SYSTEM$GENERATE_SCIM_ACCESS_TOKEN system function.
-func SystemGenerateSCIMAccessToken(integrationName string) *SystemGenerateSCIMAccessTokenBuilder {
+func NewSystemGenerateSCIMAccessTokenBuilder(integrationName string) *SystemGenerateSCIMAccessTokenBuilder {
 	return &SystemGenerateSCIMAccessTokenBuilder{
 		integrationName: integrationName,
 	}
@@ -23,13 +23,13 @@ func (pb *SystemGenerateSCIMAccessTokenBuilder) Select() string {
 	return fmt.Sprintf(`SELECT SYSTEM$GENERATE_SCIM_ACCESS_TOKEN('%v') AS "TOKEN"`, pb.integrationName)
 }
 
-type scimAccessToken struct {
+type SCIMAccessToken struct {
 	Token string `db:"TOKEN"`
 }
 
 // ScanSCIMAccessToken convert a result into a.
-func ScanSCIMAccessToken(row *sqlx.Row) (*scimAccessToken, error) {
-	p := &scimAccessToken{}
+func ScanSCIMAccessToken(row *sqlx.Row) (*SCIMAccessToken, error) {
+	p := &SCIMAccessToken{}
 	e := row.StructScan(p)
 	return p, e
 }

--- a/pkg/snowflake/system_generate_scim_access_token_test.go
+++ b/pkg/snowflake/system_generate_scim_access_token_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestSystemGenerateSCIMAccessToken(t *testing.T) {
 	r := require.New(t)
-	sb := SystemGenerateSCIMAccessToken("AAD_PROVISIONING")
+	sb := NewSystemGenerateSCIMAccessTokenBuilder("AAD_PROVISIONING")
 
 	r.Equal(`SELECT SYSTEM$GENERATE_SCIM_ACCESS_TOKEN('AAD_PROVISIONING') AS "TOKEN"`, sb.Select())
 }

--- a/pkg/snowflake/system_get_aws_sns_iam_policy.go
+++ b/pkg/snowflake/system_get_aws_sns_iam_policy.go
@@ -12,7 +12,7 @@ type SystemGetAWSSNSIAMPolicyBuilder struct {
 }
 
 // SystemGetAWSSNSIAMPolicy returns a pointer to a builder that abstracts calling the the SYSTEM$GET_AWS_SNS_IAM_POLICY system function.
-func SystemGetAWSSNSIAMPolicy(awsSnsTopicArn string) *SystemGetAWSSNSIAMPolicyBuilder {
+func NewSystemGetAWSSNSIAMPolicyBuilder(awsSnsTopicArn string) *SystemGetAWSSNSIAMPolicyBuilder {
 	return &SystemGetAWSSNSIAMPolicyBuilder{
 		awsSnsTopicArn: awsSnsTopicArn,
 	}
@@ -23,13 +23,13 @@ func (pb *SystemGetAWSSNSIAMPolicyBuilder) Select() string {
 	return fmt.Sprintf(`SELECT SYSTEM$GET_AWS_SNS_IAM_POLICY('%v') AS "policy"`, pb.awsSnsTopicArn)
 }
 
-type awsSNSIAMPolicy struct {
+type AWSSNSIAMPolicy struct {
 	Policy string `db:"policy"`
 }
 
 // ScanAWSSNSIAMPolicy convert a result into a.
-func ScanAWSSNSIAMPolicy(row *sqlx.Row) (*awsSNSIAMPolicy, error) {
-	p := &awsSNSIAMPolicy{}
+func ScanAWSSNSIAMPolicy(row *sqlx.Row) (*AWSSNSIAMPolicy, error) {
+	p := &AWSSNSIAMPolicy{}
 	e := row.StructScan(p)
 	return p, e
 }

--- a/pkg/snowflake/system_get_aws_sns_iam_policy_test.go
+++ b/pkg/snowflake/system_get_aws_sns_iam_policy_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestSystemGetAWSSNSIAMPolicy(t *testing.T) {
 	r := require.New(t)
-	sb := SystemGetAWSSNSIAMPolicy("arn:aws:sns:us-east-1:1234567890123456:mytopic")
+	sb := NewSystemGetAWSSNSIAMPolicyBuilder("arn:aws:sns:us-east-1:1234567890123456:mytopic")
 
 	r.Equal(`SELECT SYSTEM$GET_AWS_SNS_IAM_POLICY('arn:aws:sns:us-east-1:1234567890123456:mytopic') AS "policy"`, sb.Select())
 }

--- a/pkg/snowflake/system_get_snowflake_platform_info.go
+++ b/pkg/snowflake/system_get_snowflake_platform_info.go
@@ -10,28 +10,28 @@ func SystemGetSnowflakePlatformInfoQuery() string {
 	return `SELECT SYSTEM$GET_SNOWFLAKE_PLATFORM_INFO() AS "INFO"`
 }
 
-type RawSnowflakePlatformInfo struct {
+type RawPlatformInfo struct {
 	Info string `db:"INFO"`
 }
 
-type snowflakePlatformInfoInternal struct {
+type platformInfoInternal struct {
 	AzureVnetSubnetIds []string `json:"snowflake-vnet-subnet-id,omitempty"`
 	AwsVpcIds          []string `json:"snowflake-vpc-id,omitempty"`
 }
 
-type SnowflakePlatformInfo struct {
+type PlatformInfo struct {
 	AzureVnetSubnetIds []string
 	AwsVpcIds          []string
 }
 
-func ScanSnowflakePlatformInfo(row *sqlx.Row) (*RawSnowflakePlatformInfo, error) {
-	info := &RawSnowflakePlatformInfo{}
+func ScanSnowflakePlatformInfo(row *sqlx.Row) (*RawPlatformInfo, error) {
+	info := &RawPlatformInfo{}
 	err := row.StructScan(info)
 	return info, err
 }
 
-func (r *RawSnowflakePlatformInfo) GetStructuredConfig() (*SnowflakePlatformInfo, error) {
-	info := &snowflakePlatformInfoInternal{}
+func (r *RawPlatformInfo) GetStructuredConfig() (*PlatformInfo, error) {
+	info := &platformInfoInternal{}
 	err := json.Unmarshal([]byte(r.Info), info)
 	if err != nil {
 		return nil, err
@@ -40,8 +40,8 @@ func (r *RawSnowflakePlatformInfo) GetStructuredConfig() (*SnowflakePlatformInfo
 	return info.getSnowflakePlatformInfo()
 }
 
-func (i *snowflakePlatformInfoInternal) getSnowflakePlatformInfo() (*SnowflakePlatformInfo, error) {
-	config := &SnowflakePlatformInfo{
+func (i *platformInfoInternal) getSnowflakePlatformInfo() (*PlatformInfo, error) {
+	config := &PlatformInfo{
 		i.AzureVnetSubnetIds,
 		i.AwsVpcIds,
 	}

--- a/pkg/snowflake/system_get_snowflake_platform_info_test.go
+++ b/pkg/snowflake/system_get_snowflake_platform_info_test.go
@@ -16,7 +16,7 @@ func TestSystemGetSnowflakePlatformInfoQuery(t *testing.T) {
 func TestSystemGetSnowflakePlatformInfoGetStructuredConfigAws(t *testing.T) {
 	r := require.New(t)
 
-	raw := &RawSnowflakePlatformInfo{
+	raw := &RawPlatformInfo{
 		Info: `{"snowflake-vpc-id": ["vpc-1", "vpc-2"]}`,
 	}
 
@@ -30,7 +30,7 @@ func TestSystemGetSnowflakePlatformInfoGetStructuredConfigAws(t *testing.T) {
 func TestSystemGetSnowflakePlatformInfoGetStructuredConfigAzure(t *testing.T) {
 	r := require.New(t)
 
-	raw := &RawSnowflakePlatformInfo{
+	raw := &RawPlatformInfo{
 		Info: `{"snowflake-vnet-subnet-id": ["/subscription/1/1", "/subscription/1/2"]}`,
 	}
 

--- a/pkg/snowflake/table.go
+++ b/pkg/snowflake/table.go
@@ -109,13 +109,13 @@ func (d *ColumnDefault) UnescapeConstantSnowflakeString(columnType string) strin
 
 // Column structure that represents a table column.
 type Column struct {
-	name           string
-	_type          string // type is reserved
-	nullable       bool
-	_default       *ColumnDefault // default is reserved
-	identity       *ColumnIdentity
-	comment        string // pointer as value is nullable
-	masking_policy string
+	name          string
+	_type         string // type is reserved
+	nullable      bool
+	_default      *ColumnDefault // default is reserved
+	identity      *ColumnIdentity
+	comment       string // pointer as value is nullable
+	maskingPolicy string
 }
 
 // WithName set the column name.
@@ -148,7 +148,7 @@ func (c *Column) WithComment(comment string) *Column {
 }
 
 func (c *Column) WithMaskingPolicy(maskingPolicy string) *Column {
-	c.masking_policy = maskingPolicy
+	c.maskingPolicy = maskingPolicy
 	return c
 }
 
@@ -178,8 +178,8 @@ func (c *Column) getColumnDefinition(withInlineConstraints bool, withComment boo
 		colDef.WriteString(fmt.Sprintf(` IDENTITY(%v, %v)`, c.identity.startNum, c.identity.stepNum))
 	}
 
-	if strings.TrimSpace(c.masking_policy) != "" {
-		colDef.WriteString(fmt.Sprintf(` WITH MASKING POLICY %v`, EscapeString(c.masking_policy)))
+	if strings.TrimSpace(c.maskingPolicy) != "" {
+		colDef.WriteString(fmt.Sprintf(` WITH MASKING POLICY %v`, EscapeString(c.maskingPolicy)))
 	}
 
 	if withComment {
@@ -238,13 +238,13 @@ func NewColumns(tds []tableDescription) Columns {
 		}
 
 		cs = append(cs, Column{
-			name:           td.Name.String,
-			_type:          td.Type.String,
-			nullable:       td.IsNullable(),
-			_default:       td.ColumnDefault(),
-			identity:       td.ColumnIdentity(),
-			comment:        td.Comment.String,
-			masking_policy: td.MaskingPolicy.String,
+			name:          td.Name.String,
+			_type:         td.Type.String,
+			nullable:      td.IsNullable(),
+			_default:      td.ColumnDefault(),
+			identity:      td.ColumnIdentity(),
+			comment:       td.Comment.String,
+			maskingPolicy: td.MaskingPolicy.String,
 		})
 	}
 	return Columns(cs)
@@ -258,7 +258,7 @@ func (c Columns) Flatten() []interface{} {
 		flat["type"] = col._type
 		flat["nullable"] = col.nullable
 		flat["comment"] = col.comment
-		flat["masking_policy"] = col.masking_policy
+		flat["masking_policy"] = col.maskingPolicy
 
 		if col._default != nil {
 			def := map[string]interface{}{}
@@ -540,13 +540,13 @@ func (tb *TableBuilder) ChangeChangeTracking(changeTracking bool) string {
 // AddColumn returns the SQL query that will add a new column to the table.
 func (tb *TableBuilder) AddColumn(name string, dataType string, nullable bool, _default *ColumnDefault, identity *ColumnIdentity, comment string, maskingPolicy string) string {
 	col := Column{
-		name:           name,
-		_type:          dataType,
-		nullable:       nullable,
-		_default:       _default,
-		identity:       identity,
-		comment:        comment,
-		masking_policy: maskingPolicy,
+		name:          name,
+		_type:         dataType,
+		nullable:      nullable,
+		_default:      _default,
+		identity:      identity,
+		comment:       comment,
+		maskingPolicy: maskingPolicy,
 	}
 	return fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s`, tb.QualifiedName(), col.getColumnDefinition(true, true))
 }

--- a/pkg/snowflake/table_constraint.go
+++ b/pkg/snowflake/table_constraint.go
@@ -30,7 +30,7 @@ type TableConstraintBuilder struct {
 	comment          string
 }
 
-func TableConstraint(name string, constraintType string, tableID string) *TableConstraintBuilder {
+func NewTableConstraintBuilder(name string, constraintType string, tableID string) *TableConstraintBuilder {
 	return &TableConstraintBuilder{
 		name:           name,
 		constraintType: constraintType,
@@ -205,7 +205,7 @@ func (b *TableConstraintBuilder) Drop() string {
 	return s
 }
 
-type tableConstraint struct {
+type TableConstraint struct {
 	ConstraintCatalog sql.NullString `db:"CONSTRAINT_CATALOG"`
 	ConstraintSchema  sql.NullString `db:"CONSTRAINT_SCHEMA"`
 	ConstraintName    sql.NullString `db:"CONSTRAINT_NAME"`
@@ -220,7 +220,7 @@ type tableConstraint struct {
 }
 
 // Show returns the SQL query that will show a table constraint by ID.
-func ShowTableConstraint(name, tableDB, tableSchema, tableName string, db *sql.DB) (*tableConstraint, error) {
+func ShowTableConstraint(name, tableDB, tableSchema, tableName string, db *sql.DB) (*TableConstraint, error) {
 	stmt := `SELECT * FROM SNOWFLAKE.INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_NAME = '?' AND TABLE_SCHEMA = '?' AND TABLE_CATALOG = '?' AND CONSTRAINT_NAME = '?'`
 	rows, err := db.Query(stmt,
 		tableName, tableSchema, tableDB, name)
@@ -228,7 +228,7 @@ func ShowTableConstraint(name, tableDB, tableSchema, tableName string, db *sql.D
 		return nil, err
 	}
 	defer rows.Close()
-	tableConstraints := []tableConstraint{}
+	tableConstraints := []TableConstraint{}
 	log.Printf("[DEBUG] tableConstraints is %v", tableConstraints)
 	if err := sqlx.StructScan(rows, &tableConstraints); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/snowflake/table_test.go
+++ b/pkg/snowflake/table_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestTableCreate(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	cols := []Column{
 		{
 			name:     "column1",
@@ -89,7 +89,7 @@ func TestTableCreate(t *testing.T) {
 
 func TestTableCreateIdentity(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	cols := []Column{
 		{
 			name:     "column1",
@@ -124,156 +124,156 @@ func TestTableCreateIdentity(t *testing.T) {
 
 func TestTableChangeComment(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" SET COMMENT = 'new table comment'`, s.ChangeComment("new table comment"))
 }
 
 func TestTableRemoveComment(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" UNSET COMMENT`, s.RemoveComment())
 }
 
 func TestTableAddColumn(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" VARIANT COMMENT ''`, s.AddColumn("new_column", "VARIANT", true, nil, nil, "", ""))
 }
 
 func TestTableAddColumnWithComment(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" VARIANT COMMENT 'some comment'`, s.AddColumn("new_column", "VARIANT", true, nil, nil, "some comment", ""))
 }
 
 func TestTableAddColumnWithDefault(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" NUMBER(38,0) DEFAULT 1 COMMENT ''`, s.AddColumn("new_column", "NUMBER(38,0)", true, NewColumnDefaultWithConstant("1"), nil, "", ""))
 }
 
 func TestTableAddColumnWithIdentity(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" NUMBER(38,0) IDENTITY(1, 4) COMMENT ''`, s.AddColumn("new_column", "NUMBER(38,0)", true, nil, &ColumnIdentity{1, 4}, "", ""))
 }
 
 func TestTableAddColumnWithMaskingPolicy(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD COLUMN "new_column" NUMBER(38,0) IDENTITY(1, 4) WITH MASKING POLICY TEST_MP COMMENT ''`, s.AddColumn("new_column", "NUMBER(38,0)", true, nil, &ColumnIdentity{1, 4}, "", "TEST_MP"))
 }
 
 func TestTableDropColumn(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" DROP COLUMN "old_column"`, s.DropColumn("old_column"))
 }
 
 func TestTableChangeColumnType(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" MODIFY COLUMN "old_column" BIGINT`, s.ChangeColumnType("old_column", "BIGINT"))
 }
 
 func TestTableChangeColumnComment(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" MODIFY COLUMN "old_column" COMMENT 'some comment'`, s.ChangeColumnComment("old_column", "some comment"))
 }
 
 func TestTableChangeColumnMaskingPolicy(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" MODIFY COLUMN "old_column" SET MASKING POLICY TEST_MP`, s.ChangeColumnMaskingPolicy("old_column", "TEST_MP"))
 }
 
 func TestTableDropColumnDefault(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" MODIFY COLUMN "old_column" DROP DEFAULT`, s.DropColumnDefault("old_column"))
 }
 
 func TestTableChangeClusterBy(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" CLUSTER BY LINEAR(column2, column3)`, s.ChangeClusterBy("column2, column3"))
 }
 
 func TestTableChangeDataRetention(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" SET DATA_RETENTION_TIME_IN_DAYS = 5`, s.ChangeDataRetention(5))
 }
 
 func TestTableChangeChangeTracking(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" SET CHANGE_TRACKING = true`, s.ChangeChangeTracking(true))
 }
 
 func TestTableDropClusterBy(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" DROP CLUSTERING KEY`, s.DropClustering())
 }
 
 func TestTableDrop(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`DROP TABLE "test_db"."test_schema"."test_table"`, s.Drop())
 }
 
 func TestTableShow(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`SHOW TABLES LIKE 'test_table' IN SCHEMA "test_db"."test_schema"`, s.Show())
 }
 
 func TestTableShowPrimaryKeys(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`SHOW PRIMARY KEYS IN TABLE "test_db"."test_schema"."test_table"`, s.ShowPrimaryKeys())
 }
 
 func TestTableDropPrimaryKeys(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" DROP PRIMARY KEY`, s.DropPrimaryKey())
 }
 
 func TestTableChangePrimaryKeysWithConstraintName(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD CONSTRAINT "MY_KEY" PRIMARY KEY("column1", "column2")`, s.ChangePrimaryKey(PrimaryKey{name: "MY_KEY", keys: []string{"column1", "column2"}}))
 }
 
 func TestTableChangePrimaryKeysWithoutConstraintName(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" ADD PRIMARY KEY("column1", "column2")`, s.ChangePrimaryKey(PrimaryKey{name: "", keys: []string{"column1", "column2"}}))
 }
 
 func TestTableAddTag(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" SET TAG "test_db"."test_schema"."tag" = "value"`, s.AddTag(TagValue{Name: "tag", Schema: "test_schema", Database: "test_db", Value: "value"}))
 }
 
 func TestTableChangeTag(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" SET TAG "test_db"."test_schema"."tag" = "value"`, s.ChangeTag(TagValue{Name: "tag", Schema: "test_schema", Database: "test_db", Value: "value"}))
 }
 
 func TestTableUnsetTag(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table", "test_db", "test_schema")
+	s := NewTableBuilder("test_table", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table" UNSET TAG "test_db"."test_schema"."tag"`, s.UnsetTag(TagValue{Name: "tag", Schema: "test_schema", Database: "test_db"}))
 }
 
 func TestTableRename(t *testing.T) {
 	r := require.New(t)
-	s := Table("test_table1", "test_db", "test_schema")
+	s := NewTableBuilder("test_table1", "test_db", "test_schema")
 	r.Equal(`ALTER TABLE "test_db"."test_schema"."test_table1" RENAME TO "test_db"."test_schema"."test_table2"`, s.Rename("test_table2"))
 }

--- a/pkg/snowflake/table_test.go
+++ b/pkg/snowflake/table_test.go
@@ -40,10 +40,10 @@ func TestTableCreate(t *testing.T) {
 			_default: NewColumnDefaultWithExpression("CURRENT_TIMESTAMP()"),
 		},
 		{
-			name:           "column6",
-			_type:          "VARCHAR",
-			nullable:       true,
-			masking_policy: "TEST_MP",
+			name:          "column6",
+			_type:         "VARCHAR",
+			nullable:      true,
+			maskingPolicy: "TEST_MP",
 		},
 	}
 
@@ -109,10 +109,10 @@ func TestTableCreateIdentity(t *testing.T) {
 			identity: &ColumnIdentity{2, 5},
 		},
 		{
-			name:           "column4",
-			_type:          "VARCHAR",
-			nullable:       true,
-			masking_policy: "TEST_MP",
+			name:          "column4",
+			_type:         "VARCHAR",
+			nullable:      true,
+			maskingPolicy: "TEST_MP",
 		},
 	}
 

--- a/pkg/snowflake/tag.go
+++ b/pkg/snowflake/tag.go
@@ -78,7 +78,7 @@ func (tb *TagBuilder) WithMaskingPolicy(mpb *MaskingPolicyBuilder) *TagBuilder {
 //   - SHOW TAGS
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/user-guide/object-tagging.html)
-func Tag(name string) *TagBuilder {
+func NewTagBuilder(name string) *TagBuilder {
 	return &TagBuilder{
 		name: name,
 	}
@@ -175,7 +175,7 @@ func (tb *TagBuilder) ShowAttachedPolicy() string {
 	return q.String()
 }
 
-type tag struct {
+type Tag struct {
 	Name          sql.NullString `db:"name"`
 	DatabaseName  sql.NullString `db:"database_name"`
 	SchemaName    sql.NullString `db:"schema_name"`
@@ -183,7 +183,7 @@ type tag struct {
 	AllowedValues sql.NullString `db:"allowed_values"`
 }
 
-type tagPolicyAttachment struct {
+type TagPolicyAttachment struct {
 	PolicyDB        sql.NullString `db:"POLICY_DB"`
 	PolicySchema    sql.NullString `db:"POLICY_SCHEMA"`
 	PolicyName      sql.NullString `db:"POLICY_NAME"`
@@ -201,20 +201,20 @@ type TagValue struct {
 	Value    string
 }
 
-func ScanTag(row *sqlx.Row) (*tag, error) {
-	r := &tag{}
+func ScanTag(row *sqlx.Row) (*Tag, error) {
+	r := &Tag{}
 	err := row.StructScan(r)
 	return r, err
 }
 
-func ScanTagPolicy(row *sqlx.Row) (*tagPolicyAttachment, error) {
-	r := &tagPolicyAttachment{}
+func ScanTagPolicy(row *sqlx.Row) (*TagPolicyAttachment, error) {
+	r := &TagPolicyAttachment{}
 	err := row.StructScan(r)
 	return r, err
 }
 
 // ListTags returns a list of tags in a database or schema.
-func ListTags(databaseName, schemaName string, db *sql.DB) ([]tag, error) {
+func ListTags(databaseName, schemaName string, db *sql.DB) ([]Tag, error) {
 	stmt := fmt.Sprintf(`SHOW TAGS IN SCHEMA "%v"."%v"`, databaseName, schemaName)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -222,7 +222,7 @@ func ListTags(databaseName, schemaName string, db *sql.DB) ([]tag, error) {
 	}
 	defer rows.Close()
 
-	tags := []tag{}
+	tags := []Tag{}
 	if err := sqlx.StructScan(rows, &tags); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no tags found")

--- a/pkg/snowflake/tag_association.go
+++ b/pkg/snowflake/tag_association.go
@@ -20,7 +20,7 @@ type TagAssociationBuilder struct {
 	tagValue         string
 }
 
-type tagAssociation struct {
+type TagAssociation struct {
 	TagValue sql.NullString `db:"TAG_VALUE"`
 }
 
@@ -65,7 +65,7 @@ func (tb *TagAssociationBuilder) GetTagSchema() string {
 //   - SYSTEM$GET_TAG (get current tag value)
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/user-guide/object-tagging.html)
-func TagAssociation(tagID string) *TagAssociationBuilder {
+func NewTagAssociationBuilder(tagID string) *TagAssociationBuilder {
 	databaseName, schemaName, tagName := validation.ParseFullyQualifiedObjectID(tagID)
 	return &TagAssociationBuilder{
 		databaseName: databaseName,
@@ -89,13 +89,13 @@ func (tb *TagAssociationBuilder) Show() string {
 	return fmt.Sprintf(`SELECT SYSTEM$GET_TAG('"%v"."%v"."%v"', '%v', '%v') TAG_VALUE WHERE TAG_VALUE IS NOT NULL`, tb.databaseName, tb.schemaName, tb.tagName, tb.objectIdentifier, tb.objectType)
 }
 
-func ScanTagAssociation(row *sqlx.Row) (*tagAssociation, error) {
-	r := &tagAssociation{}
+func ScanTagAssociation(row *sqlx.Row) (*TagAssociation, error) {
+	r := &TagAssociation{}
 	err := row.StructScan(r)
 	return r, err
 }
 
-func ListTagAssociations(tb *TagAssociationBuilder, db *sql.DB) ([]tagAssociation, error) {
+func ListTagAssociations(tb *TagAssociationBuilder, db *sql.DB) ([]TagAssociation, error) {
 	stmt := `SELECT SYSTEM$GET_TAG('"?"."?"."?"', '?', '?') TAG_VALUE WHERE TAG_VALUE IS NOT NULL`
 	rows, err := db.Query(stmt,
 		tb.databaseName, tb.schemaName, tb.tagName, tb.objectIdentifier, tb.objectType)
@@ -103,7 +103,7 @@ func ListTagAssociations(tb *TagAssociationBuilder, db *sql.DB) ([]tagAssociatio
 		return nil, err
 	}
 	defer rows.Close()
-	tagAssociations := []tagAssociation{}
+	tagAssociations := []TagAssociation{}
 	log.Printf("[DEBUG] tagAssociations is %v", tagAssociations)
 	if err := sqlx.StructScan(rows, &tagAssociations); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/snowflake/tag_test.go
+++ b/pkg/snowflake/tag_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestTagCreate(t *testing.T) {
 	r := require.New(t)
-	o := Tag("test")
+	o := NewTagBuilder("test")
 	r.Equal(`"test"`, o.QualifiedName())
 
 	o.WithDB("db")
@@ -28,57 +28,57 @@ func TestTagCreate(t *testing.T) {
 
 func TestTagRename(t *testing.T) {
 	r := require.New(t)
-	o := Tag("test")
+	o := NewTagBuilder("test")
 	r.Equal(`ALTER TAG "test" RENAME TO "bob"`, o.Rename("bob"))
 }
 
 func TestTagChangeComment(t *testing.T) {
 	r := require.New(t)
-	o := Tag("test")
+	o := NewTagBuilder("test")
 	r.Equal(`ALTER TAG "test" SET COMMENT = 'worst\' tag ever'`, o.ChangeComment("worst' tag ever"))
 }
 
 func TestTagRemoveComment(t *testing.T) {
 	r := require.New(t)
-	o := Tag("test")
+	o := NewTagBuilder("test")
 	r.Equal(`ALTER TAG "test" UNSET COMMENT`, o.RemoveComment())
 }
 
 func TestTagAddAllowedValues(t *testing.T) {
 	r := require.New(t)
-	o := Tag("test")
+	o := NewTagBuilder("test")
 	avs := []string{"foo", "bar"}
 	r.Equal(`ALTER TAG "test" ADD ALLOWED_VALUES 'foo', 'bar'`, o.AddAllowedValues(avs))
 }
 
 func TestTagDropAllowedValues(t *testing.T) {
 	r := require.New(t)
-	o := Tag("test")
+	o := NewTagBuilder("test")
 	avs := []string{"foo"}
 	r.Equal(`ALTER TAG "test" DROP ALLOWED_VALUES 'foo'`, o.DropAllowedValues(avs))
 }
 
 func TestTagRemoveAllowedValues(t *testing.T) {
 	r := require.New(t)
-	o := Tag("test")
+	o := NewTagBuilder("test")
 	r.Equal(`ALTER TAG "test" UNSET ALLOWED_VALUES`, o.RemoveAllowedValues())
 }
 
 func TestTagDrop(t *testing.T) {
 	r := require.New(t)
-	o := Tag("test")
+	o := NewTagBuilder("test")
 	r.Equal(`DROP TAG "test"`, o.Drop())
 }
 
 func TestTagUndrop(t *testing.T) {
 	r := require.New(t)
-	o := Tag("test")
+	o := NewTagBuilder("test")
 	r.Equal(`UNDROP TAG "test"`, o.Undrop())
 }
 
 func TestTagShow(t *testing.T) {
 	r := require.New(t)
-	o := Tag("test")
+	o := NewTagBuilder("test")
 	r.Equal(`SHOW TAGS LIKE 'test'`, o.Show())
 
 	o.WithDB("db")
@@ -90,7 +90,7 @@ func TestTagShow(t *testing.T) {
 
 func TestTagShowAttachedPolicy(t *testing.T) {
 	r := require.New(t)
-	o := Tag("test")
+	o := NewTagBuilder("test")
 	r.Equal(`SHOW TAGS LIKE 'test'`, o.Show())
 
 	o.WithDB("db")

--- a/pkg/snowflake/task_test.go
+++ b/pkg/snowflake/task_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestTaskCreate(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`"test_db"."test_schema"."test_task"`, st.QualifiedName())
 
 	st.WithWarehouse("test_wh")
@@ -41,134 +41,134 @@ func TestTaskCreate(t *testing.T) {
 
 func TestChangeWarehouse(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET WAREHOUSE = "much_wh"`, st.ChangeWarehouse("much_wh"))
 }
 
 func TestSwitchWarehouseToManaged(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET WAREHOUSE = null`, st.SwitchWarehouseToManaged())
 }
 
 func TestSwitchManagedWithInitialSize(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = 'SMALL'`, st.SwitchManagedWithInitialSize("SMALL"))
 }
 
 func TestChangeSchedule(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET SCHEDULE = 'USING CRON 0 9-17 * * SUN America/New_York'`, st.ChangeSchedule("USING CRON 0 9-17 * * SUN America/New_York"))
 }
 
 func TestRemoveSchedule(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" UNSET SCHEDULE`, st.RemoveSchedule())
 }
 
 func TestChangeTimeout(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET USER_TASK_TIMEOUT_MS = 100`, st.ChangeTimeout(100))
 }
 
 func TestRemoveTimeout(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" UNSET USER_TASK_TIMEOUT_MS`, st.RemoveTimeout())
 }
 
 func TestChangeComment(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET COMMENT = 'much comment wow'`, st.ChangeComment("much comment wow"))
 }
 
 func TestRemoveComment(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" UNSET COMMENT`, st.RemoveComment())
 }
 
 func TestAddAfter(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" ADD AFTER "test_db"."test_schema"."other_task"`, st.AddAfter([]string{"other_task"}))
 }
 
 func TestRemoveAfter(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" REMOVE AFTER "test_db"."test_schema"."first_me_task"`, st.RemoveAfter([]string{"first_me_task"}))
 }
 
 func TestAddSessionParameters(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	params := map[string]interface{}{"TIMESTAMP_INPUT_FORMAT": "YYYY-MM-DD HH24", "CLIENT_TIMESTAMP_TYPE_MAPPING": "TIMESTAMP_LTZ"}
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET CLIENT_TIMESTAMP_TYPE_MAPPING = "TIMESTAMP_LTZ", TIMESTAMP_INPUT_FORMAT = "YYYY-MM-DD HH24"`, st.AddSessionParameters(params))
 }
 
 func TestRemoveSessionParameters(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	params := map[string]interface{}{"TIMESTAMP_INPUT_FORMAT": "YYYY-MM-DD HH24", "CLIENT_TIMESTAMP_TYPE_MAPPING": "TIMESTAMP_LTZ"}
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" UNSET CLIENT_TIMESTAMP_TYPE_MAPPING, TIMESTAMP_INPUT_FORMAT`, st.RemoveSessionParameters(params))
 }
 
 func TestChangeCondition(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" MODIFY WHEN TRUE = TRUE`, st.ChangeCondition("TRUE = TRUE"))
 }
 
 func TestChangeSqlStatement(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" MODIFY AS SELECT * FROM table`, st.ChangeSQLStatement("SELECT * FROM table"))
 }
 
 func TestSuspend(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SUSPEND`, st.Suspend())
 }
 
 func TestResume(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" RESUME`, st.Resume())
 }
 
 func TestShowParameters(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`SHOW PARAMETERS IN TASK "test_db"."test_schema"."test_task"`, st.ShowParameters())
 }
 
 func TestDrop(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`DROP TASK "test_db"."test_schema"."test_task"`, st.Drop())
 }
 
 func TestDescribe(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`DESCRIBE TASK "test_db"."test_schema"."test_task"`, st.Describe())
 }
 
 func TestShow(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`SHOW TASKS LIKE 'test_task' IN SCHEMA "test_db"."test_schema"`, st.Show())
 }
 
 func TestSetAllowOverlappingExecution(t *testing.T) {
 	r := require.New(t)
-	st := Task("test_task", "test_db", "test_schema")
+	st := NewTaskBuilder("test_task", "test_db", "test_schema")
 	r.Equal(`ALTER TASK "test_db"."test_schema"."test_task" SET ALLOW_OVERLAPPING_EXECUTION = TRUE`, st.SetAllowOverlappingExecutionParameter())
 }

--- a/pkg/snowflake/user.go
+++ b/pkg/snowflake/user.go
@@ -10,14 +10,14 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func User(name string) *Builder {
+func NewUserBuilder(name string) *Builder {
 	return &Builder{
 		entityType: UserType,
 		name:       name,
 	}
 }
 
-type user struct {
+type User struct {
 	Comment               sql.NullString `db:"comment"`
 	DefaultNamespace      sql.NullString `db:"default_namespace"`
 	DefaultRole           sql.NullString `db:"default_role"`
@@ -33,14 +33,14 @@ type user struct {
 	Name                  sql.NullString `db:"name"`
 }
 
-func ScanUser(row *sqlx.Row) (*user, error) {
-	r := &user{}
+func ScanUser(row *sqlx.Row) (*User, error) {
+	r := &User{}
 	err := row.StructScan(r)
 	return r, err
 }
 
-func ScanUserDescription(rows *sqlx.Rows) (*user, error) {
-	r := &user{}
+func ScanUserDescription(rows *sqlx.Rows) (*User, error) {
+	r := &User{}
 	var err error
 
 	for rows.Next() {
@@ -100,7 +100,7 @@ type DescribeUserProp struct {
 	Value    sql.NullString `db:"value"`
 }
 
-func ListUsers(pattern string, db *sql.DB) ([]user, error) {
+func ListUsers(pattern string, db *sql.DB) ([]User, error) {
 	stmt := fmt.Sprintf(`SHOW USERS like '%s'`, pattern)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -108,7 +108,7 @@ func ListUsers(pattern string, db *sql.DB) ([]user, error) {
 	}
 	defer rows.Close()
 
-	dbs := []user{}
+	dbs := []User{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no users found")

--- a/pkg/snowflake/user_ownership_grant.go
+++ b/pkg/snowflake/user_ownership_grant.go
@@ -19,7 +19,7 @@ type UserOwnershipGrantExecutable struct {
 	currentGrants string
 }
 
-func UserOwnershipGrant(user string, currentGrants string) *UserOwnershipGrantBuilder {
+func NewUserOwnershipGrantBuilder(user string, currentGrants string) *UserOwnershipGrantBuilder {
 	return &UserOwnershipGrantBuilder{user: user, currentGrants: currentGrants}
 }
 
@@ -40,7 +40,7 @@ func (gr *UserOwnershipGrantExecutable) Revoke() string {
 	return fmt.Sprintf(`GRANT OWNERSHIP ON %s "%s" TO ROLE "%s" %s CURRENT GRANTS`, gr.granteeType, gr.grantee, gr.role, gr.currentGrants) // nolint: gosec
 }
 
-type userOwnershipGrant struct {
+type UserOwnershipGrant struct {
 	Name                  sql.NullString `db:"name"`
 	CreatedOn             sql.NullString `db:"created_on"`
 	LoginName             sql.NullString `db:"login_name"`
@@ -69,8 +69,8 @@ type userOwnershipGrant struct {
 	HasRsaPublicKey       sql.NullString `db:"has_rsa_public_key"`
 }
 
-func ScanUserOwnershipGrant(row *sqlx.Row) (*userOwnershipGrant, error) {
-	uog := &userOwnershipGrant{}
+func ScanUserOwnershipGrant(row *sqlx.Row) (*UserOwnershipGrant, error) {
+	uog := &UserOwnershipGrant{}
 	err := row.StructScan(uog)
 	return uog, err
 }

--- a/pkg/snowflake/user_ownership_grant_test.go
+++ b/pkg/snowflake/user_ownership_grant_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestUserOwnershipGrantQuery(t *testing.T) {
 	r := require.New(t)
-	copy := snowflake.UserOwnershipGrant("user1", "COPY")
-	revoke := snowflake.UserOwnershipGrant("user1", "REVOKE")
+	copy := snowflake.NewUserOwnershipGrantBuilder("user1", "COPY")
+	revoke := snowflake.NewUserOwnershipGrantBuilder("user1", "REVOKE")
 
 	g1 := copy.Role("role1").Grant()
 	r.Equal(`GRANT OWNERSHIP ON USER "user1" TO ROLE "role1" COPY CURRENT GRANTS`, g1)

--- a/pkg/snowflake/user_test.go
+++ b/pkg/snowflake/user_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestUser(t *testing.T) {
 	r := require.New(t)
-	u := snowflake.User("user1")
+	u := snowflake.NewUserBuilder("user1")
 	r.NotNil(u)
 
 	q := u.Show()

--- a/pkg/snowflake/validation.go
+++ b/pkg/snowflake/validation.go
@@ -7,17 +7,17 @@ import "fmt"
 func ValidateIdentifier(val interface{}, exclusions []string) (warns []string, errs []error) {
 	name, ok := val.(string)
 	if !ok {
-		errs = append(errs, fmt.Errorf("Unable to assert identifier as string type."))
+		errs = append(errs, fmt.Errorf("unable to assert identifier as string type"))
 		return
 	}
 
 	if len(name) == 0 {
-		errs = append(errs, fmt.Errorf("Identifier must be at least 1 character."))
+		errs = append(errs, fmt.Errorf("Identifier must be at least 1 character"))
 		return
 	}
 
 	if len(name) > 256 {
-		errs = append(errs, fmt.Errorf("Identifier must be <= 256 characters."))
+		errs = append(errs, fmt.Errorf("Identifier must be <= 256 characters"))
 		return
 	}
 
@@ -28,12 +28,12 @@ func ValidateIdentifier(val interface{}, exclusions []string) (warns []string, e
 	}
 	for k, r := range name {
 		if k == 0 && !isInitialIdentifierRune(r) {
-			errs = append(errs, fmt.Errorf("'%s' can not start an identifier.", string(r)))
+			errs = append(errs, fmt.Errorf("'%s' can not start an identifier", string(r)))
 			continue
 		}
 
 		if !isIdentifierRune(r, excludedCharacterMap) {
-			errs = append(errs, fmt.Errorf("'%s' is not valid identifier character.", string(r)))
+			errs = append(errs, fmt.Errorf("'%s' is not valid identifier character", string(r)))
 		}
 	}
 	return

--- a/pkg/snowflake/view.go
+++ b/pkg/snowflake/view.go
@@ -102,7 +102,7 @@ func (vb *ViewBuilder) UnsetTag(tag TagValue) string {
 //   - DESCRIBE VIEW
 //
 // [Snowflake Reference](https://docs.snowflake.net/manuals/sql-reference/ddl-table.html#standard-view-management)
-func View(name string) *ViewBuilder {
+func NewViewBuilder(name string) *ViewBuilder {
 	return &ViewBuilder{
 		name: name,
 	}
@@ -208,7 +208,7 @@ func (vb *ViewBuilder) Drop() (string, error) {
 	return fmt.Sprintf(`DROP VIEW %v`, qn), nil
 }
 
-type view struct {
+type View struct {
 	Comment      sql.NullString `db:"comment"`
 	IsSecure     bool           `db:"is_secure"`
 	Name         sql.NullString `db:"name"`
@@ -217,13 +217,13 @@ type view struct {
 	DatabaseName sql.NullString `db:"database_name"`
 }
 
-func ScanView(row *sqlx.Row) (*view, error) {
-	r := &view{}
+func ScanView(row *sqlx.Row) (*View, error) {
+	r := &View{}
 	err := row.StructScan(r)
 	return r, err
 }
 
-func ListViews(databaseName string, schemaName string, db *sql.DB) ([]view, error) {
+func ListViews(databaseName string, schemaName string, db *sql.DB) ([]View, error) {
 	stmt := fmt.Sprintf(`SHOW VIEWS IN SCHEMA "%s"."%v"`, databaseName, schemaName)
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -231,7 +231,7 @@ func ListViews(databaseName string, schemaName string, db *sql.DB) ([]view, erro
 	}
 	defer rows.Close()
 
-	dbs := []view{}
+	dbs := []View{}
 
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/snowflake/view_test.go
+++ b/pkg/snowflake/view_test.go
@@ -13,7 +13,7 @@ func TestView(t *testing.T) {
 	schema := "some_schema"
 	view := "test"
 
-	v := View(view).WithDB(db).WithSchema(schema)
+	v := NewViewBuilder(view).WithDB(db).WithSchema(schema)
 	r.NotNil(v)
 	r.False(v.secure)
 	qn, err := v.QualifiedName()
@@ -79,7 +79,7 @@ func TestView(t *testing.T) {
 
 func TestQualifiedName(t *testing.T) {
 	r := require.New(t)
-	v := View("view").WithDB("db").WithSchema("schema")
+	v := NewViewBuilder("view").WithDB("db").WithSchema("schema")
 	qn, err := v.QualifiedName()
 	r.NoError(err)
 	r.Equal(`"db"."schema"."view"`, qn)
@@ -87,7 +87,7 @@ func TestQualifiedName(t *testing.T) {
 
 func TestRename(t *testing.T) {
 	r := require.New(t)
-	v := View("test").WithDB("db").WithSchema("schema")
+	v := NewViewBuilder("test").WithDB("db").WithSchema("schema")
 
 	q, err := v.Rename("test2")
 	r.NoError(err)
@@ -98,7 +98,7 @@ func TestRename(t *testing.T) {
 	r.NoError(err)
 	r.Equal(`ALTER VIEW "testDB"."schema"."test2" RENAME TO "testDB"."schema"."test3"`, q)
 
-	v = View("test4").WithDB("db").WithSchema("testSchema")
+	v = NewViewBuilder("test4").WithDB("db").WithSchema("testSchema")
 	q, err = v.Rename("test5")
 	r.NoError(err)
 	r.Equal(`ALTER VIEW "db"."testSchema"."test4" RENAME TO "db"."testSchema"."test5"`, q)

--- a/pkg/snowflake/warehouse.go
+++ b/pkg/snowflake/warehouse.go
@@ -43,7 +43,7 @@ func (wb *WarehouseBuilder) ShowParameters() string {
 	return fmt.Sprintf("SHOW PARAMETERS IN WAREHOUSE %q", wb.Builder.name)
 }
 
-func Warehouse(name string) *WarehouseBuilder {
+func NewWarehouseBuilder(name string) *WarehouseBuilder {
 	return &WarehouseBuilder{
 		&Builder{
 			name:       name,
@@ -54,7 +54,7 @@ func Warehouse(name string) *WarehouseBuilder {
 
 // warehouse is a go representation of a grant that can be used in conjunction
 // with github.com/jmoiron/sqlx.
-type warehouse struct {
+type Warehouse struct {
 	Name                            string        `db:"name"`
 	State                           string        `db:"state"`
 	Type                            string        `db:"type"`
@@ -90,7 +90,7 @@ type warehouse struct {
 }
 
 // warehouseParams struct to represent a row of parameters.
-type warehouseParams struct {
+type WarehouseParams struct {
 	Key          string `db:"key"`
 	Value        string `db:"value"`
 	DefaultValue string `db:"default"`
@@ -99,18 +99,18 @@ type warehouseParams struct {
 	Type         string `db:"type"`
 }
 
-func ScanWarehouse(row *sqlx.Row) (*warehouse, error) {
-	w := &warehouse{}
+func ScanWarehouse(row *sqlx.Row) (*Warehouse, error) {
+	w := &Warehouse{}
 	err := row.StructScan(w)
 	return w, err
 }
 
 // ScanWarehouseParameters takes a database row and converts it to a warehouse parameter pointer.
-func ScanWarehouseParameters(rows *sqlx.Rows) ([]*warehouseParams, error) {
-	params := []*warehouseParams{}
+func ScanWarehouseParameters(rows *sqlx.Rows) ([]*WarehouseParams, error) {
+	params := []*WarehouseParams{}
 
 	for rows.Next() {
-		w := &warehouseParams{}
+		w := &WarehouseParams{}
 		if err := rows.StructScan(w); err != nil {
 			return nil, err
 		}
@@ -119,7 +119,7 @@ func ScanWarehouseParameters(rows *sqlx.Rows) ([]*warehouseParams, error) {
 	return params, nil
 }
 
-func ListWarehouses(db *sql.DB) ([]warehouse, error) {
+func ListWarehouses(db *sql.DB) ([]Warehouse, error) {
 	stmt := "SHOW WAREHOUSES"
 	rows, err := Query(db, stmt)
 	if err != nil {
@@ -127,7 +127,7 @@ func ListWarehouses(db *sql.DB) ([]warehouse, error) {
 	}
 	defer rows.Close()
 
-	dbs := []warehouse{}
+	dbs := []Warehouse{}
 	if err := sqlx.StructScan(rows, &dbs); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			log.Println("[DEBUG] no warehouses found")


### PR DESCRIPTION
This PR adds `revive`.

Please check after merging https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/1410 .

For example, this PR fixes the following warning.

```
pkg/resources/function_grant.go:149:21: error-strings: error strings should not be capitalized or end with punctuation or a newline (revive)

pkg/snowflake/user.go:36:31: unexported-return: exported func ScanUser returns unexported type *snowflake.user, which can be annoying to use (revive)
func ScanUser(row *sqlx.Row) (*user, error) {
                              ^
pkg/snowflake/user_ownership_grant.go:72:45: unexported-return: exported func ScanUserOwnershipGrant returns unexported type *snowflake.userOwnershipGrant, which can be annoying to use (revive)
func ScanUserOwnershipGrant(row *sqlx.Row) (*userOwnershipGrant, error) {
                                            ^
pkg/snowflake/user.go:42:44: unexported-return: exported func ScanUserDescription returns unexported type *snowflake.user, which can be annoying to use (revive)
func ScanUserDescription(rows *sqlx.Rows) (*user, error) {
                                           ^
pkg/snowflake/user.go:103:45: unexported-return: exported func ListUsers returns unexported type []snowflake.user, which can be annoying to use (revive)
func ListUsers(pattern string, db *sql.DB) ([]user, error) {
```


Reference
- https://github.com/mgechev/revive