### PR TITLE
feat: Support for UpdateResourceMonitor

### DIFF
--- a/pkg/resources/resource_monitor_acceptance_test.go
+++ b/pkg/resources/resource_monitor_acceptance_test.go
@@ -27,6 +27,15 @@ func TestAcc_ResourceMonitor(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "set_for_account", "false"),
 				),
 			},
+			// CHANGE PROPERTIES
+			{
+				Config: resourceMonitorConfig2(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "name", name),
+					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "credit_quota", "150"),
+					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "set_for_account", "false"),
+				),
+			},
 			// IMPORT
 			{
 				ResourceName:      "snowflake_resource_monitor.test",
@@ -42,6 +51,16 @@ func resourceMonitorConfig(accName string) string {
 resource "snowflake_resource_monitor" "test" {
 	name            = "%v"
 	credit_quota    = 100
+	set_for_account = false
+}
+`, accName)
+}
+
+func resourceMonitorConfig2(accName string) string {
+	return fmt.Sprintf(`
+resource "snowflake_resource_monitor" "test" {
+	name            = "%v"
+	credit_quota    = 150
 	set_for_account = false
 }
 `, accName)


### PR DESCRIPTION
Add basic support for `UpdateResourceMonitor`

Checks `credit_quota`, `frequency`, `start_timestamp`, and `end_timestamp`

## Test Plan
```
make test
CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic  ./...
?       github.com/Snowflake-Labs/terraform-provider-snowflake  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/datasources  2.537s  coverage: 3.6% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/db   [no test files]
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers      [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider     1.797s  coverage: 25.5% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources    14.257s coverage: 47.2% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake    1.050s  coverage: 46.9% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/validation   1.494s  coverage: 31.8% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/version      [no test files]
```

## References
- https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1310
- https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/876
