### PR TITLE
fix: err when reading profile

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -466,19 +466,26 @@ func DSN(
 		config.Token = oauthAccessToken
 	} else if password != "" {
 		config.Password = password
-	} else if account == "" && user == "" {
+	} else if account == "" || user == "" {
 		// If account and user are empty then we need to fall back on using profile config
 		log.Printf("[DEBUG] No account or user provided, falling back to profile %s\n", profile)
-		profileConfig, err := sdk.ProfileConfig(profile)
-		if err != nil {
-			return "", errors.New("could not retrieve profile config: " + err.Error())
+		if profile == "default" {
+			defaultConfig := sdk.DefaultConfig()
+			if defaultConfig.Account == "" || defaultConfig.User == "" {
+				return "", errors.New("Account and User must be set in provider config, ~/.snowflake/config, or as an environment variable.")
+			}
+			config = sdk.MergeConfig(config, defaultConfig)
+		} else {
+			profileConfig, err := sdk.ProfileConfig(profile)
+			if err != nil {
+				return "", errors.New("could not retrieve profile config: " + err.Error())
+			}
+			if profileConfig == nil {
+				return "", errors.New("profile with name: " + profile + " not found in config file")
+			}
+			// merge any credentials found in profile with config
+			config = sdk.MergeConfig(config, profileConfig)
 		}
-		if profileConfig == nil {
-			// try reading environment variables
-			profileConfig = sdk.EnvConfig()
-		}
-		// merge any credentials found in profile or environment with config
-		config = sdk.MergeConfig(config, profileConfig)
 	}
 	config.Application = "terraform-provider-snowflake"
 	return gosnowflake.DSN(config)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -471,8 +471,13 @@ func DSN(
 		log.Printf("[DEBUG] No account or user provided, falling back to profile %s\n", profile)
 		profileConfig, err := sdk.ProfileConfig(profile)
 		if err != nil {
-			return "", errors.New("no authentication method provided")
+			return "", errors.New("could not retrieve profile config: " + err.Error())
 		}
+		if profileConfig == nil {
+			// try reading environment variables
+			profileConfig = sdk.EnvConfig()
+		}
+		// merge any credentials found in profile or environment with config
 		config = sdk.MergeConfig(config, profileConfig)
 	}
 	config.Application = "terraform-provider-snowflake"

--- a/pkg/sdk/client_integration_test.go
+++ b/pkg/sdk/client_integration_test.go
@@ -7,13 +7,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestClient_newClient(t *testing.T) {
+func TestClient_NewClient(t *testing.T) {
 	t.Run("with default config", func(t *testing.T) {
 		config := DefaultConfig()
 		_, err := NewClient(config)
 		require.NoError(t, err)
 	})
-
 	t.Run("uses env vars if values are missing", func(t *testing.T) {
 		cleanupEnvVars := setupEnvVars(t, "TEST_ACCOUNT", "TEST_USER", "abcd1234", "ACCOUNTADMIN", "")
 		t.Cleanup(cleanupEnvVars)

--- a/pkg/sdk/config.go
+++ b/pkg/sdk/config.go
@@ -33,6 +33,11 @@ func ProfileConfig(profile string) (*gosnowflake.Config, error) {
 		config = cfg
 	}
 
+	if config == nil {
+		log.Printf("[DEBUG] no config found for profile: \"%s\"", profile)
+		return nil, nil
+	}
+
 	// us-west-2 is Snowflake's default region, but if you actually specify that it won't trigger the default code
 	//  https://github.com/snowflakedb/gosnowflake/blob/52137ce8c32eaf93b0bd22fc5c7297beff339812/dsn.go#L61
 	if config.Region == "us-west-2" {

--- a/pkg/sdk/config_test.go
+++ b/pkg/sdk/config_test.go
@@ -47,14 +47,25 @@ func TestProfileConfig(t *testing.T) {
 	role='SECURITYADMIN'
 	`
 	configPath := testFile(t, "config", []byte(c))
-	cleanupEnvVars := setupEnvVars(t, "", "", "", "", configPath)
-	t.Cleanup(cleanupEnvVars)
-	config, err := ProfileConfig("securityadmin")
-	require.NoError(t, err)
-	assert.Equal(t, "TEST_ACCOUNT", config.Account)
-	assert.Equal(t, "TEST_USER", config.User)
-	assert.Equal(t, "abcd1234", config.Password)
-	assert.Equal(t, "SECURITYADMIN", config.Role)
+
+	t.Run("with found profile", func(t *testing.T) {
+		cleanupEnvVars := setupEnvVars(t, "", "", "", "", configPath)
+		t.Cleanup(cleanupEnvVars)
+		config, err := ProfileConfig("securityadmin")
+		require.NoError(t, err)
+		assert.Equal(t, "TEST_ACCOUNT", config.Account)
+		assert.Equal(t, "TEST_USER", config.User)
+		assert.Equal(t, "abcd1234", config.Password)
+		assert.Equal(t, "SECURITYADMIN", config.Role)
+	})
+
+	t.Run("with not found profile", func(t *testing.T) {
+		cleanupEnvVars := setupEnvVars(t, "", "", "", "", configPath)
+		t.Cleanup(cleanupEnvVars)
+		config, err := ProfileConfig("orgadmin")
+		require.NoError(t, err)
+		require.Nil(t, config)
+	})
 }
 
 func TestEnvConfig(t *testing.T) {


### PR DESCRIPTION
If no profile is found with a given name, return nil. Then if config is nil, fall back to using credentials.
fixes:
https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1852