### PR TITLE
feat: add ON STAGE support for Stream resource

### DIFF
--- a/pkg/resources/stream.go
+++ b/pkg/resources/stream.go
@@ -47,14 +47,21 @@ var streamSchema = map[string]*schema.Schema{
 		Optional:     true,
 		ForceNew:     true,
 		Description:  "Name of the table the stream will monitor.",
-		ExactlyOneOf: []string{"on_table", "on_view"},
+		ExactlyOneOf: []string{"on_table", "on_view", "on_stage"},
 	},
 	"on_view": {
 		Type:         schema.TypeString,
 		Optional:     true,
 		ForceNew:     true,
 		Description:  "Name of the view the stream will monitor.",
-		ExactlyOneOf: []string{"on_table", "on_view"},
+		ExactlyOneOf: []string{"on_table", "on_view", "on_stage"},
+	},
+	"on_stage": {
+		Type:         schema.TypeString,
+		Optional:     true,
+		ForceNew:     true,
+		Description:  "Name of the stage the stream will monitor.",
+		ExactlyOneOf: []string{"on_table", "on_view", "on_stage"},
 	},
 	"append_only": {
 		Type:        schema.TypeBool,
@@ -189,9 +196,21 @@ func CreateStream(d *schema.ResourceData, meta interface{}) error {
 
 	onTable, onTableSet := d.GetOk("on_table")
 	onView, onViewSet := d.GetOk("on_view")
+	onStage, onStageSet := d.GetOk("on_stage")
 
-	if (onTableSet && onViewSet) || !(onTableSet || onViewSet) { //nolint:gocritic // todo: please fix this to pass gocritic
-		return fmt.Errorf("exactly one of 'on_table' or 'on_view' expected")
+	var sourceCount = 0
+	if onTableSet {
+		sourceCount++
+	}
+	if onViewSet {
+		sourceCount++
+	}
+	if onStageSet {
+		sourceCount++
+	}
+
+	if sourceCount == 0 || sourceCount > 1 {
+		return fmt.Errorf("exactly one of 'on_table' or 'on_view' or 'on_stage' expected")
 	} else if onTableSet {
 		id, err := streamOnObjectIDFromString(onTable.(string))
 		if err != nil {
@@ -223,6 +242,29 @@ func CreateStream(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		builder.WithOnView(t.DatabaseName.String, t.SchemaName.String, t.Name.String)
+	} else if onStageSet {
+		id, err := streamOnObjectIDFromString(onStage.(string))
+		if err != nil {
+			return err
+		}
+
+		tq := snowflake.Stage(id.Name, id.DatabaseName, id.SchemaName).Show()
+		stageRow := snowflake.QueryRow(db, tq)
+
+		t, err := snowflake.ScanStageShow(stageRow)
+		if err != nil {
+			return err
+		}
+
+		sq := snowflake.Stage(id.Name, id.DatabaseName, id.SchemaName).Describe()
+		d, err := snowflake.DescStage(db, sq)
+		if err != nil {
+			return err
+		} else if !strings.Contains(d.Directory, "ENABLE = true") {
+			return fmt.Errorf("directory must be enabled on stage")
+		}
+
+		builder.WithOnStage(*t.DatabaseName, *t.SchemaName, *t.Name)
 	}
 
 	builder.WithAppendOnly(appendOnly)

--- a/pkg/resources/stream.go
+++ b/pkg/resources/stream.go
@@ -198,20 +198,7 @@ func CreateStream(d *schema.ResourceData, meta interface{}) error {
 	onView, onViewSet := d.GetOk("on_view")
 	onStage, onStageSet := d.GetOk("on_stage")
 
-	var sourceCount = 0
 	if onTableSet {
-		sourceCount++
-	}
-	if onViewSet {
-		sourceCount++
-	}
-	if onStageSet {
-		sourceCount++
-	}
-
-	if sourceCount == 0 || sourceCount > 1 {
-		return fmt.Errorf("exactly one of 'on_table' or 'on_view' or 'on_stage' expected")
-	} else if onTableSet {
 		id, err := streamOnObjectIDFromString(onTable.(string))
 		if err != nil {
 			return err
@@ -260,7 +247,8 @@ func CreateStream(d *schema.ResourceData, meta interface{}) error {
 		d, err := snowflake.DescStage(db, sq)
 		if err != nil {
 			return err
-		} else if !strings.Contains(d.Directory, "ENABLE = true") {
+		}
+		if !strings.Contains(d.Directory, "ENABLE = true") {
 			return fmt.Errorf("directory must be enabled on stage")
 		}
 

--- a/pkg/resources/stream.go
+++ b/pkg/resources/stream.go
@@ -235,14 +235,6 @@ func CreateStream(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		tq := snowflake.Stage(id.Name, id.DatabaseName, id.SchemaName).Show()
-		stageRow := snowflake.QueryRow(db, tq)
-
-		t, err := snowflake.ScanStageShow(stageRow)
-		if err != nil {
-			return err
-		}
-
 		sq := snowflake.Stage(id.Name, id.DatabaseName, id.SchemaName).Describe()
 		d, err := snowflake.DescStage(db, sq)
 		if err != nil {
@@ -252,7 +244,7 @@ func CreateStream(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("directory must be enabled on stage")
 		}
 
-		builder.WithOnStage(*t.DatabaseName, *t.SchemaName, *t.Name)
+		builder.WithOnStage(id.DatabaseName, id.SchemaName, id.Name)
 	}
 
 	builder.WithAppendOnly(appendOnly)

--- a/pkg/resources/stream_test.go
+++ b/pkg/resources/stream_test.go
@@ -93,7 +93,48 @@ func TestStreamCreateOnView(t *testing.T) {
 	})
 }
 
-func TestStreamOnTableOrView(t *testing.T) {
+func TestStreamCreateOnStage(t *testing.T) {
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"name":     "stream_name",
+		"database": "database_name",
+		"schema":   "schema_name",
+		"comment":  "great comment",
+		"on_stage": "target_db.target_schema.target_stage",
+	}
+	d := stream(t, "database_name|schema_name|stream_name", in)
+
+	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(`CREATE STREAM "database_name"."schema_name"."stream_name" ON STAGE "target_db"."target_schema"."target_stage" COMMENT = 'great comment'`).WillReturnResult(sqlmock.NewResult(1, 1))
+		expectStreamRead(mock)
+		expectOnStageRead(mock, true)
+		err := resources.CreateStream(d, db)
+		r.NoError(err)
+		r.Equal("stream_name", d.Get("name").(string))
+	})
+}
+
+func TestStreamCreateOnStageWithoutDirectoryEnabled(t *testing.T) {
+	r := require.New(t)
+
+	in := map[string]interface{}{
+		"name":     "stream_name",
+		"database": "database_name",
+		"schema":   "schema_name",
+		"comment":  "great comment",
+		"on_stage": "target_db.target_schema.target_stage",
+	}
+	d := stream(t, "database_name|schema_name|stream_name", in)
+
+	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		expectOnStageRead(mock, false)
+		err := resources.CreateStream(d, db)
+		r.Errorf(err, "directory must be enabled on stage")
+	})
+}
+
+func TestStreamOnMultipleSource(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
@@ -133,6 +174,18 @@ func expectOnExternalTableRead(mock sqlmock.Sqlmock) {
 func expectOnViewRead(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{"created_on", "name", "database_name", "schema_name", "kind", "comment", "cluster_by", "row", "bytes", "owner", "retention_time", "automatic_clustering", "change_tracking", "is_external"}).AddRow("", "target_view", "target_db", "target_schema", "VIEW", "mock comment", "", "", "", "", 1, "OFF", "OFF", "Y")
 	mock.ExpectQuery(`SHOW VIEWS LIKE 'target_view' IN SCHEMA "target_db"."target_schema"`).WillReturnRows(rows)
+}
+
+func expectOnStageRead(mock sqlmock.Sqlmock, directoryEnabled bool) {
+	rowsShow := sqlmock.NewRows([]string{"created_on", "name", "database_name", "schema_name", "url", "has_credentials", "has_encryption_key", "owner", "comment", "region", "type", "cloud", "notification_channel", "storage_integration"}).AddRow("", "target_stage", "target_db", "target_schema", "", "N", "N", "", "mock comment", nil, "INTERNAL", nil, nil, nil)
+	mock.ExpectQuery(`SHOW STAGES LIKE 'target_stage' IN SCHEMA "target_db"."target_schema"`).WillReturnRows(rowsShow)
+
+	var directoryEnabledStr = "false"
+	if directoryEnabled {
+		directoryEnabledStr = "true"
+	}
+	rowsDesc := sqlmock.NewRows([]string{"parent_property", "property", "property_type", "property_value", "property_default"}).AddRow("DIRECTORY", "ENABLE", "Boolean", directoryEnabledStr, "false")
+	mock.ExpectQuery(`DESCRIBE STAGE "target_db"."target_schema"."target_stage"`).WillReturnRows(rowsDesc)
 }
 
 func TestStreamRead(t *testing.T) {

--- a/pkg/snowflake/stream.go
+++ b/pkg/snowflake/stream.go
@@ -18,6 +18,7 @@ type StreamBuilder struct {
 	externalTable   bool
 	onTable         string
 	onView          string
+	onStage         string
 	appendOnly      bool
 	insertOnly      bool
 	showInitialRows bool
@@ -62,6 +63,11 @@ func (sb *StreamBuilder) WithExternalTable(b bool) *StreamBuilder {
 
 func (sb *StreamBuilder) WithOnView(d string, s string, t string) *StreamBuilder {
 	sb.onView = fmt.Sprintf(`"%v"."%v"."%v"`, d, s, t)
+	return sb
+}
+
+func (sb *StreamBuilder) WithOnStage(d string, s string, t string) *StreamBuilder {
+	sb.onStage = fmt.Sprintf(`"%v"."%v"."%v"`, d, s, t)
 	return sb
 }
 
@@ -112,17 +118,21 @@ func (sb *StreamBuilder) Create() string {
 		q.WriteString(fmt.Sprintf(` TABLE %v`, sb.onTable))
 	} else if sb.onView != "" {
 		q.WriteString(fmt.Sprintf(` VIEW %v`, sb.onView))
+	} else if sb.onStage != "" {
+		q.WriteString(fmt.Sprintf(` STAGE %v`, sb.onStage))
 	}
 
 	if sb.comment != "" {
 		q.WriteString(fmt.Sprintf(` COMMENT = '%v'`, EscapeString(sb.comment)))
 	}
 
-	q.WriteString(fmt.Sprintf(` APPEND_ONLY = %v`, sb.appendOnly))
+	if sb.onStage == "" {
+		q.WriteString(fmt.Sprintf(` APPEND_ONLY = %v`, sb.appendOnly))
 
-	q.WriteString(fmt.Sprintf(` INSERT_ONLY = %v`, sb.insertOnly))
+		q.WriteString(fmt.Sprintf(` INSERT_ONLY = %v`, sb.insertOnly))
 
-	q.WriteString(fmt.Sprintf(` SHOW_INITIAL_ROWS = %v`, sb.showInitialRows))
+		q.WriteString(fmt.Sprintf(` SHOW_INITIAL_ROWS = %v`, sb.showInitialRows))
+	}
 
 	return q.String()
 }

--- a/pkg/snowflake/stream_test.go
+++ b/pkg/snowflake/stream_test.go
@@ -29,6 +29,17 @@ func TestStreamCreate(t *testing.T) {
 	r.Equal(`CREATE STREAM "test_db"."test_schema"."test_stream" ON EXTERNAL TABLE "test_db"."test_schema"."test_target_table" COMMENT = 'Test Comment' APPEND_ONLY = true INSERT_ONLY = true SHOW_INITIAL_ROWS = true`, s.Create())
 }
 
+func TestStreamOnStageCreate(t *testing.T) {
+	r := require.New(t)
+	s := Stream("test_stream", "test_db", "test_schema")
+
+	s.WithOnStage("test_db", "test_schema", "test_target_stage")
+	r.Equal(`CREATE STREAM "test_db"."test_schema"."test_stream" ON STAGE "test_db"."test_schema"."test_target_stage"`, s.Create())
+
+	s.WithComment("Test Comment")
+	r.Equal(`CREATE STREAM "test_db"."test_schema"."test_stream" ON STAGE "test_db"."test_schema"."test_target_stage" COMMENT = 'Test Comment'`, s.Create())
+}
+
 func TestStreamChangeComment(t *testing.T) {
 	r := require.New(t)
 	s := Stream("test_stream", "test_db", "test_schema")


### PR DESCRIPTION
This PR adds support for Streams to work with Stages.

## Test Plan
I've just used the `make test` command locally
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] compatibility with https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/pkg/resources/stream.go#L257
* [ ] compatibility with https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/pkg/snowflake/stream.go#L150

^ I wasnt sure on whether those 2 functions needed to be updated or not, so left it for now.

## References
Full disclosure: this is my first time contributing to a terraform provider project, so I'm not 100% sure if I've changed all the correct things. If I've missed anything, let me know and I'll add it in.

* https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1412