### PR TITLE
fix: added force_new option to role grant when the role_name has been changed

### DIFF
--- a/pkg/resources/role_grants_acceptance_test.go
+++ b/pkg/resources/role_grants_acceptance_test.go
@@ -151,6 +151,14 @@ func TestAcc_GrantRole(t *testing.T) {
 					},
 				),
 			},
+			// RENAMING
+			{
+				Config:       rgConfig2(role1+"foo", role2, role3, user1, user2),
+				ResourceName: "snowflake_role_grants.w",
+				Check: resource.ComposeTestCheckFunc(
+					testCheckRolesAndUsers(t, "snowflake_role_grants.w", []string{role2}, []string{user1, user2})),
+			},
+			baselineStep,
 			// IMPORT
 			{
 				ResourceName:            "snowflake_role_grants.w",

--- a/pkg/resources/role_grants_test.go
+++ b/pkg/resources/role_grants_test.go
@@ -2,8 +2,9 @@ package resources_test
 
 import (
 	"database/sql"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake"
 	"testing"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider"


### PR DESCRIPTION
- role_grants resource is now recreated if the role_name is changed
- when refreshing the resource, the code checks now first, if the grantee role still exists (in case it was manually deleted in snowflake)

## Test Plan
* [x] unit tests
* [x] manuel tests
* [x] acceptance tests of role_grants module

## References

Issue is described in #1590 
