### PR TITLE
fix: multiple share grants

### DIFF
--- a/pkg/resources/grant_helpers.go
+++ b/pkg/resources/grant_helpers.go
@@ -271,13 +271,13 @@ func readGenericGrant(
 	multipleGrantFeatureFlag := d.Get("enable_multiple_grants").(bool)
 	var roles, shares []string
 
-	// Now see which roles have our privilege
+	// Now see which roles have our privilege.
 	for roleName, privileges := range rolePrivileges {
 		if privileges.hasString(priv) {
-			// If multiple grants is not enabled then we care about what roles have privilige
+			// If multiple grants is not enabled then we care about what roles have privilige.
 			if !multipleGrantFeatureFlag {
 				roles = append(roles, roleName)
-				// otherwise we only care if the role is something we are already managing, or if future object grants are enabled
+				// otherwise we only care if the role is something we are already managing, or if future object grants are enabled.
 			} else if existingRoles.Contains(roleName) && !futureObjects {
 				roles = append(roles, roleName)
 			}
@@ -285,14 +285,14 @@ func readGenericGrant(
 	}
 
 	existingShares := d.Get("shares").(*schema.Set)
-	// Now see which shares have our privilege
+	// Now see which shares have our privilege.
 	for shareName, privileges := range sharePrivileges {
 		if privileges.hasString(priv) {
-			// If multiple grants is not enabled then we care about what shares have privilige
+			// If multiple grants is not enabled then we care about what shares have privilige.
 			if !multipleGrantFeatureFlag {
 				shares = append(shares, shareName)
 			} else if existingShares.Contains(shareName) && !futureObjects {
-				// otherwise we only care if the share is something we are already managing or if future object grants are enabled
+				// otherwise we only care if the share is something we are already managing or if future object grants are enabled.
 				shares = append(shares, shareName)
 			}
 		}

--- a/pkg/resources/grant_helpers.go
+++ b/pkg/resources/grant_helpers.go
@@ -267,10 +267,12 @@ func readGenericGrant(
 		}
 	}
 
-	existingRoles := d.Get("roles").(*schema.Set)
+	var existingRoles *schema.Set
+	if v, ok := d.GetOk("roles"); ok {
+		existingRoles = v.(*schema.Set)
+	}
 	multipleGrantFeatureFlag := d.Get("enable_multiple_grants").(bool)
 	var roles, shares []string
-
 	// Now see which roles have our privilege.
 	for roleName, privileges := range rolePrivileges {
 		if privileges.hasString(priv) {
@@ -284,7 +286,10 @@ func readGenericGrant(
 		}
 	}
 
-	existingShares := d.Get("shares").(*schema.Set)
+	var existingShares *schema.Set
+	if v, ok := d.GetOk("shares"); ok {
+		existingShares = v.(*schema.Set)
+	}
 	// Now see which shares have our privilege.
 	for shareName, privileges := range sharePrivileges {
 		if privileges.hasString(priv) {

--- a/pkg/resources/grant_helpers.go
+++ b/pkg/resources/grant_helpers.go
@@ -277,11 +277,9 @@ func readGenericGrant(
 			// If multiple grants is not enabled then we care about what roles have privilige
 			if !multipleGrantFeatureFlag {
 				roles = append(roles, roleName)
-			} else {
 				// otherwise we only care if the role is something we are already managing, or if future object grants are enabled
-				if existingRoles.Contains(roleName) && !futureObjects {
-					roles = append(roles, roleName)
-				}
+			} else if existingRoles.Contains(roleName) && !futureObjects {
+				roles = append(roles, roleName)
 			}
 		}
 	}
@@ -293,11 +291,9 @@ func readGenericGrant(
 			// If multiple grants is not enabled then we care about what shares have privilige
 			if !multipleGrantFeatureFlag {
 				shares = append(shares, shareName)
-			} else {
+			} else if existingShares.Contains(shareName) && !futureObjects {
 				// otherwise we only care if the share is something we are already managing or if future object grants are enabled
-				if existingShares.Contains(shareName) && !futureObjects {
-					shares = append(shares, shareName)
-				}
+				shares = append(shares, shareName)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->
closes #1459. cleans up some of the logic when enabling multiple grants . Previously if you had two grants that managed the same resources, then one would overwrite the other during subsequent apply.
<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests

## References
<!-- issues documentation links, etc  -->

* 