### PR TITLE
fix: allow password_policy.max_age_days = 0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,4 +13,5 @@
     "go.lintFlags": [
         "--fast"
     ],
+    "files.trimTrailingWhitespace": true,
 }

--- a/pkg/resources/password_policy.go
+++ b/pkg/resources/password_policy.go
@@ -142,48 +142,19 @@ func CreatePasswordPolicy(d *schema.ResourceData, meta interface{}) error {
 	database := d.Get("database").(string)
 	schema := d.Get("schema").(string)
 	objectIdentifier := sdk.NewSchemaObjectIdentifier(database, schema, name)
-	createOptions := &sdk.PasswordPolicyCreateOptions{}
 
-	if v, ok := d.GetOk("or_replace"); ok {
-		createOptions.OrReplace = sdk.Bool(v.(bool))
-	}
-
-	if v, ok := d.GetOk("if_not_exists"); ok {
-		createOptions.IfNotExists = sdk.Bool(v.(bool))
-	}
-
-	if v, ok := d.GetOk("min_length"); ok {
-		createOptions.PasswordMinLength = sdk.Int(v.(int))
-	}
-
-	if v, ok := d.GetOk("max_length"); ok {
-		createOptions.PasswordMaxLength = sdk.Int(v.(int))
-	}
-
-	if v, ok := d.GetOk("min_upper_case_chars"); ok {
-		createOptions.PasswordMinUpperCaseChars = sdk.Int(v.(int))
-	}
-
-	if v, ok := d.GetOk("min_lower_case_chars"); ok {
-		createOptions.PasswordMinLowerCaseChars = sdk.Int(v.(int))
-	}
-
-	if v, ok := d.GetOk("min_numeric_chars"); ok {
-		createOptions.PasswordMinNumericChars = sdk.Int(v.(int))
-	}
-
-	if v, ok := d.GetOk("min_special_chars"); ok {
-		createOptions.PasswordMinSpecialChars = sdk.Int(v.(int))
-	}
-
-	createOptions.PasswordMaxAgeDays = sdk.Int(d.Get("max_age_days").(int))
-
-	if v, ok := d.GetOk("max_retries"); ok {
-		createOptions.PasswordMaxRetries = sdk.Int(v.(int))
-	}
-
-	if v, ok := d.GetOk("lockout_time_mins"); ok {
-		createOptions.PasswordLockoutTimeMins = sdk.Int(v.(int))
+	createOptions := &sdk.PasswordPolicyCreateOptions{
+		OrReplace:                 sdk.Bool(d.Get("or_replace").(bool)),
+		IfNotExists:               sdk.Bool(d.Get("if_not_exists").(bool)),
+		PasswordMinLength:         sdk.Int(d.Get("min_length").(int)),
+		PasswordMaxLength:         sdk.Int(d.Get("max_length").(int)),
+		PasswordMinUpperCaseChars: sdk.Int(d.Get("min_upper_case_chars").(int)),
+		PasswordMinLowerCaseChars: sdk.Int(d.Get("min_lower_case_chars").(int)),
+		PasswordMinNumericChars:   sdk.Int(d.Get("min_numeric_chars").(int)),
+		PasswordMinSpecialChars:   sdk.Int(d.Get("min_special_chars").(int)),
+		PasswordMaxAgeDays:        sdk.Int(d.Get("max_age_days").(int)),
+		PasswordMaxRetries:        sdk.Int(d.Get("max_retries").(int)),
+		PasswordLockoutTimeMins:   sdk.Int(d.Get("lockout_time_mins").(int)),
 	}
 
 	if v, ok := d.GetOk("comment"); ok {
@@ -264,15 +235,10 @@ func UpdatePasswordPolicy(d *schema.ResourceData, meta interface{}) error {
 	objectIdentifier := helpers.DecodeSnowflakeID(d.Id()).(sdk.SchemaObjectIdentifier)
 
 	if d.HasChange("min_length") {
-		alterOptions := &sdk.PasswordPolicyAlterOptions{}
-		if v, ok := d.GetOk("min_length"); ok {
-			alterOptions.Set = &sdk.PasswordPolicySet{
-				PasswordMinLength: sdk.Int(v.(int)),
-			}
-		} else {
-			alterOptions.Unset = &sdk.PasswordPolicyUnset{
-				PasswordMinLength: sdk.Bool(true),
-			}
+		alterOptions := &sdk.PasswordPolicyAlterOptions{
+			Set: &sdk.PasswordPolicySet{
+				PasswordMinLength: sdk.Int(d.Get("min_length").(int)),
+			},
 		}
 		err := client.PasswordPolicies.Alter(ctx, objectIdentifier, alterOptions)
 		if err != nil {
@@ -280,15 +246,10 @@ func UpdatePasswordPolicy(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	if d.HasChange("max_length") {
-		alterOptions := &sdk.PasswordPolicyAlterOptions{}
-		if v, ok := d.GetOk("max_length"); ok {
-			alterOptions.Set = &sdk.PasswordPolicySet{
-				PasswordMaxLength: sdk.Int(v.(int)),
-			}
-		} else {
-			alterOptions.Unset = &sdk.PasswordPolicyUnset{
-				PasswordMaxLength: sdk.Bool(true),
-			}
+		alterOptions := &sdk.PasswordPolicyAlterOptions{
+			Set: &sdk.PasswordPolicySet{
+				PasswordMaxLength: sdk.Int(d.Get("max_length").(int)),
+			},
 		}
 		err := client.PasswordPolicies.Alter(ctx, objectIdentifier, alterOptions)
 		if err != nil {
@@ -296,15 +257,10 @@ func UpdatePasswordPolicy(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	if d.HasChange("min_upper_case_chars") {
-		alterOptions := &sdk.PasswordPolicyAlterOptions{}
-		if v, ok := d.GetOk("min_upper_case_chars"); ok {
-			alterOptions.Set = &sdk.PasswordPolicySet{
-				PasswordMinUpperCaseChars: sdk.Int(v.(int)),
-			}
-		} else {
-			alterOptions.Unset = &sdk.PasswordPolicyUnset{
-				PasswordMinUpperCaseChars: sdk.Bool(true),
-			}
+		alterOptions := &sdk.PasswordPolicyAlterOptions{
+			Set: &sdk.PasswordPolicySet{
+				PasswordMinUpperCaseChars: sdk.Int(d.Get("min_upper_case_chars").(int)),
+			},
 		}
 		err := client.PasswordPolicies.Alter(ctx, objectIdentifier, alterOptions)
 		if err != nil {
@@ -312,15 +268,10 @@ func UpdatePasswordPolicy(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	if d.HasChange("min_lower_case_chars") {
-		alterOptions := &sdk.PasswordPolicyAlterOptions{}
-		if v, ok := d.GetOk("min_lower_case_chars"); ok {
-			alterOptions.Set = &sdk.PasswordPolicySet{
-				PasswordMinLowerCaseChars: sdk.Int(v.(int)),
-			}
-		} else {
-			alterOptions.Unset = &sdk.PasswordPolicyUnset{
-				PasswordMinLowerCaseChars: sdk.Bool(true),
-			}
+		alterOptions := &sdk.PasswordPolicyAlterOptions{
+			Set: &sdk.PasswordPolicySet{
+				PasswordMinLowerCaseChars: sdk.Int(d.Get("min_lower_case_chars").(int)),
+			},
 		}
 		err := client.PasswordPolicies.Alter(ctx, objectIdentifier, alterOptions)
 		if err != nil {
@@ -329,15 +280,10 @@ func UpdatePasswordPolicy(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("min_numeric_chars") {
-		alterOptions := &sdk.PasswordPolicyAlterOptions{}
-		if v, ok := d.GetOk("min_numeric_chars"); ok {
-			alterOptions.Set = &sdk.PasswordPolicySet{
-				PasswordMinNumericChars: sdk.Int(v.(int)),
-			}
-		} else {
-			alterOptions.Unset = &sdk.PasswordPolicyUnset{
-				PasswordMinNumericChars: sdk.Bool(true),
-			}
+		alterOptions := &sdk.PasswordPolicyAlterOptions{
+			Set: &sdk.PasswordPolicySet{
+				PasswordMinNumericChars: sdk.Int(d.Get("min_numeric_chars").(int)),
+			},
 		}
 		err := client.PasswordPolicies.Alter(ctx, objectIdentifier, alterOptions)
 		if err != nil {
@@ -346,15 +292,10 @@ func UpdatePasswordPolicy(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("min_special_chars") {
-		alterOptions := &sdk.PasswordPolicyAlterOptions{}
-		if v, ok := d.GetOk("min_special_chars"); ok {
-			alterOptions.Set = &sdk.PasswordPolicySet{
-				PasswordMinSpecialChars: sdk.Int(v.(int)),
-			}
-		} else {
-			alterOptions.Unset = &sdk.PasswordPolicyUnset{
-				PasswordMinSpecialChars: sdk.Bool(true),
-			}
+		alterOptions := &sdk.PasswordPolicyAlterOptions{
+			Set: &sdk.PasswordPolicySet{
+				PasswordMinSpecialChars: sdk.Int(d.Get("min_special_chars").(int)),
+			},
 		}
 		err := client.PasswordPolicies.Alter(ctx, objectIdentifier, alterOptions)
 		if err != nil {
@@ -375,15 +316,10 @@ func UpdatePasswordPolicy(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("max_retries") {
-		alterOptions := &sdk.PasswordPolicyAlterOptions{}
-		if v, ok := d.GetOk("max_retries"); ok {
-			alterOptions.Set = &sdk.PasswordPolicySet{
-				PasswordMaxRetries: sdk.Int(v.(int)),
-			}
-		} else {
-			alterOptions.Unset = &sdk.PasswordPolicyUnset{
-				PasswordMaxRetries: sdk.Bool(true),
-			}
+		alterOptions := &sdk.PasswordPolicyAlterOptions{
+			Set: &sdk.PasswordPolicySet{
+				PasswordMaxRetries: sdk.Int(d.Get("max_retries").(int)),
+			},
 		}
 		err := client.PasswordPolicies.Alter(ctx, objectIdentifier, alterOptions)
 		if err != nil {
@@ -391,15 +327,10 @@ func UpdatePasswordPolicy(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	if d.HasChange("lockout_time_mins") {
-		alterOptions := &sdk.PasswordPolicyAlterOptions{}
-		if v, ok := d.GetOk("lockout_time_mins"); ok {
-			alterOptions.Set = &sdk.PasswordPolicySet{
-				PasswordLockoutTimeMins: sdk.Int(v.(int)),
-			}
-		} else {
-			alterOptions.Unset = &sdk.PasswordPolicyUnset{
-				PasswordLockoutTimeMins: sdk.Bool(true),
-			}
+		alterOptions := &sdk.PasswordPolicyAlterOptions{
+			Set: &sdk.PasswordPolicySet{
+				PasswordLockoutTimeMins: sdk.Int(d.Get("lockout_time_mins").(int)),
+			},
 		}
 		err := client.PasswordPolicies.Alter(ctx, objectIdentifier, alterOptions)
 		if err != nil {

--- a/pkg/resources/password_policy.go
+++ b/pkg/resources/password_policy.go
@@ -176,9 +176,7 @@ func CreatePasswordPolicy(d *schema.ResourceData, meta interface{}) error {
 		createOptions.PasswordMinSpecialChars = sdk.Int(v.(int))
 	}
 
-	if v, ok := d.GetOk("max_age_days"); ok {
-		createOptions.PasswordMaxAgeDays = sdk.Int(v.(int))
-	}
+	createOptions.PasswordMaxAgeDays = sdk.Int(d.Get("max_age_days").(int))
 
 	if v, ok := d.GetOk("max_retries"); ok {
 		createOptions.PasswordMaxRetries = sdk.Int(v.(int))
@@ -365,15 +363,10 @@ func UpdatePasswordPolicy(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("max_age_days") {
-		alterOptions := &sdk.PasswordPolicyAlterOptions{}
-		if v, ok := d.GetOk("max_age_days"); ok {
-			alterOptions.Set = &sdk.PasswordPolicySet{
-				PasswordMaxAgeDays: sdk.Int(v.(int)),
-			}
-		} else {
-			alterOptions.Unset = &sdk.PasswordPolicyUnset{
-				PasswordMaxAgeDays: sdk.Bool(true),
-			}
+		alterOptions := &sdk.PasswordPolicyAlterOptions{
+			Set: &sdk.PasswordPolicySet{
+				PasswordMaxAgeDays: sdk.Int(d.Get("max_age_days").(int)),
+			},
 		}
 		err := client.PasswordPolicies.Alter(ctx, objectIdentifier, alterOptions)
 		if err != nil {

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -169,11 +169,17 @@ func CreateWarehouse(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	objectIdentifier := sdk.NewAccountObjectIdentifier(name)
 
-	createOptions := &sdk.WarehouseCreateOptions{}
-
-	if v, ok := d.GetOk("comment"); ok {
-		createOptions.Comment = sdk.String(v.(string))
+	whType := sdk.WarehouseType(d.Get("warehouse_type").(string))
+	createOptions := &sdk.WarehouseCreateOptions{
+		Comment:                         sdk.String(d.Get("comment").(string)),
+		StatementTimeoutInSeconds:       sdk.Int(d.Get("statement_timeout_in_seconds").(int)),
+		StatementQueuedTimeoutInSeconds: sdk.Int(d.Get("statement_queued_timeout_in_seconds").(int)),
+		MaxConcurrencyLevel:             sdk.Int(d.Get("max_concurrency_level").(int)),
+		EnableQueryAcceleration:         sdk.Bool(d.Get("enable_query_acceleration").(bool)),
+		QueryAccelerationMaxScaleFactor: sdk.Int(d.Get("query_acceleration_max_scale_factor").(int)),
+		WarehouseType:                   &whType,
 	}
+
 	if v, ok := d.GetOk("warehouse_size"); ok {
 		size := sdk.WarehouseSize(strings.ReplaceAll(v.(string), "-", ""))
 		createOptions.WarehouseSize = &size
@@ -199,25 +205,6 @@ func CreateWarehouse(d *schema.ResourceData, meta interface{}) error {
 	}
 	if v, ok := d.GetOk("resource_monitor"); ok {
 		createOptions.ResourceMonitor = sdk.String(v.(string))
-	}
-	if v, ok := d.GetOk("statement_timeout_in_seconds"); ok {
-		createOptions.StatementTimeoutInSeconds = sdk.Int(v.(int))
-	}
-	if v, ok := d.GetOk("statement_queued_timeout_in_seconds"); ok {
-		createOptions.StatementQueuedTimeoutInSeconds = sdk.Int(v.(int))
-	}
-	if v, ok := d.GetOk("max_concurrency_level"); ok {
-		createOptions.MaxConcurrencyLevel = sdk.Int(v.(int))
-	}
-	if v, ok := d.GetOk("enable_query_acceleration"); ok {
-		createOptions.EnableQueryAcceleration = sdk.Bool(v.(bool))
-	}
-	if v, ok := d.GetOk("query_acceleration_max_scale_factor"); ok {
-		createOptions.QueryAccelerationMaxScaleFactor = sdk.Int(v.(int))
-	}
-	if v, ok := d.GetOk("warehouse_type"); ok {
-		whType := sdk.WarehouseType(v.(string))
-		createOptions.WarehouseType = &whType
 	}
 
 	err := client.Warehouses.Create(ctx, objectIdentifier, createOptions)
@@ -314,23 +301,13 @@ func UpdateWarehouse(d *schema.ResourceData, meta interface{}) error {
 	set := sdk.WarehouseSet{}
 	unset := sdk.WarehouseUnset{}
 	if d.HasChange("comment") {
-		if v, ok := d.GetOk("comment"); ok {
-			runSet = true
-			set.Comment = sdk.String(v.(string))
-		} else {
-			runUnset = true
-			unset.Comment = sdk.Bool(true)
-		}
+		runSet = true
+		set.Comment = sdk.String(d.Get("comment").(string))
 	}
 	if d.HasChange("warehouse_size") {
-		if v, ok := d.GetOk("warehouse_size"); ok {
-			runSet = true
-			size := sdk.WarehouseSize(strings.ReplaceAll(v.(string), "-", ""))
-			set.WarehouseSize = &size
-		} else {
-			runUnset = true
-			unset.WarehouseSize = sdk.Bool(true)
-		}
+		runSet = true
+		size := sdk.WarehouseSize(strings.ReplaceAll(d.Get("warehouse_size").(string), "-", ""))
+		set.WarehouseSize = &size
 	}
 	if d.HasChange("max_cluster_count") {
 		if v, ok := d.GetOk("max_cluster_count"); ok {
@@ -388,49 +365,24 @@ func UpdateWarehouse(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	if d.HasChange("statement_timeout_in_seconds") {
-		if v, ok := d.GetOk("statement_timeout_in_seconds"); ok {
-			runSet = true
-			set.StatementTimeoutInSeconds = sdk.Int(v.(int))
-		} else {
-			runUnset = true
-			unset.StatementTimeoutInSeconds = sdk.Bool(true)
-		}
+		runSet = true
+		set.StatementTimeoutInSeconds = sdk.Int(d.Get("statement_timeout_in_seconds").(int))
 	}
 	if d.HasChange("statement_queued_timeout_in_seconds") {
-		if v, ok := d.GetOk("statement_queued_timeout_in_seconds"); ok {
-			runSet = true
-			set.StatementQueuedTimeoutInSeconds = sdk.Int(v.(int))
-		} else {
-			runUnset = true
-			unset.StatementQueuedTimeoutInSeconds = sdk.Bool(true)
-		}
+		runSet = true
+		set.StatementQueuedTimeoutInSeconds = sdk.Int(d.Get("statement_queued_timeout_in_seconds").(int))
 	}
 	if d.HasChange("max_concurrency_level") {
-		if v, ok := d.GetOk("max_concurrency_level"); ok {
-			runSet = true
-			set.MaxConcurrencyLevel = sdk.Int(v.(int))
-		} else {
-			runUnset = true
-			unset.MaxConcurrencyLevel = sdk.Bool(true)
-		}
+		runSet = true
+		set.MaxConcurrencyLevel = sdk.Int(d.Get("max_concurrency_level").(int))
 	}
 	if d.HasChange("enable_query_acceleration") {
-		if v, ok := d.GetOk("enable_query_acceleration"); ok {
-			runSet = true
-			set.EnableQueryAcceleration = sdk.Bool(v.(bool))
-		} else {
-			runUnset = true
-			unset.EnableQueryAcceleration = sdk.Bool(true)
-		}
+		runSet = true
+		set.EnableQueryAcceleration = sdk.Bool(d.Get("enable_query_acceleration").(bool))
 	}
 	if d.HasChange("query_acceleration_max_scale_factor") {
-		if v, ok := d.GetOk("query_acceleration_max_scale_factor"); ok {
-			runSet = true
-			set.QueryAccelerationMaxScaleFactor = sdk.Int(v.(int))
-		} else {
-			runUnset = true
-			unset.QueryAccelerationMaxScaleFactor = sdk.Bool(true)
-		}
+		runSet = true
+		set.QueryAccelerationMaxScaleFactor = sdk.Int(d.Get("query_acceleration_max_scale_factor").(int))
 	}
 	if d.HasChange("warehouse_type") {
 		if v, ok := d.GetOk("warehouse_type"); ok {


### PR DESCRIPTION
Fix a bug (#1762) where setting max_age_days to 0 would be ignored and default back to 90 (default value). This is fixed for other resources too.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [X] added new acceptance test to cover creation and update of password policies with max_age_days=0

## References

* #1762 