### PR TITLE
fix: warehouse size validations

### DIFF
--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -119,12 +119,6 @@ func (opts *CreateWarehouseOptions) validate() error {
 	if !validObjectidentifier(opts.name) {
 		return ErrInvalidObjectIdentifier
 	}
-	if valueSet(opts.MaxClusterCount) && !validateIntInRange(*opts.MaxClusterCount, 1, 10) {
-		return fmt.Errorf("MaxClusterCount must be between 1 and 10")
-	}
-	if valueSet(opts.MinClusterCount) && !validateIntInRange(*opts.MinClusterCount, 1, 10) {
-		return fmt.Errorf("MinClusterCount must be between 1 and 10")
-	}
 	if valueSet(opts.MinClusterCount) && valueSet(opts.MaxClusterCount) && !validateIntGreaterThanOrEqual(*opts.MaxClusterCount, *opts.MinClusterCount) {
 		return fmt.Errorf("MinClusterCount must be less than or equal to MaxClusterCount")
 	}
@@ -225,14 +219,9 @@ type WarehouseSet struct {
 }
 
 func (v *WarehouseSet) validate() error {
-	if v.MaxClusterCount != nil {
-		if ok := validateIntInRange(*v.MaxClusterCount, 1, 10); !ok {
-			return fmt.Errorf("MaxClusterCount must be between 1 and 10")
-		}
-	}
 	if v.MinClusterCount != nil {
-		if ok := validateIntInRange(*v.MinClusterCount, 1, 10); !ok {
-			return fmt.Errorf("MinClusterCount must be between 1 and 10")
+		if ok := validateIntInRange(*v.MinClusterCount, 1, *v.MaxClusterCount); !ok {
+			return fmt.Errorf("MinClusterCount must be less than or equal to MaxClusterCount")
 		}
 	}
 	if v.AutoSuspend != nil {

--- a/pkg/sdk/warehouses_test.go
+++ b/pkg/sdk/warehouses_test.go
@@ -61,6 +61,45 @@ func TestWarehouseCreate(t *testing.T) {
 	})
 }
 
+func TestWarehouseSizing(t *testing.T) {
+	t.Run("Min bigger than Max", func(t *testing.T) {
+		opts := &CreateWarehouseOptions{
+			name:            NewAccountObjectIdentifier("mywarehouse"),
+			MaxClusterCount: Int(1),
+			MinClusterCount: Int(2),
+		}
+		err := opts.validate()
+		require.Error(t, err)
+	})
+	t.Run("Max equal Min", func(t *testing.T) {
+		opts := &CreateWarehouseOptions{
+			name:            NewAccountObjectIdentifier("mywarehouse"),
+			MaxClusterCount: Int(2),
+			MinClusterCount: Int(2),
+		}
+		lerr := opts.validate()
+		require.NoError(t, lerr)
+	})
+	t.Run("Max greater than Min", func(t *testing.T) {
+		opts := &CreateWarehouseOptions{
+			name:            NewAccountObjectIdentifier("mywarehouse"),
+			MaxClusterCount: Int(2),
+			MinClusterCount: Int(1),
+		}
+		err := opts.validate()
+		require.NoError(t, err)
+	})
+	t.Run("Allow large Min Max Values", func(t *testing.T) {
+		opts := &CreateWarehouseOptions{
+			name:            NewAccountObjectIdentifier("mywarehouse"),
+			MaxClusterCount: Int(100),
+			MinClusterCount: Int(11),
+		}
+		err := opts.validate()
+		require.NoError(t, err)
+	})
+}
+
 func TestWarehouseAlter(t *testing.T) {
 	t.Run("with set params", func(t *testing.T) {
 		opts := &AlterWarehouseOptions{


### PR DESCRIPTION
max clusters of 10 is a soft limit and can be lifted via support. this removes some validation on the max clusters to allow for these soft limit elevations.