### PR TITLE
fix: prevent view drop when copy_grants attribute changes

### DIFF
--- a/docs/resources/view.md
+++ b/docs/resources/view.md
@@ -48,6 +48,7 @@ SQL
 
 ### Read-Only
 
+- `created_on` (String) The timestamp at which the view was created.
 - `id` (String) The ID of this resource.
 
 <a id="nestedblock--tag"></a>

--- a/pkg/resources/stream_test.go
+++ b/pkg/resources/stream_test.go
@@ -3,6 +3,7 @@ package resources_test
 import (
 	"database/sql"
 	"testing"
+	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider"
@@ -131,7 +132,7 @@ func expectOnExternalTableRead(mock sqlmock.Sqlmock) {
 }
 
 func expectOnViewRead(mock sqlmock.Sqlmock) {
-	rows := sqlmock.NewRows([]string{"created_on", "name", "database_name", "schema_name", "kind", "comment", "cluster_by", "row", "bytes", "owner", "retention_time", "automatic_clustering", "change_tracking", "is_external"}).AddRow("", "target_view", "target_db", "target_schema", "VIEW", "mock comment", "", "", "", "", 1, "OFF", "OFF", "Y")
+	rows := sqlmock.NewRows([]string{"created_on", "name", "database_name", "schema_name", "kind", "comment", "cluster_by", "row", "bytes", "owner", "retention_time", "automatic_clustering", "change_tracking", "is_external"}).AddRow(time.Now(), "target_view", "target_db", "target_schema", "VIEW", "mock comment", "", "", "", "", 1, "OFF", "OFF", "Y")
 	mock.ExpectQuery(`SHOW VIEWS LIKE 'target_view' IN SCHEMA "target_db"."target_schema"`).WillReturnRows(rows)
 }
 

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -65,6 +65,11 @@ var viewSchema = map[string]*schema.Schema{
 		ForceNew:         true,
 		DiffSuppressFunc: DiffSuppressStatement,
 	},
+	"created_on": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The timestamp at which the view was created.",
+	},
 	"tag": tagReferenceSchema,
 }
 
@@ -242,6 +247,9 @@ func ReadView(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	if err = d.Set("schema", v.SchemaName.String); err != nil {
+		return err
+	}
+	if err = d.Set("created_on", v.CreatedOn.String()); err != nil {
 		return err
 	}
 

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -45,7 +45,9 @@ var viewSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Default:     false,
 		Description: "Retains the access permissions from the original view when a new view is created using the OR REPLACE clause.",
-		ForceNew:    true,
+		DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+			return oldValue != "" && oldValue != newValue
+		},
 	},
 	"is_secure": {
 		Type:        schema.TypeBool,

--- a/pkg/resources/view_test.go
+++ b/pkg/resources/view_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"testing"
+	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider"
@@ -100,7 +101,7 @@ func expectReadView(mock sqlmock.Sqlmock) {
 	rows := sqlmock.NewRows([]string{
 		"created_on", "name", "reserved", "database_name", "schema_name", "owner", "comment", "text", "is_secure", "is_materialized",
 	},
-	).AddRow("2019-05-19 16:55:36.530 -0700", "good_name", "", "test_db", "test_schema", "admin", "great comment", "SELECT * FROM test_db.GREAT_SCHEMA.GREAT_TABLE WHERE account_id = 'bobs-account-id'", true, false)
+	).AddRow(time.Now(), "good_name", "", "test_db", "test_schema", "admin", "great comment", "SELECT * FROM test_db.GREAT_SCHEMA.GREAT_TABLE WHERE account_id = 'bobs-account-id'", true, false)
 	mock.ExpectQuery(`^SHOW VIEWS LIKE 'good_name' IN SCHEMA "test_db"."test_schema"$`).WillReturnRows(rows)
 }
 

--- a/pkg/snowflake/view.go
+++ b/pkg/snowflake/view.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -226,6 +227,7 @@ type View struct {
 	SchemaName   sql.NullString `db:"schema_name"`
 	Text         sql.NullString `db:"text"`
 	DatabaseName sql.NullString `db:"database_name"`
+	CreatedOn    time.Time      `db:"created_on"`
 }
 
 func ScanView(row *sqlx.Row) (*View, error) {


### PR DESCRIPTION
Fixes a bug where a view would get dropped whenever the copy_grants attribute changes.

## Test Plan
* [X] new regression acceptance tests