### PR TITLE
Add support for `packages`, `imports`, `handler` and `runtimeVersion` to `snowflake_procedure` resource

### DIFF
--- a/pkg/resources/procedure.go
+++ b/pkg/resources/procedure.go
@@ -89,7 +89,7 @@ var procedureSchema = map[string]*schema.Schema{
 	"statement": {
 		Type:             schema.TypeString,
 		Required:         true,
-		Description:      "Specifies the javascript code used to create the procedure.",
+		Description:      "Specifies the code used to create the procedure.",
 		ForceNew:         true,
 		DiffSuppressFunc: DiffSuppressStatement,
 	},
@@ -136,7 +136,7 @@ var procedureSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
 		ForceNew:    true,
-		Description: "Required for Python functions. Specifies Python runtime version.",
+		Description: "Required for Python procedures. Specifies Python runtime version.",
 	},
 	"packages": {
 		Type: schema.TypeList,
@@ -145,7 +145,7 @@ var procedureSchema = map[string]*schema.Schema{
 		},
 		Optional:    true,
 		ForceNew:    true,
-		Description: "List of package imports to use for Java / Python functions. For Java, package imports should be of the form: package_name:version_number, where package_name is snowflake_domain:package. For Python use it should be: ('numpy','pandas','xgboost==1.5.0').",
+		Description: "List of package imports to use for Java / Python procedures. For Java, package imports should be of the form: package_name:version_number, where package_name is snowflake_domain:package. For Python use it should be: ('numpy','pandas','xgboost==1.5.0').",
 	},
 	"imports": {
 		Type: schema.TypeList,
@@ -154,13 +154,13 @@ var procedureSchema = map[string]*schema.Schema{
 		},
 		Optional:    true,
 		ForceNew:    true,
-		Description: "Imports for Java / Python functions. For Java this a list of jar files, for Python this is a list of Python files.",
+		Description: "Imports for Java / Python procedures. For Java this a list of jar files, for Python this is a list of Python files.",
 	},
 	"handler": {
 		Type:        schema.TypeString,
 		Optional:    true,
 		ForceNew:    true,
-		Description: "The handler method for Java / Python function.",
+		Description: "The handler method for Java / Python procedures.",
 	},
 }
 

