### PR TITLE
fix: schema name is optional for future function_grant

### DIFF
--- a/docs/resources/function_grant.md
+++ b/docs/resources/function_grant.md
@@ -44,7 +44,7 @@ resource "snowflake_function_grant" "grant" {
 ### Required
 
 - `database_name` (String) The name of the database containing the current or future functions on which to grant privileges.
-- `schema_name` (String) The name of the schema containing the current or future functions on which to grant privileges.
+- `roles` (Set of String) Grants privilege to these roles.
 
 ### Optional
 
@@ -54,7 +54,7 @@ resource "snowflake_function_grant" "grant" {
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future functions in the given schema. When this is true and no schema_name is provided apply this grant on all future functions in the given database. The function_name, arguments, return_type, and shares fields must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future function. Must be one of `USAGE` or `OWNERSHIP`.
 - `return_type` (String) The return type of the function (must be present if function_name is present)
-- `roles` (Set of String) Grants privilege to these roles.
+- `schema_name` (String) The name of the schema containing the current or future functions on which to grant privileges.
 - `shares` (Set of String) Grants privilege to these shares (only valid if on_future is false).
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.
 

--- a/pkg/resources/function_grant.go
+++ b/pkg/resources/function_grant.go
@@ -77,13 +77,13 @@ var functionGrantSchema = map[string]*schema.Schema{
 	},
 	"roles": {
 		Type:        schema.TypeSet,
-		Required: true,
+		Required:    true,
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Description: "Grants privilege to these roles.",
 	},
 	"schema_name": {
 		Type:        schema.TypeString,
-		Optional: true,
+		Optional:    true,
 		Description: "The name of the schema containing the current or future functions on which to grant privileges.",
 		ForceNew:    true,
 	},


### PR DESCRIPTION
Closes #658 

```
make test
CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic  ./...
?       github.com/Snowflake-Labs/terraform-provider-snowflake  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/datasources  2.031s  coverage: 3.6% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/db   [no test files]
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers      [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider     2.735s  coverage: 25.5% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources    12.432s coverage: 46.9% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake    0.395s  coverage: 46.8% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/validation   0.253s  coverage: 31.8% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/version      [no test files]
```