### PR TITLE
fix: schema name is optional for future external_table_grant

### DIFF
--- a/docs/resources/external_table_grant.md
+++ b/docs/resources/external_table_grant.md
@@ -34,6 +34,7 @@ resource "snowflake_external_table_grant" "grant" {
 ### Required
 
 - `database_name` (String) The name of the database containing the current or future external tables on which to grant privileges.
+- `roles` (Set of String) Grants privilege to these roles.
 
 ### Optional
 
@@ -41,7 +42,6 @@ resource "snowflake_external_table_grant" "grant" {
 - `external_table_name` (String) The name of the external table on which to grant privileges immediately (only valid if on_future is false).
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future external tables in the given schema. When this is true and no schema_name is provided apply this grant on all future external tables in the given database. The external_table_name and shares fields must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future external table.
-- `roles` (Set of String) Grants privilege to these roles.
 - `schema_name` (String) The name of the schema containing the current or future external tables on which to grant privileges.
 - `shares` (Set of String) Grants privilege to these shares (only valid if on_future is false).
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.


### PR DESCRIPTION
Closes #996 
Closes #1115 

```
make test
CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic  ./...
?       github.com/Snowflake-Labs/terraform-provider-snowflake  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/datasources  4.077s  coverage: 3.6% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/db   [no test files]
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers      [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider     2.668s  coverage: 25.5% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources    12.826s coverage: 46.9% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake    1.318s  coverage: 46.8% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/validation   0.696s  coverage: 31.8% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/version      [no test files]
```
