### PR TITLE
fix: wildcards in database name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,6 @@ builds:
 - env:
   - CGO_ENABLED=0
   goos:
-    - openbsd
     - solaris
     - windows
     - linux
@@ -17,10 +16,6 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
-    - goos: openbsd
-      goarch: arm
-    - goos: openbsd
-      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 
 archives:

--- a/pkg/datasources/database.go
+++ b/pkg/datasources/database.go
@@ -62,7 +62,6 @@ func Database() *schema.Resource {
 func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*sql.DB)
 	dbx := sqlx.NewDb(db, "snowflake")
-	log.Printf("[DEBUG] database: %v", d.Get("name"))
 	dbData, err := snowflake.ListDatabase(dbx, d.Get("name").(string))
 	if err != nil {
 		log.Println("[DEBUG] list database failed to decode")

--- a/pkg/resources/database_acceptance_test.go
+++ b/pkg/resources/database_acceptance_test.go
@@ -10,6 +10,27 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+func TestAcc_DatabaseWithUnderscore(t *testing.T) {
+	if _, ok := os.LookupEnv("SKIP_DATABASE_TESTS"); ok {
+		t.Skip("Skipping TestAccDatabase")
+	}
+
+	prefix := "_" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    providers(),
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: dbConfig(prefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_database.db", "name", prefix),
+					resource.TestCheckResourceAttr("snowflake_database.db", "comment", "test comment"),
+					resource.TestCheckResourceAttrSet("snowflake_database.db", "data_retention_time_in_days"),
+				),
+			},
+		},
+	})
+}
 func TestAcc_Database(t *testing.T) {
 	if _, ok := os.LookupEnv("SKIP_DATABASE_TESTS"); ok {
 		t.Skip("Skipping TestAccDatabase")
@@ -78,3 +99,4 @@ resource "snowflake_database" "db" {
 `
 	return fmt.Sprintf(s, prefix)
 }
+

--- a/pkg/snowflake/database.go
+++ b/pkg/snowflake/database.go
@@ -307,7 +307,9 @@ func ListDatabase(sdb *sqlx.DB, databaseName string) (*Database, error) {
 	db := &Database{}
 	for _, d := range dbs {
 		d := d
+		log.Printf("[DEBUG] database: %v", d.DBName.String)
 		if d.DBName.String == databaseName {
+			log.Printf("[DEBUG] match database: %v with string %s", d.DBName.String,databaseName)
 			db = &d
 			break
 		}


### PR DESCRIPTION
Describe the bug

Issue with two databases due to their names since the query used by Terraform (SHOW DATABASES LIKE '') returns more than one value generating a Terraform plan with unexpected replacements (image attached)

Expected behavior

It should be presenting 1 result instead of 2 .

Code samples and commands

SHOW DATABASES LIKE ''; --return 2 rows

Additional context

Customer wants Snowflake to enhance the terraform script.
The underscore wild card is SQL standard, and works in oracle, mysql, sql server and postegresql .They are not willing to change the database name but rather wants us to make the Terraform script changes.They want to make Terraform provider for Snowflake, wildcard proof.
SQL wildcards are supported in pattern:
An underscore (_) matches any single character.
A percent sign (%) matches any sequence of zero or more characters.
Wildcards in pattern include newline characters (\n) in subject as matches.
LIKE pattern matching covers the entire string. To match a sequence anywhere within a string, start and end the pattern with %.
We asked customer to use account_usage.databases view or information_schema.databases view, and filter by the DATABASE_NAME='dbname'.
SHOW DATABASE is doing "LIKE" condition and querying the account_usage.databases view where DATABASE_NAME='dbname' will provide the exact match.
The above suggestion was rejected since the same query cannot be injected into Terraform’s source cod