### PR TITLE
fix: Always set MUST_CHANGE_PASSWORD on account creation

### DIFF
--- a/pkg/resources/account.go
+++ b/pkg/resources/account.go
@@ -242,9 +242,11 @@ func CreateAccount(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("last_name"); ok {
 		createOptions.LastName = sdk.String(v.(string))
 	}
-	if v, ok := d.GetOk("must_change_password"); ok {
-		createOptions.MustChangePassword = sdk.Bool(v.(bool))
-	}
+
+	// Has default, don't fetch with GetOk because this can be falsey and valid
+	v := d.Get("must_change_password")
+	createOptions.MustChangePassword = sdk.Bool(v.(bool))
+
 	if v, ok := d.GetOk("region_group"); ok {
 		createOptions.RegionGroup = sdk.String(v.(string))
 	} else {

--- a/pkg/sdk/accounts_test.go
+++ b/pkg/sdk/accounts_test.go
@@ -42,6 +42,26 @@ func TestAccountCreate(t *testing.T) {
 		expected := `CREATE ACCOUNT "newaccount" ADMIN_NAME = 'someadmin' ADMIN_RSA_PUBLIC_KEY = 's3cr3tk3y' FIRST_NAME = 'Ad' LAST_NAME = 'Min' EMAIL = 'admin@example.com' MUST_CHANGE_PASSWORD = true EDITION = BUSINESS_CRITICAL REGION_GROUP = 'groupid' REGION = 'regionid' COMMENT = 'Test account'`
 		assert.Equal(t, expected, actual)
 	})
+
+	t.Run("static password", func(t *testing.T) {
+		opts := &CreateAccountOptions{
+			name:               NewAccountObjectIdentifier("newaccount"),
+			AdminName:          "someadmin",
+			AdminPassword:      String("v3rys3cr3t"),
+			FirstName:          String("Ad"),
+			LastName:           String("Min"),
+			Email:              "admin@example.com",
+			MustChangePassword: Bool(false),
+			Edition:            EditionBusinessCritical,
+			RegionGroup:        String("groupid"),
+			Region:             String("regionid"),
+			Comment:            String("Test account"),
+		}
+		actual, err := structToSQL(opts)
+		require.NoError(t, err)
+		expected := `CREATE ACCOUNT "newaccount" ADMIN_NAME = 'someadmin' ADMIN_PASSWORD = 'v3rys3cr3t' FIRST_NAME = 'Ad' LAST_NAME = 'Min' EMAIL = 'admin@example.com' MUST_CHANGE_PASSWORD = false EDITION = BUSINESS_CRITICAL REGION_GROUP = 'groupid' REGION = 'regionid' COMMENT = 'Test account'`
+		assert.Equal(t, expected, actual)
+	})
 }
 
 func TestAccountAlter(t *testing.T) {


### PR DESCRIPTION
- Previoulsy, GetOK was returning false on a falsely-set value for this, stopping it from going into the query string.  We can safely use Get instead to always get this clause into the query string (The resource param has a default of false already).
- This has the added benefit of not relying on the default behavior on the snowflake side, which has changed in the past.  So tf users shouldn't be caught off guard if it changes again.
- I wrote a test for this before I realized this issue lied in the provider code

this addresses https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1607
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
* [x] unit tests
<!-- add more below if you think they are relevant -->
* [x] local testing, debug logs, and activity logs on snowflake side

## References
<!-- issues documentation links, etc  -->

* 