### PR TITLE
chore: fix parameters datasource acceptance test

### DIFF
--- a/pkg/datasources/parameters_acceptance_test.go
+++ b/pkg/datasources/parameters_acceptance_test.go
@@ -57,7 +57,7 @@ func TestAcc_ParametersOnObject(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.snowflake_parameters.p", "parameters.#"),
 					resource.TestCheckResourceAttrSet("data.snowflake_parameters.p", "parameters.0.key"),
-					resource.TestCheckResourceAttrSet("data.snowflake_parameters.p", "parameters.0.value"),
+					resource.TestCheckResourceAttrSet("data.snowflake_parameters.p", "parameters.0.type"),
 					resource.TestCheckResourceAttr("data.snowflake_parameters.p", "object_type", "DATABASE"),
 					resource.TestCheckResourceAttr("data.snowflake_parameters.p", "object_name", dbName),
 				),

--- a/pkg/resources/object_parameter_acceptance_test.go
+++ b/pkg/resources/object_parameter_acceptance_test.go
@@ -16,10 +16,10 @@ func TestAcc_ObjectParameter(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: objectParameterConfigBasic(prefix, "ENABLE_STREAM_TASK_REPLICATION", "true"),
+				Config: objectParameterConfigBasic(prefix, "USER_TASK_TIMEOUT_MS", "1000"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("snowflake_object_parameter.p", "key", "ENABLE_STREAM_TASK_REPLICATION"),
-					resource.TestCheckResourceAttr("snowflake_object_parameter.p", "value", "true"),
+					resource.TestCheckResourceAttr("snowflake_object_parameter.p", "key", "USER_TASK_TIMEOUT_MS"),
+					resource.TestCheckResourceAttr("snowflake_object_parameter.p", "value", "1000"),
 					resource.TestCheckResourceAttr("snowflake_object_parameter.p", "on_account", "false"),
 				),
 			},


### PR DESCRIPTION
The value field can sometime be null. Recently the first parameters returned has changed and that new parameter has a null value. We'll stop relying on the value field being set for acceptance tests.