### PR TITLE
fix: change resource monitor suspend properties to number

### DIFF
--- a/docs/resources/resource_monitor.md
+++ b/docs/resources/resource_monitor.md
@@ -21,9 +21,9 @@ resource "snowflake_resource_monitor" "monitor" {
   start_timestamp = "2020-12-07 00:00"
   end_timestamp   = "2021-12-07 00:00"
 
-  notify_triggers            = [40]
-  suspend_triggers           = [50]
-  suspend_immediate_triggers = [90]
+  notify_triggers            = [40, 50]
+  suspend_triggers           = 50
+  suspend_immediate_triggers = 90
 
   notify_users = ["USERONE", "USERTWO"]
 }
@@ -43,10 +43,10 @@ resource "snowflake_resource_monitor" "monitor" {
 - `frequency` (String) The frequency interval at which the credit usage resets to 0. If you set a frequency for a resource monitor, you must also set START_TIMESTAMP.
 - `notify_triggers` (Set of Number) A list of percentage thresholds at which to send an alert to subscribed users.
 - `notify_users` (Set of String) Specifies the list of users to receive email notifications on resource monitors.
-- `set_for_account` (Boolean) Specifies whether the resource monitor should be applied globally to your Snowflake account.
+- `set_for_account` (Boolean) Specifies whether the resource monitor should be applied globally to your Snowflake account (defaults to false).
 - `start_timestamp` (String) The date and time when the resource monitor starts monitoring credit usage for the assigned warehouses.
-- `suspend_immediate_triggers` (Set of Number) A list of percentage thresholds at which to immediately suspend all warehouses.
-- `suspend_triggers` (Set of Number) A list of percentage thresholds at which to suspend all warehouses.
+- `suspend_immediate_trigger` (Number) The number that represents the percentage threshold at which to immediately suspend all warehouses.
+- `suspend_trigger` (Number) The number that represents the percentage threshold at which to suspend all warehouses.
 - `warehouses` (Set of String) A list of warehouses to apply the resource monitor to.
 
 ### Read-Only
@@ -58,5 +58,6 @@ resource "snowflake_resource_monitor" "monitor" {
 Import is supported using the following syntax:
 
 ```shell
-terraform import snowflake_resource_monitor.example
+# format is the resource monitor name
+terraform import snowflake_resource_monitor.example 'resourceMonitorName'
 ```

--- a/examples/resources/snowflake_resource_monitor/import.sh
+++ b/examples/resources/snowflake_resource_monitor/import.sh
@@ -1,1 +1,2 @@
-terraform import snowflake_resource_monitor.example
+# format is the resource monitor name
+terraform import snowflake_resource_monitor.example 'resourceMonitorName'

--- a/examples/resources/snowflake_resource_monitor/resource.tf
+++ b/examples/resources/snowflake_resource_monitor/resource.tf
@@ -6,9 +6,9 @@ resource "snowflake_resource_monitor" "monitor" {
   start_timestamp = "2020-12-07 00:00"
   end_timestamp   = "2021-12-07 00:00"
 
-  notify_triggers            = [40]
-  suspend_triggers           = [50]
-  suspend_immediate_triggers = [90]
+  notify_triggers            = [40, 50]
+  suspend_triggers           = 50
+  suspend_immediate_triggers = 90
 
   notify_users = ["USERONE", "USERTWO"]
 }

--- a/pkg/resources/resource_monitor_test.go
+++ b/pkg/resources/resource_monitor_test.go
@@ -24,13 +24,13 @@ func TestResourceMonitorCreate(t *testing.T) {
 	r := require.New(t)
 
 	in := map[string]interface{}{
-		"name":                       "good_name",
-		"notify_users":               []interface{}{"USERONE", "USERTWO"},
-		"credit_quota":               100,
-		"notify_triggers":            []interface{}{75, 88},
-		"suspend_triggers":           []interface{}{99},
-		"suspend_immediate_triggers": []interface{}{105},
-		"set_for_account":            true,
+		"name":                      "good_name",
+		"notify_users":              []interface{}{"USERONE", "USERTWO"},
+		"credit_quota":              100,
+		"notify_triggers":           []interface{}{75, 88},
+		"suspend_trigger":           99,
+		"suspend_immediate_trigger": 105,
+		"set_for_account":           true,
 	}
 
 	d := schema.TestResourceDataRaw(t, resources.ResourceMonitor().Schema, in)


### PR DESCRIPTION
Fixing https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1538

Both the `suspend trigger` and `suspend immediate trigger` properties for a resource monitor are just a single number, not a set of numbers.

Also adding missing information for importing the resource monitor Terraform resource.

Also adding a note for `set_for_account` property, as it defaults to false.

NOTE: Important to notice that due to the change of the properties (removing the s) this is a breaking change

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests

## References
https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/resource_monitor
https://docs.snowflake.com/en/sql-reference/sql/create-resource-monitor