### PR TITLE
fix: 

### DIFF
--- a/pkg/resources/database_grant.go
+++ b/pkg/resources/database_grant.go
@@ -123,6 +123,13 @@ func ReadDatabaseGrant(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	// IMPORTED PRIVILEGES is not a real resource, so we can't actually verify
+	// that it is still there. However, it is needed to grant usage for the snowflake database to custom roles.
+	// Just exit for now
+	if grantID.Privilege == "IMPORTED PRIVILEGES" {
+		return nil
+	}
+
 	builder := snowflake.DatabaseGrant(grantID.DatabaseName)
 	return readGenericGrant(d, meta, databaseGrantSchema, builder, false, validDatabasePrivileges)
 }


### PR DESCRIPTION
- readded imported privileges special case for database grants

It was removed in #1522, however it is needed for the edge case of the shared databases as the snowflake database. In order to give custom roles the permission to use the shared databases, the privilege must be given "IMPORTED PRIVILEGES". However, in the information_schema tables the privilege is shown as "USAGE".

Without this code snippet, the terraform provider wants to regive this permission every time.

## Test Plan
* [x] unit tests
* [x] manual test with snowflake

## References
(https://docs.snowflake.com/en/user-guide/data-exchange-marketplace-privileges)
