### PR TITLE
fix: resource monitor read SI trigger bug

### DIFF
--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -318,7 +318,7 @@ func ReadResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 		setSuspendImmediateTrigger = true
 	}
 	if !setSuspendImmediateTrigger {
-		if len(sTrig) > 0 {
+		if len(siTrig) > 0 {
 			if err := d.Set("suspend_immediate_trigger", siTrig[0]); err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixing a bug that causes a plugin crash when attempting to set suspend immediate trigger in the special case.

closes #1732 