### PR TITLE
fix: proc id parsing for legacy id

### DIFF
--- a/pkg/resources/function_grant.go
+++ b/pkg/resources/function_grant.go
@@ -344,12 +344,15 @@ func parseFunctionGrantID(s string) (*FunctionGrantID, error) {
 			objectIdentifier = objectIdentifier[0:idx]
 		}
 		objectNameParts := strings.Split(objectIdentifier, "(")
-
+		argumentDataTypes := []string{}
+		if len(objectNameParts) > 1 {
+			argumentDataTypes = helpers.SplitStringToSlice(objectNameParts[1], ",")
+		}
 		return &FunctionGrantID{
 			DatabaseName:      idParts[0],
 			SchemaName:        idParts[1],
 			ObjectName:        objectNameParts[0],
-			ArgumentDataTypes: helpers.SplitStringToSlice(objectNameParts[1], ","),
+			ArgumentDataTypes: argumentDataTypes,
 			Privilege:         idParts[3],
 			Roles:             helpers.SplitStringToSlice(idParts[4], ","),
 			Shares:            []string{},

--- a/pkg/resources/procedure_grant.go
+++ b/pkg/resources/procedure_grant.go
@@ -354,12 +354,15 @@ func parseProcedureGrantID(s string) (*ProcedureGrantID, error) {
 			objectIdentifier = objectIdentifier[0:idx]
 		}
 		objectNameParts := strings.Split(objectIdentifier, "(")
-
+		argumentDataTypes := []string{}
+		if len(objectNameParts) > 1 {
+			argumentDataTypes = helpers.SplitStringToSlice(objectNameParts[1], ",")
+		}
 		return &ProcedureGrantID{
 			DatabaseName:      idParts[0],
 			SchemaName:        idParts[1],
 			ObjectName:        objectNameParts[0],
-			ArgumentDataTypes: helpers.SplitStringToSlice(objectNameParts[1], ","),
+			ArgumentDataTypes: argumentDataTypes,
 			Privilege:         idParts[3],
 			Roles:             helpers.SplitStringToSlice(idParts[4], ","),
 			Shares:            []string{},


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->
Fixes out of bound index exception when arguments are not supplied (i.e. on_future) parsing of old procedure and function grant IDs
<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->


## References
<!-- issues documentation links, etc  -->
#1547 
