### PR TITLE
Added password_mfa option for mfa caching

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ provider snowflake {
 - `oauth_redirect_url` (String, Sensitive) Required when `oauth_refresh_token` is used. Can be sourced from `SNOWFLAKE_OAUTH_REDIRECT_URL` environment variable.
 - `oauth_refresh_token` (String, Sensitive) Token for use with OAuth. Setup and generation of the token is left to other tools. Should be used in conjunction with `oauth_client_id`, `oauth_client_secret`, `oauth_endpoint`, `oauth_redirect_url`. Cannot be used with `browser_auth`, `private_key_path`, `oauth_access_token` or `password`. Can be sourced from `SNOWFLAKE_OAUTH_REFRESH_TOKEN` environment variable.
 - `password` (String, Sensitive) Password for username+password auth. Cannot be used with `browser_auth` or `private_key_path`. Can be sourced from `SNOWFLAKE_PASSWORD` environment variable.
+- `password_mfa` (String, Sensitive) Password + MFA for username+password auth with MFA caching support. Cannot be used with `browser_auth` or `private_key_path`. Can be sourced from `SNOWFLAKE_PASSWORD_MFA` environment variable.
 - `port` (Number) Support custom port values to snowflake go driver for use with privatelink. Can be sourced from `SNOWFLAKE_PORT` environment variable.
 - `private_key` (String, Sensitive) Private Key for username+private-key auth. Cannot be used with `browser_auth` or `password`. Can be sourced from `SNOWFLAKE_PRIVATE_KEY` environment variable.
 - `private_key_passphrase` (String, Sensitive) Supports the encryption ciphers aes-128-cbc, aes-128-gcm, aes-192-cbc, aes-192-gcm, aes-256-cbc, aes-256-gcm, and des-ede3-cbc

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -40,6 +40,7 @@ func TestDSN(t *testing.T) {
 		account      string
 		user         string
 		password     string
+		passwordMFA  string
 		browserAuth  bool
 		region       string
 		role         string
@@ -58,34 +59,34 @@ func TestDSN(t *testing.T) {
 	}{
 		{
 			"simple",
-			args{"acct", "user", "pass", false, "region", "role", "", "https", 443, "", false, "default"},
+			args{"acct", "user", "pass", "", false, "region", "role", "", "https", 443, "", false, "default"},
 			"user:pass@acct.region.snowflakecomputing.com:443?application=terraform-provider-snowflake&ocspFailOpen=true&region=region&role=role&validateDefaultParameters=true", false,
 		},
 		{
 			"us-west-2 special case",
-			args{"acct2", "user2", "pass2", false, "us-west-2", "role2", "", "https", 443, "", false, "default"},
+			args{"acct2", "user2", "pass2", "", false, "us-west-2", "role2", "", "https", 443, "", false, "default"},
 			"user2:pass2@acct2.snowflakecomputing.com:443?application=terraform-provider-snowflake&ocspFailOpen=true&role=role2&validateDefaultParameters=true", false,
 		},
 		{
 			"customhostwregion",
-			args{"acct3", "user3", "pass3", false, "", "role3", "zha123.us-east-1.privatelink.snowflakecomputing.com", "https", 443, "", false, "default"},
+			args{"acct3", "user3", "pass3", "", false, "", "role3", "zha123.us-east-1.privatelink.snowflakecomputing.com", "https", 443, "", false, "default"},
 			"user3:pass3@zha123.us-east-1.privatelink.snowflakecomputing.com:443?account=acct3&application=terraform-provider-snowflake&ocspFailOpen=true&role=role3&validateDefaultParameters=true", false,
 		},
 		{
 			"customhostignoreregion",
-			args{"acct4", "user4", "pass4", false, "fakeregion", "role4", "zha1234.us-east-1.privatelink.snowflakecomputing.com", "https", 8443, "", false, "default"},
+			args{"acct4", "user4", "pass4", "", false, "fakeregion", "role4", "zha1234.us-east-1.privatelink.snowflakecomputing.com", "https", 8443, "", false, "default"},
 			"user4:pass4@zha1234.us-east-1.privatelink.snowflakecomputing.com:8443?account=acct4&application=terraform-provider-snowflake&ocspFailOpen=true&role=role4&validateDefaultParameters=true", false,
 		},
 		{
 			"profile",
-			args{"", "", "", false, "", "", "", "", 0, "", false, "default"},
+			args{"", "", "", "", false, "", "", "", "", 0, "", false, "default"},
 			"TEST_USER:abcd1234@TEST_ACCOUNT.snowflakecomputing.com:443?application=terraform-provider-snowflake&ocspFailOpen=true&role=ACCOUNTADMIN&validateDefaultParameters=true", false,
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := provider.DSN(tt.args.account, tt.args.user, tt.args.password, tt.args.browserAuth, "", "", "", "", tt.args.region, tt.args.role, tt.args.host, tt.args.protocol, tt.args.port, tt.args.warehouse, tt.args.insecureMode, tt.args.profile)
+			got, err := provider.DSN(tt.args.account, tt.args.user, tt.args.password, tt.args.passwordMFA, tt.args.browserAuth, "", "", "", "", tt.args.region, tt.args.role, tt.args.host, tt.args.protocol, tt.args.port, tt.args.warehouse, tt.args.insecureMode, tt.args.profile)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DSN() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -135,7 +136,7 @@ func TestOAuthDSN(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := provider.DSN(tt.args.account, tt.args.user, "", false, "", "", "", tt.args.oauthAccessToken, tt.args.region, tt.args.role, tt.args.host, tt.args.protocol, tt.args.port, "", false, "default")
+			got, err := provider.DSN(tt.args.account, tt.args.user, "", "", false, "", "", "", tt.args.oauthAccessToken, tt.args.region, tt.args.role, tt.args.host, tt.args.protocol, tt.args.port, "", false, "default")
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DSN() error = %v, dsn = %v, wantErr %v", err, got, tt.wantErr)


### PR DESCRIPTION
We have had several reports of not being able to use MFA caching even though the go driver supports it.  THe reason is you must use a specific authenticator for password MFA:

AuthTypeUsernamePasswordMFA

This PR adds a "password_mfa" authentication option to the snowflake provider to utilize the above authenticator and allow for MFA caching.