### PR TITLE
feat: add in more functionality for UpdateResourceMonitor 

### DIFF
--- a/pkg/resources/helper_expansion.go
+++ b/pkg/resources/helper_expansion.go
@@ -1,5 +1,7 @@
 package resources
 
+import "golang.org/x/exp/slices"
+
 // borrowed from https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/structure.go#L924:6
 
 func expandIntList(configured []interface{}) []int {
@@ -35,4 +37,17 @@ func expandObjectIdentifier(objectIdentifier interface{}) (string, string, strin
 		objectDatabase = v.(string)
 	}
 	return objectDatabase, objectSchema, objectName
+}
+
+// intersectionAAndNotB takes the intersection of set A and the intersection of not set B. A∩B′ in set notation.
+func intersectionAAndNotB(setA []interface{}, setB []interface{}) []string {
+	res := make([]string, 0)
+	sliceA := expandStringList(setA)
+	sliceB := expandStringList(setB)
+	for _, s := range sliceA {
+		if !slices.Contains(sliceB, s) {
+			res = append(res, s)
+		}
+	}
+	return res
 }

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -287,22 +287,22 @@ func inSlice(n string, h []string) bool {
 	return false
 }
 
-// convertTerraformSetToStringSlice turns a terraform set into a string slice
+// convertTerraformSetToStringSlice turns a terraform set into a string slice.
 func convertTerraformSetToStringSlice(i interface{}) []string {
-	var s []string
-	for _, w := range i.(*schema.Set).List() {
-		s = append(s, w.(string))
+	s := make([]string, len(i.(*schema.Set).List()))
+	for x, w := range i.(*schema.Set).List() {
+		s[x] = w.(string)
 	}
 	return s
 }
 
 // compareTerraformSets compares two terraform sets and returns a string slice of all values in the first set that is
 // not in the second set.
-func compareTerraformSets(firstSet interface{}, SecondSet interface{}) []string {
+func compareTerraformSets(firstSet interface{}, secondSet interface{}) []string {
 	res := make([]string, 0)
 	sliceOne := convertTerraformSetToStringSlice(firstSet)
 
-	sliceTwo := convertTerraformSetToStringSlice(SecondSet)
+	sliceTwo := convertTerraformSetToStringSlice(secondSet)
 
 	for _, s := range sliceOne {
 		if !inSlice(s, sliceTwo) {
@@ -369,7 +369,7 @@ func UpdateResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Remove from account
-	if d.HasChange("set_for_account") && d.Get("set_for_account").(bool) == false {
+	if d.HasChange("set_for_account") && !d.Get("set_for_account").(bool) {
 		if err := snowflake.Exec(db, stmt.UnsetOnAccount()); err != nil {
 			return fmt.Errorf("error unsetting resource monitor %v on account err = %w", id, err)
 		}

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -25,7 +25,6 @@ var resourceMonitorSchema = map[string]*schema.Schema{
 	"notify_users": {
 		Type:        schema.TypeSet,
 		Optional:    true,
-		ForceNew:    true,
 		Description: "Specifies the list of users to receive email notifications on resource monitors.",
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
@@ -60,35 +59,30 @@ var resourceMonitorSchema = map[string]*schema.Schema{
 		Elem:        &schema.Schema{Type: schema.TypeInt},
 		Optional:    true,
 		Description: "A list of percentage thresholds at which to suspend all warehouses.",
-		ForceNew:    true,
 	},
 	"suspend_immediate_triggers": {
 		Type:        schema.TypeSet,
 		Elem:        &schema.Schema{Type: schema.TypeInt},
 		Optional:    true,
 		Description: "A list of percentage thresholds at which to immediately suspend all warehouses.",
-		ForceNew:    true,
 	},
 	"notify_triggers": {
 		Type:        schema.TypeSet,
 		Elem:        &schema.Schema{Type: schema.TypeInt},
 		Optional:    true,
 		Description: "A list of percentage thresholds at which to send an alert to subscribed users.",
-		ForceNew:    true,
 	},
 	"set_for_account": {
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Description: "Specifies whether the resource monitor should be applied globally to your Snowflake account.",
 		Default:     false,
-		ForceNew:    true,
 	},
 	"warehouses": {
 		Type:        schema.TypeSet,
 		Optional:    true,
 		Description: "A list of warehouses to apply the resource monitor to.",
 		Elem:        &schema.Schema{Type: schema.TypeString},
-		ForceNew:    true,
 	},
 }
 
@@ -107,7 +101,7 @@ func ResourceMonitor() *schema.Resource {
 	}
 }
 
-// CreateResourceMonitor implents schema.CreateFunc.
+// CreateResourceMonitor implements schema.CreateFunc.
 func CreateResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	name := d.Get("name").(string)
@@ -283,12 +277,53 @@ func extractTriggerInts(s sql.NullString) ([]int, error) {
 	return out, nil
 }
 
+// inSlice returns true if n is in string slice h otherwise false.
+func inSlice(n string, h []string) bool {
+	for _, v := range h {
+		if v == n {
+			return true
+		}
+	}
+	return false
+}
+
+// convertTerraformSetToStringSlice turns a terraform set into a string slice
+func convertTerraformSetToStringSlice(i interface{}) []string {
+	var s []string
+	for _, w := range i.(*schema.Set).List() {
+		s = append(s, w.(string))
+	}
+	return s
+}
+
+// compareTerraformSets compares two terraform sets and returns a string slice of all values in the first set that is
+// not in the second set.
+func compareTerraformSets(firstSet interface{}, SecondSet interface{}) []string {
+	res := make([]string, 0)
+	sliceOne := convertTerraformSetToStringSlice(firstSet)
+
+	sliceTwo := convertTerraformSetToStringSlice(SecondSet)
+
+	for _, s := range sliceOne {
+		if !inSlice(s, sliceTwo) {
+			res = append(res, s)
+		}
+	}
+	return res
+}
+
+// UpdateResourceMonitor implements schema.UpdateFunc.
 func UpdateResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	id := d.Id()
 
 	stmt := snowflake.NewResourceMonitorBuilder(id).Alter()
 	var runSetStatement bool
+
+	if d.HasChange("notify_users") {
+		runSetStatement = true
+		stmt.SetStringList(`NOTIFY_USERS`, expandStringList(d.Get("notify_users").(*schema.Set).List()))
+	}
 
 	if d.HasChange("credit_quota") {
 		runSetStatement = true
@@ -310,9 +345,62 @@ func UpdateResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 		stmt.SetString(`END_TIMESTAMP`, d.Get("end_timestamp").(string))
 	}
 
+	// Set triggers
+	sTrigs := expandIntList(d.Get("suspend_triggers").(*schema.Set).List())
+	for _, t := range sTrigs {
+		runSetStatement = true
+		stmt.SuspendAt(t)
+	}
+	siTrigs := expandIntList(d.Get("suspend_immediate_triggers").(*schema.Set).List())
+	for _, t := range siTrigs {
+		runSetStatement = true
+		stmt.SuspendImmediatelyAt(t)
+	}
+	nTrigs := expandIntList(d.Get("notify_triggers").(*schema.Set).List())
+	for _, t := range nTrigs {
+		runSetStatement = true
+		stmt.NotifyAt(t)
+	}
+
 	if runSetStatement {
 		if err := snowflake.Exec(db, stmt.Statement()); err != nil {
 			return fmt.Errorf("error updating resource monitor %v\n%w", id, err)
+		}
+	}
+
+	// Remove from account
+	if d.HasChange("set_for_account") && d.Get("set_for_account").(bool) == false {
+		if err := snowflake.Exec(db, stmt.UnsetOnAccount()); err != nil {
+			return fmt.Errorf("error unsetting resource monitor %v on account err = %w", id, err)
+		}
+	}
+
+	// Remove from all old warehouses
+	if d.HasChange("warehouses") {
+		oldV, v := d.GetChange("warehouses")
+		res := compareTerraformSets(oldV, v)
+		for _, w := range res {
+			if err := snowflake.Exec(db, stmt.UnsetOnWarehouse(w)); err != nil {
+				return fmt.Errorf("error setting resource monitor %v on warehouse %v err = %w", id, w, err)
+			}
+		}
+	}
+
+	// Add to account
+	if d.HasChange("set_for_account") && d.Get("set_for_account").(bool) {
+		if err := snowflake.Exec(db, stmt.SetOnAccount()); err != nil {
+			return fmt.Errorf("error setting resource monitor %v on account err = %w", id, err)
+		}
+	}
+
+	// Add to all new warehouses
+	if d.HasChange("warehouses") {
+		oldV, v := d.GetChange("warehouses")
+		res := compareTerraformSets(v, oldV)
+		for _, w := range res {
+			if err := snowflake.Exec(db, stmt.SetOnWarehouse(w)); err != nil {
+				return fmt.Errorf("error setting resource monitor %v on warehouse %v err = %w", id, w, err)
+			}
 		}
 	}
 

--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -73,16 +73,18 @@ var resourceMonitorSchema = map[string]*schema.Schema{
 		Description: "A list of percentage thresholds at which to send an alert to subscribed users.",
 	},
 	"set_for_account": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "Specifies whether the resource monitor should be applied globally to your Snowflake account.",
-		Default:     false,
+		Type:          schema.TypeBool,
+		Optional:      true,
+		ConflictsWith: []string{"warehouses"},
+		Description:   "Specifies whether the resource monitor should be applied globally to your Snowflake account.",
+		Default:       false,
 	},
 	"warehouses": {
-		Type:        schema.TypeSet,
-		Optional:    true,
-		Description: "A list of warehouses to apply the resource monitor to.",
-		Elem:        &schema.Schema{Type: schema.TypeString},
+		Type:          schema.TypeSet,
+		Optional:      true,
+		ConflictsWith: []string{"set_for_account"},
+		Description:   "A list of warehouses to apply the resource monitor to.",
+		Elem:          &schema.Schema{Type: schema.TypeString},
 	},
 }
 

--- a/pkg/resources/resource_monitor_acceptance_test.go
+++ b/pkg/resources/resource_monitor_acceptance_test.go
@@ -25,6 +25,7 @@ func TestAcc_ResourceMonitor(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "name", name),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "credit_quota", "100"),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "set_for_account", "false"),
+					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "notify_triggers.0", "40"),
 				),
 			},
 			// CHANGE PROPERTIES
