### PR TITLE
fix: SNOW-889027 Schema Object Id Fix for Functions / Procedures

### DIFF
--- a/pkg/sdk/file_format.go
+++ b/pkg/sdk/file_format.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -662,7 +663,7 @@ func (v *fileFormats) ShowByID(ctx context.Context, id SchemaObjectIdentifier) (
 		return nil, err
 	}
 	for _, FileFormat := range fileFormats {
-		if FileFormat.ID() == id {
+		if reflect.DeepEqual(FileFormat.ID(), id) {
 			return FileFormat, nil
 		}
 	}

--- a/pkg/sdk/identifier_helpers_test.go
+++ b/pkg/sdk/identifier_helpers_test.go
@@ -1,0 +1,28 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSchemaObjectIdentifierFromFullyQualifiedName(t *testing.T) {
+	type test struct {
+		input string
+		want  SchemaObjectIdentifier
+	}
+
+	tests := []test{
+		{input: "\"MY_DB\".\"MY_SCHEMA\".\"multiply\"(number, number)", want: SchemaObjectIdentifier{databaseName: "MY_DB", schemaName: "MY_SCHEMA", name: "multiply", arguments: []DataType{DataTypeNumber, DataTypeNumber}}},
+		{input: "MY_DB.MY_SCHEMA.add(number, number)", want: SchemaObjectIdentifier{databaseName: "MY_DB", schemaName: "MY_SCHEMA", name: "add", arguments: []DataType{DataTypeNumber, DataTypeNumber}}},
+		{input: "\"MY_DB\".\"MY_SCHEMA\".\"MY_UDF\"()", want: SchemaObjectIdentifier{databaseName: "MY_DB", schemaName: "MY_SCHEMA", name: "MY_UDF", arguments: []DataType{}}},
+		{input: "\"MY_DB\".\"MY_SCHEMA\".\"MY_PIPE\"", want: SchemaObjectIdentifier{databaseName: "MY_DB", schemaName: "MY_SCHEMA", name: "MY_PIPE", arguments: nil}},
+		{input: "MY_DB.MY_SCHEMA.MY_STAGE", want: SchemaObjectIdentifier{databaseName: "MY_DB", schemaName: "MY_SCHEMA", name: "MY_STAGE", arguments: nil}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			id := NewSchemaObjectIdentifierFromFullyQualifiedName(tc.input)
+			require.Equal(t, tc.want, id)
+		})
+	}
+}


### PR DESCRIPTION
Fixes the SchemaObjectIdentifier to work with procedures and functions, which also have arguments. Added test cases to ensure that parsing of all different types of IDs works as expected.

```
## Test Plan
=== RUN   TestNewSchemaObjectIdentifierFromFullyQualifiedName
=== RUN   TestNewSchemaObjectIdentifierFromFullyQualifiedName/"MY_DB"."MY_SCHEMA"."multiply"(number,_number)
=== RUN   TestNewSchemaObjectIdentifierFromFullyQualifiedName/MY_DB.MY_SCHEMA.add(number,_number)
=== RUN   TestNewSchemaObjectIdentifierFromFullyQualifiedName/"MY_DB"."MY_SCHEMA"."MY_UDF"()
=== RUN   TestNewSchemaObjectIdentifierFromFullyQualifiedName/"MY_DB"."MY_SCHEMA"."MY_PIPE"
=== RUN   TestNewSchemaObjectIdentifierFromFullyQualifiedName/MY_DB.MY_SCHEMA.MY_STAGE
--- PASS: TestNewSchemaObjectIdentifierFromFullyQualifiedName (0.00s)
    --- PASS: TestNewSchemaObjectIdentifierFromFullyQualifiedName/"MY_DB"."MY_SCHEMA"."multiply"(number,_number) (0.00s)
    --- PASS: TestNewSchemaObjectIdentifierFromFullyQualifiedName/MY_DB.MY_SCHEMA.add(number,_number) (0.00s)
    --- PASS: TestNewSchemaObjectIdentifierFromFullyQualifiedName/"MY_DB"."MY_SCHEMA"."MY_UDF"() (0.00s)
    --- PASS: TestNewSchemaObjectIdentifierFromFullyQualifiedName/"MY_DB"."MY_SCHEMA"."MY_PIPE" (0.00s)
    --- PASS: TestNewSchemaObjectIdentifierFromFullyQualifiedName/MY_DB.MY_SCHEMA.MY_STAGE (0.00s)
PASS
ok  	github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk	0.630s
```

## References
https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2002
