### PR TITLE
fix: conditional set "query_acceleration_max_scale_factor"

### DIFF
--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -169,8 +169,14 @@ func CreateWarehouse(d *schema.ResourceData, meta interface{}) error {
 		StatementQueuedTimeoutInSeconds: sdk.Int(d.Get("statement_queued_timeout_in_seconds").(int)),
 		MaxConcurrencyLevel:             sdk.Int(d.Get("max_concurrency_level").(int)),
 		EnableQueryAcceleration:         sdk.Bool(d.Get("enable_query_acceleration").(bool)),
-		QueryAccelerationMaxScaleFactor: sdk.Int(d.Get("query_acceleration_max_scale_factor").(int)),
 		WarehouseType:                   &whType,
+	}
+
+	if enable := *sdk.Bool(d.Get("enable_query_acceleration").(bool)); enable {
+		if v, ok := d.GetOk("query_acceleration_max_scale_factor"); ok {
+			queryAccelerationMaxScaleFactor := sdk.Int(v.(int))
+			createOptions.QueryAccelerationMaxScaleFactor = queryAccelerationMaxScaleFactor
+		}
 	}
 
 	if v, ok := d.GetOk("warehouse_size"); ok {


### PR DESCRIPTION
Do not set "query_acceleration_max_scale_factor" if Query Acceleration is not enabled on Warehouse creation.

## Test Plan
* [ ] acceptance tests

Note: I could not run acceptance tests; my configuration has a strange problem ('two regions specified' error). I'll continue trying to fix this issue, but it would be great if anyone could run those tests.

## References
Issues:
* [1343](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1343)
* [1628](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1628)

Related PR:
* [1474](https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/1474) — this PR fixed a similar problem but only for updating the existing Warehouse. The problem still occurs on a Standard Snowflake Edition on creating a new Warehouse