### PR TITLE
fix: schema name is optional for future file_format_grant

### DIFF
--- a/docs/resources/file_format_grant.md
+++ b/docs/resources/file_format_grant.md
@@ -32,6 +32,7 @@ resource "snowflake_file_format_grant" "grant" {
 ### Required
 
 - `database_name` (String) The name of the database containing the current or future file formats on which to grant privileges.
+- `roles` (Set of String) Grants privilege to these roles.
 
 ### Optional
 
@@ -39,7 +40,6 @@ resource "snowflake_file_format_grant" "grant" {
 - `file_format_name` (String) The name of the file format on which to grant privileges immediately (only valid if on_future is false).
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future file formats in the given schema. When this is true and no schema_name is provided apply this grant on all future file formats in the given database. The file_format_name field must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future file format.
-- `roles` (Set of String) Grants privilege to these roles.
 - `schema_name` (String) The name of the schema containing the current or future file formats on which to grant privileges.
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.
 

--- a/docs/resources/file_format_grant.md
+++ b/docs/resources/file_format_grant.md
@@ -32,7 +32,6 @@ resource "snowflake_file_format_grant" "grant" {
 ### Required
 
 - `database_name` (String) The name of the database containing the current or future file formats on which to grant privileges.
-- `schema_name` (String) The name of the schema containing the current or future file formats on which to grant privileges.
 
 ### Optional
 
@@ -41,6 +40,7 @@ resource "snowflake_file_format_grant" "grant" {
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future file formats in the given schema. When this is true and no schema_name is provided apply this grant on all future file formats in the given database. The file_format_name field must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future file format.
 - `roles` (Set of String) Grants privilege to these roles.
+- `schema_name` (String) The name of the schema containing the current or future file formats on which to grant privileges.
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.
 
 ### Read-Only

--- a/pkg/resources/file_format_grant.go
+++ b/pkg/resources/file_format_grant.go
@@ -50,8 +50,8 @@ var fileFormatGrantSchema = map[string]*schema.Schema{
 	},
 	"roles": {
 		Type:        schema.TypeSet,
+		Required:    true,
 		Elem:        &schema.Schema{Type: schema.TypeString},
-		Optional:    true,
 		Description: "Grants privilege to these roles.",
 	},
 	"schema_name": {
@@ -105,6 +105,9 @@ func CreateFileFormatGrant(d *schema.ResourceData, meta interface{}) error {
 	}
 	if (fileFormatName != "") && onFuture {
 		return errors.New("file_format_name must be empty if on_future is true")
+	}
+	if (schemaName == "") && !onFuture {
+		return errors.New("schema_name must be set unless on_future is true")
 	}
 
 	var builder snowflake.GrantBuilder


### PR DESCRIPTION

```
make test
CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic  ./...
?       github.com/Snowflake-Labs/terraform-provider-snowflake  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/datasources  1.780s  coverage: 3.6% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/db   [no test files]
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers      [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider     2.523s  coverage: 25.5% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources    12.532s coverage: 46.9% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake    0.426s  coverage: 46.8% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/validation   0.268s  coverage: 31.8% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/version      [no test files]
```