### PR TITLE
fix(file format): allow single quote to be used in nullif by escaping them

### DIFF
--- a/pkg/resources/file_format.go
+++ b/pkg/resources/file_format.go
@@ -402,7 +402,8 @@ func CreateFileFormat(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok, err := getFormatTypeOption(d, formatType, "null_if"); ok && err == nil {
-		builder.WithNullIf(expandStringListAllowEmpty(v.([]interface{})))
+		expanded := expandStringListAllowEmpty(v.([]interface{}))
+		builder.WithNullIf(snowflake.EscapeAllString(expanded))
 	} else if err != nil {
 		return err
 	}
@@ -955,7 +956,8 @@ func UpdateFileFormat(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("null_if") {
 		change := d.Get("null_if")
-		q := builder.ChangeNullIf(expandStringListAllowEmpty(change.([]interface{})))
+		expanded := expandStringListAllowEmpty(change.([]interface{}))
+		q := builder.ChangeNullIf(snowflake.EscapeAllString(expanded))
 		if err := snowflake.Exec(db, q); err != nil {
 			return fmt.Errorf("error updating file format null_if on %v err = %w", d.Id(), err)
 		}

--- a/pkg/resources/helper_expansion.go
+++ b/pkg/resources/helper_expansion.go
@@ -27,14 +27,14 @@ func expandStringList(configured []interface{}) []string {
 
 func expandStringListAllowEmpty(configured []interface{}) []string {
 	// Allow empty values during expansion
-    vs := make([]string, 0, len(configured))
-    for _, v := range configured {
-            val, ok := v.(string)
-            if ok {
-                    vs = append(vs, val)
-            }
-    }
-    return vs
+	vs := make([]string, 0, len(configured))
+	for _, v := range configured {
+		val, ok := v.(string)
+		if ok {
+			vs = append(vs, val)
+		}
+	}
+	return vs
 }
 
 func expandObjectIdentifier(objectIdentifier interface{}) (string, string, string) {

--- a/pkg/snowflake/escaping.go
+++ b/pkg/snowflake/escaping.go
@@ -14,6 +14,14 @@ func EscapeString(in string) string {
 	return out
 }
 
+func EscapeAllString(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		out = append(out, EscapeString(v))
+	}
+	return out
+}
+
 // UnescapeString reverses EscapeString.
 func UnescapeString(in string) string {
 	out := strings.ReplaceAll(in, `\\`, `\`)


### PR DESCRIPTION
## Summary

The Snowflake file format allows the use of `NULL_IF` values, including the use of the double single-quote value `''`. The Snowflake Terraform provider however does not handle this value due to how the `CREATE` and `ALTER` queries are built using the single-quote `'`, this results in a single quote being written to Snowflake: `''` becomes `'`.

This PR aims to fix this issue by escaping any single quote used in all `NULL_IF` values. To achieve this result, I created a new escaping function `EscapeAllString` that calls `EscapeString` for every values listed in `NULL_IF` and call it in the create/alter functions for the file format. The read function does not have the problem, and changes are correctly detected.

## Test Plan

* [ ] acceptance tests
* [x] unit tests

## References
