### PR TITLE
fix: 1969  change default privilege to OPERATE

### DIFF
--- a/pkg/resources/pipe_grant.go
+++ b/pkg/resources/pipe_grant.go
@@ -42,7 +42,7 @@ var pipeGrantSchema = map[string]*schema.Schema{
 		Type:         schema.TypeString,
 		Optional:     true,
 		Description:  "The privilege to grant on the current or future pipe. To grant all privileges, use the value `ALL PRIVILEGES`",
-		Default:      "USAGE",
+		Default:      "OPERATE",
 		ValidateFunc: validation.StringInSlice(validPipePrivileges.ToList(), true),
 		ForceNew:     true,
 	},

--- a/pkg/resources/pipe_grant_acceptance_test.go
+++ b/pkg/resources/pipe_grant_acceptance_test.go
@@ -48,6 +48,35 @@ func TestAcc_PipeGrant(t *testing.T) {
 	})
 }
 
+func TestAcc_PipeGrantWithDefaultPrivilege(t *testing.T) {
+	accName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.Test(t, resource.TestCase{
+		Providers:    providers(),
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: pipeGrantConfigWithDefaultPrivilege(accName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_pipe_grant.test", "database_name", accName),
+					resource.TestCheckResourceAttr("snowflake_pipe_grant.test", "schema_name", accName),
+					resource.TestCheckResourceAttr("snowflake_pipe_grant.test", "pipe_name", accName),
+					resource.TestCheckResourceAttr("snowflake_pipe_grant.test", "with_grant_option", "false"),
+					resource.TestCheckResourceAttr("snowflake_pipe_grant.test", "privilege", "OPERATE"),
+				),
+			},
+			{
+				ResourceName:      "snowflake_pipe_grant.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"enable_multiple_grants", // feature flag attribute not defined in Snowflake, can't be imported
+				},
+			},
+		},
+	})
+}
+
 func pipeGrantConfig(name, privilege string) string {
 	s := `
 resource "snowflake_database" "test" {
@@ -108,4 +137,65 @@ CMD
 }
 `
 	return fmt.Sprintf(s, name, name, privilege)
+}
+
+func pipeGrantConfigWithDefaultPrivilege(name string) string {
+	s := `
+resource "snowflake_database" "test" {
+  name = "%v"
+  comment = "Terraform acceptance test"
+}
+
+resource "snowflake_schema" "test" {
+  name = snowflake_database.test.name
+  database = snowflake_database.test.name
+  comment = "Terraform acceptance test"
+}
+
+resource "snowflake_table" "test" {
+  database = snowflake_database.test.name
+  schema   = snowflake_schema.test.name
+  name     = snowflake_schema.test.name
+  column {
+	name = "id"
+	type = "NUMBER(5,0)"
+  }
+  column {
+    name = "data"
+	type = "VARCHAR(16)"
+  }
+}
+
+resource "snowflake_role" "test" {
+  name = "%v"
+}
+
+resource "snowflake_stage" "test" {
+  name = snowflake_schema.test.name
+  database = snowflake_database.test.name
+  schema = snowflake_schema.test.name
+  comment = "Terraform acceptance test"
+}
+
+resource "snowflake_pipe_grant" "test" {
+  pipe_name = snowflake_pipe.test.name
+  database_name = snowflake_database.test.name
+  roles         = [snowflake_role.test.name]
+  schema_name   = snowflake_schema.test.name
+}
+
+resource "snowflake_pipe" "test" {
+  database       = snowflake_database.test.name
+  schema         = snowflake_schema.test.name
+  name           = snowflake_schema.test.name
+  comment        = "Terraform acceptance test"
+  copy_statement = <<CMD
+COPY INTO "${snowflake_table.test.database}"."${snowflake_table.test.schema}"."${snowflake_table.test.name}"
+  FROM @"${snowflake_stage.test.database}"."${snowflake_stage.test.schema}"."${snowflake_stage.test.name}"
+  FILE_FORMAT = (TYPE = CSV)
+CMD
+  auto_ingest    = false
+}
+`
+	return fmt.Sprintf(s, name, name)
 }


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
Changes the default privilege of a snowflake_pipe_grant to be `OPERATE`
Fixes #1969 

## Test Plan
- [X] New acceptance test for default privilege

## References
