### PR TITLE
fix: Generate security integration statements using double quoted names.

### DIFF
--- a/pkg/resources/external_oauth_integration.go
+++ b/pkg/resources/external_oauth_integration.go
@@ -210,7 +210,7 @@ func CreateExternalOauthIntegration(d *schema.ResourceData, meta interface{}) er
 	}
 
 	db := meta.(*sql.DB)
-	_, err = db.Exec(stmt)
+	err = snowflake.Exec(db, stmt)
 	if err != nil {
 		return fmt.Errorf("error executing create statement: %w", err)
 	}
@@ -271,13 +271,13 @@ func ReadExternalOauthIntegration(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("couldn't generate describe statement: %w", err)
 	}
 
-	rows, err := db.Query(stmt)
+	rows, err := snowflake.Query(db, stmt)
 	if err != nil {
 		return fmt.Errorf("error querying external oauth integration: %w", err)
 	}
 
 	defer rows.Close()
-	describeOutput, err := manager.ParseDescribe(rows)
+	describeOutput, err := manager.ParseDescribe(rows.Rows)
 	if err != nil {
 		return fmt.Errorf("failed to parse result of describe: %w", err)
 	}
@@ -525,7 +525,7 @@ func UpdateExternalOauthIntegration(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("couldn't generate alter statement for external oauth integration: %w", err)
 		}
 
-		_, err = db.Exec(stmt)
+		err = snowflake.Exec(db, stmt)
 		if err != nil {
 			return fmt.Errorf("error executing alter statement: %w", err)
 		}
@@ -537,7 +537,7 @@ func UpdateExternalOauthIntegration(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("couldn't generate unset statement for external oauth integration: %w", err)
 		}
 
-		_, err = db.Exec(stmt)
+		err = snowflake.Exec(db, stmt)
 		if err != nil {
 			return fmt.Errorf("error executing unset statement: %w", err)
 		}
@@ -565,7 +565,7 @@ func DeleteExternalOauthIntegration(d *schema.ResourceData, meta interface{}) er
 	}
 
 	db := meta.(*sql.DB)
-	_, err = db.Exec(stmt)
+	err = snowflake.Exec(db, stmt)
 	if err != nil {
 		return fmt.Errorf("error executing drop statement: %w", err)
 	}

--- a/pkg/resources/external_oauth_integration_acceptance_test.go
+++ b/pkg/resources/external_oauth_integration_acceptance_test.go
@@ -42,6 +42,38 @@ func TestAcc_ExternalOauthIntegration(t *testing.T) {
 	})
 }
 
