### PR TITLE
fix: saml2_sign_request and saml2_force_authn cast type

### DIFF
--- a/pkg/resources/saml_integration.go
+++ b/pkg/resources/saml_integration.go
@@ -184,7 +184,7 @@ func CreateSAMLIntegration(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if _, ok := d.GetOk("saml2_sign_request"); ok {
-		stmt.SetString(`SAML2_SIGN_REQUEST`, d.Get("saml2_sign_request").(string))
+		stmt.SetBool(`SAML2_SIGN_REQUEST`, d.Get("saml2_sign_request").(bool))
 	}
 
 	if _, ok := d.GetOk("saml2_requested_nameid_format"); ok {

--- a/pkg/resources/saml_integration.go
+++ b/pkg/resources/saml_integration.go
@@ -196,7 +196,7 @@ func CreateSAMLIntegration(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if _, ok := d.GetOk("saml2_force_authn"); ok {
-		stmt.SetString(`SAML2_FORCE_AUTHN`, d.Get("saml2_force_authn").(string))
+		stmt.SetBool(`SAML2_FORCE_AUTHN`, d.Get("saml2_force_authn").(bool))
 	}
 
 	if _, ok := d.GetOk("saml2_snowflake_issuer_url"); ok {


### PR DESCRIPTION
* Fix `saml2_sign_request` cast type which leads to plugin crash:
```
Stack trace from the terraform-provider-snowflake_v0.54.0 plugin:

panic: interface conversion: interface {} is bool, not string

goroutine 16 [running]:
github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources.CreateSAMLIntegration(0x0?, {0x103bf9e00?, 0x140000b7ba0})
        github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources/saml_integration.go:187 +0x9a4
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0x103c23c20?, {0x103c23c20?, 0x14000495a40?}, 0xd?, {0x103bf9e00?, 0x140000b7ba0?})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/resource.go:695 +0x134
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0x140001f9180, {0x103c23c20, 0x14000495a40}, 0x1400043c820, 0x14000215180, {0x103bf9e00, 0x140000b7ba0})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/resource.go:837 +0x86c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0x14000321e78, {0x103c23c20?, 0x14000495920?}, 0x14000376500)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/grpc_provider.go:1021 +0xb70
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0x1400027f180, {0x103c23c20?, 0x14000495110?}, 0x140002d1960)
        github.com/hashicorp/terraform-plugin-go@v0.14.1/tfprotov5/tf5server/server.go:818 +0x3b8
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x103bc6d60?, 0x1400027f180}, {0x103c23c20, 0x14000495110}, 0x140002d1880, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.14.1/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0x140000ea000, {0x103c29660, 0x14000582680}, 0x1400014d200, 0x14000576240, 0x10437c9c0, 0x0)
        google.golang.org/grpc@v1.50.1/server.go:1340 +0xb7c
google.golang.org/grpc.(*Server).handleStream(0x140000ea000, {0x103c29660, 0x14000582680}, 0x1400014d200, 0x0)
        google.golang.org/grpc@v1.50.1/server.go:1713 +0x82c
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        google.golang.org/grpc@v1.50.1/server.go:965 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.50.1/server.go:963 +0x290

Error: The terraform-provider-snowflake_v0.54.0 plugin crashed!
```
* Fix `saml2_force_authn` cast type

## Test Plan

```
CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic  ./...
?       github.com/Snowflake-Labs/terraform-provider-snowflake  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/datasources  0.687s  coverage: 3.6% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/db   [no test files]
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers      [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider     0.538s  coverage: 25.5% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources    11.094s coverage: 47.3% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake    0.313s  coverage: 46.9% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/validation   0.393s  coverage: 31.8% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/version      [no test files]
```

## References
-