### PR TITLE
fix: gorelease freebsd

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -5,6 +5,7 @@ builds:
     - windows
     - linux
     - darwin
+    - freebsd
   goarch:
     - amd64
     - arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ builds:
     - windows
     - linux
     - darwin
+    - freebsd
   goarch:
     - amd64
     - arm64


### PR DESCRIPTION
Build FreeBSD package

## Test Plan

This builds cleanly on FreeBSD with no modifications, using `gmake install`, as well as `goreleaser build --single-target --snapshot`. I have used the resulting binary to create snowflake resources.

## Before

```
Initializing provider plugins...
- Finding snowflake-labs/snowflake versions matching "~> 0.64"...
╷
│ Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/snowflake-labs/snowflake v0.64.0 does not have a package
│ available for your current platform, freebsd_amd64.
│ 
│ Provider releases are separate from Terraform CLI releases, so not all providers are
│ available for all platforms. Other versions of this provider may have different platforms
│ supported.
```

## After

`Apply complete! Resources: 2 added, 0 changed, 0 destroyed.`