### PR TITLE
fix: schema name is optional for future sequence_grant

### DIFF
--- a/docs/resources/sequence_grant.md
+++ b/docs/resources/sequence_grant.md
@@ -32,14 +32,14 @@ resource "snowflake_sequence_grant" "grant" {
 ### Required
 
 - `database_name` (String) The name of the database containing the current or future sequences on which to grant privileges.
-- `schema_name` (String) The name of the schema containing the current or future sequences on which to grant privileges.
+- `roles` (Set of String) Grants privilege to these roles.
 
 ### Optional
 
 - `enable_multiple_grants` (Boolean) When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.
 - `on_future` (Boolean) When this is set to true and a schema_name is provided, apply this grant on all future sequences in the given schema. When this is true and no schema_name is provided apply this grant on all future sequences in the given database. The sequence_name field must be unset in order to use on_future.
 - `privilege` (String) The privilege to grant on the current or future sequence.
-- `roles` (Set of String) Grants privilege to these roles.
+- `schema_name` (String) The name of the schema containing the current or future sequences on which to grant privileges.
 - `sequence_name` (String) The name of the sequence on which to grant privileges immediately (only valid if on_future is false).
 - `with_grant_option` (Boolean) When this is set to true, allows the recipient role to grant the privileges to other roles.
 

--- a/pkg/resources/sequence_grant.go
+++ b/pkg/resources/sequence_grant.go
@@ -14,22 +14,24 @@ var validSequencePrivileges = NewPrivilegeSet(
 )
 
 var sequenceGrantSchema = map[string]*schema.Schema{
-	"sequence_name": {
-		Type:        schema.TypeString,
-		Optional:    true,
-		Description: "The name of the sequence on which to grant privileges immediately (only valid if on_future is false).",
-		ForceNew:    true,
-	},
-	"schema_name": {
-		Type:        schema.TypeString,
-		Required:    true,
-		Description: "The name of the schema containing the current or future sequences on which to grant privileges.",
-		ForceNew:    true,
-	},
 	"database_name": {
 		Type:        schema.TypeString,
 		Required:    true,
 		Description: "The name of the database containing the current or future sequences on which to grant privileges.",
+		ForceNew:    true,
+	},
+	"enable_multiple_grants": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
+		Default:     false,
+		ForceNew:    true,
+	},
+	"on_future": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "When this is set to true and a schema_name is provided, apply this grant on all future sequences in the given schema. When this is true and no schema_name is provided apply this grant on all future sequences in the given database. The sequence_name field must be unset in order to use on_future.",
+		Default:     false,
 		ForceNew:    true,
 	},
 	"privilege": {
@@ -42,28 +44,26 @@ var sequenceGrantSchema = map[string]*schema.Schema{
 	},
 	"roles": {
 		Type:        schema.TypeSet,
+		Required:    true,
 		Elem:        &schema.Schema{Type: schema.TypeString},
-		Optional:    true,
 		Description: "Grants privilege to these roles.",
 	},
-	"on_future": {
-		Type:        schema.TypeBool,
+	"schema_name": {
+		Type:        schema.TypeString,
 		Optional:    true,
-		Description: "When this is set to true and a schema_name is provided, apply this grant on all future sequences in the given schema. When this is true and no schema_name is provided apply this grant on all future sequences in the given database. The sequence_name field must be unset in order to use on_future.",
-		Default:     false,
+		Description: "The name of the schema containing the current or future sequences on which to grant privileges.",
+		ForceNew:    true,
+	},
+	"sequence_name": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The name of the sequence on which to grant privileges immediately (only valid if on_future is false).",
 		ForceNew:    true,
 	},
 	"with_grant_option": {
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Description: "When this is set to true, allows the recipient role to grant the privileges to other roles.",
-		Default:     false,
-		ForceNew:    true,
-	},
-	"enable_multiple_grants": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When this is set to true, multiple grants of the same type can be created. This will cause Terraform to not revoke grants applied to roles and objects outside Terraform.",
 		Default:     false,
 		ForceNew:    true,
 	},
