### PR TITLE
chore: Remove lint ignore comments - test

### DIFF
--- a/pkg/sdk/accounts.go
+++ b/pkg/sdk/accounts.go
@@ -33,8 +33,8 @@ var (
 )
 
 type CreateAccountOptions struct {
-	create  bool                    `ddl:"static" sql:"CREATE"`  //lint:ignore U1000 This is used in the ddl tag
-	account bool                    `ddl:"static" sql:"ACCOUNT"` //lint:ignore U1000 This is used in the ddl tag
+	create  bool                    `ddl:"static" sql:"CREATE"`
+	account bool                    `ddl:"static" sql:"ACCOUNT"`
 	name    AccountObjectIdentifier `ddl:"identifier"`
 
 	// Object properties
@@ -84,8 +84,8 @@ func (c *accounts) Create(ctx context.Context, id AccountObjectIdentifier, opts 
 }
 
 type AlterAccountOptions struct {
-	alter   bool `ddl:"static" sql:"ALTER"`   //lint:ignore U1000 This is used in the ddl tag
-	account bool `ddl:"static" sql:"ACCOUNT"` //lint:ignore U1000 This is used in the ddl tag
+	alter   bool `ddl:"static" sql:"ALTER"`
+	account bool `ddl:"static" sql:"ACCOUNT"`
 
 	Set    *AccountSet    `ddl:"keyword" sql:"SET"`
 	Unset  *AccountUnset  `ddl:"list,no_parentheses" sql:"UNSET"`
@@ -283,8 +283,8 @@ func (c *accounts) Alter(ctx context.Context, opts *AlterAccountOptions) error {
 }
 
 type ShowAccountOptions struct {
-	show     bool  `ddl:"static" sql:"SHOW"`                  //lint:ignore U1000 This is used in the ddl tag
-	accounts bool  `ddl:"static" sql:"ORGANIZATION ACCOUNTS"` //lint:ignore U1000 This is used in the ddl tag
+	show     bool  `ddl:"static" sql:"SHOW"`
+	accounts bool  `ddl:"static" sql:"ORGANIZATION ACCOUNTS"`
 	Like     *Like `ddl:"keyword" sql:"LIKE"`
 }
 

--- a/pkg/sdk/alerts.go
+++ b/pkg/sdk/alerts.go
@@ -31,9 +31,9 @@ type alerts struct {
 }
 
 type CreateAlertOptions struct {
-	create      bool                   `ddl:"static" sql:"CREATE"` //lint:ignore U1000 This is used in the ddl tag
+	create      bool                   `ddl:"static" sql:"CREATE"`
 	OrReplace   *bool                  `ddl:"keyword" sql:"OR REPLACE"`
-	alert       bool                   `ddl:"static" sql:"ALERT"` //lint:ignore U1000 This is used in the ddl tag
+	alert       bool                   `ddl:"static" sql:"ALERT"`
 	IfNotExists *bool                  `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name        SchemaObjectIdentifier `ddl:"identifier"`
 
@@ -99,8 +99,8 @@ var (
 )
 
 type AlterAlertOptions struct {
-	alter    bool                   `ddl:"static" sql:"ALTER"` //lint:ignore U1000 This is used in the ddl tag
-	alert    bool                   `ddl:"static" sql:"ALERT"` //lint:ignore U1000 This is used in the ddl tag
+	alter    bool                   `ddl:"static" sql:"ALTER"`
+	alert    bool                   `ddl:"static" sql:"ALERT"`
 	IfExists *bool                  `ddl:"keyword" sql:"IF EXISTS"`
 	name     SchemaObjectIdentifier `ddl:"identifier"`
 
@@ -166,8 +166,8 @@ func (v *alerts) Alter(ctx context.Context, id SchemaObjectIdentifier, opts *Alt
 }
 
 type dropAlertOptions struct {
-	drop  bool                   `ddl:"static" sql:"DROP"`  //lint:ignore U1000 This is used in the ddl tag
-	alert bool                   `ddl:"static" sql:"ALERT"` //lint:ignore U1000 This is used in the ddl tag
+	drop  bool                   `ddl:"static" sql:"DROP"`
+	alert bool                   `ddl:"static" sql:"ALERT"`
 	name  SchemaObjectIdentifier `ddl:"identifier"`
 }
 
@@ -198,9 +198,9 @@ func (v *alerts) Drop(ctx context.Context, id SchemaObjectIdentifier) error {
 }
 
 type ShowAlertOptions struct {
-	show   bool  `ddl:"static" sql:"SHOW"` //lint:ignore U1000 This is used in the ddl tag
+	show   bool  `ddl:"static" sql:"SHOW"`
 	Terse  *bool `ddl:"keyword" sql:"TERSE"`
-	alerts bool  `ddl:"static" sql:"ALERTS"` //lint:ignore U1000 This is used in the ddl tag
+	alerts bool  `ddl:"static" sql:"ALERTS"`
 
 	// optional
 	Like       *Like   `ddl:"keyword" sql:"LIKE"`
@@ -316,8 +316,8 @@ func (v *alerts) ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Aler
 }
 
 type describeAlertOptions struct {
-	describe bool                   `ddl:"static" sql:"DESCRIBE"` //lint:ignore U1000 This is used in the ddl tag
-	alert    bool                   `ddl:"static" sql:"ALERT"`    //lint:ignore U1000 This is used in the ddl tag
+	describe bool                   `ddl:"static" sql:"DESCRIBE"`
+	alert    bool                   `ddl:"static" sql:"ALERT"`
 	name     SchemaObjectIdentifier `ddl:"identifier"`
 }
 

--- a/pkg/sdk/databases.go
+++ b/pkg/sdk/databases.go
@@ -132,11 +132,11 @@ func (row *databaseRow) toDatabase() *Database {
 }
 
 type CreateDatabaseOptions struct {
-	create                     bool                    `ddl:"static" sql:"CREATE"` //lint:ignore U1000 This is used in the ddl tag
+	create                     bool                    `ddl:"static" sql:"CREATE"`
 	OrReplace                  *bool                   `ddl:"keyword" sql:"OR REPLACE"`
 	Transient                  *bool                   `ddl:"keyword" sql:"TRANSIENT"`
-	database                   bool                    `ddl:"static" sql:"DATABASE"` //lint:ignore U1000 This is used in the ddl tag
-	name                       AccountObjectIdentifier `ddl:"identifier"`            //lint:ignore U1000 This is used in the ddl tag
+	database                   bool                    `ddl:"static" sql:"DATABASE"`
+	name                       AccountObjectIdentifier `ddl:"identifier"`
 	IfNotExists                *bool                   `ddl:"keyword" sql:"IF NOT EXISTS"`
 	Clone                      *Clone                  `ddl:"-"`
 	DataRetentionTimeInDays    *int                    `ddl:"parameter" sql:"DATA_RETENTION_TIME_IN_DAYS"`
@@ -174,9 +174,9 @@ func (v *databases) Create(ctx context.Context, id AccountObjectIdentifier, opts
 }
 
 type CreateSharedDatabaseOptions struct {
-	create    bool                     `ddl:"static" sql:"CREATE"`   //lint:ignore U1000 This is used in the ddl tag
-	database  bool                     `ddl:"static" sql:"DATABASE"` //lint:ignore U1000 This is used in the ddl tag
-	name      AccountObjectIdentifier  `ddl:"identifier"`            //lint:ignore U1000 This is used in the ddl tag
+	create    bool                     `ddl:"static" sql:"CREATE"`
+	database  bool                     `ddl:"static" sql:"DATABASE"`
+	name      AccountObjectIdentifier  `ddl:"identifier"`
 	fromShare ExternalObjectIdentifier `ddl:"identifier" sql:"FROM SHARE"`
 	Comment   *string                  `ddl:"parameter,single_quotes" sql:"COMMENT"`
 }
@@ -211,9 +211,9 @@ func (v *databases) CreateShared(ctx context.Context, id AccountObjectIdentifier
 }
 
 type CreateSecondaryDatabaseOptions struct {
-	create                  bool                     `ddl:"static" sql:"CREATE"`   //lint:ignore U1000 This is used in the ddl tag
-	database                bool                     `ddl:"static" sql:"DATABASE"` //lint:ignore U1000 This is used in the ddl tag
-	name                    AccountObjectIdentifier  `ddl:"identifier"`            //lint:ignore U1000 This is used in the ddl tag
+	create                  bool                     `ddl:"static" sql:"CREATE"`
+	database                bool                     `ddl:"static" sql:"DATABASE"`
+	name                    AccountObjectIdentifier  `ddl:"identifier"`
 	primaryDatabase         ExternalObjectIdentifier `ddl:"identifier" sql:"AS REPLICA OF"`
 	DataRetentionTimeInDays *int                     `ddl:"parameter" sql:"DATA_RETENTION_TIME_IN_DAYS"`
 }
@@ -246,8 +246,8 @@ func (v *databases) CreateSecondary(ctx context.Context, id AccountObjectIdentif
 }
 
 type AlterDatabaseOptions struct {
-	alter    bool                    `ddl:"static" sql:"ALTER"`    //lint:ignore U1000 This is used in the ddl tag
-	database bool                    `ddl:"static" sql:"DATABASE"` //lint:ignore U1000 This is used in the ddl tag
+	alter    bool                    `ddl:"static" sql:"ALTER"`
+	database bool                    `ddl:"static" sql:"DATABASE"`
 	IfExists *bool                   `ddl:"keyword" sql:"IF EXISTS"`
 	name     AccountObjectIdentifier `ddl:"identifier"`
 	NewName  AccountObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
@@ -329,8 +329,8 @@ func (v *databases) Alter(ctx context.Context, id AccountObjectIdentifier, opts 
 }
 
 type AlterDatabaseReplicationOptions struct {
-	alter              bool                    `ddl:"static" sql:"ALTER"`    //lint:ignore U1000 This is used in the ddl tag
-	database           bool                    `ddl:"static" sql:"DATABASE"` //lint:ignore U1000 This is used in the ddl tag
+	alter              bool                    `ddl:"static" sql:"ALTER"`
+	database           bool                    `ddl:"static" sql:"DATABASE"`
 	name               AccountObjectIdentifier `ddl:"identifier"`
 	EnableReplication  *EnableReplication      `ddl:"keyword" sql:"ENABLE REPLICATION"`
 	DisableReplication *DisableReplication     `ddl:"keyword" sql:"DISABLE REPLICATION"`
@@ -394,8 +394,8 @@ func (v *databases) AlterReplication(ctx context.Context, id AccountObjectIdenti
 }
 
 type AlterDatabaseFailoverOptions struct {
-	alter           bool                    `ddl:"static" sql:"ALTER"`    //lint:ignore U1000 This is used in the ddl tag
-	database        bool                    `ddl:"static" sql:"DATABASE"` //lint:ignore U1000 This is used in the ddl tag
+	alter           bool                    `ddl:"static" sql:"ALTER"`
+	database        bool                    `ddl:"static" sql:"DATABASE"`
 	name            AccountObjectIdentifier `ddl:"identifier"`
 	EnableFailover  *EnableFailover         `ddl:"keyword" sql:"ENABLE FAILOVER"`
 	DisableFailover *DisableFailover        `ddl:"keyword" sql:"DISABLE FAILOVER"`
@@ -458,10 +458,10 @@ func (v *databases) AlterFailover(ctx context.Context, id AccountObjectIdentifie
 }
 
 type DropDatabaseOptions struct {
-	drop     bool                    `ddl:"static" sql:"DROP"`     //lint:ignore U1000 This is used in the ddl tag
-	database bool                    `ddl:"static" sql:"DATABASE"` //lint:ignore U1000 This is used in the ddl tag
+	drop     bool                    `ddl:"static" sql:"DROP"`
+	database bool                    `ddl:"static" sql:"DATABASE"`
 	IfExists *bool                   `ddl:"keyword" sql:"IF EXISTS"`
-	name     AccountObjectIdentifier `ddl:"identifier"` //lint:ignore U1000 This is used in the ddl tag
+	name     AccountObjectIdentifier `ddl:"identifier"`
 }
 
 func (opts *DropDatabaseOptions) validate() error {
@@ -488,9 +488,9 @@ func (v *databases) Drop(ctx context.Context, id AccountObjectIdentifier, opts *
 }
 
 type undropDatabaseOptions struct {
-	undrop   bool                    `ddl:"static" sql:"UNDROP"`   //lint:ignore U1000 This is used in the ddl tag
-	database bool                    `ddl:"static" sql:"DATABASE"` //lint:ignore U1000 This is used in the ddl tag
-	name     AccountObjectIdentifier `ddl:"identifier"`            //lint:ignore U1000 This is used in the ddl tag
+	undrop   bool                    `ddl:"static" sql:"UNDROP"`
+	database bool                    `ddl:"static" sql:"DATABASE"`
+	name     AccountObjectIdentifier `ddl:"identifier"`
 }
 
 func (opts *undropDatabaseOptions) validate() error {
@@ -516,9 +516,9 @@ func (v *databases) Undrop(ctx context.Context, id AccountObjectIdentifier) erro
 }
 
 type ShowDatabasesOptions struct {
-	show       bool       `ddl:"static" sql:"SHOW"` //lint:ignore U1000 This is used in the ddl tag
+	show       bool       `ddl:"static" sql:"SHOW"`
 	Terse      *bool      `ddl:"keyword" sql:"TERSE"`
-	databases  bool       `ddl:"static" sql:"DATABASES"` //lint:ignore U1000 This is used in the ddl tag
+	databases  bool       `ddl:"static" sql:"DATABASES"`
 	History    *bool      `ddl:"keyword" sql:"HISTORY"`
 	Like       *Like      `ddl:"keyword" sql:"LIKE"`
 	StartsWith *string    `ddl:"parameter,single_quotes,no_equals" sql:"STARTS WITH"`
@@ -577,9 +577,9 @@ type DatabaseDetailsRow struct {
 }
 
 type describeDatabaseOptions struct {
-	describe bool                    `ddl:"static" sql:"DESCRIBE"` //lint:ignore U1000 This is used in the ddl tag
-	database bool                    `ddl:"static" sql:"DATABASE"` //lint:ignore U1000 This is used in the ddl tag
-	name     AccountObjectIdentifier `ddl:"identifier"`            //lint:ignore U1000 This is used in the ddl tag
+	describe bool                    `ddl:"static" sql:"DESCRIBE"`
+	database bool                    `ddl:"static" sql:"DATABASE"`
+	name     AccountObjectIdentifier `ddl:"identifier"`
 }
 
 func (opts *describeDatabaseOptions) validate() error {

--- a/pkg/sdk/failover_groups.go
+++ b/pkg/sdk/failover_groups.go
@@ -51,8 +51,8 @@ const (
 )
 
 type CreateFailoverGroupOptions struct {
-	create        bool                    `ddl:"static" sql:"CREATE"`         //lint:ignore U1000 This is used in the ddl tag
-	failoverGroup bool                    `ddl:"static" sql:"FAILOVER GROUP"` //lint:ignore U1000 This is used in the ddl tag
+	create        bool                    `ddl:"static" sql:"CREATE"`
+	failoverGroup bool                    `ddl:"static" sql:"FAILOVER GROUP"`
 	IfNotExists   *bool                   `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name          AccountObjectIdentifier `ddl:"identifier"`
 
@@ -91,8 +91,8 @@ func (v *failoverGroups) Create(ctx context.Context, id AccountObjectIdentifier,
 }
 
 type CreateSecondaryReplicationGroupOptions struct {
-	create               bool                     `ddl:"static" sql:"CREATE"`         //lint:ignore U1000 This is used in the ddl tag
-	failoverGroup        bool                     `ddl:"static" sql:"FAILOVER GROUP"` //lint:ignore U1000 This is used in the ddl tag
+	create               bool                     `ddl:"static" sql:"CREATE"`
+	failoverGroup        bool                     `ddl:"static" sql:"FAILOVER GROUP"`
 	IfNotExists          *bool                    `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name                 AccountObjectIdentifier  `ddl:"identifier"`
 	primaryFailoverGroup ExternalObjectIdentifier `ddl:"identifier" sql:"AS REPLICA OF"`
@@ -126,8 +126,8 @@ func (v *failoverGroups) CreateSecondaryReplicationGroup(ctx context.Context, id
 }
 
 type AlterSourceFailoverGroupOptions struct {
-	alter         bool                    `ddl:"static" sql:"ALTER"`          //lint:ignore U1000 This is used in the ddl tag
-	failoverGroup bool                    `ddl:"static" sql:"FAILOVER GROUP"` //lint:ignore U1000 This is used in the ddl tag
+	alter         bool                    `ddl:"static" sql:"ALTER"`
+	failoverGroup bool                    `ddl:"static" sql:"FAILOVER GROUP"`
 	IfExists      *bool                   `ddl:"keyword" sql:"IF EXISTS"`
 	name          AccountObjectIdentifier `ddl:"identifier"`
 	NewName       AccountObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
@@ -232,8 +232,8 @@ func (v *failoverGroups) AlterSource(ctx context.Context, id AccountObjectIdenti
 }
 
 type AlterTargetFailoverGroupOptions struct {
-	alter         bool                    `ddl:"static" sql:"ALTER"`          //lint:ignore U1000 This is used in the ddl tag
-	failoverGroup bool                    `ddl:"static" sql:"FAILOVER GROUP"` //lint:ignore U1000 This is used in the ddl tag
+	alter         bool                    `ddl:"static" sql:"ALTER"`
+	failoverGroup bool                    `ddl:"static" sql:"FAILOVER GROUP"`
 	IfExists      *bool                   `ddl:"keyword" sql:"IF EXISTS"`
 	name          AccountObjectIdentifier `ddl:"identifier"`
 	Refresh       *bool                   `ddl:"keyword" sql:"REFRESH"`
@@ -269,8 +269,8 @@ func (v *failoverGroups) AlterTarget(ctx context.Context, id AccountObjectIdenti
 }
 
 type DropFailoverGroupOptions struct {
-	drop          bool                    `ddl:"static" sql:"DROP"`           //lint:ignore U1000 This is used in the ddl tag
-	failoverGroup bool                    `ddl:"static" sql:"FAILOVER GROUP"` //lint:ignore U1000 This is used in the ddl tag
+	drop          bool                    `ddl:"static" sql:"DROP"`
+	failoverGroup bool                    `ddl:"static" sql:"FAILOVER GROUP"`
 	IfExists      *bool                   `ddl:"keyword" sql:"IF EXISTS"`
 	name          AccountObjectIdentifier `ddl:"identifier"`
 }
@@ -303,8 +303,8 @@ func (v *failoverGroups) Drop(ctx context.Context, id AccountObjectIdentifier, o
 
 // ShowFailoverGroupOptions represents the options for listing failover groups.
 type ShowFailoverGroupOptions struct {
-	show           bool              `ddl:"static" sql:"SHOW"`            //lint:ignore U1000 This is used in the ddl tag
-	failoverGroups bool              `ddl:"static" sql:"FAILOVER GROUPS"` //lint:ignore U1000 This is used in the ddl tag
+	show           bool              `ddl:"static" sql:"SHOW"`
+	failoverGroups bool              `ddl:"static" sql:"FAILOVER GROUPS"`
 	InAccount      AccountIdentifier `ddl:"identifier" sql:"IN ACCOUNT"`
 }
 
@@ -489,8 +489,8 @@ func (v *failoverGroups) ShowByID(ctx context.Context, id AccountObjectIdentifie
 }
 
 type showFailoverGroupDatabasesOptions struct {
-	show      bool                    `ddl:"static" sql:"SHOW"`      //lint:ignore U1000 This is used in the ddl tag
-	databases bool                    `ddl:"static" sql:"DATABASES"` //lint:ignore U1000 This is used in the ddl tag
+	show      bool                    `ddl:"static" sql:"SHOW"`
+	databases bool                    `ddl:"static" sql:"DATABASES"`
 	in        AccountObjectIdentifier `ddl:"identifier" sql:"IN FAILOVER GROUP"`
 }
 
@@ -527,8 +527,8 @@ func (v *failoverGroups) ShowDatabases(ctx context.Context, id AccountObjectIden
 }
 
 type showFailoverGroupSharesOptions struct {
-	show      bool                    `ddl:"static" sql:"SHOW"`   //lint:ignore U1000 This is used in the ddl tag
-	databases bool                    `ddl:"static" sql:"SHARES"` //lint:ignore U1000 This is used in the ddl tag
+	show      bool                    `ddl:"static" sql:"SHOW"`
+	databases bool                    `ddl:"static" sql:"SHARES"`
 	in        AccountObjectIdentifier `ddl:"identifier" sql:"IN FAILOVER GROUP"`
 }
 

--- a/pkg/sdk/file_format.go
+++ b/pkg/sdk/file_format.go
@@ -319,10 +319,10 @@ type NullString struct {
 }
 
 type CreateFileFormatOptions struct {
-	create      bool                   `ddl:"static" sql:"CREATE"` //lint:ignore U1000 This is used in the ddl tag
+	create      bool                   `ddl:"static" sql:"CREATE"`
 	OrReplace   *bool                  `ddl:"keyword" sql:"OR REPLACE"`
 	Temporary   *bool                  `ddl:"keyword" sql:"TEMPORARY"`
-	fileFormat  bool                   `ddl:"static" sql:"FILE FORMAT"` //lint:ignore U1000 This is used in the ddl tag
+	fileFormat  bool                   `ddl:"static" sql:"FILE FORMAT"`
 	IfNotExists *bool                  `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name        SchemaObjectIdentifier `ddl:"identifier"`
 	Type        FileFormatType         `ddl:"parameter" sql:"TYPE"`
@@ -367,8 +367,8 @@ func (v *fileFormats) Create(ctx context.Context, id SchemaObjectIdentifier, opt
 }
 
 type AlterFileFormatOptions struct {
-	alter      bool                   `ddl:"static" sql:"ALTER"`       //lint:ignore U1000 This is used in the ddl tag
-	fileFormat bool                   `ddl:"static" sql:"FILE FORMAT"` //lint:ignore U1000 This is used in the ddl tag
+	alter      bool                   `ddl:"static" sql:"ALTER"`
+	fileFormat bool                   `ddl:"static" sql:"FILE FORMAT"`
 	IfExists   *bool                  `ddl:"keyword" sql:"IF EXISTS"`
 	name       SchemaObjectIdentifier `ddl:"identifier"`
 
@@ -593,8 +593,8 @@ func (v *fileFormats) Alter(ctx context.Context, id SchemaObjectIdentifier, opts
 }
 
 type DropFileFormatOptions struct {
-	drop       bool                   `ddl:"static" sql:"DROP"`        //lint:ignore U1000 This is used in the ddl tag
-	fileFormat string                 `ddl:"static" sql:"FILE FORMAT"` //lint:ignore U1000 This is used in the ddl tag
+	drop       bool                   `ddl:"static" sql:"DROP"`
+	fileFormat string                 `ddl:"static" sql:"FILE FORMAT"`
 	IfExists   *bool                  `ddl:"keyword" sql:"IF EXISTS"`
 	name       SchemaObjectIdentifier `ddl:"identifier"`
 }
@@ -620,8 +620,8 @@ func (v *fileFormats) Drop(ctx context.Context, id SchemaObjectIdentifier, opts 
 }
 
 type ShowFileFormatsOptions struct {
-	show        bool  `ddl:"static" sql:"SHOW"`         //lint:ignore U1000 This is used in the ddl tag
-	fileFormats bool  `ddl:"static" sql:"FILE FORMATS"` //lint:ignore U1000 This is used in the ddl tag
+	show        bool  `ddl:"static" sql:"SHOW"`
+	fileFormats bool  `ddl:"static" sql:"FILE FORMATS"`
 	Like        *Like `ddl:"keyword" sql:"LIKE"`
 	In          *In   `ddl:"keyword" sql:"IN"`
 }
@@ -683,8 +683,8 @@ type FileFormatDetailsRow struct {
 }
 
 type describeFileFormatOptions struct {
-	describe   bool                   `ddl:"static" sql:"DESCRIBE"`    //lint:ignore U1000 This is used in the ddl tag
-	fileFormat string                 `ddl:"static" sql:"FILE FORMAT"` //lint:ignore U1000 This is used in the ddl tag
+	describe   bool                   `ddl:"static" sql:"DESCRIBE"`
+	fileFormat string                 `ddl:"static" sql:"FILE FORMAT"`
 	name       SchemaObjectIdentifier `ddl:"identifier"`
 }
 

--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -80,7 +80,7 @@ func (row *grantRow) toGrant() (*Grant, error) {
 }
 
 type GrantPrivilegesToAccountRoleOptions struct {
-	grant           bool                        `ddl:"static" sql:"GRANT"` //lint:ignore U1000 This is used in the ddl tag
+	grant           bool                        `ddl:"static" sql:"GRANT"`
 	privileges      *AccountRoleGrantPrivileges `ddl:"-"`
 	on              *AccountRoleGrantOn         `ddl:"keyword" sql:"ON"`
 	accountRole     AccountObjectIdentifier     `ddl:"identifier" sql:"TO ROLE"`
@@ -225,7 +225,7 @@ func (v *grants) GrantPrivilegesToAccountRole(ctx context.Context, privileges *A
 }
 
 type RevokePrivilegesFromAccountRoleOptions struct {
-	revoke         bool                        `ddl:"static" sql:"REVOKE"` //lint:ignore U1000 This is used in the ddl tag
+	revoke         bool                        `ddl:"static" sql:"REVOKE"`
 	GrantOptionFor *bool                       `ddl:"keyword" sql:"GRANT OPTION FOR"`
 	privileges     *AccountRoleGrantPrivileges `ddl:"-"`
 	on             *AccountRoleGrantOn         `ddl:"keyword" sql:"ON"`
@@ -278,7 +278,7 @@ func (v *grants) RevokePrivilegesFromAccountRole(ctx context.Context, privileges
 }
 
 type grantPrivilegeToShareOptions struct {
-	grant     bool                     `ddl:"static" sql:"GRANT"` //lint:ignore U1000 This is used in the ddl tag
+	grant     bool                     `ddl:"static" sql:"GRANT"`
 	privilege ObjectPrivilege          `ddl:"keyword"`
 	On        *GrantPrivilegeToShareOn `ddl:"keyword" sql:"ON"`
 	to        AccountObjectIdentifier  `ddl:"identifier" sql:"TO SHARE"`
@@ -347,7 +347,7 @@ func (v *grants) GrantPrivilegeToShare(ctx context.Context, privilege ObjectPriv
 }
 
 type revokePrivilegeFromShareOptions struct {
-	revoke    bool                        `ddl:"static" sql:"REVOKE"` //lint:ignore U1000 This is used in the ddl tag
+	revoke    bool                        `ddl:"static" sql:"REVOKE"`
 	privilege ObjectPrivilege             `ddl:"keyword"`
 	On        *RevokePrivilegeFromShareOn `ddl:"keyword" sql:"ON"`
 	from      AccountObjectIdentifier     `ddl:"identifier" sql:"FROM SHARE"`
@@ -421,9 +421,9 @@ func (v *grants) RevokePrivilegeFromShare(ctx context.Context, privilege ObjectP
 }
 
 type ShowGrantOptions struct {
-	show   bool          `ddl:"static" sql:"SHOW"` //lint:ignore U1000 This is used in the ddl tag
+	show   bool          `ddl:"static" sql:"SHOW"`
 	Future *bool         `ddl:"keyword" sql:"FUTURE"`
-	grants bool          `ddl:"static" sql:"GRANTS"` //lint:ignore U1000 This is used in the ddl tag
+	grants bool          `ddl:"static" sql:"GRANTS"`
 	On     *ShowGrantsOn `ddl:"keyword" sql:"ON"`
 	To     *ShowGrantsTo `ddl:"keyword" sql:"TO"`
 	Of     *ShowGrantsOf `ddl:"keyword" sql:"OF"`

--- a/pkg/sdk/masking_policy.go
+++ b/pkg/sdk/masking_policy.go
@@ -36,9 +36,9 @@ type maskingPolicies struct {
 }
 
 type CreateMaskingPolicyOptions struct {
-	create        bool                   `ddl:"static" sql:"CREATE"` //lint:ignore U1000 This is used in the ddl tag
+	create        bool                   `ddl:"static" sql:"CREATE"`
 	OrReplace     *bool                  `ddl:"keyword" sql:"OR REPLACE"`
-	maskingPolicy bool                   `ddl:"static" sql:"MASKING POLICY"` //lint:ignore U1000 This is used in the ddl tag
+	maskingPolicy bool                   `ddl:"static" sql:"MASKING POLICY"`
 	IfNotExists   *bool                  `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name          SchemaObjectIdentifier `ddl:"identifier"`
 
@@ -80,8 +80,8 @@ func (v *maskingPolicies) Create(ctx context.Context, id SchemaObjectIdentifier,
 }
 
 type AlterMaskingPolicyOptions struct {
-	alter         bool                   `ddl:"static" sql:"ALTER"`          //lint:ignore U1000 This is used in the ddl tag
-	maskingPolicy bool                   `ddl:"static" sql:"MASKING POLICY"` //lint:ignore U1000 This is used in the ddl tag
+	alter         bool                   `ddl:"static" sql:"ALTER"`
+	maskingPolicy bool                   `ddl:"static" sql:"MASKING POLICY"`
 	IfExists      *bool                  `ddl:"keyword" sql:"IF EXISTS"`
 	name          SchemaObjectIdentifier `ddl:"identifier"`
 	NewName       SchemaObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
@@ -161,8 +161,8 @@ func (v *maskingPolicies) Alter(ctx context.Context, id SchemaObjectIdentifier, 
 }
 
 type DropMaskingPolicyOptions struct {
-	drop          bool                   `ddl:"static" sql:"DROP"`           //lint:ignore U1000 This is used in the ddl tag
-	maskingPolicy bool                   `ddl:"static" sql:"MASKING POLICY"` //lint:ignore U1000 This is used in the ddl tag
+	drop          bool                   `ddl:"static" sql:"DROP"`
+	maskingPolicy bool                   `ddl:"static" sql:"MASKING POLICY"`
 	name          SchemaObjectIdentifier `ddl:"identifier"`
 }
 
@@ -194,8 +194,8 @@ func (v *maskingPolicies) Drop(ctx context.Context, id SchemaObjectIdentifier) e
 
 // ShowMaskingPolicyOptions represents the options for listing masking policies.
 type ShowMaskingPolicyOptions struct {
-	show            bool  `ddl:"static" sql:"SHOW"`             //lint:ignore U1000 This is used in the ddl tag
-	maskingPolicies bool  `ddl:"static" sql:"MASKING POLICIES"` //lint:ignore U1000 This is used in the ddl tag
+	show            bool  `ddl:"static" sql:"SHOW"`
+	maskingPolicies bool  `ddl:"static" sql:"MASKING POLICIES"`
 	Like            *Like `ddl:"keyword" sql:"LIKE"`
 	In              *In   `ddl:"keyword" sql:"IN"`
 	Limit           *int  `ddl:"parameter,no_equals" sql:"LIMIT"`
@@ -303,8 +303,8 @@ func (v *maskingPolicies) ShowByID(ctx context.Context, id SchemaObjectIdentifie
 }
 
 type describeMaskingPolicyOptions struct {
-	describe      bool                   `ddl:"static" sql:"DESCRIBE"`       //lint:ignore U1000 This is used in the ddl tag
-	maskingPolicy bool                   `ddl:"static" sql:"MASKING POLICY"` //lint:ignore U1000 This is used in the ddl tag
+	describe      bool                   `ddl:"static" sql:"DESCRIBE"`
+	maskingPolicy bool                   `ddl:"static" sql:"MASKING POLICY"`
 	name          SchemaObjectIdentifier `ddl:"identifier"`
 }
 

--- a/pkg/sdk/password_policy.go
+++ b/pkg/sdk/password_policy.go
@@ -33,9 +33,9 @@ type passwordPolicies struct {
 }
 
 type CreatePasswordPolicyOptions struct {
-	create         bool                   `ddl:"static" sql:"CREATE"` //lint:ignore U1000 This is used in the ddl tag
+	create         bool                   `ddl:"static" sql:"CREATE"`
 	OrReplace      *bool                  `ddl:"keyword" sql:"OR REPLACE"`
-	passwordPolicy bool                   `ddl:"static" sql:"PASSWORD POLICY"` //lint:ignore U1000 This is used in the ddl tag
+	passwordPolicy bool                   `ddl:"static" sql:"PASSWORD POLICY"`
 	IfNotExists    *bool                  `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name           SchemaObjectIdentifier `ddl:"identifier"`
 
@@ -77,8 +77,8 @@ func (v *passwordPolicies) Create(ctx context.Context, id SchemaObjectIdentifier
 }
 
 type AlterPasswordPolicyOptions struct {
-	alter          bool                   `ddl:"static" sql:"ALTER"`           //lint:ignore U1000 This is used in the ddl tag
-	passwordPolicy bool                   `ddl:"static" sql:"PASSWORD POLICY"` //lint:ignore U1000 This is used in the ddl tag
+	alter          bool                   `ddl:"static" sql:"ALTER"`
+	passwordPolicy bool                   `ddl:"static" sql:"PASSWORD POLICY"`
 	IfExists       *bool                  `ddl:"keyword" sql:"IF EXISTS"`
 	name           SchemaObjectIdentifier `ddl:"identifier"`
 	NewName        SchemaObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
@@ -205,8 +205,8 @@ func (v *passwordPolicies) Alter(ctx context.Context, id SchemaObjectIdentifier,
 }
 
 type DropPasswordPolicyOptions struct {
-	drop           bool                   `ddl:"static" sql:"DROP"`            //lint:ignore U1000 This is used in the ddl tag
-	passwordPolicy bool                   `ddl:"static" sql:"PASSWORD POLICY"` //lint:ignore U1000 This is used in the ddl tag
+	drop           bool                   `ddl:"static" sql:"DROP"`
+	passwordPolicy bool                   `ddl:"static" sql:"PASSWORD POLICY"`
 	IfExists       *bool                  `ddl:"keyword" sql:"IF EXISTS"`
 	name           SchemaObjectIdentifier `ddl:"identifier"`
 }
@@ -236,8 +236,8 @@ func (v *passwordPolicies) Drop(ctx context.Context, id SchemaObjectIdentifier, 
 
 // PasswordPolicyShowOptions represents the options for listing password policies.
 type PasswordPolicyShowOptions struct {
-	show             bool  `ddl:"static" sql:"SHOW"`              //lint:ignore U1000 This is used in the ddl tag
-	passwordPolicies bool  `ddl:"static" sql:"PASSWORD POLICIES"` //lint:ignore U1000 This is used in the ddl tag
+	show             bool  `ddl:"static" sql:"SHOW"`
+	passwordPolicies bool  `ddl:"static" sql:"PASSWORD POLICIES"`
 	Like             *Like `ddl:"keyword" sql:"LIKE"`
 	In               *In   `ddl:"keyword" sql:"IN"`
 	Limit            *int  `ddl:"parameter,no_equals" sql:"LIMIT"`
@@ -339,8 +339,8 @@ func (v *passwordPolicies) ShowByID(ctx context.Context, id SchemaObjectIdentifi
 }
 
 type describePasswordPolicyOptions struct {
-	describe       bool                   `ddl:"static" sql:"DESCRIBE"`        //lint:ignore U1000 This is used in the ddl tag
-	passwordPolicy bool                   `ddl:"static" sql:"PASSWORD POLICY"` //lint:ignore U1000 This is used in the ddl tag
+	describe       bool                   `ddl:"static" sql:"DESCRIBE"`
+	passwordPolicy bool                   `ddl:"static" sql:"PASSWORD POLICY"`
 	name           SchemaObjectIdentifier `ddl:"identifier"`
 }
 

--- a/pkg/sdk/pipes.go
+++ b/pkg/sdk/pipes.go
@@ -25,9 +25,9 @@ type Pipes interface {
 //
 // Based on https://docs.snowflake.com/en/sql-reference/sql/create-pipe.
 type PipeCreateOptions struct {
-	create      bool                   `ddl:"static" sql:"CREATE"` //lint:ignore U1000 This is used in the ddl tag
+	create      bool                   `ddl:"static" sql:"CREATE"`
 	OrReplace   *bool                  `ddl:"keyword" sql:"OR REPLACE"`
-	pipe        bool                   `ddl:"static" sql:"PIPE"` //lint:ignore U1000 This is used in the ddl tag
+	pipe        bool                   `ddl:"static" sql:"PIPE"`
 	IfNotExists *bool                  `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name        SchemaObjectIdentifier `ddl:"identifier"`
 
@@ -37,7 +37,7 @@ type PipeCreateOptions struct {
 	Integration      *string `ddl:"parameter,single_quotes" sql:"INTEGRATION"`
 	Comment          *string `ddl:"parameter,single_quotes" sql:"COMMENT"`
 
-	as            bool   `ddl:"static" sql:"AS"` //lint:ignore U1000 This is used in the ddl tag
+	as            bool   `ddl:"static" sql:"AS"`
 	copyStatement string `ddl:"keyword,no_quotes"`
 }
 
@@ -45,8 +45,8 @@ type PipeCreateOptions struct {
 //
 // Based on https://docs.snowflake.com/en/sql-reference/sql/alter-pipe.
 type PipeAlterOptions struct {
-	alter    bool                   `ddl:"static" sql:"ALTER"` //lint:ignore U1000 This is used in the ddl tag
-	role     bool                   `ddl:"static" sql:"PIPE"`  //lint:ignore U1000 This is used in the ddl tag
+	alter    bool                   `ddl:"static" sql:"ALTER"`
+	role     bool                   `ddl:"static" sql:"PIPE"`
 	IfExists *bool                  `ddl:"keyword" sql:"IF EXISTS"`
 	name     SchemaObjectIdentifier `ddl:"identifier"`
 
@@ -86,8 +86,8 @@ type PipeRefresh struct {
 //
 // Based on https://docs.snowflake.com/en/sql-reference/sql/drop-pipe.
 type PipeDropOptions struct {
-	drop     bool                   `ddl:"static" sql:"DROP"` //lint:ignore U1000 This is used in the ddl tag
-	pipe     bool                   `ddl:"static" sql:"PIPE"` //lint:ignore U1000 This is used in the ddl tag
+	drop     bool                   `ddl:"static" sql:"DROP"`
+	pipe     bool                   `ddl:"static" sql:"PIPE"`
 	IfExists *bool                  `ddl:"keyword" sql:"IF EXISTS"`
 	name     SchemaObjectIdentifier `ddl:"identifier"`
 }
@@ -96,8 +96,8 @@ type PipeDropOptions struct {
 //
 // https://docs.snowflake.com/en/sql-reference/sql/show-pipes
 type PipeShowOptions struct {
-	show  bool  `ddl:"static" sql:"SHOW"`  //lint:ignore U1000 This is used in the ddl tag
-	pipes bool  `ddl:"static" sql:"PIPES"` //lint:ignore U1000 This is used in the ddl tag
+	show  bool  `ddl:"static" sql:"SHOW"`
+	pipes bool  `ddl:"static" sql:"PIPES"`
 	Like  *Like `ddl:"keyword" sql:"LIKE"`
 	In    *In   `ddl:"keyword" sql:"IN"`
 }
@@ -183,7 +183,7 @@ func (row pipeDBRow) toPipe() *Pipe {
 //
 // Based on https://docs.snowflake.com/en/sql-reference/sql/desc-pipe.
 type describePipeOptions struct {
-	describe bool                   `ddl:"static" sql:"DESCRIBE"` //lint:ignore U1000 This is used in the ddl tag
-	pipe     bool                   `ddl:"static" sql:"PIPE"`     //lint:ignore U1000 This is used in the ddl tag
+	describe bool                   `ddl:"static" sql:"DESCRIBE"`
+	pipe     bool                   `ddl:"static" sql:"PIPE"`
 	name     SchemaObjectIdentifier `ddl:"identifier"`
 }

--- a/pkg/sdk/replication_functions.go
+++ b/pkg/sdk/replication_functions.go
@@ -85,8 +85,8 @@ func (row *regionRow) toRegion() *Region {
 }
 
 type ShowRegionsOptions struct {
-	show    bool  `ddl:"static" sql:"SHOW"`    //lint:ignore U1000 This is used in the ddl tag
-	regions bool  `ddl:"static" sql:"REGIONS"` //lint:ignore U1000 This is used in the ddl tag
+	show    bool  `ddl:"static" sql:"SHOW"`
+	regions bool  `ddl:"static" sql:"REGIONS"`
 	Like    *Like `ddl:"keyword" sql:"LIKE"`
 }
 

--- a/pkg/sdk/resource_monitors.go
+++ b/pkg/sdk/resource_monitors.go
@@ -177,9 +177,9 @@ func (v *ResourceMonitor) ObjectType() ObjectType {
 
 // CreateResourceMonitorOptions contains options for creating a resource monitor.
 type CreateResourceMonitorOptions struct {
-	create          bool                    `ddl:"static" sql:"CREATE"` //lint:ignore U1000 This is used in the ddl tag
+	create          bool                    `ddl:"static" sql:"CREATE"`
 	OrReplace       *bool                   `ddl:"keyword" sql:"OR REPLACE"`
-	resourceMonitor bool                    `ddl:"static" sql:"RESOURCE MONITOR"` //lint:ignore U1000 This is used in the ddl tag
+	resourceMonitor bool                    `ddl:"static" sql:"RESOURCE MONITOR"`
 	name            AccountObjectIdentifier `ddl:"identifier"`
 	With            *ResourceMonitorWith    `ddl:"keyword" sql:"WITH"`
 }
@@ -269,8 +269,8 @@ const (
 
 // AlterResourceMonitorOptions contains options for altering a resource monitor.
 type AlterResourceMonitorOptions struct {
-	alter           bool                    `ddl:"static" sql:"ALTER"`            //lint:ignore U1000 This is used in the ddl tag
-	resourceMonitor bool                    `ddl:"static" sql:"RESOURCE MONITOR"` //lint:ignore U1000 This is used in the ddl tag
+	alter           bool                    `ddl:"static" sql:"ALTER"`
+	resourceMonitor bool                    `ddl:"static" sql:"RESOURCE MONITOR"`
 	IfExists        *bool                   `ddl:"keyword" sql:"IF EXISTS"`
 	name            AccountObjectIdentifier `ddl:"identifier"`
 	Set             *ResourceMonitorSet     `ddl:"keyword" sql:"SET"`
@@ -319,8 +319,8 @@ type ResourceMonitorSet struct {
 
 // resourceMonitorDropOptions contains options for dropping a resource monitor.
 type dropResourceMonitorOptions struct {
-	drop            bool                    `ddl:"static" sql:"DROP"`             //lint:ignore U1000 This is used in the ddl tag
-	resourceMonitor bool                    `ddl:"static" sql:"RESOURCE MONITOR"` //lint:ignore U1000 This is used in the ddl tag
+	drop            bool                    `ddl:"static" sql:"DROP"`
+	resourceMonitor bool                    `ddl:"static" sql:"RESOURCE MONITOR"`
 	name            AccountObjectIdentifier `ddl:"identifier"`
 }
 
@@ -348,8 +348,8 @@ func (v *resourceMonitors) Drop(ctx context.Context, id AccountObjectIdentifier)
 
 // ShowResourceMonitorOptions contains options for listing resource monitors.
 type ShowResourceMonitorOptions struct {
-	show             bool  `ddl:"static" sql:"SHOW"`              //lint:ignore U1000 This is used in the ddl tag
-	resourceMonitors bool  `ddl:"static" sql:"RESOURCE MONITORS"` //lint:ignore U1000 This is used in the ddl tag
+	show             bool  `ddl:"static" sql:"SHOW"`
+	resourceMonitors bool  `ddl:"static" sql:"RESOURCE MONITORS"`
 	Like             *Like `ddl:"keyword" sql:"LIKE"`
 }
 

--- a/pkg/sdk/schemas.go
+++ b/pkg/sdk/schemas.go
@@ -89,10 +89,10 @@ func (row schemaDBRow) toSchema() Schema {
 
 // CreateSchemaOptions based on https://docs.snowflake.com/en/sql-reference/sql/create-schema
 type CreateSchemaOptions struct {
-	create                     bool             `ddl:"static" sql:"CREATE"` //lint:ignore U1000 This is used in the ddl tag
+	create                     bool             `ddl:"static" sql:"CREATE"`
 	OrReplace                  *bool            `ddl:"keyword" sql:"OR REPLACE"`
 	Transient                  *bool            `ddl:"keyword" sql:"TRANSIENT"`
-	schema                     bool             `ddl:"static" sql:"SCHEMA"` //lint:ignore U1000 This is used in the ddl tag
+	schema                     bool             `ddl:"static" sql:"SCHEMA"`
 	IfNotExists                *bool            `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name                       SchemaIdentifier `ddl:"identifier"`
 	Clone                      *Clone           `ddl:"-"`
@@ -138,8 +138,8 @@ func (v *schemas) Create(ctx context.Context, id SchemaIdentifier, opts *CreateS
 
 // AlterSchemaOptions based on https://docs.snowflake.com/en/sql-reference/sql/alter-schema
 type AlterSchemaOptions struct {
-	alter    bool             `ddl:"static" sql:"ALTER"`  //lint:ignore U1000 This is used in the ddl tag
-	schema   bool             `ddl:"static" sql:"SCHEMA"` //lint:ignore U1000 This is used in the ddl tag
+	alter    bool             `ddl:"static" sql:"ALTER"`
+	schema   bool             `ddl:"static" sql:"SCHEMA"`
 	IfExists *bool            `ddl:"keyword" sql:"IF EXISTS"`
 	name     SchemaIdentifier `ddl:"identifier"`
 	NewName  SchemaIdentifier `ddl:"identifier" sql:"RENAME TO"`
@@ -220,7 +220,7 @@ func (v *schemas) Alter(ctx context.Context, id SchemaIdentifier, opts *AlterSch
 
 // DropSchemaOptions Based on https://docs.snowflake.com/en/sql-reference/sql/drop-schema
 type DropSchemaOptions struct {
-	drop     bool             `ddl:"static" sql:"DROP"` //lint:ignore U1000 This is used in the ddl tag
+	drop     bool             `ddl:"static" sql:"DROP"`
 	schema   bool             `ddl:"static" sql:"SCHEMA"`
 	IfExists *bool            `ddl:"keyword" sql:"IF EXISTS"`
 	name     SchemaIdentifier `ddl:"identifier"`
@@ -257,8 +257,8 @@ func (v *schemas) Drop(ctx context.Context, id SchemaIdentifier, opts *DropSchem
 }
 
 type undropSchemaOptions struct {
-	undrop bool             `ddl:"static" sql:"UNDROP"` //lint:ignore U1000 This is used in the ddl tag
-	schema bool             `ddl:"static" sql:"SCHEMA"` //lint:ignore U1000 This is used in the ddl tag
+	undrop bool             `ddl:"static" sql:"UNDROP"`
+	schema bool             `ddl:"static" sql:"SCHEMA"`
 	name   SchemaIdentifier `ddl:"identifier"`
 }
 
@@ -285,9 +285,9 @@ func (v *schemas) Undrop(ctx context.Context, id SchemaIdentifier) error {
 }
 
 type describeSchemaOptions struct {
-	describe bool             `ddl:"static" sql:"DESCRIBE"` //lint:ignore U1000 This is used in the ddl tag
-	database bool             `ddl:"static" sql:"SCHEMA"`   //lint:ignore U1000 This is used in the ddl tag
-	name     SchemaIdentifier `ddl:"identifier"`            //lint:ignore U1000 This is used in the ddl tag
+	describe bool             `ddl:"static" sql:"DESCRIBE"`
+	database bool             `ddl:"static" sql:"SCHEMA"`
+	name     SchemaIdentifier `ddl:"identifier"`
 }
 
 func (opts *describeSchemaOptions) validate() error {
@@ -330,9 +330,9 @@ type SchemaIn struct {
 
 // ShowSchemaOptions based on https://docs.snowflake.com/en/sql-reference/sql/show-schemas
 type ShowSchemaOptions struct {
-	show       bool       `ddl:"static" sql:"SHOW"` //lint:ignore U1000 This is used in the ddl tag
+	show       bool       `ddl:"static" sql:"SHOW"`
 	Terse      *bool      `ddl:"keyword" sql:"TERSE"`
-	schemas    bool       `ddl:"static" sql:"SCHEMAS"` //lint:ignore U1000 This is used in the ddl tag
+	schemas    bool       `ddl:"static" sql:"SCHEMAS"`
 	History    *bool      `ddl:"keyword" sql:"HISTORY"`
 	Like       *Like      `ddl:"keyword" sql:"LIKE"`
 	In         *SchemaIn  `ddl:"keyword" sql:"IN"`

--- a/pkg/sdk/session_policies.go
+++ b/pkg/sdk/session_policies.go
@@ -55,8 +55,8 @@ func (v *SessionPolicy) ObjectType() ObjectType {
 
 // CreateSessionPolicyOptions contains options for creating a session policy.
 type CreateSessionPolicyOptions struct {
-	create        bool                   `ddl:"static" sql:"CREATE"`         //lint:ignore U1000 This is used in the ddl tag
-	sessionPolicy bool                   `ddl:"static" sql:"SESSION POLICY"` //lint:ignore U1000 This is used in the ddl tag
+	create        bool                   `ddl:"static" sql:"CREATE"`
+	sessionPolicy bool                   `ddl:"static" sql:"SESSION POLICY"`
 	name          SchemaObjectIdentifier `ddl:"identifier"`
 }
 
@@ -92,8 +92,8 @@ func (v *sessionPolicies) Alter(ctx context.Context, id SchemaObjectIdentifier, 
 
 // DropSessionPolicyOptions contains options for dropping a session policy.
 type DropSessionPolicyOptions struct {
-	drop          bool                   `ddl:"static" sql:"DROP"`           //lint:ignore U1000 This is used in the ddl tag
-	sessionPolicy bool                   `ddl:"static" sql:"SESSION POLICY"` //lint:ignore U1000 This is used in the ddl tag
+	drop          bool                   `ddl:"static" sql:"DROP"`
+	sessionPolicy bool                   `ddl:"static" sql:"SESSION POLICY"`
 	IfExists      *bool                  `ddl:"keyword" sql:"IF EXISTS"`
 	name          SchemaObjectIdentifier `ddl:"identifier"`
 }
@@ -123,8 +123,8 @@ func (v *sessionPolicies) Drop(ctx context.Context, id SchemaObjectIdentifier, o
 
 // sessionPolicyShowOptions contains options for listing session policies.
 type sessionPolicyShowOptions struct {
-	show            bool `ddl:"static" sql:"SHOW"`             //lint:ignore U1000 This is used in the ddl tag
-	sessionPolicies bool `ddl:"static" sql:"SESSION POLICIES"` //lint:ignore U1000 This is used in the ddl tag
+	show            bool `ddl:"static" sql:"SHOW"`
+	sessionPolicies bool `ddl:"static" sql:"SESSION POLICIES"`
 }
 
 func (opts *sessionPolicyShowOptions) validate() error {

--- a/pkg/sdk/sessions.go
+++ b/pkg/sdk/sessions.go
@@ -28,8 +28,8 @@ type sessions struct {
 }
 
 type AlterSessionOptions struct {
-	alter   bool          `ddl:"static" sql:"ALTER"`   //lint:ignore U1000 This is used in the ddl tag
-	session bool          `ddl:"static" sql:"SESSION"` //lint:ignore U1000 This is used in the ddl tag
+	alter   bool          `ddl:"static" sql:"ALTER"`
+	session bool          `ddl:"static" sql:"SESSION"`
 	Set     *SessionSet   `ddl:"keyword" sql:"SET"`
 	Unset   *SessionUnset `ddl:"keyword" sql:"UNSET"`
 }
@@ -89,8 +89,8 @@ func (v *sessions) AlterSession(ctx context.Context, opts *AlterSessionOptions) 
 }
 
 type ShowParametersOptions struct {
-	show       bool          `ddl:"static" sql:"SHOW"`       //lint:ignore U1000 This is used in the ddl tag
-	parameters bool          `ddl:"static" sql:"PARAMETERS"` //lint:ignore U1000 This is used in the ddl tag
+	show       bool          `ddl:"static" sql:"SHOW"`
+	parameters bool          `ddl:"static" sql:"PARAMETERS"`
 	Like       *Like         `ddl:"keyword" sql:"LIKE"`
 	In         *ParametersIn `ddl:"keyword" sql:"IN"`
 }

--- a/pkg/sdk/shares.go
+++ b/pkg/sdk/shares.go
@@ -100,9 +100,9 @@ func (r *shareRow) toShare() *Share {
 }
 
 type CreateShareOptions struct {
-	create    bool                    `ddl:"static" sql:"CREATE"` //lint:ignore U1000 This is used in the ddl tag
+	create    bool                    `ddl:"static" sql:"CREATE"`
 	OrReplace *bool                   `ddl:"keyword" sql:"OR REPLACE"`
-	share     bool                    `ddl:"static" sql:"SHARE"` //lint:ignore U1000 This is used in the ddl tag
+	share     bool                    `ddl:"static" sql:"SHARE"`
 	name      AccountObjectIdentifier `ddl:"identifier"`
 	Comment   *string                 `ddl:"parameter,single_quotes" sql:"COMMENT"`
 }
@@ -131,7 +131,7 @@ func (v *shares) Create(ctx context.Context, id AccountObjectIdentifier, opts *C
 }
 
 type shareDropOptions struct {
-	drop  bool                    `ddl:"static" sql:"DROP"` //lint:ignore U1000 This is used in the ddl tag
+	drop  bool                    `ddl:"static" sql:"DROP"`
 	share bool                    `ddl:"static" sql:"SHARE"`
 	name  AccountObjectIdentifier `ddl:"identifier"`
 }
@@ -149,8 +149,8 @@ func (v *shares) Drop(ctx context.Context, id AccountObjectIdentifier) error {
 }
 
 type AlterShareOptions struct {
-	alter    bool                    `ddl:"static" sql:"ALTER"` //lint:ignore U1000 This is used in the ddl tag
-	share    bool                    `ddl:"static" sql:"SHARE"` //lint:ignore U1000 This is used in the ddl tag
+	alter    bool                    `ddl:"static" sql:"ALTER"`
+	share    bool                    `ddl:"static" sql:"SHARE"`
 	IfExists *bool                   `ddl:"keyword" sql:"IF EXISTS"`
 	name     AccountObjectIdentifier `ddl:"identifier"`
 	Add      *ShareAdd               `ddl:"keyword" sql:"ADD"`
@@ -254,8 +254,8 @@ func (v *shares) Alter(ctx context.Context, id AccountObjectIdentifier, opts *Al
 }
 
 type ShowShareOptions struct {
-	show       bool       `ddl:"static" sql:"SHOW"`   //lint:ignore U1000 This is used in the ddl tag
-	shares     bool       `ddl:"static" sql:"SHARES"` //lint:ignore U1000 This is used in the ddl tag
+	show       bool       `ddl:"static" sql:"SHOW"`
+	shares     bool       `ddl:"static" sql:"SHARES"`
 	Like       *Like      `ddl:"keyword" sql:"LIKE"`
 	StartsWith *string    `ddl:"parameter,single_quotes,no_equals" sql:"STARTS WITH"`
 	Limit      *LimitFrom `ddl:"keyword" sql:"LIMIT"`
@@ -341,8 +341,8 @@ func shareDetailsFromRows(rows []shareDetailsRow) *ShareDetails {
 }
 
 type shareDescribeOptions struct {
-	describe bool             `ddl:"static" sql:"DESCRIBE"` //lint:ignore U1000 This is used in the ddl tag
-	share    bool             `ddl:"static" sql:"SHARE"`    //lint:ignore U1000 This is used in the ddl tag
+	describe bool             `ddl:"static" sql:"DESCRIBE"`
+	share    bool             `ddl:"static" sql:"SHARE"`
 	name     ObjectIdentifier `ddl:"identifier"`
 }
 

--- a/pkg/sdk/users.go
+++ b/pkg/sdk/users.go
@@ -151,9 +151,9 @@ func (v *User) ObjectType() ObjectType {
 // CreateUserOptions contains options for creating a user.
 // Based on https://docs.snowflake.com/en/sql-reference/sql/create-user.
 type CreateUserOptions struct {
-	create            bool                    `ddl:"static" sql:"CREATE"` //lint:ignore U1000 This is used in the ddl tag
+	create            bool                    `ddl:"static" sql:"CREATE"`
 	OrReplace         *bool                   `ddl:"keyword" sql:"OR REPLACE"`
-	user              bool                    `ddl:"static" sql:"USER"` //lint:ignore U1000 This is used in the ddl tag
+	user              bool                    `ddl:"static" sql:"USER"`
 	IfNotExists       *bool                   `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name              AccountObjectIdentifier `ddl:"identifier"`
 	ObjectProperties  *UserObjectProperties   `ddl:"keyword"`
@@ -214,10 +214,10 @@ type UserObjectProperties struct {
 }
 
 type SecondaryRoles struct {
-	equals     bool            `ddl:"static" sql:"="` //lint:ignore U1000 This is used in the ddl tag
-	leftParen  bool            `ddl:"static" sql:"("` //lint:ignore U1000 This is used in the ddl tag
+	equals     bool            `ddl:"static" sql:"="`
+	leftParen  bool            `ddl:"static" sql:"("`
 	Roles      []SecondaryRole `ddl:"list,no_parentheses"`
-	rightParen bool            `ddl:"static" sql:")"` //lint:ignore U1000 This is used in the ddl tag
+	rightParen bool            `ddl:"static" sql:")"`
 }
 
 type SecondaryRole struct {
@@ -257,8 +257,8 @@ type UserObjectParametersUnset struct {
 // AlterUserOptions contains options for altering a user.
 // Based on https://docs.snowflake.com/en/sql-reference/sql/alter-user.
 type AlterUserOptions struct {
-	alter    bool                    `ddl:"static" sql:"ALTER"` //lint:ignore U1000 This is used in the ddl tag
-	user     bool                    `ddl:"static" sql:"USER"`  //lint:ignore U1000 This is used in the ddl tag
+	alter    bool                    `ddl:"static" sql:"ALTER"`
+	user     bool                    `ddl:"static" sql:"USER"`
 	IfExists *bool                   `ddl:"keyword" sql:"IF EXISTS"`
 	name     AccountObjectIdentifier `ddl:"identifier"`
 
@@ -387,8 +387,8 @@ func (opts *UserUnset) validate() error {
 // DropUserOptions contains options for dropping a user.
 // Based on https://docs.snowflake.com/en/sql-reference/sql/drop-user.
 type DropUserOptions struct {
-	drop bool                    `ddl:"static" sql:"DROP"` //lint:ignore U1000 This is used in the ddl tag
-	user bool                    `ddl:"static" sql:"USER"` //lint:ignore U1000 This is used in the ddl tag
+	drop bool                    `ddl:"static" sql:"DROP"`
+	user bool                    `ddl:"static" sql:"USER"`
 	name AccountObjectIdentifier `ddl:"identifier"`
 }
 
@@ -523,8 +523,8 @@ func userDetailsFromRows(rows []propertyRow) *UserDetails {
 // describeUserOptions contains options for describing the properties specified for users, as well as the default values of the properties.
 // Based on https://docs.snowflake.com/en/sql-reference/sql/desc-user.
 type describeUserOptions struct {
-	describe bool                    `ddl:"static" sql:"DESCRIBE"` //lint:ignore U1000 This is used in the ddl tag
-	user     bool                    `ddl:"static" sql:"USER"`     //lint:ignore U1000 This is used in the ddl tag
+	describe bool                    `ddl:"static" sql:"DESCRIBE"`
+	user     bool                    `ddl:"static" sql:"USER"`
 	name     AccountObjectIdentifier `ddl:"identifier"`
 }
 
@@ -559,9 +559,9 @@ func (v *users) Describe(ctx context.Context, id AccountObjectIdentifier) (*User
 // ShowUserOptions contains options for listing users.
 // Based on https://docs.snowflake.com/en/sql-reference/sql/show-users.
 type ShowUserOptions struct {
-	show       bool    `ddl:"static" sql:"SHOW"`  //lint:ignore U1000 This is used in the ddl tag
-	Terse      *bool   `ddl:"static" sql:"TERSE"` //lint:ignore U1000 This is used in the ddl tag
-	users      bool    `ddl:"static" sql:"USERS"` //lint:ignore U1000 This is used in the ddl tag
+	show       bool    `ddl:"static" sql:"SHOW"`
+	Terse      *bool   `ddl:"static" sql:"TERSE"`
+	users      bool    `ddl:"static" sql:"USERS"`
 	Like       *Like   `ddl:"keyword" sql:"LIKE"`
 	StartsWith *string `ddl:"parameter,single_quotes,no_equals" sql:"STARTS WITH"`
 	Limit      *int    `ddl:"parameter,no_equals" sql:"LIMIT"`

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -88,9 +88,9 @@ var (
 )
 
 type CreateWarehouseOptions struct {
-	create      bool                    `ddl:"static" sql:"CREATE"` //lint:ignore U1000 This is used in the ddl tag
+	create      bool                    `ddl:"static" sql:"CREATE"`
 	OrReplace   *bool                   `ddl:"keyword" sql:"OR REPLACE"`
-	warehouse   bool                    `ddl:"static" sql:"WAREHOUSE"` //lint:ignore U1000 This is used in the ddl tag
+	warehouse   bool                    `ddl:"static" sql:"WAREHOUSE"`
 	IfNotExists *bool                   `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name        AccountObjectIdentifier `ddl:"identifier"`
 
@@ -145,8 +145,8 @@ func (c *warehouses) Create(ctx context.Context, id AccountObjectIdentifier, opt
 }
 
 type AlterWarehouseOptions struct {
-	alter     bool                    `ddl:"static" sql:"ALTER"`     //lint:ignore U1000 This is used in the ddl tag
-	warehouse bool                    `ddl:"static" sql:"WAREHOUSE"` //lint:ignore U1000 This is used in the ddl tag
+	alter     bool                    `ddl:"static" sql:"ALTER"`
+	warehouse bool                    `ddl:"static" sql:"WAREHOUSE"`
 	IfExists  *bool                   `ddl:"keyword" sql:"IF EXISTS"`
 	name      AccountObjectIdentifier `ddl:"identifier"`
 
@@ -286,8 +286,8 @@ func (c *warehouses) Alter(ctx context.Context, id AccountObjectIdentifier, opts
 }
 
 type DropWarehouseOptions struct {
-	drop      bool                    `ddl:"static" sql:"DROP"`      //lint:ignore U1000 This is used in the ddl tag
-	warehouse bool                    `ddl:"static" sql:"WAREHOUSE"` //lint:ignore U1000 This is used in the ddl tag
+	drop      bool                    `ddl:"static" sql:"DROP"`
+	warehouse bool                    `ddl:"static" sql:"WAREHOUSE"`
 	IfExists  *bool                   `ddl:"keyword" sql:"IF EXISTS"`
 	name      AccountObjectIdentifier `ddl:"identifier"`
 }
@@ -321,8 +321,8 @@ func (c *warehouses) Drop(ctx context.Context, id AccountObjectIdentifier, opts 
 }
 
 type ShowWarehouseOptions struct {
-	show       bool  `ddl:"static" sql:"SHOW"`       //lint:ignore U1000 This is used in the ddl tag
-	warehouses bool  `ddl:"static" sql:"WAREHOUSES"` //lint:ignore U1000 This is used in the ddl tag
+	show       bool  `ddl:"static" sql:"SHOW"`
+	warehouses bool  `ddl:"static" sql:"WAREHOUSES"`
 	Like       *Like `ddl:"keyword" sql:"LIKE"`
 }
 
@@ -488,8 +488,8 @@ func (c *warehouses) ShowByID(ctx context.Context, id AccountObjectIdentifier) (
 }
 
 type warehouseDescribeOptions struct {
-	describe  bool                    `ddl:"static" sql:"DESCRIBE"`  //lint:ignore U1000 This is used in the ddl tag
-	warehouse bool                    `ddl:"static" sql:"WAREHOUSE"` //lint:ignore U1000 This is used in the ddl tag
+	describe  bool                    `ddl:"static" sql:"DESCRIBE"`
+	warehouse bool                    `ddl:"static" sql:"WAREHOUSE"`
 	name      AccountObjectIdentifier `ddl:"identifier"`
 }
 


### PR DESCRIPTION
## Description
We copy-paste lint ignore while doing SDK rewrite. This suppression seems to be outdated. The reason for this change is to confirm that no check triggers without aforementioned comment.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] run all actions normally, but without lint ignore in one of the files
* [x] if above is confirmed, remove comment from all files and repeat
 