+func TestAcc_ExternalOauthIntegrationLowercaseName(t *testing.T) {
+	oauthIntName := strings.ToLower(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	integrationType := "AZURE"
+
+	issuer := fmt.Sprintf("https://sts.windows.net/%s", uuid.NewString())
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    providers(),
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: externalOauthIntegrationConfig(oauthIntName, integrationType, issuer),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "name", oauthIntName),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "type", integrationType),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "enabled", "true"),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "issuer", issuer),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "snowflake_user_mapping_attribute", "LOGIN_NAME"),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "token_user_mapping_claims.#", "2"),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "token_user_mapping_claims.0", "test"),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "token_user_mapping_claims.1", "upn"),
+				),
+			},
+			{
+				ResourceName:      "snowflake_external_oauth_integration.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAcc_ExternalOauthIntegrationCustom(t *testing.T) {
 	oauthIntName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	integrationType := "CUSTOM"

--- a/pkg/snowflake/builder.go
+++ b/pkg/snowflake/builder.go
@@ -267,7 +267,7 @@ func (b *SQLBuilder) Create(obj Identifier) (string, error) {
 	sb.WriteString(after)
 
 	// eg. "my_table"
-	sb.WriteString(fmt.Sprintf(` %v`, (obj).QualifiedName()))
+	sb.WriteString(fmt.Sprintf(` "%v"`, (obj).QualifiedName()))
 
 	// eg. `PARAM = "value"`
 	params, err := b.renderParameters(obj, b.createConfig.parameters, true)
@@ -296,7 +296,7 @@ func (b *SQLBuilder) Alter(obj Identifier) (string, error) {
 	sb.WriteString(after)
 
 	// eg. "my_table"
-	sb.WriteString(fmt.Sprintf(` %v`, obj.QualifiedName()))
+	sb.WriteString(fmt.Sprintf(` "%v"`, obj.QualifiedName()))
 
 	sb.WriteString(" SET")
 
@@ -327,7 +327,7 @@ func (b *SQLBuilder) Unset(obj Identifier) (string, error) {
 	sb.WriteString(after)
 
 	// eg. "my_table"
-	sb.WriteString(fmt.Sprintf(` %v`, obj.QualifiedName()))
+	sb.WriteString(fmt.Sprintf(` "%v"`, obj.QualifiedName()))
 
 	sb.WriteString(" UNSET")
 
@@ -358,7 +358,7 @@ func (b *SQLBuilder) Drop(obj Identifier) (string, error) {
 	sb.WriteString(after)
 
 	// eg. "my_table"
-	sb.WriteString(fmt.Sprintf(` %v`, obj.QualifiedName()))
+	sb.WriteString(fmt.Sprintf(` "%v"`, obj.QualifiedName()))
 
 	sb.WriteString(";")
 
@@ -390,7 +390,7 @@ func (b *SQLBuilder) Describe(obj Identifier) (string, error) {
 	sb.WriteString(fmt.Sprintf(" %v", b.objectType))
 
 	// eg. "my_table"
-	sb.WriteString(fmt.Sprintf(` %v`, obj.QualifiedName()))
+	sb.WriteString(fmt.Sprintf(` "%v"`, obj.QualifiedName()))
 
 	sb.WriteString(";")
 

--- a/pkg/snowflake/external_oauth_integration_test.go
+++ b/pkg/snowflake/external_oauth_integration_test.go
@@ -26,7 +26,7 @@ func TestCreateExternalOauthIntegration3(t *testing.T) {
 	r.Nil(err)
 	createStmt, err := mb.Create(input)
 	r.Nil(err)
-	r.Equal(`CREATE SECURITY INTEGRATION azure type = 'EXTERNAL_OAUTH' EXTERNAL_OAUTH_TYPE = 'AZURE';`, createStmt)
+	r.Equal(`CREATE SECURITY INTEGRATION "azure" type = 'EXTERNAL_OAUTH' EXTERNAL_OAUTH_TYPE = 'AZURE';`, createStmt)
 }
 
 func TestAlterExternalOauthIntegration3(t *testing.T) {
@@ -52,7 +52,7 @@ func TestAlterExternalOauthIntegration3(t *testing.T) {
 	alterStmt, err := mb.Update(input)
 	r.Nil(err)
 	r.Equal(
-		`ALTER SECURITY INTEGRATION IF EXISTS azure SET EXTERNAL_OAUTH_ISSUER = 'someissuer' EXTERNAL_OAUTH_BLOCKED_ROLES_LIST = ('a', 'b');`,
+		`ALTER SECURITY INTEGRATION IF EXISTS "azure" SET EXTERNAL_OAUTH_ISSUER = 'someissuer' EXTERNAL_OAUTH_BLOCKED_ROLES_LIST = ('a', 'b');`,
 		alterStmt,
 	)
 }
@@ -74,7 +74,7 @@ func TestUnsetExternalOauthIntegration3(t *testing.T) {
 	unsetStmt, err := mb.Unset(input)
 	r.Nil(err)
 	r.Equal(
-		`ALTER SECURITY INTEGRATION azure UNSET EXTERNAL_OAUTH_TOKEN_USER_MAPPING_CLAIM;`,
+		`ALTER SECURITY INTEGRATION "azure" UNSET EXTERNAL_OAUTH_TOKEN_USER_MAPPING_CLAIM;`,
 		unsetStmt,
 	)
 }
@@ -92,7 +92,7 @@ func TestDeleteExternalOauthIntegration3(t *testing.T) {
 	r.Nil(err)
 	dropStmt, err := mb.Delete(input)
 	r.Nil(err)
-	r.Equal(`DROP SECURITY INTEGRATION azure;`, dropStmt)
+	r.Equal(`DROP SECURITY INTEGRATION "azure";`, dropStmt)
 }
 
 func TestReadDescribeExternalOauthIntegration3(t *testing.T) {
@@ -106,7 +106,7 @@ func TestReadDescribeExternalOauthIntegration3(t *testing.T) {
 	r.Nil(err)
 	describeStmt, err := mb.ReadDescribe(input)
 	r.Nil(err)
-	r.Equal(`DESCRIBE SECURITY INTEGRATION azure;`, describeStmt)
+	r.Equal(`DESCRIBE SECURITY INTEGRATION "azure";`, describeStmt)
 }
 
 func TestReadShowExternalOauthIntegration3(t *testing.T) {


### PR DESCRIPTION
Generates security integration statements with double-quoted names to prevent issues with mis-cased objects.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [X] New acceptance test
<!-- add more below if you think they are relevant -->
* [X] Updated oauth integration integration test