@@ -96,19 +96,22 @@ func CreateSequenceGrant(d *schema.ResourceData, meta interface{}) error {
 	dbName := d.Get("database_name").(string)
 	schemaName := d.Get("schema_name").(string)
 	priv := d.Get("privilege").(string)
-	futureSequences := d.Get("on_future").(bool)
+	onFuture := d.Get("on_future").(bool)
 	grantOption := d.Get("with_grant_option").(bool)
 	roles := expandStringList(d.Get("roles").(*schema.Set).List())
 
-	if (sequenceName == "") && !futureSequences {
+	if (sequenceName == "") && !onFuture {
 		return errors.New("sequence_name must be set unless on_future is true")
 	}
-	if (sequenceName != "") && futureSequences {
+	if (sequenceName != "") && onFuture {
 		return errors.New("sequence_name must be empty if on_future is true")
+	}
+	if (schemaName == "") && !onFuture {
+		return errors.New("schema_name must be set unless on_future is true")
 	}
 
 	var builder snowflake.GrantBuilder
-	if futureSequences {
+	if onFuture {
 		builder = snowflake.FutureSequenceGrant(dbName, schemaName)
 	} else {
 		builder = snowflake.SequenceGrant(dbName, schemaName, sequenceName)
@@ -152,14 +155,14 @@ func ReadSequenceGrant(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("schema_name", schemaName); err != nil {
 		return err
 	}
-	futureSequencesEnabled := false
+	onFuture := false
 	if sequenceName == "" {
-		futureSequencesEnabled = true
+		onFuture = true
 	}
 	if err := d.Set("sequence_name", sequenceName); err != nil {
 		return err
 	}
-	if err := d.Set("on_future", futureSequencesEnabled); err != nil {
+	if err := d.Set("on_future", onFuture); err != nil {
 		return err
 	}
 	if err := d.Set("privilege", priv); err != nil {
@@ -170,13 +173,13 @@ func ReadSequenceGrant(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	var builder snowflake.GrantBuilder
-	if futureSequencesEnabled {
+	if onFuture {
 		builder = snowflake.FutureSequenceGrant(dbName, schemaName)
 	} else {
 		builder = snowflake.SequenceGrant(dbName, schemaName, sequenceName)
 	}
 
-	return readGenericGrant(d, meta, sequenceGrantSchema, builder, futureSequencesEnabled, validSequencePrivileges)
+	return readGenericGrant(d, meta, sequenceGrantSchema, builder, onFuture, validSequencePrivileges)
 }
 
 // DeleteSequenceGrant implements schema.DeleteFunc.
@@ -189,10 +192,10 @@ func DeleteSequenceGrant(d *schema.ResourceData, meta interface{}) error {
 	schemaName := grantID.SchemaName
 	sequenceName := grantID.ObjectName
 
-	futureSequences := (sequenceName == "")
+	onFuture := (sequenceName == "")
 
 	var builder snowflake.GrantBuilder
-	if futureSequences {
+	if onFuture {
 		builder = snowflake.FutureSequenceGrant(dbName, schemaName)
 	} else {
 		builder = snowflake.SequenceGrant(dbName, schemaName, sequenceName)
@@ -223,10 +226,10 @@ func UpdateSequenceGrant(d *schema.ResourceData, meta interface{}) error {
 	dbName := grantID.ResourceName
 	schemaName := grantID.SchemaName
 	sequenceName := grantID.ObjectName
-	futureSequences := (sequenceName == "")
+	onFuture := (sequenceName == "")
 
 	var builder snowflake.GrantBuilder
-	if futureSequences {
+	if onFuture {
 		builder = snowflake.FutureSequenceGrant(dbName, schemaName)
 	} else {
 		builder = snowflake.SequenceGrant(dbName, schemaName, sequenceName)


### PR DESCRIPTION
Closes #1197 

```
make test
CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic  ./...
?       github.com/Snowflake-Labs/terraform-provider-snowflake  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/datasources  1.784s  coverage: 3.6% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/db   [no test files]
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers      [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider     2.444s  coverage: 25.5% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources    12.531s coverage: 46.9% of statements
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake    0.308s  coverage: 46.8% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers  [no test files]
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/validation   0.188s  coverage: 31.8% of statements
?       github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/version      [no test files]
```