@@ -33,7 +34,8 @@ func TestAcc_ResourceMonitor(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "name", name),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "credit_quota", "150"),
-					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "set_for_account", "false"),
+					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "set_for_account", "true"),
+					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "notify_triggers.0", "50"),
 				),
 			},
 			// IMPORT
@@ -52,6 +54,7 @@ resource "snowflake_resource_monitor" "test" {
 	name            = "%v"
 	credit_quota    = 100
 	set_for_account = false
+  	notify_triggers = [40]
 }
 `, accName)
 }
@@ -61,7 +64,8 @@ func resourceMonitorConfig2(accName string) string {
 resource "snowflake_resource_monitor" "test" {
 	name            = "%v"
 	credit_quota    = 150
-	set_for_account = false
+	set_for_account = true
+	notify_triggers = [50]
 }
 `, accName)
 }

--- a/pkg/snowflake/resource_monitor.go
+++ b/pkg/snowflake/resource_monitor.go
@@ -214,7 +214,7 @@ func (rcb *ResourceMonitorAlterBuilder) SetOnAccount() string {
 }
 
 func (rcb *ResourceMonitorAlterBuilder) UnsetOnAccount() string {
-	return fmt.Sprintf(`ALTER ACCOUNT SET RESOURCE_MONITOR = NULL`)
+	return `ALTER ACCOUNT SET RESOURCE_MONITOR = NULL`
 }
 
 // SetOnWarehouse returns the SQL query that will set the resource monitor on the specified warehouse.

