### PR TITLE
fix: Don't throw an error on unhandled Role Grants

### DIFF
--- a/pkg/resources/role_grants.go
+++ b/pkg/resources/role_grants.go
@@ -145,7 +145,7 @@ func ReadRoleGrants(d *schema.ResourceData, meta interface{}) error {
 				}
 			}
 		default:
-			return fmt.Errorf("unknown grant type %s", grant.GrantedTo.String)
+			log.Printf("[WARN] Ignoring unknown grant type %s", grant.GrantedTo.String)
 		}
 	}
 


### PR DESCRIPTION
Some preview functionality to Snowflake can result in extra role grants which can break this provider, e.g. `unknown grantee type ...`. While it's not a great idea to update this provider with non-public role grants, it's very helpful to simply ignore the roles that the provider doesn't currently handle.

## Test Plan
* [ ] acceptance tests
* [ ] acceptance test against a Snowflake account with a preview enabled which adds new role grants

## References
None

I'll see if I can get the acceptance tests working against such an account.