### PR TITLE
fix: alert condition and action fix

### DIFF
--- a/pkg/resources/alert_acceptance_test.go
+++ b/pkg/resources/alert_acceptance_test.go
@@ -91,8 +91,8 @@ var (
 		Alert: &AlertSettings{
 			Name:      alertName,
 			Schema:    schemaName,
-			Condition: "select 2 as c",
-			Action:    "select 2 as c",
+			Condition: "select 's' as c where 1=0",
+			Action:    "SELECT SYSTEM$TYPEOF(null) FROM (values(1)) v",
 			Enabled:   false,
 			Schedule:  5,
 		},

--- a/pkg/snowflake/alert.go
+++ b/pkg/snowflake/alert.go
@@ -127,8 +127,8 @@ func (builder *AlertBuilder) Create() string {
 		q.WriteString(fmt.Sprintf(` COMMENT = '%v'`, EscapeString(builder.comment)))
 	}
 
-	q.WriteString(fmt.Sprintf(` IF (EXISTS ( %v ))`, EscapeString(builder.condition)))
-	q.WriteString(fmt.Sprintf(` THEN %v`, EscapeString(builder.action)))
+	q.WriteString(fmt.Sprintf(` IF (EXISTS ( %v ))`, builder.condition))
+	q.WriteString(fmt.Sprintf(` THEN %v`, builder.action))
 
 	return q.String()
 }
@@ -181,7 +181,7 @@ func (builder *AlertBuilder) ChangeCondition(newCondition string) string {
 
 // ChangeAction returns the sql that will update the sql the alert executes.
 func (builder *AlertBuilder) ChangeAction(newAction string) string {
-	return fmt.Sprintf(`ALTER ALERT %v MODIFY ACTION %v`, builder.QualifiedName(), UnescapeString(newAction))
+	return fmt.Sprintf(`ALTER ALERT %v MODIFY ACTION %v`, builder.QualifiedName(), newAction)
 }
 
 // Suspend returns the sql that will suspend the alert.


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
alert's action and condition clauses support special characters which were wrongly escaped.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->
fix for #1753 
* 