### PR TITLE
docs: default_secondary_roles doc

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -47,7 +47,7 @@ resource "snowflake_user" "user" {
 - `comment` (String)
 - `default_namespace` (String) Specifies the namespace (database only or database and schema) that is active by default for the user’s session upon login.
 - `default_role` (String) Specifies the role that is active by default for the user’s session upon login.
-- `default_secondary_roles` (Set of String) Specifies the set of secondary roles that are active for the user’s session upon login.
+- `default_secondary_roles` (Set of String) Specifies the set of secondary roles that are active for the user’s session upon login. Currently only ["ALL"] value is supported - more information can be found in [doc](https://docs.snowflake.com/en/sql-reference/sql/create-user#optional-object-properties-objectproperties)
 - `default_warehouse` (String) Specifies the virtual warehouse that is active by default for the user’s session upon login.
 - `disabled` (Boolean)
 - `display_name` (String) Name displayed for the user in the Snowflake web interface.

--- a/pkg/resources/user.go
+++ b/pkg/resources/user.go
@@ -84,7 +84,7 @@ var userSchema = map[string]*schema.Schema{
 		Type:        schema.TypeSet,
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Optional:    true,
-		Description: "Specifies the set of secondary roles that are active for the user’s session upon login.",
+		Description: "Specifies the set of secondary roles that are active for the user’s session upon login. Currently only [\"ALL\"] value is supported - more information can be found in [doc](https://docs.snowflake.com/en/sql-reference/sql/create-user#optional-object-properties-objectproperties)",
 	},
 	"rsa_public_key": {
 		Type:        schema.TypeString,


### PR DESCRIPTION
Extending the documentation for `default_secondary_roles`parameter about allowed values.
Fixing #1579 