### PR TITLE
fix: add us-east4.gcp to regionMapping

### DIFF
--- a/pkg/snowflake/current_account.go
+++ b/pkg/snowflake/current_account.go
@@ -23,6 +23,7 @@ var regionMapping = map[string]string{
 	"aws_ap_southeast_1":     "ap-southeast-1",
 	"aws_ap_southeast_2":     "ap-southeast-2",
 	"gcp_us_central1":        "us-central1.gcp",
+	"gcp_us_east4":           "us-east4.gcp",
 	"gcp_europe_west2":       "europe-west2.gcp",
 	"gcp_europe_west4":       "europe-west4.gcp",
 	"azure_westus2":          "west-us-2.azure",


### PR DESCRIPTION

<!-- summary of changes -->

added the region us-east4.gcp to regionMapping. currently snowflake_current_acount values resolve in nulls

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* 