### PR TITLE
Fix handling of TIME(*)

### DIFF
--- a/pkg/sdk/data_types.go
+++ b/pkg/sdk/data_types.go
@@ -35,8 +35,6 @@ func DataTypeFromString(s string) DataType {
 	switch dType {
 	case "DATE":
 		return DataTypeDate
-	case "TIME":
-		return DataTypeTime
 	case "VARIANT":
 		return DataTypeVariant
 	case "OBJECT":
@@ -69,6 +67,11 @@ func DataTypeFromString(s string) DataType {
 	booleanSynonyms := []string{"BOOLEAN", "BOOL"}
 	if slices.Contains(booleanSynonyms, dType) {
 		return DataTypeBoolean
+	}
+
+	timeSynonyms := []string{"TIME"}
+	if slices.ContainsFunc(timeSynonyms, func(s string) bool { return strings.HasPrefix(dType, s) }) {
+		return DataTypeTime
 	}
 
 	timestampLTZSynonyms := []string{"TIMESTAMP_LTZ"}

--- a/pkg/sdk/data_types_test.go
+++ b/pkg/sdk/data_types_test.go
@@ -66,9 +66,12 @@ func TestDataTypeFromString(t *testing.T) {
 		{input: "timestamp_ltz", want: DataTypeTimestampLTZ},
 		{input: "timestamp_ltz(9)", want: DataTypeTimestampLTZ},
 
+		// time types.
+		{input: "time", want: DataTypeTime},
+		{input: "time(9)", want: DataTypeTime},
+
 		// all othertypes
 		{input: "date", want: DataTypeDate},
-		{input: "time", want: DataTypeTime},
 		{input: "variant", want: DataTypeVariant},
 		{input: "object", want: DataTypeObject},
 		{input: "array", want: DataTypeArray},


### PR DESCRIPTION
Updates the [DataTypeFromString](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/1037f9833131ca6d5a0e75adcafe9b99f5f86173/pkg/sdk/data_types.go#L32) function so that that TIME(<precision>) map to TIME, rather than UNKNOWN.

Thank you @ogr003 for the pattern on how to address the bug I reported.

References
My original report of the issue: https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1791
Related issue for TIMESTAMP_TZ and TIMESTAMP_LTZ being incorrectly mapped to TIMESTAMP_NTZ: https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1809
@ogr003's fix to the above issue, which I followed the footsteps: https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/1810
