### PR TITLE
fix: snowflake_object_parameter add missing option

### DIFF
--- a/pkg/snowflake/parameters.go
+++ b/pkg/snowflake/parameters.go
@@ -548,6 +548,14 @@ func ParameterDefaults() map[string]ParameterDefault {
 				ObjectTypeFailoverGroup,
 			},
 		},
+		"ENABLE_UNREDACTED_QUERY_SYNTAX_ERROR": {
+			TypeSet:      []ParameterType{ParameterTypeObject, ParameterTypeAccount},
+			DefaultValue: false,
+			Validate:     validateBoolFunc,
+			AllowedObjectTypes: []ObjectType{
+				ObjectTypeUser,
+			},
+		},
 		"MAX_CONCURRENCY_LEVEL": {
 			TypeSet:      []ParameterType{ParameterTypeObject},
 			DefaultValue: 0,


### PR DESCRIPTION
Add missing option as per https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1923