### PR TITLE
fix: support multiple grant_privilege_to_role resources on the same role

### DIFF
--- a/pkg/resources/grant_privileges_to_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_role_acceptance_test.go
@@ -857,7 +857,12 @@ func TestAccGrantPrivilegesToRole_multipleResources(t *testing.T) {
 			},
 			// IMPORT
 			{
-				ResourceName:      "snowflake_grant_privileges_to_role.g",
+				ResourceName:      "snowflake_grant_privileges_to_role.g1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "snowflake_grant_privileges_to_role.g2",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},


### PR DESCRIPTION
When using two `grant_privileges_to_role` resources for the same role, they conflict with each other and try to delete each other’s grants. This makes managing permissions difficult as grants for a single role have to be managed in a single place, no modularity is possible.

The following snippet will consistently drift:

```hcl
resource "snowflake_role" "r" {
	name = "testrole"
}

resource "snowflake_grant_privileges_to_role" "g1" {
	role_name  = snowflake_role.r.name
	privileges = ["CREATE ACCOUNT", "CREATE ROLE"]
	on_account = true
}

resource "snowflake_grant_privileges_to_role" "g2" {
	role_name  = snowflake_role.r.name
	privileges = ["IMPORT SHARE", "MANAGE GRANTS"]
	on_account = true
}
```

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [X] new acceptance test

## References
<!-- issues documentation links, etc  -->

* 