### PR TITLE
fix: schema name is optional for future procedure_grant

### DIFF
--- a/docs/resources/procedure_grant.md
+++ b/docs/resources/procedure_grant.md
@@ -44,7 +44,7 @@ resource "snowflake_procedure_grant" "grant" {
 ### Required
 
 - `database_name` (String) The name of the database containing the current or future procedures on which to grant privileges.
-- `schema_name` (String) The name of the schema containing the current or future procedures on which to grant privileges.
+- `roles` (Set of String) Grants privilege to these roles.
 
 ### Optional
 
@@ -54,7 +54,7 @@ resource "snowflake_procedure_grant" "grant" {
 - `privilege` (String) The privilege to grant on the current or future procedure.
 - `procedure_name` (String) The name of the procedure on which to grant privileges immediately (only valid if on_future is false).
 - `return_type` (String) The return type of the procedure (must be present if procedure_name is present)
-- `roles` (Set of String) Grants privilege to these roles.
+- `schema_name` (String) The name of the schema containing the current or future procedures on which to grant privileges.
 - `shares` (Set of String) Grants privilege to these shares (only valid if on_future is false).
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.
 


### PR DESCRIPTION
Closes #682 
Closes #766 

```
make test
CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic  ./...
?       github.com/Snowflake-Labs/terraform-provider-snowflake  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/datasources  2.830s  coverage: 3.6% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/db   [no test files]
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers      [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider     2.052s  coverage: 25.5% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources    12.399s coverage: 46.9% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake    0.377s  coverage: 46.8% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/validation   0.227s  coverage: 31.8% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/version      [no test files]
```