### PR TITLE
fix: update on failover group

### DIFF
--- a/pkg/snowflake/failover_group.go
+++ b/pkg/snowflake/failover_group.go
@@ -151,7 +151,7 @@ func (b *FailoverGroupBuilder) ChangeObjectTypes(objectTypes []string) string {
 // ChangeReplicationCronSchedule returns the SQL query that will change the replication schedule of a failover group.
 func (b *FailoverGroupBuilder) ChangeReplicationCronSchedule(replicationScheduleCronExpression string, replicationScheduleTimeZone string) string {
 	q := strings.Builder{}
-	q.WriteString(fmt.Sprintf(`ALTER FAILOVER GROUP %v SET REPLICATION_SCHEDULE = 'CRON %v`, b.name, replicationScheduleCronExpression))
+	q.WriteString(fmt.Sprintf(`ALTER FAILOVER GROUP %v SET REPLICATION_SCHEDULE = 'USING CRON %v`, b.name, replicationScheduleCronExpression))
 
 	if replicationScheduleTimeZone != "" {
 		q.WriteString(fmt.Sprintf(` %v`, replicationScheduleTimeZone))
@@ -236,6 +236,7 @@ func ListFailoverGroups(db *sql.DB, accountLocator string) ([]FailoverGroup, err
 		log.Println("[DEBUG] no failover groups found")
 		return nil, nil
 	}
+
 	return v, nil
 }
 


### PR DESCRIPTION
This PR fixes update method on failover group. So previously when updating replication schedule would get an index out of range exception
```
Stack trace from the terraform-provider-snowflake_v0.55.0 plugin:
413panic: runtime error: index out of range [0] with length 0
414goroutine 107 [running]:[415github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources.UpdateFailoverGroup](https://415github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources.UpdateFailoverGroup)(0xc000532600, {0x12dc720?, 0xc00052f110?})
416 [github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources/failover_group.go:566](https://github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources/failover_group.go:566) +0x16cf[417github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).update](https://417github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).update)(0x15496e0?, {0x15496e0?, 0xc000906a80?}, 0xd?, {0x12dc720?, 0xc00052f110?})
418 [github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/resource.go:729](https://github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/resource.go:729) +0x178[419github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply](https://419github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply)(0xc000746380, {0x15496e0, 0xc000906a80}, 0xc00052e8f0, 0xc000532480, {0x12dc720, 0xc00052f110})
420 [github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/resource.go:847](https://github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/resource.go:847) +0x83a[421github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange](https://421github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange)(0xc000738cf0, {0x15496e0?, 0xc000906960?}, 0xc0001540a0)
422 [github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/grpc_provider.go:1021](https://github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/grpc_provider.go:1021) +0xe8d[423github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange](https://423github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange)(0xc0004219a0, {0x15496e0?, 0xc000906330?}, 0xc00024c3f0)
424 [github.com/hashicorp/terraform-plugin-go@v0.14.1/tfprotov5/tf5server/server.go:818](https://github.com/hashicorp/terraform-plugin-go@v0.14.1/tfprotov5/tf5server/server.go:818) +0x574[425github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler](https://425github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler)({0x12a8e40?, 0xc0004219a0}, {0x15496e0, 0xc000906330}, 0xc00024c1c0, 0x0)
426 [github.com/hashicorp/terraform-plugin-go@v0.14.1/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385](https://github.com/hashicorp/terraform-plugin-go@v0.14.1/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385) +0x170[427google.golang.org/grpc.(*Server).processUnaryRPC](https://427google.golang.org/grpc.(*Server).processUnaryRPC)(0xc000742000, {0x154f380, 0xc000582680}, 0xc000667200, 0xc00040e4b0, 0x1ce7dc0, 0x0)
428 [google.golang.org/grpc@v1.50.1/server.go:1340](https://google.golang.org/grpc@v1.50.1/server.go:1340) +0xd23[429google.golang.org/grpc.(*Server).handleStream](https://429google.golang.org/grpc.(*Server).handleStream)(0xc000742000, {0x154f380, 0xc000582680}, 0xc000667200, 0x0)
430 [google.golang.org/grpc@v1.50.1/server.go:1713](https://google.golang.org/grpc@v1.50.1/server.go:1713) +0xa2f[431google.golang.org/grpc.(*Server).serveStreams.func1.2()](https://431google.golang.org/grpc.(*Server).serveStreams.func1.2())
432 [google.golang.org/grpc@v1.50.1/server.go:965](https://google.golang.org/grpc@v1.50.1/server.go:965) +0x98
433created by [google.golang.org/grpc.(*Server).serveStreams.func1](https://google.golang.org/grpc.(*Server).serveStreams.func1)
434 [google.golang.org/grpc@v1.50.1/server.go:963](https://google.golang.org/grpc@v1.50.1/server.go:963) +0x28a
435Error: The terraform-provider-snowflake_v0.55.0 plugin crashed!
436This is always indicative of a bug within the plugin. It would be immensely
437helpful if you could report the crash with the plugin's maintainers so that it
438can be fixed. The output above should help diagnose the issue.

The error occurs when changing the replication schedule in Terraform.
```

The same fix that was done https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1417 needed to be implemented for update.
<!-- summary of changes -->

## Test Plan
Changing replication schedule, setting interval vs cron expression and verifying apply is succesful.

## References
<!-- issues documentation links, etc  -->

* 