--- a/pkg/resources/procedure.go
+++ b/pkg/resources/procedure.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var procedureLanguages = []string{"javascript", "java", "scala", "SQL"}
+var procedureLanguages = []string{"javascript", "java", "scala", "SQL", "python"}
 
 var procedureSchema = map[string]*schema.Schema{
 	"name": {

--- a/pkg/snowflake/procedure.go
+++ b/pkg/snowflake/procedure.go
@@ -19,11 +19,15 @@ type ProcedureBuilder struct {
 	args              []map[string]string
 	returnBehavior    string // VOLATILE, IMMUTABLE
 	nullInputBehavior string // "CALLED ON NULL INPUT" or "RETURNS NULL ON NULL INPUT"
-	language          string // SQL, JAVASCRIPT, JAVA, SCALA
 	returnType        string
+	language          string // SQL, JAVASCRIPT, JAVA, SCALA
+	packages          []string
+	imports           []string // for Java / Python imports
+	handler           string   // for Java / Python handler
 	executeAs         string
 	comment           string
 	statement         string
+	runtimeVersion    string // for Python runtime version
 }
 
 // QualifiedName prepends the db and schema and appends argument types.
@@ -83,9 +87,33 @@ func (pb *ProcedureBuilder) WithExecuteAs(s string) *ProcedureBuilder {
 	return pb
 }
 
+// WithReturnType adds the data type of the return type to the FunctionBuilder.
+func (pb *FunctionBuilder) WithReturnType(s string) *FunctionBuilder {
+	pb.returnType = strings.ToUpper(s)
+	return pb
+}
+
 // WithLanguage sets the language to SQL, JAVA, SCALA or JAVASCRIPT.
 func (pb *ProcedureBuilder) WithLanguage(s string) *ProcedureBuilder {
 	pb.language = s
+	return pb
+}
+
+// WithPackages.
+func (pb *FunctionBuilder) WithPackages(s []string) *FunctionBuilder {
+	pb.packages = s
+	return pb
+}
+
+// WithImports adds jar files to import for Java function or Python file for Python function.
+func (pb *FunctionBuilder) WithImports(s []string) *FunctionBuilder {
+	pb.imports = s
+	return pb
+}
+
+// WithHandler sets the handler method for Java / Python function.
+func (pb *FunctionBuilder) WithHandler(s string) *FunctionBuilder {
+	pb.handler = s
 	return pb
 }
 
@@ -147,14 +175,38 @@ func (pb *ProcedureBuilder) Create() (string, error) {
 	q.WriteString(`)`)
 
 	q.WriteString(fmt.Sprintf(" RETURNS %v", pb.returnType))
-	if pb.language != "" {
-		q.WriteString(fmt.Sprintf(" LANGUAGE %v", EscapeString(pb.language)))
-	}
 	if pb.nullInputBehavior != "" {
 		q.WriteString(fmt.Sprintf(` %v`, EscapeString(pb.nullInputBehavior)))
 	}
 	if pb.returnBehavior != "" {
 		q.WriteString(fmt.Sprintf(` %v`, EscapeString(pb.returnBehavior)))
+	}
+	if pb.language != "" {
+		q.WriteString(fmt.Sprintf(" LANGUAGE %v", EscapeString(pb.language)))
+	}
+	if pb.runtimeVersion != "" {
+		q.WriteString(fmt.Sprintf(" RUNTIME_VERSION = '%v'", EscapeString(pb.runtimeVersion)))
+	}
+	if len(pb.packages) > 0 {
+		q.WriteString(` PACKAGES = (`)
+		packages := []string{}
+		for _, pack := range pb.packages {
+			packages = append(packages, fmt.Sprintf(`'%v'`, pack))
+		}
+		q.WriteString(strings.Join(packages, ", "))
+		q.WriteString(`)`)
+	}
+	if len(pb.imports) > 0 {
+		q.WriteString(` IMPORTS = (`)
+		imports := []string{}
+		for _, imp := range pb.imports {
+			imports = append(imports, fmt.Sprintf(`'%v'`, imp))
+		}
+		q.WriteString(strings.Join(imports, ", "))
+		q.WriteString(`)`)
+	}
+	if pb.handler != "" {
+		q.WriteString(fmt.Sprintf(" HANDLER = '%v'", pb.handler))
 	}
 	if pb.comment != "" {
 		q.WriteString(fmt.Sprintf(" COMMENT = '%v'", EscapeString(pb.comment)))

--- a/pkg/snowflake/procedure.go
+++ b/pkg/snowflake/procedure.go
@@ -87,32 +87,32 @@ func (pb *ProcedureBuilder) WithExecuteAs(s string) *ProcedureBuilder {
 	return pb
 }
 
-// WithReturnType adds the data type of the return type to the FunctionBuilder.
-func (pb *FunctionBuilder) WithReturnType(s string) *FunctionBuilder {
-	pb.returnType = strings.ToUpper(s)
-	return pb
-}
-
 // WithLanguage sets the language to SQL, JAVA, SCALA or JAVASCRIPT.
 func (pb *ProcedureBuilder) WithLanguage(s string) *ProcedureBuilder {
 	pb.language = s
 	return pb
 }
 
+// WithRuntimeVersion.
+func (pb *ProcedureBuilder) WithRuntimeVersion(r string) *ProcedureBuilder {
+	pb.runtimeVersion = r
+	return pb
+}
+
 // WithPackages.
-func (pb *FunctionBuilder) WithPackages(s []string) *FunctionBuilder {
+func (pb *ProcedureBuilder) WithPackages(s []string) *ProcedureBuilder {
 	pb.packages = s
 	return pb
 }
 
 // WithImports adds jar files to import for Java function or Python file for Python function.
-func (pb *FunctionBuilder) WithImports(s []string) *FunctionBuilder {
+func (pb *ProcedureBuilder) WithImports(s []string) *ProcedureBuilder {
 	pb.imports = s
 	return pb
 }
 
 // WithHandler sets the handler method for Java / Python function.
-func (pb *FunctionBuilder) WithHandler(s string) *FunctionBuilder {
+func (pb *ProcedureBuilder) WithHandler(s string) *ProcedureBuilder {
 	pb.handler = s
 	return pb
 }
@@ -175,14 +175,14 @@ func (pb *ProcedureBuilder) Create() (string, error) {
 	q.WriteString(`)`)
 
 	q.WriteString(fmt.Sprintf(" RETURNS %v", pb.returnType))
+	if pb.language != "" {
+		q.WriteString(fmt.Sprintf(" LANGUAGE %v", EscapeString(pb.language)))
+	}
 	if pb.nullInputBehavior != "" {
 		q.WriteString(fmt.Sprintf(` %v`, EscapeString(pb.nullInputBehavior)))
 	}
 	if pb.returnBehavior != "" {
 		q.WriteString(fmt.Sprintf(` %v`, EscapeString(pb.returnBehavior)))
-	}
-	if pb.language != "" {
-		q.WriteString(fmt.Sprintf(" LANGUAGE %v", EscapeString(pb.language)))
 	}
 	if pb.runtimeVersion != "" {
 		q.WriteString(fmt.Sprintf(" RUNTIME_VERSION = '%v'", EscapeString(pb.runtimeVersion)))

--- a/pkg/snowflake/procedure_test.go
+++ b/pkg/snowflake/procedure_test.go
@@ -46,13 +46,18 @@ func TestProcedureCreateWithOptionalParams(t *testing.T) {
 	s := getProcedure(true)
 	s.WithNullInputBehavior("RETURNS NULL ON NULL INPUT")
 	s.WithReturnBehavior("IMMUTABLE")
-	s.WithLanguage("JAVASCRIPT")
+	s.WithLanguage("PYTHON")
+	s.WithRuntimeVersion("3.8")
+	s.WithPackages([]string{"snowflake-snowpark-python", "pandas"})
+	s.WithImports([]string{"@\"test_db\".\"test_schema\".\"test_stage\"/handler.py"})
+	s.WithHandler("handler.test")
 	s.WithComment("this is cool proc!")
 	createStmnt, _ := s.Create()
 	expected := `CREATE OR REPLACE PROCEDURE "test_db"."test_schema"."test_proc"` +
-		`(user VARCHAR, eventdt DATE) RETURNS VARCHAR LANGUAGE JAVASCRIPT RETURNS NULL ON NULL INPUT` +
-		` IMMUTABLE COMMENT = 'this is cool proc!' EXECUTE AS CALLER AS $$` +
-		`var message = "Hi"` + "\nreturn message$$"
+		`(user VARCHAR, eventdt DATE) RETURNS VARCHAR LANGUAGE PYTHON RETURNS NULL ON NULL INPUT ` +
+		`IMMUTABLE RUNTIME_VERSION = '3.8' PACKAGES = ('snowflake-snowpark-python', 'pandas') ` +
+		`IMPORTS = ('@"test_db"."test_schema"."test_stage"/handler.py') HANDLER = 'handler.test' ` +
+		`COMMENT = 'this is cool proc!' EXECUTE AS CALLER AS $$var message = "Hi"` + "\nreturn message$$"
 	r.Equal(expected, createStmnt)
 }
 


### PR DESCRIPTION
This PR adds support for the following optional parameters for `PROCEDURE`:

- `packages` for Python and Java stored procedures
- `imports` again for Python and Java
- `handler` the target handler function
- `runtimeVersion` required for Python procedures

## Test Plan
- The `TestProcedureCreateWithOptionalParams` test in `procedure_test.go` has been updated to include the added optional parameters
  - The `getProcedure` func includes a statement, which doesn't make a huge amount of sense given that we are using a handler, but the equivalent `getPythonFunction` in `function_test.go` does too, so I assume this is ok
- Tested that a local version of the provider with the new params successfully deploys a procedure to Snowflake 🎉
