### PR TITLE
fix: openbsd build

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -20,6 +20,8 @@ builds:
       goarch: arm
     - goos: openbsd
       goarch: arm64
+    - goos: freebsd
+      goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 
 archives:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,8 @@ builds:
       goarch: arm
     - goos: openbsd
       goarch: arm64
+    - goos: freebsd
+      goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 
 archives:


### PR DESCRIPTION
Recent upgrade of gosnowflake libraries causes problems building freebsd with arch 386. Since this is probably not a very popular OS anyhow, best just to remove it. Otherwise will need to file a PR with gosnowflake to get them to downgrade the arrow library.
```
$ export GOOS=freebsd
$ export GOARCH=386
$ go install
# github.com/apache/arrow/go/v10/internal/utils
../../../../pkg/mod/github.com/apache/arrow/go/v10@v10.0.1/internal/utils/transpose_ints_def.go:76:4: undefined: TransposeInt8Int8
../../../../pkg/mod/github.com/apache/arrow/go/v10@v10.0.1/internal/utils/transpose_ints_def.go:78:4: undefined: TransposeInt8Int16
../../../../pkg/mod/github.com/apache/arrow/go/v10@v10.0.1/internal/utils/transpose_ints_def.go:80:4: undefined: TransposeInt8Int32
../../../../pkg/mod/github.com/apache/arrow/go/v10@v10.0.1/internal/utils/transpose_ints_def.go:82:4: undefined: TransposeInt8Int64
../../../../pkg/mod/github.com/apache/arrow/go/v10@v10.0.1/internal/utils/transpose_ints_def.go:84:4: undefined: TransposeInt8Uint8
../../../../pkg/mod/github.com/apache/arrow/go/v10@v10.0.1/internal/utils/transpose_ints_def.go:86:4: undefined: TransposeInt8Uint16
../../../../pkg/mod/github.com/apache/arrow/go/v10@v10.0.1/internal/utils/transpose_ints_def.go:88:4: undefined: TransposeInt8Uint32
../../../../pkg/mod/github.com/apache/arrow/go/v10@v10.0.1/internal/utils/transpose_ints_def.go:90:4: undefined: TransposeInt8Uint64
../../../../pkg/mod/github.com/apache/arrow/go/v10@v10.0.1/internal/utils/transpose_ints_def.go:95:4: undefined: TransposeInt16Int8
../../../../pkg/mod/github.com/apache/arrow/go/v10@v10.0.1/internal/utils/transpose_ints_def.go:97:4: undefined: TransposeInt16Int16
../../../../pkg/mod/github.com/apache/arrow/go/v10@v10.0.1/internal/utils/transpose_ints_def.go:97:4: too many errors
```