### PR TITLE
fix: reading file formats with no default schema

### DIFF
--- a/pkg/sdk/file_format.go
+++ b/pkg/sdk/file_format.go
@@ -654,6 +654,9 @@ func (v *fileFormats) ShowByID(ctx context.Context, id SchemaObjectIdentifier) (
 		Like: &Like{
 			Pattern: String(id.Name()),
 		},
+		In: &In{
+			Schema: NewSchemaIdentifier(id.databaseName, id.schemaName),
+		},
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/sdk/file_format_integration_test.go
+++ b/pkg/sdk/file_format_integration_test.go
@@ -493,3 +493,33 @@ func TestInt_FileFormatsShow(t *testing.T) {
 		assert.Contains(t, fileFormats, fileFormatTest2)
 	})
 }
+
+func TestInt_FileFormatsShowById(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	databaseTest, cleanupDatabase := createDatabase(t, client)
+	t.Cleanup(cleanupDatabase)
+	schemaTest, cleanupSchema := createSchema(t, client, databaseTest)
+	t.Cleanup(cleanupSchema)
+	fileFormatTest, cleanupFileFormat := createFileFormat(t, client, schemaTest.ID())
+	t.Cleanup(cleanupFileFormat)
+
+	databaseTest2, cleanupDatabase2 := createDatabase(t, client)
+	t.Cleanup(cleanupDatabase2)
+	schemaTest2, cleanupSchema2 := createSchema(t, client, databaseTest2)
+	t.Cleanup(cleanupSchema2)
+
+	t.Run("show format in different schema", func(t *testing.T) {
+		err := client.Sessions.UseDatabase(ctx, databaseTest2.ID())
+		require.NoError(t, err)
+		err = client.Sessions.UseSchema(ctx, schemaTest2.ID())
+		require.NoError(t, err)
+
+		fileFormat, err := client.FileFormats.ShowByID(ctx, fileFormatTest.ID())
+		require.NoError(t, err)
+		assert.Equal(t, databaseTest.Name, fileFormat.Name.databaseName)
+		assert.Equal(t, schemaTest.Name, fileFormat.Name.schemaName)
+		assert.Equal(t, fileFormatTest.Name.name, fileFormat.Name.name)
+	})
+}

--- a/pkg/sdk/file_format_test.go
+++ b/pkg/sdk/file_format_test.go
@@ -293,14 +293,18 @@ func TestFileFormatsShow(t *testing.T) {
 
 func TestFileFormatsShowById(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
+		id := NewSchemaObjectIdentifier("db", "schema", "ff")
 		opts := &ShowFileFormatsOptions{
 			Like: &Like{
-				Pattern: String(NewSchemaObjectIdentifier("db", "schema", "ff").Name()),
+				Pattern: String(id.Name()),
+			},
+			In: &In{
+				Schema: NewSchemaIdentifier(id.databaseName, id.schemaName),
 			},
 		}
 		actual, err := structToSQL(opts)
 		require.NoError(t, err)
-		expected := `SHOW FILE FORMATS LIKE 'ff'`
+		expected := `SHOW FILE FORMATS LIKE 'ff' IN SCHEMA "db"."schema"`
 		assert.Equal(t, expected, actual)
 	})
 }


### PR DESCRIPTION
Updates the ShowById sdk method to specify the schema (`IN SCHEMA "db"."schema"`) in which to search for a file format.

## Test Plan
* [X] New integration test covering broken case

## References
* Fixes #1934 