### PR TITLE
feat: [PoC] Set up integration tests - without setup

### DIFF
--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -174,3 +174,10 @@ func (c *Client) queryOne(ctx context.Context, dest interface{}, sql string) err
 	ctx = context.WithValue(ctx, snowflakeAccountLocatorContextKey, c.accountLocator)
 	return decodeDriverError(c.db.GetContext(ctx, dest, sql))
 }
+
+// TODO: do not export this method (it was just a quick workaround for PoC)
+func (c *Client) ExecForTests(ctx context.Context, sql string) (sql.Result, error) {
+	ctx = context.WithValue(ctx, snowflakeAccountLocatorContextKey, c.accountLocator)
+	result, err := c.db.ExecContext(ctx, sql)
+	return result, decodeDriverError(err)
+}

--- a/pkg/sdk/integration_tests/helpers.go
+++ b/pkg/sdk/integration_tests/helpers.go
@@ -1,0 +1,177 @@
+package sdk_integration_tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/stretchr/testify/require"
+)
+
+func testClient(t *testing.T) *sdk.Client {
+	t.Helper()
+
+	client, err := sdk.NewDefaultClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return client
+}
+
+func createDatabaseWithIdentifier(t *testing.T, client *sdk.Client, id sdk.AccountObjectIdentifier) (*sdk.Database, func()) {
+	t.Helper()
+	return createDatabaseWithOptions(t, client, id, &sdk.CreateDatabaseOptions{})
+}
+
+func createDatabaseWithOptions(t *testing.T, client *sdk.Client, id sdk.AccountObjectIdentifier, _ *sdk.CreateDatabaseOptions) (*sdk.Database, func()) {
+	t.Helper()
+	ctx := context.Background()
+	err := client.Databases.Create(ctx, id, nil)
+	require.NoError(t, err)
+	database, err := client.Databases.ShowByID(ctx, id)
+	require.NoError(t, err)
+	return database, func() {
+		err := client.Databases.Drop(ctx, id, nil)
+		require.NoError(t, err)
+	}
+}
+
+func createSchema(t *testing.T, client *sdk.Client, database *sdk.Database) (*sdk.Schema, func()) {
+	t.Helper()
+	return createSchemaWithIdentifier(t, client, database, randomStringRange(t, 8, 28))
+}
+
+func createSchemaWithIdentifier(t *testing.T, client *sdk.Client, database *sdk.Database, name string) (*sdk.Schema, func()) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := client.ExecForTests(ctx, fmt.Sprintf("CREATE SCHEMA \"%s\".\"%s\"", database.Name, name))
+	require.NoError(t, err)
+	return &sdk.Schema{
+			DatabaseName: database.Name,
+			Name:         name,
+		}, func() {
+			_, err := client.ExecForTests(ctx, fmt.Sprintf("DROP SCHEMA \"%s\".\"%s\"", database.Name, name))
+			require.NoError(t, err)
+		}
+}
+
+func useDatabase(t *testing.T, client *sdk.Client, databaseID sdk.AccountObjectIdentifier) func() {
+	t.Helper()
+	ctx := context.Background()
+	orgDB, err := client.ContextFunctions.CurrentDatabase(ctx)
+	require.NoError(t, err)
+	err = client.Sessions.UseDatabase(ctx, databaseID)
+	require.NoError(t, err)
+	return func() {
+		err := client.Sessions.UseDatabase(ctx, sdk.NewAccountObjectIdentifier(orgDB))
+		require.NoError(t, err)
+	}
+}
+
+func useSchema(t *testing.T, client *sdk.Client, schemaID sdk.SchemaIdentifier) func() {
+	t.Helper()
+	ctx := context.Background()
+	orgDB, err := client.ContextFunctions.CurrentDatabase(ctx)
+	require.NoError(t, err)
+	orgSchema, err := client.ContextFunctions.CurrentSchema(ctx)
+	require.NoError(t, err)
+	err = client.Sessions.UseSchema(ctx, schemaID)
+	require.NoError(t, err)
+	return func() {
+		err := client.Sessions.UseSchema(ctx, sdk.NewSchemaIdentifier(orgDB, orgSchema))
+		require.NoError(t, err)
+	}
+}
+
+func createTable(t *testing.T, client *sdk.Client, database *sdk.Database, schema *sdk.Schema) (*sdk.Table, func()) {
+	t.Helper()
+	name := randomStringRange(t, 8, 28)
+	ctx := context.Background()
+	_, err := client.ExecForTests(ctx, fmt.Sprintf("CREATE TABLE \"%s\".\"%s\".\"%s\" (id NUMBER)", database.Name, schema.Name, name))
+	require.NoError(t, err)
+	return &sdk.Table{
+			DatabaseName: database.Name,
+			SchemaName:   schema.Name,
+			Name:         name,
+		}, func() {
+			_, err := client.ExecForTests(ctx, fmt.Sprintf("DROP TABLE \"%s\".\"%s\".\"%s\"", database.Name, schema.Name, name))
+			require.NoError(t, err)
+		}
+}
+
+func createTag(t *testing.T, client *sdk.Client, database *sdk.Database, schema *sdk.Schema) (*sdk.Tag, func()) {
+	t.Helper()
+	return createTagWithOptions(t, client, database, schema, &sdk.TagCreateOptions{})
+}
+
+func createTagWithOptions(t *testing.T, client *sdk.Client, database *sdk.Database, schema *sdk.Schema, _ *sdk.TagCreateOptions) (*sdk.Tag, func()) {
+	t.Helper()
+	name := randomStringRange(t, 8, 28)
+	ctx := context.Background()
+	_, err := client.ExecForTests(ctx, fmt.Sprintf("CREATE TAG \"%s\".\"%s\".\"%s\"", database.Name, schema.Name, name))
+	require.NoError(t, err)
+	return &sdk.Tag{
+			Name:         name,
+			DatabaseName: database.Name,
+			SchemaName:   schema.Name,
+		}, func() {
+			_, err := client.ExecForTests(ctx, fmt.Sprintf("DROP TAG \"%s\".\"%s\".\"%s\"", database.Name, schema.Name, name))
+			require.NoError(t, err)
+		}
+}
+
+func createStage(t *testing.T, client *sdk.Client, database *sdk.Database, schema *sdk.Schema, name string) (*sdk.Stage, func()) {
+	t.Helper()
+	require.NotNil(t, database, "database has to be created")
+	require.NotNil(t, schema, "schema has to be created")
+
+	id := sdk.NewSchemaObjectIdentifier(database.Name, schema.Name, name)
+	ctx := context.Background()
+
+	stageCleanup := func() {
+		_, err := client.ExecForTests(ctx, fmt.Sprintf("DROP STAGE %s", id.FullyQualifiedName()))
+		require.NoError(t, err)
+	}
+
+	_, err := client.ExecForTests(ctx, fmt.Sprintf("CREATE STAGE %s", id.FullyQualifiedName()))
+	if err != nil {
+		return nil, stageCleanup
+	}
+	require.NoError(t, err)
+
+	return &sdk.Stage{
+		DatabaseName: database.Name,
+		SchemaName:   schema.Name,
+		Name:         name,
+	}, stageCleanup
+}
+
+func createPipe(t *testing.T, client *sdk.Client, database *sdk.Database, schema *sdk.Schema, name string, copyStatement string) (*sdk.Pipe, func()) {
+	t.Helper()
+	require.NotNil(t, database, "database has to be created")
+	require.NotNil(t, schema, "schema has to be created")
+
+	id := sdk.NewSchemaObjectIdentifier(database.Name, schema.Name, name)
+	ctx := context.Background()
+
+	pipeCleanup := func() {
+		err := client.Pipes.Drop(ctx, id)
+		require.NoError(t, err)
+	}
+
+	err := client.Pipes.Create(ctx, id, copyStatement, &sdk.PipeCreateOptions{})
+	if err != nil {
+		return nil, pipeCleanup
+	}
+	require.NoError(t, err)
+
+	createdPipe, errDescribe := client.Pipes.Describe(ctx, id)
+	if errDescribe != nil {
+		return nil, pipeCleanup
+	}
+	require.NoError(t, errDescribe)
+
+	return createdPipe, pipeCleanup
+}

