### PR TITLE
fix: remove grant id roles from read

### DIFF
--- a/pkg/resources/account_grant.go
+++ b/pkg/resources/account_grant.go
@@ -201,9 +201,6 @@ func ReadAccountGrant(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("privilege", grantID.Privilege); err != nil {
 		return err
 	}
-	if err := d.Set("roles", grantID.Roles); err != nil {
-		return err
-	}
 	if err := d.Set("with_grant_option", grantID.WithGrantOption); err != nil {
 		return err
 	}

--- a/pkg/resources/database_grant.go
+++ b/pkg/resources/database_grant.go
@@ -133,9 +133,6 @@ func ReadDatabaseGrant(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("privilege", grantID.Privilege); err != nil {
 		return err
 	}
-	if err := d.Set("roles", grantID.Roles); err != nil {
-		return err
-	}
 	if err := d.Set("with_grant_option", grantID.WithGrantOption); err != nil {
 		return err
 	}

--- a/pkg/resources/file_format_grant.go
+++ b/pkg/resources/file_format_grant.go
@@ -136,9 +136,6 @@ func ReadFileFormatGrant(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err := d.Set("roles", grantID.Roles); err != nil {
-		return err
-	}
 	if err := d.Set("database_name", grantID.DatabaseName); err != nil {
 		return err
 	}

--- a/pkg/resources/integration_grant.go
+++ b/pkg/resources/integration_grant.go
@@ -94,9 +94,6 @@ func ReadIntegrationGrant(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err := d.Set("roles", grantID.Roles); err != nil {
-		return err
-	}
 	if err := d.Set("integration_name", grantID.ObjectName); err != nil {
 		return err
 	}

--- a/pkg/resources/masking_policy_grant.go
+++ b/pkg/resources/masking_policy_grant.go
@@ -111,9 +111,6 @@ func ReadMaskingPolicyGrant(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err := d.Set("roles", grantID.Roles); err != nil {
-		return err
-	}
 	if err := d.Set("database_name", grantID.DatabaseName); err != nil {
 		return err
 	}

--- a/pkg/resources/materialized_view_grant.go
+++ b/pkg/resources/materialized_view_grant.go
@@ -179,10 +179,6 @@ func ReadMaterializedViewGrant(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err := d.Set("roles", grantID.Roles); err != nil {
-		return err
-	}
-
 	if err := d.Set("database_name", grantID.DatabaseName); err != nil {
 		return err
 	}

--- a/pkg/resources/pipe_grant.go
+++ b/pkg/resources/pipe_grant.go
@@ -138,9 +138,6 @@ func ReadPipeGrant(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if err := d.Set("roles", grantID.Roles); err != nil {
-		return err
-	}
 	if err := d.Set("database_name", grantID.DatabaseName); err != nil {
 		return err
 	}

--- a/pkg/resources/resource_monitor_grant.go
+++ b/pkg/resources/resource_monitor_grant.go
@@ -93,9 +93,6 @@ func ReadResourceMonitorGrant(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err := d.Set("roles", grantID.Roles); err != nil {
-		return err
-	}
 	if err := d.Set("monitor_name", grantID.ObjectName); err != nil {
 		return err
 	}


### PR DESCRIPTION
Grant IDs currently stuck in pepetual read from roles being read in ID, when this could change and not updated in ID