### PR TITLE
feat: Add gcp_pubsub_topic_name parameter for gcp notification integr…

### DIFF
--- a/docs/resources/notification_integration.md
+++ b/docs/resources/notification_integration.md
@@ -57,6 +57,7 @@ resource "snowflake_notification_integration" "integration" {
 - `direction` (String) Direction of the cloud messaging with respect to Snowflake (required only for error notifications)
 - `enabled` (Boolean)
 - `gcp_pubsub_subscription_name` (String) The subscription id that Snowflake will listen to when using the GCP_PUBSUB provider.
+- `gcp_pubsub_topic_name` (String) The topic id that Snowflake will use to push notifications.
 - `notification_provider` (String) The third-party cloud message queuing service (e.g. AZURE_STORAGE_QUEUE, AWS_SQS, AWS_SNS)
 - `type` (String) A type of integration
 

--- a/pkg/resources/notification_integration.go
+++ b/pkg/resources/notification_integration.go
@@ -111,6 +111,11 @@ var notificationIntegrationSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Description: "The subscription id that Snowflake will listen to when using the GCP_PUBSUB provider.",
 	},
+	"gcp_pubsub_topic_name": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The topic id that Snowflake will use to push notifications.",
+	},
 	"gcp_pubsub_service_account": {
 		Type:        schema.TypeString,
 		Computed:    true,
@@ -177,6 +182,9 @@ func CreateNotificationIntegration(d *schema.ResourceData, meta interface{}) err
 	}
 	if v, ok := d.GetOk("gcp_pubsub_subscription_name"); ok {
 		stmt.SetString(`GCP_PUBSUB_SUBSCRIPTION_NAME`, v.(string))
+	}
+	if v, ok := d.GetOk("gcp_pubsub_topic_name"); ok {
+		stmt.SetString(`GCP_PUBSUB_TOPIC_NAME`, v.(string))
 	}
 
 	if err := snowflake.Exec(db, stmt.Statement()); err != nil {
@@ -297,6 +305,10 @@ func ReadNotificationIntegration(d *schema.ResourceData, meta interface{}) error
 			if err := d.Set("gcp_pubsub_subscription_name", v.(string)); err != nil {
 				return err
 			}
+		case "GCP_PUBSUB_TOPIC_NAME":
+			if err := d.Set("gcp_pubsub_topic_name", v.(string)); err != nil {
+				return err
+			}
 		case "GCP_PUBSUB_SERVICE_ACCOUNT":
 			if err := d.Set("gcp_pubsub_service_account", v.(string)); err != nil {
 				return err
@@ -378,6 +390,11 @@ func UpdateNotificationIntegration(d *schema.ResourceData, meta interface{}) err
 	if d.HasChange("gcp_pubsub_subscription_name") {
 		runSetStatement = true
 		stmt.SetString("GCP_PUBSUB_SUBSCRIPTION_NAME", d.Get("gcp_pubsub_subscription_name").(string))
+	}
+
+	if d.HasChange("gcp_pubsub_topic_name") {
+		runSetStatement = true
+		stmt.SetString("GCP_PUBSUB_TOPIC_NAME", d.Get("gcp_pubsub_topic_name").(string))
 	}
 
 	if runSetStatement {

--- a/pkg/resources/notification_integration_acceptance_test.go
+++ b/pkg/resources/notification_integration_acceptance_test.go
@@ -60,6 +60,31 @@ func TestAcc_NotificationGCPIntegration(t *testing.T) {
 	})
 }
 
+func TestAcc_NotificationGCPPushIntegration(t *testing.T) {
+	if _, ok := os.LookupEnv("SKIP_NOTIFICATION_INTEGRATION_TESTS"); ok {
+		t.Skip("Skipping TestAcc_NotificationGCPPushIntegration")
+	}
+	accName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	gcpNotificationDirection := "OUTBOUND"
+
+	topicName := "projects/project-1234/subscriptions/sub2"
+	resource.Test(t, resource.TestCase{
+		Providers:    providers(),
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: gcpNotificationPushIntegrationConfig(accName, topicName, gcpNotificationDirection),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_notification_integration.test", "name", accName),
+					resource.TestCheckResourceAttr("snowflake_notification_integration.test", "notification_provider", "GCP_PUBSUB"),
+					resource.TestCheckResourceAttr("snowflake_notification_integration.test", "gcp_pubsub_topic_name", topicName),
+					resource.TestCheckResourceAttr("snowflake_notification_integration.test", "direction", gcpNotificationDirection),
+				),
+			},
+		},
+	})
+}
+
 func azureNotificationIntegrationConfig(name string, azureStorageQueuePrimaryURI string, azureTenantID string) string {
 	s := `
 resource "snowflake_notification_integration" "test" {
@@ -82,4 +107,16 @@ resource "snowflake_notification_integration" "test" {
 }
 `
 	return fmt.Sprintf(s, name, "GCP_PUBSUB", gcpPubsubSubscriptionName, gcpNotificationDirection)
+}
+
+func gcpNotificationPushIntegrationConfig(name string, gcpPubsubTopicName string, gcpNotificationDirection string) string {
+	s := `
+resource "snowflake_notification_integration" "test" {
+  name                            = "%s"
+  notification_provider           = "%s"
+  gcp_pubsub_topic_name           = "%s"
+  direction                       = "%s"
+}
+`
+	return fmt.Sprintf(s, name, "GCP_PUBSUB", gcpPubsubTopicName, gcpNotificationDirection)
 }

