### PR TITLE
feat: support is_org_admin column in SHOW ORGANIZATION ACCOUNTS

### DIFF
--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -60,6 +60,7 @@ resource "snowflake_account" "ac1" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `is_org_admin` (Boolean) Indicates whether the ORGADMIN role is enabled in an account. If TRUE, the role is enabled.
 
 ## Import
 

--- a/pkg/resources/account.go
+++ b/pkg/resources/account.go
@@ -187,6 +187,11 @@ var accountSchema = map[string]*schema.Schema{
 		Description: "Specifies a comment for the account.",
 		ForceNew:    true, // Apparently there is no API to change comments on accounts. ALTER ACCOUNT and COMMENT commands do not work
 	},
+	"is_org_admin": {
+		Type:        schema.TypeBool,
+		Computed:    true,
+		Description: "Indicates whether the ORGADMIN role is enabled in an account. If TRUE, the role is enabled.",
+	},
 }
 
 func Account() *schema.Resource {
@@ -299,6 +304,10 @@ func ReadAccount(d *schema.ResourceData, meta interface{}) error {
 	err = d.Set("comment", account.Comment.String)
 	if err != nil {
 		return fmt.Errorf("error setting comment: %w", err)
+	}
+	err = d.Set("is_org_admin", account.IsOrgAdmin.Bool)
+	if err != nil {
+		return fmt.Errorf("error setting is_org_admin: %w", err)
 	}
 
 	return nil

--- a/pkg/snowflake/account.go
+++ b/pkg/snowflake/account.go
@@ -177,6 +177,7 @@ type Account struct {
 	MarketplaceConsumerBillingEntityName sql.NullString `db:"marketplace_consumer_billing_entity_name"`
 	MarketplaceProviderBillingEntityName sql.NullString `db:"marketplace_provider_billing_entity_name"`
 	OldAccountURL                        sql.NullString `db:"old_account_url"`
+	IsOrgAdmin                           sql.NullBool   `db:"is_org_admin"`
 }
 
 // Show returns the SQL query that will show a specific account by pattern.

--- a/pkg/snowflake/account_test.go
+++ b/pkg/snowflake/account_test.go
@@ -1,0 +1,31 @@
+package snowflake_test
+
+import (
+	"database/sql"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake"
+	. "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccount(t *testing.T) {
+	r := require.New(t)
+
+	WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		rows := sqlmock.NewRows([]string{
+			"organization_name", "account_name", "snowflake_region", "edition", "account_url", "created_on", "comment", "account_locator", "account_locator_url", "managed_accounts", "consumption_billing_entity_name", "marketplace_consumer_billing_entity_name", "marketplace_provider_billing_entity_name", "old_account_url", "is_org_admin",
+		},
+		).AddRow(
+			"TEST_ORG", "TEST_ACC", "AWS_US_WEST_2", "STANDARD", "https://acc.snowflakecomputing.com", "2020-01-01 12:00:00.123 -0800", "SNOWFLAKE", "LOCATOR", "https://loc.snowflakecomputing.com", 0, "BillingEntity", "", "", "", true,
+		)
+		mock.ExpectQuery(`SHOW ORGANIZATION ACCOUNTS LIKE 'test_account'`).WillReturnRows(rows)
+		a, err := snowflake.ShowAccount(db, "test_account")
+		r.NoError(err)
+		r.Equal("TEST_ORG", a.OrganizationName.String)
+		r.Equal("TEST_ACC", a.AccountName.String)
+		r.Equal("AWS_US_WEST_2", a.SnowflakeRegion.String)
+		r.Equal(true, a.IsOrgAdmin.Bool)
+	})
+}


### PR DESCRIPTION
## Test Plan
* [X] sdk tests
* no acceptance tests as we can't automate the deletion of accounts

## References
<!-- issues documentation links, etc  -->
* fixes #1606 