--- a/pkg/snowflake/resource_monitor.go
+++ b/pkg/snowflake/resource_monitor.go
@@ -52,18 +52,20 @@ type ResourceMonitorAlterBuilder struct {
 	triggers []trigger
 }
 
+type action string
+
 type trigger struct {
-	action    string
+	action    action
 	threshold int
 }
 
 const (
 	// SuspendTrigger suspends all assigned warehouses while allowing currently running queries to complete.
-	SuspendTrigger = "SUSPEND"
+	SuspendTrigger action = "SUSPEND"
 	// SuspendImmediatelyTrigger suspends all assigned warehouses immediately and cancel any currently running queries or statements using the warehouses.
-	SuspendImmediatelyTrigger = "SUSPEND_IMMEDIATE"
+	SuspendImmediatelyTrigger action = "SUSPEND_IMMEDIATE"
 	// NotifyTrigger sends an alert (to all users who have enabled notifications for themselves), but do not take any other action.
-	NotifyTrigger = "NOTIFY"
+	NotifyTrigger action = "NOTIFY"
 )
 
 // Create returns a pointer to a ResourceMonitorCreateBuilder.

--- a/pkg/snowflake/resource_monitor.go
+++ b/pkg/snowflake/resource_monitor.go
@@ -44,6 +44,14 @@ type ResourceMonitorCreateBuilder struct {
 	triggers []trigger
 }
 
