### PR TITLE
feat: add on_account to session and object params

### DIFF
--- a/docs/data-sources/parameters.md
+++ b/docs/data-sources/parameters.md
@@ -34,6 +34,7 @@ data "snowflake_parameters" "p2" {
 data "snowflake_parameters" "p3" {
   parameter_type = "SESSION"
   pattern        = "ROWS_PER_RESULTSET"
+  user           = "TEST_USER"
 }
 ```
 

--- a/docs/data-sources/parameters.md
+++ b/docs/data-sources/parameters.md
@@ -46,6 +46,7 @@ data "snowflake_parameters" "p3" {
 - `object_type` (String) If parameter_type is set to "OBJECT" then object_type is the type of object to display object parameters for. Valid values are any object supported by the IN clause of the [SHOW PARAMETERS](https://docs.snowflake.com/en/sql-reference/sql/show-parameters.html#parameters) statement, including: WAREHOUSE | DATABASE | SCHEMA | TASK | TABLE
 - `parameter_type` (String) The type of parameter to filter by. Valid values are: "ACCOUNT", "SESSION", "OBJECT".
 - `pattern` (String) Allows limiting the list of parameters by name using LIKE clause. Refer to [Limiting the List of Parameters by Name](https://docs.snowflake.com/en/sql-reference/parameters.html#limiting-the-list-of-parameters-by-name)
+- `user` (String) If parameter_type is set to "SESSION" then user is the name of the user to display session parameters for.
 
 ### Read-Only
 

--- a/docs/resources/object_parameter.md
+++ b/docs/resources/object_parameter.md
@@ -64,8 +64,9 @@ resource "snowflake_object_parameter" "o3" {
 
 // Setting object parameter at account level
 resource "snowflake_object_parameter" "o4" {
-  key   = "DATA_RETENTION_TIME_IN_DAYS"
-  value = "89"
+  key        = "DATA_RETENTION_TIME_IN_DAYS"
+  value      = "89"
+  on_account = true
 }
 ```
 
@@ -81,6 +82,7 @@ resource "snowflake_object_parameter" "o4" {
 
 - `object_identifier` (Block List) Specifies the object identifier for the object parameter. If no value is provided, then the resource will default to setting the object parameter at account level. (see [below for nested schema](#nestedblock--object_identifier))
 - `object_type` (String) Type of object to which the parameter applies. Valid values are those in [object types](https://docs.snowflake.com/en/sql-reference/parameters.html#object-types). If no value is provided, then the resource will default to setting the object parameter at account level.
+- `on_account` (Boolean) If true, the object parameter will be set on the account level.
 
 ### Read-Only
 

--- a/docs/resources/session_parameter.md
+++ b/docs/resources/session_parameter.md
@@ -16,6 +16,13 @@ description: |-
 resource "snowflake_session_parameter" "s" {
   key   = "AUTOCOMMIT"
   value = "false"
+  user  = "TEST_USER"
+}
+
+resource "snowflake_session_parameter" "s2" {
+  key        = "BINARY_OUTPUT_FORMAT"
+  value      = "BASE64"
+  on_account = true
 }
 ```
 
@@ -26,6 +33,11 @@ resource "snowflake_session_parameter" "s" {
 
 - `key` (String) Name of session parameter. Valid values are those in [session parameters](https://docs.snowflake.com/en/sql-reference/parameters.html#session-parameters).
 - `value` (String) Value of session parameter, as a string. Constraints are the same as those for the parameters in Snowflake documentation.
+
+### Optional
+
+- `on_account` (Boolean) If true, the session parameter will be set on the account level.
+- `user` (String) The user to set the session parameter for. Required if on_account is false
 
 ### Read-Only
 

--- a/examples/data-sources/snowflake_parameters/data-source.tf
+++ b/examples/data-sources/snowflake_parameters/data-source.tf
@@ -19,4 +19,5 @@ data "snowflake_parameters" "p2" {
 data "snowflake_parameters" "p3" {
   parameter_type = "SESSION"
   pattern        = "ROWS_PER_RESULTSET"
+  user           = "TEST_USER"
 }

--- a/examples/resources/snowflake_object_parameter/resource.tf
+++ b/examples/resources/snowflake_object_parameter/resource.tf
@@ -49,6 +49,7 @@ resource "snowflake_object_parameter" "o3" {
 
 // Setting object parameter at account level
 resource "snowflake_object_parameter" "o4" {
-  key   = "DATA_RETENTION_TIME_IN_DAYS"
-  value = "89"
+  key        = "DATA_RETENTION_TIME_IN_DAYS"
+  value      = "89"
+  on_account = true
 }

--- a/examples/resources/snowflake_session_parameter/resource.tf
+++ b/examples/resources/snowflake_session_parameter/resource.tf
@@ -1,4 +1,11 @@
 resource "snowflake_session_parameter" "s" {
   key   = "AUTOCOMMIT"
   value = "false"
+  user  = "TEST_USER"
+}
+
+resource "snowflake_session_parameter" "s2" {
+  key        = "BINARY_OUTPUT_FORMAT"
+  value      = "BASE64"
+  on_account = true
 }

--- a/pkg/datasources/parameters.go
+++ b/pkg/datasources/parameters.go
@@ -16,7 +16,7 @@ var parametersSchema = map[string]*schema.Schema{
 	"parameter_type": {
 		Type:         schema.TypeString,
 		Optional:     true,
-		Default:      "SESSION",
+		Default:      "ACCOUNT",
 		Description:  "The type of parameter to filter by. Valid values are: \"ACCOUNT\", \"SESSION\", \"OBJECT\".",
 		ValidateFunc: validation.StringInSlice([]string{"ACCOUNT", "SESSION", "OBJECT"}, true),
 	},
@@ -96,38 +96,9 @@ func ReadParameters(d *schema.ResourceData, meta interface{}) error {
 	if ok {
 		pattern = p.(string)
 	}
-	parameterType := snowflake.ParameterType(strings.ToUpper(d.Get("parameter_type").(string)))
-	if parameterType == snowflake.ParameterTypeObject {
-		oType := d.Get("object_type").(string)
-		objectType := snowflake.ObjectType(oType)
-		objectName := d.Get("object_name").(string)
-		parameters, err := snowflake.ListObjectParameters(db, objectType, objectName, pattern)
-		if errors.Is(err, sql.ErrNoRows) {
-			log.Printf("[DEBUG] parameters not found")
-			d.SetId("")
-			return nil
-		} else if err != nil {
-			log.Printf("[DEBUG] error occurred during read: %v", err.Error())
-			return err
-		}
-		d.SetId("parameters")
-		params := []map[string]interface{}{}
-		for _, param := range parameters {
-			paramMap := map[string]interface{}{}
-
-			paramMap["key"] = param.Key.String
-			paramMap["value"] = param.Value.String
-			paramMap["default"] = param.Default.String
-			paramMap["level"] = param.Level.String
-			paramMap["description"] = param.Description.String
-			paramMap["type"] = param.PType.String
-
-			params = append(params, paramMap)
-		}
-		return d.Set("parameters", params)
-	}
 	var parameters []snowflake.Parameter
 	var err error
+	parameterType := snowflake.ParameterType(strings.ToUpper(d.Get("parameter_type").(string)))
 	switch parameterType {
 	case snowflake.ParameterTypeAccount:
 		parameters, err = snowflake.ListAccountParameters(db, pattern)
@@ -136,7 +107,12 @@ func ReadParameters(d *schema.ResourceData, meta interface{}) error {
 		if user == "" {
 			return fmt.Errorf("user is required when parameter_type is set to SESSION")
 		}
-		parameters, err = snowflake.ListSessionParameters(db, user, pattern)
+		parameters, err = snowflake.ListSessionParameters(db, pattern, user)
+	case snowflake.ParameterTypeObject:
+		oType := d.Get("object_type").(string)
+		objectType := snowflake.ObjectType(oType)
+		objectName := d.Get("object_name").(string)
+		parameters, err = snowflake.ListObjectParameters(db, objectType, objectName, pattern)
 	}
 	if errors.Is(err, sql.ErrNoRows) {
 		log.Printf("[DEBUG] parameters not found")

--- a/pkg/datasources/parameters_acceptance_test.go
+++ b/pkg/datasources/parameters_acceptance_test.go
@@ -1,21 +1,25 @@
 package datasources_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAcc_Parameters(t *testing.T) {
+func TestAcc_ParametersOnAccount(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    providers(),
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: parameters(),
+				Config: parametersConfigOnAccount(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.snowflake_parameters.p", "parameters.#"),
-					resource.TestCheckResourceAttrSet("data.snowflake_parameters.p", "parameters.0.key"),
+					resource.TestCheckResourceAttr("data.snowflake_parameters.p", "pattern", "AUTOCOMMIT"),
+					resource.TestCheckResourceAttr("data.snowflake_parameters.p", "parameters.#", "1"),
+					resource.TestCheckResourceAttr("data.snowflake_parameters.p", "parameters.0.key", "AUTOCOMMIT"),
 					resource.TestCheckResourceAttrSet("data.snowflake_parameters.p", "parameters.0.value"),
 				),
 			},
@@ -23,6 +27,74 @@ func TestAcc_Parameters(t *testing.T) {
 	})
 }
 
-func parameters() string {
-	return `data "snowflake_parameters" "p" {}`
+func TestAcc_ParametersOnSession(t *testing.T) {
+	userName := "TEST_USER_" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    providers(),
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: parametersConfigOnSession(userName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.snowflake_parameters.p", "parameters.#"),
+					resource.TestCheckResourceAttrSet("data.snowflake_parameters.p", "parameters.0.key"),
+					resource.TestCheckResourceAttrSet("data.snowflake_parameters.p", "parameters.0.value"),
+					resource.TestCheckResourceAttr("data.snowflake_parameters.p", "user", userName),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_ParametersOnObject(t *testing.T) {
+	dbName := "TEST_DB_" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    providers(),
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: parametersConfigOnObject(dbName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.snowflake_parameters.p", "parameters.#"),
+					resource.TestCheckResourceAttrSet("data.snowflake_parameters.p", "parameters.0.key"),
+					resource.TestCheckResourceAttrSet("data.snowflake_parameters.p", "parameters.0.value"),
+					resource.TestCheckResourceAttr("data.snowflake_parameters.p", "object_type", "DATABASE"),
+					resource.TestCheckResourceAttr("data.snowflake_parameters.p", "object_name", dbName),
+				),
+			},
+		},
+	})
+}
+
+func parametersConfigOnAccount() string {
+	return `data "snowflake_parameters" "p" {
+		parameter_type = "ACCOUNT"
+		pattern = "AUTOCOMMIT"
+	}`
+}
+
+func parametersConfigOnSession(user string) string {
+	s := `
+	resource "snowflake_user" "u" {
+		name = "%s"
+	}
+
+	data "snowflake_parameters" "p" {
+		parameter_type = "SESSION"
+		user = snowflake_user.u.name
+	}`
+	return fmt.Sprintf(s, user)
+}
+
+func parametersConfigOnObject(name string) string {
+	stmt := `
+	resource "snowflake_database" "d" {
+		name = "%s"
+	}
+	data "snowflake_parameters" "p" {
+		parameter_type = "OBJECT"
+		object_type = "DATABASE"
+		object_name = snowflake_database.d.name
+	}`
+	return fmt.Sprintf(stmt, name)
 }

--- a/pkg/resources/account_parameter.go
+++ b/pkg/resources/account_parameter.go
@@ -59,7 +59,7 @@ func CreateAccountParameter(d *schema.ResourceData, meta interface{}) error {
 		value = fmt.Sprintf("'%s'", snowflake.EscapeString(value))
 	}
 
-	builder := snowflake.NewParameter(key, value, snowflake.ParameterTypeAccount, db)
+	builder := snowflake.NewAccountParameter(key, value, db)
 	err := builder.SetParameter()
 	if err != nil {
 		return fmt.Errorf("error creating account parameter err = %w", err)
@@ -111,7 +111,7 @@ func DeleteAccountParameter(d *schema.ResourceData, meta interface{}) error {
 	if reflect.TypeOf(parameterDefault.DefaultValue) == typeString {
 		value = fmt.Sprintf("'%s'", value)
 	}
-	builder := snowflake.NewParameter(key, value, snowflake.ParameterTypeAccount, db)
+	builder := snowflake.NewAccountParameter(key, value, db)
 	err := builder.SetParameter()
 	if err != nil {
 		return fmt.Errorf("error creating account parameter err = %w", err)

--- a/pkg/resources/session_parameter.go
+++ b/pkg/resources/session_parameter.go
@@ -97,7 +97,9 @@ func CreateSessionParameter(d *schema.ResourceData, meta interface{}) error {
 	} else {
 		p, err = snowflake.ShowSessionParameter(db, key, user)
 	}
-
+	if err != nil {
+		return fmt.Errorf("error reading session parameter err = %w", err)
+	}
 	err = d.Set("value", p.Value.String)
 	if err != nil {
 		return fmt.Errorf("error setting session parameter err = %w", err)

--- a/pkg/resources/session_parameter_acceptance_test.go
+++ b/pkg/resources/session_parameter_acceptance_test.go
@@ -2,32 +2,71 @@ package resources_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAcc_SessionParameter(t *testing.T) {
+func TestAcc_SessionParameterWithUser(t *testing.T) {
+	prefix := "TEST_USER_" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    providers(),
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: sessionParameterBasic("AUTOCOMMIT", "false"),
+				Config: sessionParameterWithUser(prefix, "BINARY_OUTPUT_FORMAT", "BASE64"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("snowflake_session_parameter.p", "key", "AUTOCOMMIT"),
-					resource.TestCheckResourceAttr("snowflake_session_parameter.p", "value", "false"),
+					resource.TestCheckResourceAttr("snowflake_session_parameter.p", "key", "BINARY_OUTPUT_FORMAT"),
+					resource.TestCheckResourceAttr("snowflake_session_parameter.p", "value", "BASE64"),
+					resource.TestCheckResourceAttr("snowflake_session_parameter.p", "user", prefix),
+					resource.TestCheckResourceAttr("snowflake_session_parameter.p", "on_account", "false"),
 				),
 			},
 		},
 	})
 }
 
-func sessionParameterBasic(key, value string) string {
+func TestAcc_SessionParameterOnAccount(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    providers(),
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: sessionParameterOnAccount("AUTOCOMMIT", "false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_session_parameter.p", "key", "AUTOCOMMIT"),
+					resource.TestCheckResourceAttr("snowflake_session_parameter.p", "value", "false"),
+					resource.TestCheckResourceAttr("snowflake_session_parameter.p", "on_account", "true"),
+				),
+			},
+		},
+	})
+}
+
+func sessionParameterWithUser(user, key, value string) string {
+	s := `
+resource "snowflake_user" "u" {
+	name = "%s"
+}
+
+resource "snowflake_session_parameter" "p" {
+	key = "%s"
+	value = "%s"
+	user = snowflake_user.u.name
+}
+`
+	return fmt.Sprintf(s, user, key, value)
+}
+
+func sessionParameterOnAccount(key, value string) string {
 	s := `
 resource "snowflake_session_parameter" "p" {
 	key = "%s"
 	value = "%s"
+	on_account = true
 }
 `
 	return fmt.Sprintf(s, key, value)

--- a/pkg/snowflake/parameters.go
+++ b/pkg/snowflake/parameters.go
@@ -683,52 +683,119 @@ func GetParameterDefault(key string) ParameterDefault {
 	return ParameterDefaults()[key]
 }
 
-// ParameterBuilder abstracts the creation of SQL queries for Snowflake parameters.
-type ParameterBuilder struct {
-	key              string
-	value            string
-	parameterType    ParameterType
-	objectType       ObjectType
-	objectIdentifier string
-	db               *sql.DB
+// AccountParameterBuilder abstracts the creation of SQL queries for Snowflake account parameters.
+type AccountParameterBuilder struct {
+	key   string
+	value string
+	db    *sql.DB
 }
 
-func NewParameter(key, value string, parameterType ParameterType, db *sql.DB) *ParameterBuilder {
-	return &ParameterBuilder{
-		key:           key,
-		value:         value,
-		parameterType: parameterType,
-		db:            db,
+func NewAccountParameter(key, value string, db *sql.DB) *AccountParameterBuilder {
+	return &AccountParameterBuilder{
+		key:   key,
+		value: value,
+		db:    db,
 	}
 }
 
-func (v *ParameterBuilder) WithObjectType(objectType ObjectType) *ParameterBuilder {
-	v.objectType = objectType
+func (v *AccountParameterBuilder) SetParameter() error {
+	stmt := fmt.Sprintf("ALTER ACCOUNT SET %s = %s", v.key, v.value)
+	_, err := v.db.Exec(stmt)
+	return err
+}
+
+// SessionParameterBuilder abstracts the creation of SQL queries for Snowflake session parameters.
+type SessionParameterBuilder struct {
+	key       string
+	value     string
+	onAccount bool
+	user      string
+	db        *sql.DB
+}
+
+func NewSessionParameter(key, value string, db *sql.DB) *SessionParameterBuilder {
+	return &SessionParameterBuilder{
+		key:   key,
+		value: value,
+		db:    db,
+	}
+}
+
+func (v *SessionParameterBuilder) SetOnAccount(onAccount bool) *SessionParameterBuilder {
+	v.onAccount = onAccount
 	return v
 }
 
-func (v *ParameterBuilder) WithObjectIdentifier(objectIdentifier string) *ParameterBuilder {
-	v.objectIdentifier = objectIdentifier
+func (v *SessionParameterBuilder) SetUser(user string) *SessionParameterBuilder {
+	v.user = user
 	return v
 }
 
-func (v *ParameterBuilder) SetParameter() error {
-	// Should this be set on the account level?
-	setOnAccount := v.parameterType == ParameterTypeAccount || v.parameterType == ParameterTypeSession || v.parameterType == ParameterTypeObject && v.objectIdentifier == ""
-	if setOnAccount {
+func (v *SessionParameterBuilder) SetParameter() error {
+	if v.onAccount {
 		// prepared statements do not work here for some reason. We already validate inputs so its okay
 		stmt := fmt.Sprintf("ALTER ACCOUNT SET %s = %s", v.key, v.value)
 		_, err := v.db.Exec(stmt)
 		return err
 	}
-	if v.parameterType == ParameterTypeObject {
-		stmt := fmt.Sprintf("ALTER %s %s SET %s = %s", v.objectType, v.objectIdentifier, v.key, v.value)
-		_, err := v.db.Exec(stmt)
-		if err != nil {
-			return err
-		}
+	if v.user == "" {
+		return fmt.Errorf("user is required when setting session parameters on a user")
 	}
-	return nil
+	stmt := fmt.Sprintf("ALTER USER %s SET %s = %s", v.user, v.key, v.value)
+	_, err := v.db.Exec(stmt)
+	return err
+}
+
+// ObjectParameterBuilder abstracts the creation of SQL queries for Snowflake object parameters.
+type ObjectParameterBuilder struct {
+	key              string
+	value            string
+	onAccount        bool
+	objectType       ObjectType
+	objectIdentifier string
+	db               *sql.DB
+}
+
+func NewObjectParameter(key, value string, db *sql.DB) *ObjectParameterBuilder {
+	return &ObjectParameterBuilder{
+		key:   key,
+		value: value,
+		db:    db,
+	}
+}
+
+func (v *ObjectParameterBuilder) SetOnAccount(onAccount bool) *ObjectParameterBuilder {
+	v.onAccount = onAccount
+	return v
+}
+
+func (v *ObjectParameterBuilder) WithObjectType(objectType ObjectType) *ObjectParameterBuilder {
+	v.objectType = objectType
+	return v
+}
+
+func (v *ObjectParameterBuilder) WithObjectIdentifier(objectIdentifier string) *ObjectParameterBuilder {
+	v.objectIdentifier = objectIdentifier
+	return v
+}
+
+func (v *ObjectParameterBuilder) SetParameter() error {
+	if v.onAccount {
+		// prepared statements do not work here for some reason. We already validate inputs so its okay
+		stmt := fmt.Sprintf("ALTER ACCOUNT SET %s = %s", v.key, v.value)
+		_, err := v.db.Exec(stmt)
+		return err
+	}
+	if v.objectType == "" {
+		return fmt.Errorf("object type is required when setting object parameters")
+	}
+	if v.objectIdentifier == "" {
+		return fmt.Errorf("object identifier is required when setting object parameters")
+	}
+
+	stmt := fmt.Sprintf("ALTER %s %s SET %s = %s", v.objectType, v.objectIdentifier, v.key, v.value)
+	_, err := v.db.Exec(stmt)
+	return err
 }
 
 type Parameter struct {
@@ -743,6 +810,24 @@ type Parameter struct {
 func ShowAccountParameter(db *sql.DB, key string) (*Parameter, error) {
 	stmt := fmt.Sprintf("SHOW PARAMETERS LIKE '%s' IN ACCOUNT", key)
 
+	rows, err := db.Query(stmt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	params := []Parameter{}
+	if err := sqlx.StructScan(rows, &params); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unable to scan row for %s err = %w", stmt, err)
+	}
+
+	return &params[0], nil
+}
+
+func ShowSessionParameter(db *sql.DB, key string, user string) (*Parameter, error) {
+	stmt := fmt.Sprintf("SHOW PARAMETERS LIKE '%s' IN USER %s", key, user)
 	rows, err := db.Query(stmt)
 	if err != nil {
 		return nil, err
@@ -779,16 +864,35 @@ func ShowObjectParameter(db *sql.DB, key string, objectType ObjectType, objectId
 	return &value, nil
 }
 
-func ListParameters(db *sql.DB, parameterType ParameterType, pattern string) ([]Parameter, error) {
+func ListAccountParameters(db *sql.DB, pattern string) ([]Parameter, error) {
 	var stmt string
-	if parameterType == ParameterTypeAccount || parameterType == ParameterTypeSession {
-		if pattern != "" {
-			stmt = fmt.Sprintf("SHOW PARAMETERS LIKE '%s' IN %v", pattern, parameterType)
-		} else {
-			stmt = fmt.Sprintf("SHOW PARAMETERS IN %v", parameterType)
-		}
+	if pattern != "" {
+		stmt = fmt.Sprintf("SHOW PARAMETERS LIKE '%s' IN ACCOUNT", pattern)
 	} else {
-		return nil, fmt.Errorf("unsupported parameter type %s", parameterType)
+		stmt = "SHOW PARAMETERS IN ACCOUNT"
+	}
+	log.Printf("[DEBUG] query = %s", stmt)
+	rows, err := db.Query(stmt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	params := []Parameter{}
+	if err := sqlx.StructScan(rows, &params); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unable to scan row for %s err = %w", stmt, err)
+	}
+	return params, nil
+}
+
+func ListSessionParameters(db *sql.DB, pattern string, user string) ([]Parameter, error) {
+	var stmt string
+	if pattern != "" {
+		stmt = fmt.Sprintf("SHOW PARAMETERS LIKE '%s' FOR USER %s", pattern, user)
+	} else {
+		stmt = fmt.Sprintf("SHOW PARAMETERS FOR USER %s", user)
 	}
 	log.Printf("[DEBUG] query = %s", stmt)
 	rows, err := db.Query(stmt)

--- a/pkg/snowflake/parameters.go
+++ b/pkg/snowflake/parameters.go
@@ -714,9 +714,9 @@ func (v *ParameterExecutor) Query(stmt string) ([]Parameter, error) {
 }
 
 func (v *ParameterExecutor) QueryOne(stmt string) (*Parameter, error) {
-	params, error := v.Query(stmt)
-	if error != nil {
-		return nil, error
+	params, err := v.Query(stmt)
+	if err != nil {
+		return nil, err
 	}
 	if len(params) == 0 {
 		return nil, nil


### PR DESCRIPTION
Allows session params to be created either on account or on user. And object params to be created either on an object, or on account.
issues #1565 , #1546 