### PR TITLE
fix: schema_name is optional to enable future pipe grant

### DIFF
--- a/docs/resources/pipe_grant.md
+++ b/docs/resources/pipe_grant.md
@@ -32,7 +32,6 @@ resource "snowflake_pipe_grant" "grant" {
 ### Required
 
 - `database_name` (String) The name of the database containing the current or future pipes on which to grant privileges.
-- `schema_name` (String) The name of the schema containing the current or future pipes on which to grant privileges.
 
 ### Optional
 
@@ -41,6 +40,7 @@ resource "snowflake_pipe_grant" "grant" {
 - `pipe_name` (String) The name of the pipe on which to grant privileges immediately (only valid if on_future is false).
 - `privilege` (String) The privilege to grant on the current or future pipe.
 - `roles` (Set of String) Grants privilege to these roles.
+- `schema_name` (String) The name of the schema containing the current or future pipes on which to grant privileges.
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.
 
 ### Read-Only

--- a/pkg/resources/pipe_grant.go
+++ b/pkg/resources/pipe_grant.go
@@ -90,7 +90,7 @@ func PipeGrant() *TerraformGrantResource {
 // CreatePipeGrant implements schema.CreateFunc.
 func CreatePipeGrant(d *schema.ResourceData, meta interface{}) error {
 	var (
-		pipeName string
+		pipeName   string
 		schemaName string
 	)
 	if name, ok := d.GetOk("pipe_name"); ok {
@@ -161,7 +161,7 @@ func ReadPipeGrant(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	onFuture := (pipeName == "")
-	
+
 	if err := d.Set("pipe_name", pipeName); err != nil {
 		return err
 	}


### PR DESCRIPTION
- `schema_name` optional for future pipe grants
- Rename `futurePipes` to `onFuture` for consistency

## Test Plan
```
make test
CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic  ./...
?       github.com/Snowflake-Labs/terraform-provider-snowflake  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/datasources  3.711s  coverage: 3.7% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/db   [no test files]
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers      [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider     2.318s  coverage: 25.5% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources    14.246s coverage: 48.2% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake    1.247s  coverage: 52.0% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/validation   0.999s  coverage: 38.0% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/version      [no test files]
```

## References
https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1219