+type ResourceMonitorAlterBuilder struct {
+	AlterPropertiesBuilder
+
+	// triggers consist of the type (DO SUSPEND | SUSPEND_IMMEDIATE | NOTIFY) and
+	// the threshold (a percentage value)
+	triggers []trigger
+}
+
 type trigger struct {
 	action    string
 	threshold int
@@ -132,6 +140,91 @@ func (rcb *ResourceMonitorCreateBuilder) SetOnAccount() string {
 // SetOnWarehouse returns the SQL query that will set the resource monitor on the specified warehouse.
 func (rcb *ResourceMonitorCreateBuilder) SetOnWarehouse(warehouse string) string {
 	return fmt.Sprintf(`ALTER WAREHOUSE "%v" SET RESOURCE_MONITOR = "%v"`, warehouse, rcb.name)
+}
+
+// Alter returns a pointer to a ResourceMonitorAlterBuilder.
+func (rb *ResourceMonitorBuilder) Alter() *ResourceMonitorAlterBuilder {
+	return &ResourceMonitorAlterBuilder{
+		AlterPropertiesBuilder{
+			name:                 rb.name,
+			entityType:           rb.entityType,
+			stringProperties:     make(map[string]string),
+			boolProperties:       make(map[string]bool),
+			intProperties:        make(map[string]int),
+			floatProperties:      make(map[string]float64),
+			stringListProperties: make(map[string][]string),
+		},
+		make([]trigger, 0),
+	}
+}
+
+// NotifyAt adds a notify trigger at the specified percentage threshold.
+func (rcb *ResourceMonitorAlterBuilder) NotifyAt(pct int) *ResourceMonitorAlterBuilder {
+	rcb.triggers = append(rcb.triggers, trigger{NotifyTrigger, pct})
+	return rcb
+}
+
+// SuspendAt adds a suspend trigger at the specified percentage threshold.
+func (rcb *ResourceMonitorAlterBuilder) SuspendAt(pct int) *ResourceMonitorAlterBuilder {
+	rcb.triggers = append(rcb.triggers, trigger{SuspendTrigger, pct})
+	return rcb
+}
+
+// SuspendImmediatelyAt adds a suspend immediately trigger at the specified percentage threshold.
+func (rcb *ResourceMonitorAlterBuilder) SuspendImmediatelyAt(pct int) *ResourceMonitorAlterBuilder {
+	rcb.triggers = append(rcb.triggers, trigger{SuspendImmediatelyTrigger, pct})
+	return rcb
+}
+
+// Statement returns the SQL statement needed to actually alter the resource.
+func (rcb *ResourceMonitorAlterBuilder) Statement() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf(`ALTER %v "%v" SET`, rcb.entityType, rcb.name))
+
+	for k, v := range rcb.stringProperties {
+		sb.WriteString(fmt.Sprintf(` %v='%v'`, strings.ToUpper(k), EscapeString(v)))
+	}
+
+	for k, v := range rcb.intProperties {
+		sb.WriteString(fmt.Sprintf(` %v=%d`, strings.ToUpper(k), v))
+	}
+
+	for k, v := range rcb.floatProperties {
+		sb.WriteString(fmt.Sprintf(` %v=%.2f`, strings.ToUpper(k), v))
+	}
+
+	for k, v := range rcb.stringListProperties {
+		sb.WriteString(fmt.Sprintf(" %s=%s", strings.ToUpper(k), formatStringList(v)))
+	}
+
+	if len(rcb.triggers) > 0 {
+		sb.WriteString(" TRIGGERS")
+	}
+
+	for _, trig := range rcb.triggers {
+		sb.WriteString(fmt.Sprintf(` ON %d PERCENT DO %v`, trig.threshold, trig.action))
+	}
+
+	return sb.String()
+}
+
+// SetOnAccount returns the SQL query that will set the resource monitor globally on your Snowflake account.
+func (rcb *ResourceMonitorAlterBuilder) SetOnAccount() string {
+	return fmt.Sprintf(`ALTER ACCOUNT SET RESOURCE_MONITOR = "%v"`, rcb.name)
+}
+
+func (rcb *ResourceMonitorAlterBuilder) UnsetOnAccount() string {
+	return fmt.Sprintf(`ALTER ACCOUNT SET RESOURCE_MONITOR = NULL`)
+}
+
+// SetOnWarehouse returns the SQL query that will set the resource monitor on the specified warehouse.
+func (rcb *ResourceMonitorAlterBuilder) SetOnWarehouse(warehouse string) string {
+	return fmt.Sprintf(`ALTER WAREHOUSE "%v" SET RESOURCE_MONITOR = "%v"`, warehouse, rcb.name)
+}
+
+// UnsetOnWarehouse returns the SQL query that will unset the resource monitor on the specified warehouse.
+func (rcb *ResourceMonitorAlterBuilder) UnsetOnWarehouse(warehouse string) string {
+	return fmt.Sprintf(`ALTER WAREHOUSE "%v" SET RESOURCE_MONITOR = NULL`, warehouse)
 }
 
 type ResourceMonitor struct {


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

resource_monitor now can update without creation and delation for 

- notify_users
- suspend_triggers
- notify_triggers
- set_for_account
- warehouses

Also fixed a typo in a comment implents to implements

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests


## References
<!-- issues documentation links, etc  -->
- https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1310
- https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/876