--- a/pkg/sdk/integration_tests/random.go
+++ b/pkg/sdk/integration_tests/random.go
@@ -1,0 +1,44 @@
+package sdk_integration_tests
+
+import (
+	"testing"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+func randomString(t *testing.T) string {
+	t.Helper()
+	return gofakeit.Password(true, true, true, true, false, 28)
+}
+
+func randomStringRange(t *testing.T, min, max int) string {
+	t.Helper()
+	if min > max {
+		t.Errorf("min %d is greater than max %d", min, max)
+	}
+	return gofakeit.Password(true, true, true, true, false, randomIntRange(t, min, max))
+}
+
+func randomIntRange(t *testing.T, min, max int) int {
+	t.Helper()
+	if min > max {
+		t.Errorf("min %d is greater than max %d", min, max)
+	}
+	return gofakeit.IntRange(min, max)
+}
+
+func randomAlphanumericN(t *testing.T, num int) string {
+	t.Helper()
+	return gofakeit.Password(true, true, true, false, false, num)
+}
+
+func alphanumericSchemaIdentifier(t *testing.T) sdk.SchemaIdentifier {
+	t.Helper()
+	return sdk.NewSchemaIdentifier(randomAlphanumericN(t, 12), randomAlphanumericN(t, 12))
+}
+
+func randomComment(t *testing.T) string {
+	t.Helper()
+	return gofakeit.Sentence(10)
+}

--- a/pkg/sdk/integration_tests/setup_integration_test.go
+++ b/pkg/sdk/integration_tests/setup_integration_test.go
@@ -1,0 +1,40 @@
+package sdk_integration_tests
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestMain(m *testing.M) {
+	exitVal := execute(m)
+	os.Exit(exitVal)
+}
+
+func execute(m *testing.M) int {
+	defer timer("tests")()
+	setup()
+	exitVal := m.Run()
+	cleanup()
+	return exitVal
+}
+
+func setup() {
+	log.Println("Running integration tests setup")
+}
+
+func cleanup() {
+	log.Println("Running integration tests cleanup")
+}
+
+// timer measures time from invocation point to the end of method.
+// It's supposed to be used like:
+//
+//	defer timer("something to measure name")()
+func timer(name string) func() {
+	start := time.Now()
+	return func() {
+		log.Printf("[DEBUG] %s took %v\n", name, time.Since(start))
+	}
+}


### PR DESCRIPTION
## Changes
This is a short PoC of introducing [TestMain wrapper](https://pkg.go.dev/testing#hdr-Main) to all integration tests to avoid common setup and cleanup (with the aim to reduce boilerplate and tests time).

There are two PRs:
- #1988 - this one, which is used as an reference
- #1989 - the one where test client and context are set up just once

On local machine the difference in running example test was around 20% time reduction (accordingly without and with set up):

```txt
2023/08/01 13:41:02 [DEBUG] tests took 35.309400583s
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/integration_tests        35.629s
```

```txt
2023/08/01 13:39:18 [DEBUG] tests took 27.170710792s
ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/integration_tests        28.069s
```

## Test Plan
* [x] none, this is just PoC
