### PR TITLE
fix: reading warehouse with underscore in name

### DIFF
--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -237,16 +237,10 @@ func ReadWarehouse(d *schema.ResourceData, meta interface{}) error {
 
 	id := helpers.DecodeSnowflakeID(d.Id()).(sdk.AccountObjectIdentifier)
 
-	warehouses, err := client.Warehouses.Show(ctx, &sdk.WarehouseShowOptions{
-		Like: &sdk.Like{
-			Pattern: sdk.String(id.Name()),
-		},
-	})
+	w, err := client.Warehouses.ShowById(ctx, id)
 	if err != nil {
 		return err
 	}
-
-	w := warehouses[0]
 
 	if err = d.Set("name", w.Name); err != nil {
 		return err

--- a/pkg/resources/warehouse_acceptance_test.go
+++ b/pkg/resources/warehouse_acceptance_test.go
@@ -70,6 +70,28 @@ func TestAcc_Warehouse(t *testing.T) {
 	})
 }
 
+func TestAcc_WarehousePattern(t *testing.T) {
+	if _, ok := os.LookupEnv("SKIP_WAREHOUSE_TESTS"); ok {
+		t.Skip("Skipping TestAccWarehouse")
+	}
+
+	prefix := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    providers(),
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: wConfigPattern(prefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_warehouse.w1", "name", fmt.Sprintf("%s_", prefix)),
+					resource.TestCheckResourceAttr("snowflake_warehouse.w2", "name", fmt.Sprintf("%s1", prefix)),
+				),
+			},
+		},
+	})
+}
+
 func wConfig(prefix string) string {
 	s := `
 resource "snowflake_warehouse" "w" {
@@ -105,4 +127,16 @@ resource "snowflake_warehouse" "w" {
 }
 `
 	return fmt.Sprintf(s, prefix)
+}
+
+func wConfigPattern(prefix string) string {
+	s := `
+resource "snowflake_warehouse" "w1" {
+	name           = "%s_"
+}
+resource "snowflake_warehouse" "w2" {
+	name           = "%s1"
+}
+`
+	return fmt.Sprintf(s, prefix, prefix)
 }

--- a/pkg/sdk/warehouse.go
+++ b/pkg/sdk/warehouse.go
@@ -19,6 +19,8 @@ type Warehouses interface {
 	Drop(ctx context.Context, id AccountObjectIdentifier, opts *WarehouseDropOptions) error
 	// Show returns a list of warehouses.
 	Show(ctx context.Context, opts *WarehouseShowOptions) ([]*Warehouse, error)
+	// Show + filter to return SHOW data for a single warehouse.
+	ShowById(ctx context.Context, id ObjectIdentifier) (*Warehouse, error)
 	// Describe returns the details of a warehouse.
 	Describe(ctx context.Context, id AccountObjectIdentifier) (*WarehouseDetails, error)
 }
@@ -414,6 +416,24 @@ func (c *warehouses) Show(ctx context.Context, opts *WarehouseShowOptions) ([]*W
 	}
 
 	return resultList, nil
+}
+
+func (c *warehouses) ShowById(ctx context.Context, id ObjectIdentifier) (*Warehouse, error) {
+	results, err := c.Show(ctx, &WarehouseShowOptions{
+		Like: &Like{
+			Pattern: String(id.Name()),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, res := range results {
+		if res.ID().name == id.Name() {
+			return res, nil
+		}
+	}
+	return nil, ErrObjectNotExistOrAuthorized
 }
 
 type warehouseDescribeOptions struct {


### PR DESCRIPTION
Fix a bug where underscore in warehouse names would be treated as wildcards (cf. https://docs.snowflake.com/en/sql-reference/functions/like) and the read operation would return the wrong warehouse, leading to unwanted changes, etc.

## Test Plan
* [X] new regression test

## References

* To be merged after https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/1792 