### PR TITLE
fix: missing 'kind' field

### DIFF
--- a/pkg/sdk/databases.go
+++ b/pkg/sdk/databases.go
@@ -55,6 +55,7 @@ type Database struct {
 	ResourceGroup string
 	DroppedOn     time.Time
 	Transient     bool
+	Kind          string
 }
 
 func (v *Database) ID() AccountObjectIdentifier {
@@ -123,6 +124,9 @@ func (row *databaseRow) toDatabase() *Database {
 				database.Transient = true
 			}
 		}
+	}
+	if row.Kind.Valid {
+		database.Kind = row.Kind.String
 	}
 	return &database
 }

--- a/pkg/sdk/databases.go
+++ b/pkg/sdk/databases.go
@@ -77,6 +77,7 @@ type databaseRow struct {
 	RetentionTime sql.NullString `db:"retention_time"`
 	ResourceGroup sql.NullString `db:"resource_group"`
 	DroppedOn     sql.NullTime   `db:"dropped_on"`
+	Kind          sql.NullString `db:"kind"`
 }
 
 func (row *databaseRow) toDatabase() *Database {


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
missing 'kind' field in database struct leading to:
_Error: unable to scan row for SHOW DATABASES LIKE 'SCRATCH' err = missing destination name kind in *[]snowflake.Databas_

## Test Plan
N/A
* [ ] acceptance tests
N/A
* [ ] …

## References
<!-- issues documentation links, etc  -->
#1868
* 