### PR TITLE
feat: Support changing cluster_by on a new column

### DIFF
--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -638,21 +638,6 @@ func UpdateTable(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error updating table comment on %v", d.Id())
 		}
 	}
-	if d.HasChange("cluster_by") {
-		cb := expandStringList(d.Get("cluster_by").([]interface{}))
-
-		var q string
-		if len(cb) != 0 {
-			builder.WithClustering(cb)
-			q = builder.ChangeClusterBy(builder.GetClusterKeyString())
-		} else {
-			q = builder.DropClustering()
-		}
-
-		if err := snowflake.Exec(db, q); err != nil {
-			return fmt.Errorf("error updating table clustering on %v", d.Id())
-		}
-	}
 	if d.HasChange("column") {
 		t, new := d.GetChange("column")
 		removed, added, changed := getColumns(t).diffs(getColumns(new))
@@ -712,6 +697,21 @@ func UpdateTable(d *schema.ResourceData, meta interface{}) error {
 					return fmt.Errorf("error changing property on %v", d.Id())
 				}
 			}
+		}
+	}
+	if d.HasChange("cluster_by") {
+		cb := expandStringList(d.Get("cluster_by").([]interface{}))
+
+		var q string
+		if len(cb) != 0 {
+			builder.WithClustering(cb)
+			q = builder.ChangeClusterBy(builder.GetClusterKeyString())
+		} else {
+			q = builder.DropClustering()
+		}
+
+		if err := snowflake.Exec(db, q); err != nil {
+			return fmt.Errorf("error updating table clustering on %v", d.Id())
 		}
 	}
 	if d.HasChange("primary_key") {


### PR DESCRIPTION
Move the cluster_by logic when updating a table to take place *after* columns are added.

This fixes https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1507

## Test Plan
Relying on CI here, don't think we need to update any existing tests

## References
N/A