### PR TITLE
Updating docs for `snowflake_system_get_privatelink_config

### DIFF
--- a/docs/data-sources/system_get_privatelink_config.md
+++ b/docs/data-sources/system_get_privatelink_config.md
@@ -59,7 +59,7 @@ resource "aws_route53_record" "snowflake_private_link_url" {
 }
 
 resource "aws_route53_record" "snowflake_private_link_ocsp_url" {
-  zone_id = aws_route53_zone.snowflake_private_link_url.zone_id
+  zone_id = aws_route53_zone.snowflake_private_link.zone_id
   name    = data.snowflake_system_get_privatelink_config.snowflake_private_link.ocsp_url
   type    = "CNAME"
   ttl     = "300"

--- a/examples/data-sources/snowflake_system_get_privatelink_config/data-source.tf
+++ b/examples/data-sources/snowflake_system_get_privatelink_config/data-source.tf
@@ -44,7 +44,7 @@ resource "aws_route53_record" "snowflake_private_link_url" {
 }
 
 resource "aws_route53_record" "snowflake_private_link_ocsp_url" {
-  zone_id = aws_route53_zone.snowflake_private_link_url.zone_id
+  zone_id = aws_route53_zone.snowflake_private_link.zone_id
   name    = data.snowflake_system_get_privatelink_config.snowflake_private_link.ocsp_url
   type    = "CNAME"
   ttl     = "300"


### PR DESCRIPTION
- Updating the example code that generates the markdown docs

I will close [my other PR](https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/1476) in favor of this one which I have hopefully done correctly thanks to guidance from @sfc-gh-swinkler.



## Test Plan
This is only a tiny documentation bugfix.  

## References
https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/1476