### PR TITLE
Update system_get_privatelink_config.md

### DIFF
--- a/docs/data-sources/system_get_privatelink_config.md
+++ b/docs/data-sources/system_get_privatelink_config.md
@@ -59,7 +59,7 @@ resource "aws_route53_record" "snowflake_private_link_url" {
 }
 
 resource "aws_route53_record" "snowflake_private_link_ocsp_url" {
-  zone_id = aws_route53_zone.snowflake_private_link_url.zone_id
+  zone_id = aws_route53_zone.snowflake_private_link.zone_id
   name    = data.snowflake_system_get_privatelink_config.snowflake_private_link.ocsp_url
   type    = "CNAME"
   ttl     = "300"


### PR DESCRIPTION
`zone_id` value for the `snowflake_private_link_ocsp_url` is incorrect.

The value should be `aws_route53_zone.snowflake_private_link.zone_id` based on the resources configured in this example.

## Test Plan
N/A this is just a tiny documentation update.

## References
