### PR TITLE
fix: support empty comments in oauth integrations

### DIFF
--- a/pkg/resources/external_oauth_integration.go
+++ b/pkg/resources/external_oauth_integration.go
@@ -199,7 +199,7 @@ func CreateExternalOauthIntegration(d *schema.ResourceData, meta interface{}) er
 			ExternalOauthScopeMappingAttribute:           d.Get("scope_mapping_attribute").(string),
 			ExternalOauthScopeMappingAttributeOk:         isOk(d.GetOk("scope_mapping_attribute")),
 
-			Comment:   d.Get("comment").(string),
+			Comment:   sql.NullString{String: d.Get("comment").(string)},
 			CommentOk: isOk(d.GetOk("comment")),
 		},
 	}
@@ -258,7 +258,7 @@ func ReadExternalOauthIntegration(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("enabled", showOutput.Enabled); err != nil {
 		return fmt.Errorf("error setting enabled: %w", err)
 	}
-	if err := d.Set("comment", showOutput.Comment); err != nil {
+	if err := d.Set("comment", showOutput.Comment.String); err != nil {
 		return fmt.Errorf("error setting comment: %w", err)
 	}
 	// if err := d.Set("created_on", showOutput.CreatedOn.String); err != nil {
@@ -508,7 +508,7 @@ func UpdateExternalOauthIntegration(d *schema.ResourceData, meta interface{}) er
 	if d.HasChange("comment") {
 		val, ok := d.GetOk("comment")
 		if ok {
-			alterInput.Comment = val.(string)
+			alterInput.Comment.String = val.(string)
 			alterInput.CommentOk = true
 			runAlter = true
 		} else {

--- a/pkg/resources/external_oauth_integration_acceptance_test.go
+++ b/pkg/resources/external_oauth_integration_acceptance_test.go
@@ -21,7 +21,39 @@ func TestAcc_ExternalOauthIntegration(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: externalOauthIntegrationConfig(oauthIntName, integrationType, issuer),
+				Config: externalOauthIntegrationConfig(oauthIntName, integrationType, issuer, "test resource"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "name", oauthIntName),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "type", integrationType),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "enabled", "true"),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "issuer", issuer),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "snowflake_user_mapping_attribute", "LOGIN_NAME"),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "token_user_mapping_claims.#", "2"),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "token_user_mapping_claims.0", "test"),
+					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "token_user_mapping_claims.1", "upn"),
+				),
+			},
+			{
+				ResourceName:      "snowflake_external_oauth_integration.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAcc_ExternalOauthIntegrationEmptyComment(t *testing.T) {
+	oauthIntName := strings.ToLower(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	integrationType := "AZURE"
+
+	issuer := fmt.Sprintf("https://sts.windows.net/%s", uuid.NewString())
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    providers(),
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: externalOauthIntegrationConfig(oauthIntName, integrationType, issuer, ""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "name", oauthIntName),
 					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "type", integrationType),
@@ -53,7 +85,7 @@ func TestAcc_ExternalOauthIntegrationLowercaseName(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: externalOauthIntegrationConfig(oauthIntName, integrationType, issuer),
+				Config: externalOauthIntegrationConfig(oauthIntName, integrationType, issuer, "test resource"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "name", oauthIntName),
 					resource.TestCheckResourceAttr("snowflake_external_oauth_integration.test", "type", integrationType),
@@ -120,7 +152,7 @@ func TestAcc_ExternalOauthIntegrationCustom(t *testing.T) {
 	})
 }
 
-func externalOauthIntegrationConfig(name, integrationType, issuer string) string {
+func externalOauthIntegrationConfig(name, integrationType, issuer, comment string) string {
 	return fmt.Sprintf(`
 	resource "snowflake_external_oauth_integration" "test" {
 		name = "%s"
@@ -131,7 +163,7 @@ func externalOauthIntegrationConfig(name, integrationType, issuer string) string
 		jws_keys_urls = ["https://login.windows.net/common/discovery/keys"]
 		audience_urls = ["https://analysis.windows.net/powerbi/connector/Snowflake"]
   		token_user_mapping_claims = ["upn", "test"]
-		comment = "hey"
+		comment = "%s"
 	}
-	`, name, integrationType, issuer)
+	`, name, integrationType, issuer, comment)
 }

--- a/pkg/snowflake/external_oauth_integration.go
+++ b/pkg/snowflake/external_oauth_integration.go
@@ -66,7 +66,7 @@ type ExternalOauthIntegration3 struct {
 	ExternalOauthScopeMappingAttribute           string `pos:"parameter" db:"EXTERNAL_OAUTH_SCOPE_MAPPING_ATTRIBUTE"`
 	ExternalOauthScopeMappingAttributeOk         bool
 
-	Comment   string `pos:"parameter" db:"comment"`
+	Comment   sql.NullString `pos:"parameter" db:"comment"`
 	CommentOk bool
 }
 


### PR DESCRIPTION
Add support for `sql.NullString` in `sqlBuilder` (pkg.snowflake) to support empty comments in resource `external_oauth_integration`.

## Test Plan
* [X] new acceptance test

## References
Fixes https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1755