### PR TITLE
fix: Add missing Google Cloud computed property api_gcp_service_accou…

### DIFF
--- a/docs/resources/api_integration.md
+++ b/docs/resources/api_integration.md
@@ -52,6 +52,7 @@ resource "snowflake_api_integration" "gcp" {
 
 - `api_aws_role_arn` (String) ARN of a cloud platform role.
 - `api_blocked_prefixes` (List of String) Lists the endpoints and resources in the HTTPS proxy service that are not allowed to be called from Snowflake.
+- `api_gcp_service_account` (String) The service account used for communication with the Google API Gateway.
 - `api_key` (String, Sensitive) The API key (also called a “subscription key”).
 - `azure_ad_application_id` (String) The 'Application (client) id' of the Azure AD app for your remote service.
 - `azure_tenant_id` (String) Specifies the ID for your Office 365 tenant that all Azure API Management instances belong to.

--- a/pkg/resources/api_integration.go
+++ b/pkg/resources/api_integration.go
@@ -70,6 +70,12 @@ var apiIntegrationSchema = map[string]*schema.Schema{
 		Default:     "",
 		Description: "The audience claim when generating the JWT (JSON Web Token) to authenticate to the Google API Gateway.",
 	},
+	"api_gcp_service_account": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The service account used for communication with the Google API Gateway.",
+		Computed:    true,
+	},
 	"api_allowed_prefixes": {
 		Type:        schema.TypeList,
 		Elem:        &schema.Schema{Type: schema.TypeString},
@@ -250,6 +256,10 @@ func ReadAPIIntegration(d *schema.ResourceData, meta interface{}) error {
 			}
 		case "GOOGLE_AUDIENCE":
 			if err := d.Set("google_audience", v.(string)); err != nil {
+				return err
+			}
+		case "API_GCP_SERVICE_ACCOUNT":
+			if err := d.Set("api_gcp_service_account", v.(string)); err != nil {
 				return err
 			}
 		default:

--- a/pkg/resources/api_integration_acceptance_test.go
+++ b/pkg/resources/api_integration_acceptance_test.go
@@ -55,6 +55,7 @@ func TestAcc_ApiIntegration(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_api_integration.test_gcp_int", "comment", "acceptance test"),
 					resource.TestCheckResourceAttrSet("snowflake_api_integration.test_gcp_int", "created_on"),
 					resource.TestCheckResourceAttrSet("snowflake_api_integration.test_gcp_int", "google_audience"),
+					resource.TestCheckResourceAttrSet("snowflake_api_integration.test_gcp_int", "api_gcp_service_account"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes #1775 

Tests:
```bash
(base) ➜  terraform-provider-snowflake git:(issue-1775) ✗ go test github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources -run "^TestAcc_ApiIntegration$" -v
=== RUN   TestAcc_ApiIntegration
--- PASS: TestAcc_ApiIntegration (7.64s)
PASS

```

