### PR TITLE
fix: remove support for openbsd

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -2,7 +2,6 @@ builds:
 - env:
   - CGO_ENABLED=0
   goos:
-    - openbsd
     - solaris
     - windows
     - linux
@@ -15,10 +14,6 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
-    - goos: openbsd
-      goarch: arm
-    - goos: openbsd
-      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 
 archives:


### PR DESCRIPTION
build error when building openbsd regarding latest gosnowflake library. Removing support for build now, could revert later if needed.