--- a/pkg/resources/notification_integration_test.go
+++ b/pkg/resources/notification_integration_test.go
@@ -69,6 +69,16 @@ func TestNotificationIntegrationCreate(t *testing.T) {
 			},
 			expectSQL: `^CREATE NOTIFICATION INTEGRATION "test_notification_integration" COMMENT='great comment' GCP_PUBSUB_SUBSCRIPTION_NAME='some-gcp-sub-name' NOTIFICATION_PROVIDER='GCP_PUBSUB' TYPE='QUEUE' ENABLED=true$`,
 		},
+		{
+			notificationProvider: "GCP_PUBSUB",
+			raw: map[string]interface{}{
+				"name":                  "test_notification_integration",
+				"comment":               "great comment",
+				"notification_provider": "GCP_PUBSUB",
+				"gcp_pubsub_topic_name": "some-gcp-topic-name",
+			},
+			expectSQL: `^CREATE NOTIFICATION INTEGRATION "test_notification_integration" COMMENT='great comment' GCP_PUBSUB_TOPIC_NAME='some-gcp-topic-name' NOTIFICATION_PROVIDER='GCP_PUBSUB' TYPE='QUEUE' ENABLED=true$`,
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -166,7 +176,8 @@ func expectReadNotificationIntegration(mock sqlmock.Sqlmock, notificationProvide
 	case "GCP_PUBSUB":
 		descRows = descRows.
 			AddRow("NOTIFICATION_PROVIDER", "String", notificationProvider, nil).
-			AddRow("GCP_PUBSUB_SUBSCRIPTION_NAME", "String", "some-gcp-sub-name", nil)
+			AddRow("GCP_PUBSUB_SUBSCRIPTION_NAME", "String", "some-gcp-sub-name", nil).
+			AddRow("GCP_PUBSUB_TOPIC_NAME", "String", "some-gcp-topic-name", nil)
 	}
 	mock.ExpectQuery(`DESCRIBE NOTIFICATION INTEGRATION "test_notification_integration"$`).WillReturnRows(descRows)
 }


### PR DESCRIPTION
Add support for `GCP_PUBSUB_TOPIC_NAME` for notification integration 

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests

## References
<!-- issues documentation links, etc  -->
- #1480 
