### PR TITLE
fix: fixing the table's database and schema name for Column tag

### DIFF
--- a/pkg/snowflake/tag_association.go
+++ b/pkg/snowflake/tag_association.go
@@ -63,9 +63,11 @@ func (tb *TagAssociationBuilder) GetTableAndColumnName() (string, string) {
 		return tb.objectIdentifier, ""
 	}
 	splObjIdentifier := strings.Split(tb.objectIdentifier, ".")
+	tableDatabase := strings.ReplaceAll(splObjIdentifier[0], "\"", "")
+	tableSchema := strings.ReplaceAll(splObjIdentifier[1], "\"", "")
 	tableName := strings.ReplaceAll(splObjIdentifier[2], "\"", "")
 	columnName := strings.ReplaceAll(splObjIdentifier[3], "\"", "")
-	return fmt.Sprintf(`"%s"."%s"."%s"`, tb.databaseName, tb.schemaName, tableName), columnName
+	return fmt.Sprintf(`"%s"."%s"."%s"`, tableDatabase, tableSchema, tableName), columnName
 }
 
 // TagAssociation returns a pointer to a Builder that abstracts the DDL operations for a tag sssociation.

--- a/pkg/snowflake/tag_association_test.go
+++ b/pkg/snowflake/tag_association_test.go
@@ -28,6 +28,12 @@ func TestTagAssociation(t *testing.T) {
 			ExpectedShow:   `SELECT SYSTEM$GET_TAG('"test_db"."test_schema"."sensitive"', '"test_db"."test_schema"."test_table"."important"', 'COLUMN') TAG_VALUE WHERE TAG_VALUE IS NOT NULL`,
 		},
 		{
+			Builder:        NewTagAssociationBuilder("tag_db|tag_schema|sensitive").WithObjectIdentifier(`"table_db"."table_schema"."test_table.important"`).WithObjectType("COLUMN").WithTagValue("true"),
+			ExpectedCreate: `ALTER TABLE "table_db"."table_schema"."test_table" MODIFY COLUMN "important" SET TAG "tag_db"."tag_schema"."sensitive" = 'true'`,
+			ExpectedDrop:   `ALTER TABLE "table_db"."table_schema"."test_table" MODIFY COLUMN "important" UNSET TAG "tag_db"."tag_schema"."sensitive"`,
+			ExpectedShow:   `SELECT SYSTEM$GET_TAG('"tag_db"."tag_schema"."sensitive"', '"table_db"."table_schema"."test_table"."important"', 'COLUMN') TAG_VALUE WHERE TAG_VALUE IS NOT NULL`,
+		},
+		{
 			Builder:        NewTagAssociationBuilder("OPERATION_DB|SECURITY|PII_2").WithObjectIdentifier(`"OPERATION_DB"."SECURITY"."test_table.important"`).WithObjectType("COLUMN").WithTagValue("true"),
 			ExpectedCreate: `ALTER TABLE "OPERATION_DB"."SECURITY"."test_table" MODIFY COLUMN "important" SET TAG "OPERATION_DB"."SECURITY"."PII_2" = 'true'`,
 			ExpectedDrop:   `ALTER TABLE "OPERATION_DB"."SECURITY"."test_table" MODIFY COLUMN "important" UNSET TAG "OPERATION_DB"."SECURITY"."PII_2"`,


### PR DESCRIPTION
When the database and schema of the table and tags are different, the code was applying the tag's database and schema to the table name. 
Error we were getting for this type of configuration
```
resource "snowflake_tag" "test_tag" {
  name           = "tag_name2"
  database       = "TAG_DB"
  schema         = "TAG_SCHEMA"
}

resource "snowflake_table" "test_table" {
  database            = "TEST_DB"
  schema              = "TEST_SCHEMA"
  name                = "test_table"
  comment             = "A table."
  
  column {
     name    = "column_name"
     type    = "VARIANT"
  }
}

resource "snowflake_tag_association" "column_association" {
  object_identifier {
    name                = "${snowflake_table.test_table.name}.${snowflake_table.test_table.column[0].name}"
    # name                = snowflake_table.test_table.column[0].name
    database            = "TEST_DB"
    schema              = "TEST_SCHEMA"
  }

  object_type = "COLUMN"
  tag_id      = snowflake_tag.test_tag.id
  tag_value   = "value"
}

```
```
ALTER TABLE "TAG_DB"."TAG_SCHEMA"."test_table" MODIFY COLUMN "column_name" SET TAG "TAG_DB"."TAG_SCHEMA"."tag_name2" = 'value'

SQL compilation error: Table 'TAG_DB.TAG_SCHEMA."test_table"' does not exist or not authorized.
```
Correct query should be like this
```
ALTER TABLE "TEST_DB"."TEST_SCHEMA"."test_table" SET TAG "TAG_DB"."TAG_SCHEMA"."table_tag" = 'value2'
```
## References
<!-- issues documentation links, etc  -->

* [issue#1558](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1558)