### PR TITLE
feat: Add missing database role operations to SDK

### DIFF
--- a/pkg/sdk/database_role.go
+++ b/pkg/sdk/database_role.go
@@ -144,7 +144,7 @@ type grantDatabaseRoleOptions struct {
 	grant        bool                            `ddl:"static" sql:"GRANT"`
 	databaseRole bool                            `ddl:"static" sql:"DATABASE ROLE"`
 	name         DatabaseObjectIdentifier        `ddl:"identifier"`
-	toRole       bool                            `ddl:"static" sql:"TO ROLE"`
+	to           bool                            `ddl:"static" sql:"TO"`
 	ParentRole   grantOrRevokeDatabaseRoleObject `ddl:"-"`
 }
 
@@ -153,14 +153,14 @@ type revokeDatabaseRoleOptions struct {
 	revoke       bool                            `ddl:"static" sql:"REVOKE"`
 	databaseRole bool                            `ddl:"static" sql:"DATABASE ROLE"`
 	name         DatabaseObjectIdentifier        `ddl:"identifier"`
-	fromRole     bool                            `ddl:"static" sql:"FROM ROLE"`
+	from         bool                            `ddl:"static" sql:"FROM"`
 	ParentRole   grantOrRevokeDatabaseRoleObject `ddl:"-"`
 }
 
 type grantOrRevokeDatabaseRoleObject struct {
 	// One of
-	DatabaseRoleName *DatabaseObjectIdentifier `ddl:"identifier"`
-	AccountRoleName  *AccountObjectIdentifier  `ddl:"identifier"`
+	DatabaseRoleName *DatabaseObjectIdentifier `ddl:"identifier" sql:"DATABASE ROLE"`
+	AccountRoleName  *AccountObjectIdentifier  `ddl:"identifier" sql:"ROLE"`
 }
 
 // grantDatabaseRoleToShareOptions is based on https://docs.snowflake.com/en/sql-reference/sql/grant-database-role-share.

--- a/pkg/sdk/database_role.go
+++ b/pkg/sdk/database_role.go
@@ -13,6 +13,11 @@ type DatabaseRoles interface {
 	Drop(ctx context.Context, request *DropDatabaseRoleRequest) error
 	Show(ctx context.Context, request *ShowDatabaseRoleRequest) ([]DatabaseRole, error)
 	ShowByID(ctx context.Context, id DatabaseObjectIdentifier) (*DatabaseRole, error)
+
+	Grant(ctx context.Context, request *GrantDatabaseRoleRequest) error
+	Revoke(ctx context.Context, request *RevokeDatabaseRoleRequest) error
+	GrantToShare(ctx context.Context, request *GrantDatabaseRoleToShareRequest) error
+	RevokeFromShare(ctx context.Context, request *RevokeDatabaseRoleFromShareRequest) error
 }
 
 // createDatabaseRoleOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-database-role.

--- a/pkg/sdk/database_role.go
+++ b/pkg/sdk/database_role.go
@@ -138,3 +138,45 @@ func (row databaseRoleDBRow) convert() *DatabaseRole {
 	}
 	return &databaseRole
 }
+
+// grantDatabaseRoleOptions is based on https://docs.snowflake.com/en/sql-reference/sql/grant-database-role.
+type grantDatabaseRoleOptions struct {
+	grant        bool                            `ddl:"static" sql:"GRANT"`
+	databaseRole bool                            `ddl:"static" sql:"DATABASE ROLE"`
+	name         DatabaseObjectIdentifier        `ddl:"identifier"`
+	toRole       bool                            `ddl:"static" sql:"TO ROLE"`
+	Role         grantOrRevokeDatabaseRoleObject `ddl:"-"`
+}
+
+// revokeDatabaseRoleOptions is based on https://docs.snowflake.com/en/sql-reference/sql/revoke-database-role.
+type revokeDatabaseRoleOptions struct {
+	revoke       bool                            `ddl:"static" sql:"REVOKE"`
+	databaseRole bool                            `ddl:"static" sql:"DATABASE ROLE"`
+	name         DatabaseObjectIdentifier        `ddl:"identifier"`
+	fromRole     bool                            `ddl:"static" sql:"FROM ROLE"`
+	Role         grantOrRevokeDatabaseRoleObject `ddl:"-"`
+}
+
+type grantOrRevokeDatabaseRoleObject struct {
+	// One of
+	DatabaseRoleName *DatabaseObjectIdentifier `ddl:"identifier"`
+	AccountRoleName  *AccountObjectIdentifier  `ddl:"identifier"`
+}
+
+// grantDatabaseRoleToShareOptions is based on https://docs.snowflake.com/en/sql-reference/sql/grant-database-role-share.
+type grantDatabaseRoleToShareOptions struct {
+	grant        bool                     `ddl:"static" sql:"GRANT"`
+	databaseRole bool                     `ddl:"static" sql:"DATABASE ROLE"`
+	name         DatabaseObjectIdentifier `ddl:"identifier"`
+	toShare      bool                     `ddl:"static" sql:"TO SHARE"`
+	Share        AccountObjectIdentifier  `ddl:"identifier"`
+}
+
+// revokeDatabaseRoleFromShareOptions is based on https://docs.snowflake.com/en/sql-reference/sql/grant-database-role-share.
+type revokeDatabaseRoleFromShareOptions struct {
+	revoke       bool                     `ddl:"static" sql:"REVOKE"`
+	databaseRole bool                     `ddl:"static" sql:"DATABASE ROLE"`
+	name         DatabaseObjectIdentifier `ddl:"identifier"`
+	fromShare    bool                     `ddl:"static" sql:"FROM SHARE"`
+	Share        AccountObjectIdentifier  `ddl:"identifier"`
+}

--- a/pkg/sdk/database_role.go
+++ b/pkg/sdk/database_role.go
@@ -145,7 +145,7 @@ type grantDatabaseRoleOptions struct {
 	databaseRole bool                            `ddl:"static" sql:"DATABASE ROLE"`
 	name         DatabaseObjectIdentifier        `ddl:"identifier"`
 	toRole       bool                            `ddl:"static" sql:"TO ROLE"`
-	Role         grantOrRevokeDatabaseRoleObject `ddl:"-"`
+	ParentRole   grantOrRevokeDatabaseRoleObject `ddl:"-"`
 }
 
 // revokeDatabaseRoleOptions is based on https://docs.snowflake.com/en/sql-reference/sql/revoke-database-role.
@@ -154,7 +154,7 @@ type revokeDatabaseRoleOptions struct {
 	databaseRole bool                            `ddl:"static" sql:"DATABASE ROLE"`
 	name         DatabaseObjectIdentifier        `ddl:"identifier"`
 	fromRole     bool                            `ddl:"static" sql:"FROM ROLE"`
-	Role         grantOrRevokeDatabaseRoleObject `ddl:"-"`
+	ParentRole   grantOrRevokeDatabaseRoleObject `ddl:"-"`
 }
 
 type grantOrRevokeDatabaseRoleObject struct {

--- a/pkg/sdk/database_role.go
+++ b/pkg/sdk/database_role.go
@@ -82,9 +82,9 @@ type databaseRoleDBRow struct {
 	IsDefault              sql.NullString `db:"is_default"`
 	IsCurrent              sql.NullString `db:"is_current"`
 	IsInherited            sql.NullString `db:"is_inherited"`
-	GrantedToRoles         sql.NullString `db:"granted_to_roles"`
-	GrantedToDatabaseRoles sql.NullString `db:"granted_to_database_roles"`
-	GrantedDatabaseRoles   sql.NullString `db:"granted_database_roles"`
+	GrantedToRoles         int            `db:"granted_to_roles"`
+	GrantedToDatabaseRoles int            `db:"granted_to_database_roles"`
+	GrantedDatabaseRoles   int            `db:"granted_database_roles"`
 	Owner                  string         `db:"owner"`
 	Comment                sql.NullString `db:"comment"`
 	OwnerRoleType          sql.NullString `db:"owner_role_type"`
@@ -98,9 +98,9 @@ type DatabaseRole struct {
 	IsDefault              bool
 	IsCurrent              bool
 	IsInherited            bool
-	GrantedToRoles         string
-	GrantedToDatabaseRoles string
-	GrantedDatabaseRoles   string
+	GrantedToRoles         int
+	GrantedToDatabaseRoles int
+	GrantedDatabaseRoles   int
 	Owner                  string
 	Comment                string
 	OwnerRoleType          string
@@ -108,9 +108,12 @@ type DatabaseRole struct {
 
 func (row databaseRoleDBRow) convert() *DatabaseRole {
 	databaseRole := DatabaseRole{
-		CreatedOn: row.CreatedOn,
-		Name:      row.Name,
-		Owner:     row.Owner,
+		CreatedOn:              row.CreatedOn,
+		Name:                   row.Name,
+		Owner:                  row.Owner,
+		GrantedToRoles:         row.GrantedToRoles,
+		GrantedToDatabaseRoles: row.GrantedToDatabaseRoles,
+		GrantedDatabaseRoles:   row.GrantedDatabaseRoles,
 	}
 	if row.IsDefault.Valid {
 		databaseRole.IsDefault = row.IsDefault.String == "Y"
@@ -120,15 +123,6 @@ func (row databaseRoleDBRow) convert() *DatabaseRole {
 	}
 	if row.IsInherited.Valid {
 		databaseRole.IsInherited = row.IsInherited.String == "Y"
-	}
-	if row.GrantedToRoles.Valid {
-		databaseRole.GrantedToRoles = row.GrantedToRoles.String
-	}
-	if row.GrantedToDatabaseRoles.Valid {
-		databaseRole.GrantedToDatabaseRoles = row.GrantedToDatabaseRoles.String
-	}
-	if row.GrantedDatabaseRoles.Valid {
-		databaseRole.GrantedDatabaseRoles = row.GrantedDatabaseRoles.String
 	}
 	if row.Comment.Valid {
 		databaseRole.Comment = row.Comment.String

--- a/pkg/sdk/database_role_dto.go
+++ b/pkg/sdk/database_role_dto.go
@@ -1,5 +1,7 @@
 package sdk
 
+//go:generate go run ./dto-builder-generator/main.go
+
 var (
 	_ optionsProvider[createDatabaseRoleOptions] = new(CreateDatabaseRoleRequest)
 	_ optionsProvider[alterDatabaseRoleOptions]  = new(AlterDatabaseRoleRequest)
@@ -44,10 +46,28 @@ type ShowDatabaseRoleRequest struct {
 	database AccountObjectIdentifier // required
 }
 
-type GrantDatabaseRoleRequest struct{}
+type GrantDatabaseRoleRequest struct {
+	name DatabaseObjectIdentifier // required
 
-type RevokeDatabaseRoleRequest struct{}
+	// One of
+	databaseRole *DatabaseObjectIdentifier
+	accountRole  *AccountObjectIdentifier
+}
 
-type GrantDatabaseRoleToShareRequest struct{}
+type RevokeDatabaseRoleRequest struct {
+	name DatabaseObjectIdentifier // required
 
-type RevokeDatabaseRoleFromShareRequest struct{}
+	// One of
+	databaseRole *DatabaseObjectIdentifier
+	accountRole  *AccountObjectIdentifier
+}
+
+type GrantDatabaseRoleToShareRequest struct {
+	name  DatabaseObjectIdentifier // required
+	share AccountObjectIdentifier  // required
+}
+
+type RevokeDatabaseRoleFromShareRequest struct {
+	name  DatabaseObjectIdentifier // required
+	share AccountObjectIdentifier  // required
+}

--- a/pkg/sdk/database_role_dto.go
+++ b/pkg/sdk/database_role_dto.go
@@ -43,3 +43,11 @@ type ShowDatabaseRoleRequest struct {
 	like     *Like
 	database AccountObjectIdentifier // required
 }
+
+type GrantDatabaseRoleRequest struct{}
+
+type RevokeDatabaseRoleRequest struct{}
+
+type GrantDatabaseRoleToShareRequest struct{}
+
+type RevokeDatabaseRoleFromShareRequest struct{}

--- a/pkg/sdk/database_role_dto_builders.go
+++ b/pkg/sdk/database_role_dto_builders.go
@@ -107,15 +107,15 @@ func NewGrantDatabaseRoleRequest(
 	return &s
 }
 
-func (s *GrantDatabaseRoleRequest) WithDatabaseRole(databaseRole *DatabaseObjectIdentifier) *GrantDatabaseRoleRequest {
+func (s *GrantDatabaseRoleRequest) WithDatabaseRole(databaseRole DatabaseObjectIdentifier) *GrantDatabaseRoleRequest {
 	s.accountRole = nil
-	s.databaseRole = databaseRole
+	s.databaseRole = &databaseRole
 	return s
 }
 
-func (s *GrantDatabaseRoleRequest) WithAccountRole(accountRole *AccountObjectIdentifier) *GrantDatabaseRoleRequest {
+func (s *GrantDatabaseRoleRequest) WithAccountRole(accountRole AccountObjectIdentifier) *GrantDatabaseRoleRequest {
 	s.databaseRole = nil
-	s.accountRole = accountRole
+	s.accountRole = &accountRole
 	return s
 }
 
@@ -127,15 +127,15 @@ func NewRevokeDatabaseRoleRequest(
 	return &s
 }
 
-func (s *RevokeDatabaseRoleRequest) WithDatabaseRole(databaseRole *DatabaseObjectIdentifier) *RevokeDatabaseRoleRequest {
+func (s *RevokeDatabaseRoleRequest) WithDatabaseRole(databaseRole DatabaseObjectIdentifier) *RevokeDatabaseRoleRequest {
 	s.accountRole = nil
-	s.databaseRole = databaseRole
+	s.databaseRole = &databaseRole
 	return s
 }
 
-func (s *RevokeDatabaseRoleRequest) WithAccountRole(accountRole *AccountObjectIdentifier) *RevokeDatabaseRoleRequest {
+func (s *RevokeDatabaseRoleRequest) WithAccountRole(accountRole AccountObjectIdentifier) *RevokeDatabaseRoleRequest {
 	s.databaseRole = nil
-	s.accountRole = accountRole
+	s.accountRole = &accountRole
 	return s
 }
 

--- a/pkg/sdk/database_role_dto_builders.go
+++ b/pkg/sdk/database_role_dto_builders.go
@@ -98,3 +98,63 @@ func (s *ShowDatabaseRoleRequest) WithLike(pattern string) *ShowDatabaseRoleRequ
 	}
 	return s
 }
+
+func NewGrantDatabaseRoleRequest(
+	name DatabaseObjectIdentifier,
+) *GrantDatabaseRoleRequest {
+	s := GrantDatabaseRoleRequest{}
+	s.name = name
+	return &s
+}
+
+func (s *GrantDatabaseRoleRequest) WithDatabaseRole(databaseRole *DatabaseObjectIdentifier) *GrantDatabaseRoleRequest {
+	s.accountRole = nil
+	s.databaseRole = databaseRole
+	return s
+}
+
+func (s *GrantDatabaseRoleRequest) WithAccountRole(accountRole *AccountObjectIdentifier) *GrantDatabaseRoleRequest {
+	s.databaseRole = nil
+	s.accountRole = accountRole
+	return s
+}
+
+func NewRevokeDatabaseRoleRequest(
+	name DatabaseObjectIdentifier,
+) *RevokeDatabaseRoleRequest {
+	s := RevokeDatabaseRoleRequest{}
+	s.name = name
+	return &s
+}
+
+func (s *RevokeDatabaseRoleRequest) WithDatabaseRole(databaseRole *DatabaseObjectIdentifier) *RevokeDatabaseRoleRequest {
+	s.accountRole = nil
+	s.databaseRole = databaseRole
+	return s
+}
+
+func (s *RevokeDatabaseRoleRequest) WithAccountRole(accountRole *AccountObjectIdentifier) *RevokeDatabaseRoleRequest {
+	s.databaseRole = nil
+	s.accountRole = accountRole
+	return s
+}
+
+func NewGrantDatabaseRoleToShareRequest(
+	name DatabaseObjectIdentifier,
+	share AccountObjectIdentifier,
+) *GrantDatabaseRoleToShareRequest {
+	s := GrantDatabaseRoleToShareRequest{}
+	s.name = name
+	s.share = share
+	return &s
+}
+
+func NewRevokeDatabaseRoleFromShareRequest(
+	name DatabaseObjectIdentifier,
+	share AccountObjectIdentifier,
+) *RevokeDatabaseRoleFromShareRequest {
+	s := RevokeDatabaseRoleFromShareRequest{}
+	s.name = name
+	s.share = share
+	return &s
+}

--- a/pkg/sdk/database_role_impl.go
+++ b/pkg/sdk/database_role_impl.go
@@ -117,7 +117,7 @@ func (s *GrantDatabaseRoleRequest) toOpts() *grantDatabaseRoleOptions {
 	if s.accountRole != nil {
 		grantToRole.AccountRoleName = s.accountRole
 	}
-	opts.Role = grantToRole
+	opts.ParentRole = grantToRole
 
 	return &opts
 }
@@ -134,7 +134,7 @@ func (s *RevokeDatabaseRoleRequest) toOpts() *revokeDatabaseRoleOptions {
 	if s.accountRole != nil {
 		revokeFromRole.AccountRoleName = s.accountRole
 	}
-	opts.Role = revokeFromRole
+	opts.ParentRole = revokeFromRole
 
 	return &opts
 }

--- a/pkg/sdk/database_role_impl.go
+++ b/pkg/sdk/database_role_impl.go
@@ -106,17 +106,49 @@ func (s *ShowDatabaseRoleRequest) toOpts() *showDatabaseRoleOptions {
 }
 
 func (s *GrantDatabaseRoleRequest) toOpts() *grantDatabaseRoleOptions {
-	return nil
+	opts := grantDatabaseRoleOptions{
+		name: s.name,
+	}
+
+	grantToRole := grantOrRevokeDatabaseRoleObject{}
+	if s.databaseRole != nil {
+		grantToRole.DatabaseRoleName = s.databaseRole
+	}
+	if s.accountRole != nil {
+		grantToRole.AccountRoleName = s.accountRole
+	}
+	opts.Role = grantToRole
+
+	return &opts
 }
 
 func (s *RevokeDatabaseRoleRequest) toOpts() *revokeDatabaseRoleOptions {
-	return nil
+	opts := revokeDatabaseRoleOptions{
+		name: s.name,
+	}
+
+	revokeFromRole := grantOrRevokeDatabaseRoleObject{}
+	if s.databaseRole != nil {
+		revokeFromRole.DatabaseRoleName = s.databaseRole
+	}
+	if s.accountRole != nil {
+		revokeFromRole.AccountRoleName = s.accountRole
+	}
+	opts.Role = revokeFromRole
+
+	return &opts
 }
 
 func (s *GrantDatabaseRoleToShareRequest) toOpts() *grantDatabaseRoleToShareOptions {
-	return nil
+	return &grantDatabaseRoleToShareOptions{
+		name:  s.name,
+		Share: s.share,
+	}
 }
 
 func (s *RevokeDatabaseRoleFromShareRequest) toOpts() *revokeDatabaseRoleFromShareOptions {
-	return nil
+	return &revokeDatabaseRoleFromShareOptions{
+		name:  s.name,
+		Share: s.share,
+	}
 }

--- a/pkg/sdk/database_role_impl.go
+++ b/pkg/sdk/database_role_impl.go
@@ -45,6 +45,26 @@ func (v *databaseRoles) ShowByID(ctx context.Context, id DatabaseObjectIdentifie
 	return findOne(databaseRoles, func(r DatabaseRole) bool { return r.Name == id.Name() })
 }
 
+func (v *databaseRoles) Grant(ctx context.Context, request *GrantDatabaseRoleRequest) error {
+	opts := request.toOpts()
+	return validateAndExec(v.client, ctx, *opts)
+}
+
+func (v *databaseRoles) Revoke(ctx context.Context, request *RevokeDatabaseRoleRequest) error {
+	opts := request.toOpts()
+	return validateAndExec(v.client, ctx, *opts)
+}
+
+func (v *databaseRoles) GrantToShare(ctx context.Context, request *GrantDatabaseRoleToShareRequest) error {
+	opts := request.toOpts()
+	return validateAndExec(v.client, ctx, *opts)
+}
+
+func (v *databaseRoles) RevokeFromShare(ctx context.Context, request *RevokeDatabaseRoleFromShareRequest) error {
+	opts := request.toOpts()
+	return validateAndExec(v.client, ctx, *opts)
+}
+
 func (s *CreateDatabaseRoleRequest) toOpts() *createDatabaseRoleOptions {
 	return &createDatabaseRoleOptions{
 		OrReplace:   Bool(s.orReplace),
@@ -83,4 +103,20 @@ func (s *ShowDatabaseRoleRequest) toOpts() *showDatabaseRoleOptions {
 		Like:     s.like,
 		Database: s.database,
 	}
+}
+
+func (s *GrantDatabaseRoleRequest) toOpts() *validatableOpts {
+	return nil
+}
+
+func (s *RevokeDatabaseRoleRequest) toOpts() *validatableOpts {
+	return nil
+}
+
+func (s *GrantDatabaseRoleToShareRequest) toOpts() *validatableOpts {
+	return nil
+}
+
+func (s *RevokeDatabaseRoleFromShareRequest) toOpts() *validatableOpts {
+	return nil
 }

--- a/pkg/sdk/database_role_impl.go
+++ b/pkg/sdk/database_role_impl.go
@@ -47,22 +47,22 @@ func (v *databaseRoles) ShowByID(ctx context.Context, id DatabaseObjectIdentifie
 
 func (v *databaseRoles) Grant(ctx context.Context, request *GrantDatabaseRoleRequest) error {
 	opts := request.toOpts()
-	return validateAndExec(v.client, ctx, *opts)
+	return validateAndExec(v.client, ctx, opts)
 }
 
 func (v *databaseRoles) Revoke(ctx context.Context, request *RevokeDatabaseRoleRequest) error {
 	opts := request.toOpts()
-	return validateAndExec(v.client, ctx, *opts)
+	return validateAndExec(v.client, ctx, opts)
 }
 
 func (v *databaseRoles) GrantToShare(ctx context.Context, request *GrantDatabaseRoleToShareRequest) error {
 	opts := request.toOpts()
-	return validateAndExec(v.client, ctx, *opts)
+	return validateAndExec(v.client, ctx, opts)
 }
 
 func (v *databaseRoles) RevokeFromShare(ctx context.Context, request *RevokeDatabaseRoleFromShareRequest) error {
 	opts := request.toOpts()
-	return validateAndExec(v.client, ctx, *opts)
+	return validateAndExec(v.client, ctx, opts)
 }
 
 func (s *CreateDatabaseRoleRequest) toOpts() *createDatabaseRoleOptions {
@@ -105,18 +105,18 @@ func (s *ShowDatabaseRoleRequest) toOpts() *showDatabaseRoleOptions {
 	}
 }
 
-func (s *GrantDatabaseRoleRequest) toOpts() *validatableOpts {
+func (s *GrantDatabaseRoleRequest) toOpts() *grantDatabaseRoleOptions {
 	return nil
 }
 
-func (s *RevokeDatabaseRoleRequest) toOpts() *validatableOpts {
+func (s *RevokeDatabaseRoleRequest) toOpts() *revokeDatabaseRoleOptions {
 	return nil
 }
 
-func (s *GrantDatabaseRoleToShareRequest) toOpts() *validatableOpts {
+func (s *GrantDatabaseRoleToShareRequest) toOpts() *grantDatabaseRoleToShareOptions {
 	return nil
 }
 
-func (s *RevokeDatabaseRoleFromShareRequest) toOpts() *validatableOpts {
+func (s *RevokeDatabaseRoleFromShareRequest) toOpts() *revokeDatabaseRoleFromShareOptions {
 	return nil
 }

--- a/pkg/sdk/database_role_integration_test.go
+++ b/pkg/sdk/database_role_integration_test.go
@@ -21,6 +21,9 @@ func TestInt_DatabaseRoles(t *testing.T) {
 		assert.Equal(t, expectedName, databaseRole.Name)
 		assert.Equal(t, "ACCOUNTADMIN", databaseRole.Owner)
 		assert.Equal(t, expectedComment, databaseRole.Comment)
+		assert.Equal(t, 0, databaseRole.GrantedToRoles)
+		assert.Equal(t, 0, databaseRole.GrantedToDatabaseRoles)
+		assert.Equal(t, 0, databaseRole.GrantedDatabaseRoles)
 	}
 
 	cleanupDatabaseRoleProvider := func(id DatabaseObjectIdentifier) func() {
@@ -214,6 +217,18 @@ func TestInt_DatabaseRoles(t *testing.T) {
 		err := client.DatabaseRoles.Grant(ctx, grantRequest)
 		require.NoError(t, err)
 
+		extractedRole, err := client.DatabaseRoles.ShowByID(ctx, id1)
+		require.NoError(t, err)
+		assert.Equal(t, 0, extractedRole.GrantedToRoles)
+		assert.Equal(t, 1, extractedRole.GrantedToDatabaseRoles)
+		assert.Equal(t, 0, extractedRole.GrantedDatabaseRoles)
+
+		extractedRole, err = client.DatabaseRoles.ShowByID(ctx, id2)
+		require.NoError(t, err)
+		assert.Equal(t, 0, extractedRole.GrantedToRoles)
+		assert.Equal(t, 0, extractedRole.GrantedToDatabaseRoles)
+		assert.Equal(t, 1, extractedRole.GrantedDatabaseRoles)
+
 		revokeRequest := NewRevokeDatabaseRoleRequest(id1).WithDatabaseRole(id2)
 		err = client.DatabaseRoles.Revoke(ctx, revokeRequest)
 		require.NoError(t, err)
@@ -229,6 +244,12 @@ func TestInt_DatabaseRoles(t *testing.T) {
 		grantRequest := NewGrantDatabaseRoleRequest(roleId).WithAccountRole(accountRole.ID())
 		err := client.DatabaseRoles.Grant(ctx, grantRequest)
 		require.NoError(t, err)
+
+		extractedRole, err := client.DatabaseRoles.ShowByID(ctx, roleId)
+		require.NoError(t, err)
+		assert.Equal(t, 1, extractedRole.GrantedToRoles)
+		assert.Equal(t, 0, extractedRole.GrantedToDatabaseRoles)
+		assert.Equal(t, 0, extractedRole.GrantedDatabaseRoles)
 
 		revokeRequest := NewRevokeDatabaseRoleRequest(roleId).WithAccountRole(accountRole.ID())
 		err = client.DatabaseRoles.Revoke(ctx, revokeRequest)

--- a/pkg/sdk/database_role_integration_test.go
+++ b/pkg/sdk/database_role_integration_test.go
@@ -263,8 +263,11 @@ func TestInt_DatabaseRoles(t *testing.T) {
 		share, shareCleanup := createShare(t, client)
 		t.Cleanup(shareCleanup)
 
+		err := client.Grants.GrantPrivilegeToShare(ctx, ObjectPrivilegeUsage, &GrantPrivilegeToShareOn{Database: database.ID()}, share.ID())
+		require.NoError(t, err)
+
 		grantRequest := NewGrantDatabaseRoleToShareRequest(roleId, share.ID())
-		err := client.DatabaseRoles.GrantToShare(ctx, grantRequest)
+		err = client.DatabaseRoles.GrantToShare(ctx, grantRequest)
 		require.NoError(t, err)
 
 		revokeRequest := NewRevokeDatabaseRoleFromShareRequest(roleId, share.ID())

--- a/pkg/sdk/database_role_test.go
+++ b/pkg/sdk/database_role_test.go
@@ -227,6 +227,8 @@ func TestDatabaseRolesShow(t *testing.T) {
 
 func TestDatabaseRoles_Grant(t *testing.T) {
 	id := randomDatabaseObjectIdentifier(t)
+	databaseRoleId := randomDatabaseObjectIdentifier(t)
+	accountRoleId := randomAccountObjectIdentifier(t)
 
 	setUpOpts := func() *grantDatabaseRoleOptions {
 		return &grantDatabaseRoleOptions{
@@ -234,8 +236,30 @@ func TestDatabaseRoles_Grant(t *testing.T) {
 		}
 	}
 
+	t.Run("validation: nil options", func(t *testing.T) {
+		var opts *grantDatabaseRoleOptions = nil
+		assertOptsInvalidJoinedErrors(t, opts, errNilOptions)
+	})
+
+	t.Run("validation: invalid identifier", func(t *testing.T) {
+		opts := setUpOpts()
+		opts.name = NewDatabaseObjectIdentifier("", "")
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: no role", func(t *testing.T) {
+		opts := setUpOpts()
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("DatabaseRoleName", "AccountRoleName"))
+	})
+
+	t.Run("validation: multiple roles", func(t *testing.T) {
+		opts := setUpOpts()
+		opts.Role.DatabaseRoleName = &databaseRoleId
+		opts.Role.AccountRoleName = &accountRoleId
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("DatabaseRoleName", "AccountRoleName"))
+	})
+
 	t.Run("grant to database role", func(t *testing.T) {
-		databaseRoleId := randomDatabaseObjectIdentifier(t)
 		opts := setUpOpts()
 		opts.Role.DatabaseRoleName = &databaseRoleId
 
@@ -243,7 +267,6 @@ func TestDatabaseRoles_Grant(t *testing.T) {
 	})
 
 	t.Run("grant to account role", func(t *testing.T) {
-		accountRoleId := randomAccountObjectIdentifier(t)
 		opts := setUpOpts()
 		opts.Role.AccountRoleName = &accountRoleId
 
@@ -253,6 +276,8 @@ func TestDatabaseRoles_Grant(t *testing.T) {
 
 func TestDatabaseRoles_Revoke(t *testing.T) {
 	id := randomDatabaseObjectIdentifier(t)
+	databaseRoleId := randomDatabaseObjectIdentifier(t)
+	accountRoleId := randomAccountObjectIdentifier(t)
 
 	setUpOpts := func() *revokeDatabaseRoleOptions {
 		return &revokeDatabaseRoleOptions{
@@ -260,8 +285,30 @@ func TestDatabaseRoles_Revoke(t *testing.T) {
 		}
 	}
 
+	t.Run("validation: nil options", func(t *testing.T) {
+		var opts *revokeDatabaseRoleOptions = nil
+		assertOptsInvalidJoinedErrors(t, opts, errNilOptions)
+	})
+
+	t.Run("validation: invalid identifier", func(t *testing.T) {
+		opts := setUpOpts()
+		opts.name = NewDatabaseObjectIdentifier("", "")
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: no role", func(t *testing.T) {
+		opts := setUpOpts()
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("DatabaseRoleName", "AccountRoleName"))
+	})
+
+	t.Run("validation: multiple roles", func(t *testing.T) {
+		opts := setUpOpts()
+		opts.Role.DatabaseRoleName = &databaseRoleId
+		opts.Role.AccountRoleName = &accountRoleId
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("DatabaseRoleName", "AccountRoleName"))
+	})
+
 	t.Run("revoke from database role", func(t *testing.T) {
-		databaseRoleId := randomDatabaseObjectIdentifier(t)
 		opts := setUpOpts()
 		opts.Role.DatabaseRoleName = &databaseRoleId
 
@@ -269,7 +316,6 @@ func TestDatabaseRoles_Revoke(t *testing.T) {
 	})
 
 	t.Run("revoke from account role", func(t *testing.T) {
-		accountRoleId := randomAccountObjectIdentifier(t)
 		opts := setUpOpts()
 		opts.Role.AccountRoleName = &accountRoleId
 
@@ -288,6 +334,23 @@ func TestDatabaseRoles_GrantToShare(t *testing.T) {
 		}
 	}
 
+	t.Run("validation: nil options", func(t *testing.T) {
+		var opts *grantDatabaseRoleToShareOptions = nil
+		assertOptsInvalidJoinedErrors(t, opts, errNilOptions)
+	})
+
+	t.Run("validation: invalid identifier", func(t *testing.T) {
+		opts := setUpOpts()
+		opts.name = NewDatabaseObjectIdentifier("", "")
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: invalid share identifier", func(t *testing.T) {
+		opts := setUpOpts()
+		opts.Share = NewAccountObjectIdentifier("")
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
 	t.Run("grant to share", func(t *testing.T) {
 		opts := setUpOpts()
 
@@ -305,6 +368,23 @@ func TestDatabaseRoles_RevokeFromShare(t *testing.T) {
 			Share: share,
 		}
 	}
+
+	t.Run("validation: nil options", func(t *testing.T) {
+		var opts *revokeDatabaseRoleFromShareOptions = nil
+		assertOptsInvalidJoinedErrors(t, opts, errNilOptions)
+	})
+
+	t.Run("validation: invalid identifier", func(t *testing.T) {
+		opts := setUpOpts()
+		opts.name = NewDatabaseObjectIdentifier("", "")
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: invalid share identifier", func(t *testing.T) {
+		opts := setUpOpts()
+		opts.Share = NewAccountObjectIdentifier("")
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
 
 	t.Run("revoke from share", func(t *testing.T) {
 		opts := setUpOpts()

--- a/pkg/sdk/database_role_test.go
+++ b/pkg/sdk/database_role_test.go
@@ -263,7 +263,7 @@ func TestDatabaseRoles_Grant(t *testing.T) {
 		opts := setUpOpts()
 		opts.ParentRole.DatabaseRoleName = &databaseRoleId
 
-		assertOptsValidAndSQLEquals(t, opts, `GRANT DATABASE ROLE %s TO ROLE %s`, id.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, `GRANT DATABASE ROLE %s TO DATABASE ROLE %s`, id.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
 	})
 
 	t.Run("grant to account role", func(t *testing.T) {
@@ -312,7 +312,7 @@ func TestDatabaseRoles_Revoke(t *testing.T) {
 		opts := setUpOpts()
 		opts.ParentRole.DatabaseRoleName = &databaseRoleId
 
-		assertOptsValidAndSQLEquals(t, opts, `REVOKE DATABASE ROLE %s FROM ROLE %s`, id.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE DATABASE ROLE %s FROM DATABASE ROLE %s`, id.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
 	})
 
 	t.Run("revoke from account role", func(t *testing.T) {

--- a/pkg/sdk/database_role_test.go
+++ b/pkg/sdk/database_role_test.go
@@ -224,3 +224,91 @@ func TestDatabaseRolesShow(t *testing.T) {
 		assertOptsValidAndSQLEquals(t, opts, `SHOW DATABASE ROLES LIKE '%s' IN DATABASE %s`, id.Name(), id.FullyQualifiedName())
 	})
 }
+
+func TestDatabaseRoles_Grant(t *testing.T) {
+	id := randomDatabaseObjectIdentifier(t)
+
+	setUpOpts := func() *grantDatabaseRoleOptions {
+		return &grantDatabaseRoleOptions{
+			name: id,
+		}
+	}
+
+	t.Run("grant to database role", func(t *testing.T) {
+		databaseRoleId := randomDatabaseObjectIdentifier(t)
+		opts := setUpOpts()
+		opts.Role.DatabaseRoleName = &databaseRoleId
+
+		assertOptsValidAndSQLEquals(t, opts, `GRANT DATABASE ROLE %s TO ROLE %s`, id.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
+	})
+
+	t.Run("grant to account role", func(t *testing.T) {
+		accountRoleId := randomAccountObjectIdentifier(t)
+		opts := setUpOpts()
+		opts.Role.AccountRoleName = &accountRoleId
+
+		assertOptsValidAndSQLEquals(t, opts, `GRANT DATABASE ROLE %s TO ROLE %s`, id.FullyQualifiedName(), accountRoleId.FullyQualifiedName())
+	})
+}
+
+func TestDatabaseRoles_Revoke(t *testing.T) {
+	id := randomDatabaseObjectIdentifier(t)
+
+	setUpOpts := func() *revokeDatabaseRoleOptions {
+		return &revokeDatabaseRoleOptions{
+			name: id,
+		}
+	}
+
+	t.Run("revoke from database role", func(t *testing.T) {
+		databaseRoleId := randomDatabaseObjectIdentifier(t)
+		opts := setUpOpts()
+		opts.Role.DatabaseRoleName = &databaseRoleId
+
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE DATABASE ROLE %s FROM ROLE %s`, id.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
+	})
+
+	t.Run("revoke from account role", func(t *testing.T) {
+		accountRoleId := randomAccountObjectIdentifier(t)
+		opts := setUpOpts()
+		opts.Role.AccountRoleName = &accountRoleId
+
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE DATABASE ROLE %s FROM ROLE %s`, id.FullyQualifiedName(), accountRoleId.FullyQualifiedName())
+	})
+}
+
+func TestDatabaseRoles_GrantToShare(t *testing.T) {
+	id := randomDatabaseObjectIdentifier(t)
+	share := randomAccountObjectIdentifier(t)
+
+	setUpOpts := func() *grantDatabaseRoleToShareOptions {
+		return &grantDatabaseRoleToShareOptions{
+			name:  id,
+			Share: share,
+		}
+	}
+
+	t.Run("grant to share", func(t *testing.T) {
+		opts := setUpOpts()
+
+		assertOptsValidAndSQLEquals(t, opts, `GRANT DATABASE ROLE %s TO SHARE %s`, id.FullyQualifiedName(), share.FullyQualifiedName())
+	})
+}
+
+func TestDatabaseRoles_RevokeFromShare(t *testing.T) {
+	id := randomDatabaseObjectIdentifier(t)
+	share := randomAccountObjectIdentifier(t)
+
+	setUpOpts := func() *revokeDatabaseRoleFromShareOptions {
+		return &revokeDatabaseRoleFromShareOptions{
+			name:  id,
+			Share: share,
+		}
+	}
+
+	t.Run("revoke from share", func(t *testing.T) {
+		opts := setUpOpts()
+
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE DATABASE ROLE %s FROM SHARE %s`, id.FullyQualifiedName(), share.FullyQualifiedName())
+	})
+}

--- a/pkg/sdk/database_role_test.go
+++ b/pkg/sdk/database_role_test.go
@@ -254,21 +254,21 @@ func TestDatabaseRoles_Grant(t *testing.T) {
 
 	t.Run("validation: multiple roles", func(t *testing.T) {
 		opts := setUpOpts()
-		opts.Role.DatabaseRoleName = &databaseRoleId
-		opts.Role.AccountRoleName = &accountRoleId
+		opts.ParentRole.DatabaseRoleName = &databaseRoleId
+		opts.ParentRole.AccountRoleName = &accountRoleId
 		assertOptsInvalidJoinedErrors(t, opts, errOneOf("DatabaseRoleName", "AccountRoleName"))
 	})
 
 	t.Run("grant to database role", func(t *testing.T) {
 		opts := setUpOpts()
-		opts.Role.DatabaseRoleName = &databaseRoleId
+		opts.ParentRole.DatabaseRoleName = &databaseRoleId
 
 		assertOptsValidAndSQLEquals(t, opts, `GRANT DATABASE ROLE %s TO ROLE %s`, id.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
 	})
 
 	t.Run("grant to account role", func(t *testing.T) {
 		opts := setUpOpts()
-		opts.Role.AccountRoleName = &accountRoleId
+		opts.ParentRole.AccountRoleName = &accountRoleId
 
 		assertOptsValidAndSQLEquals(t, opts, `GRANT DATABASE ROLE %s TO ROLE %s`, id.FullyQualifiedName(), accountRoleId.FullyQualifiedName())
 	})
@@ -303,21 +303,21 @@ func TestDatabaseRoles_Revoke(t *testing.T) {
 
 	t.Run("validation: multiple roles", func(t *testing.T) {
 		opts := setUpOpts()
-		opts.Role.DatabaseRoleName = &databaseRoleId
-		opts.Role.AccountRoleName = &accountRoleId
+		opts.ParentRole.DatabaseRoleName = &databaseRoleId
+		opts.ParentRole.AccountRoleName = &accountRoleId
 		assertOptsInvalidJoinedErrors(t, opts, errOneOf("DatabaseRoleName", "AccountRoleName"))
 	})
 
 	t.Run("revoke from database role", func(t *testing.T) {
 		opts := setUpOpts()
-		opts.Role.DatabaseRoleName = &databaseRoleId
+		opts.ParentRole.DatabaseRoleName = &databaseRoleId
 
 		assertOptsValidAndSQLEquals(t, opts, `REVOKE DATABASE ROLE %s FROM ROLE %s`, id.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
 	})
 
 	t.Run("revoke from account role", func(t *testing.T) {
 		opts := setUpOpts()
-		opts.Role.AccountRoleName = &accountRoleId
+		opts.ParentRole.AccountRoleName = &accountRoleId
 
 		assertOptsValidAndSQLEquals(t, opts, `REVOKE DATABASE ROLE %s FROM ROLE %s`, id.FullyQualifiedName(), accountRoleId.FullyQualifiedName())
 	})

--- a/pkg/sdk/database_role_validations.go
+++ b/pkg/sdk/database_role_validations.go
@@ -7,6 +7,10 @@ var (
 	_ validatableOpts = new(alterDatabaseRoleOptions)
 	_ validatableOpts = new(dropDatabaseRoleOptions)
 	_ validatableOpts = new(showDatabaseRoleOptions)
+	_ validatableOpts = new(grantDatabaseRoleOptions)
+	_ validatableOpts = new(revokeDatabaseRoleOptions)
+	_ validatableOpts = new(grantDatabaseRoleToShareOptions)
+	_ validatableOpts = new(revokeDatabaseRoleFromShareOptions)
 )
 
 var errDifferentDatabase = errors.New("database must be the same")
@@ -79,4 +83,24 @@ func (opts *showDatabaseRoleOptions) validateProp() error {
 		errs = append(errs, errPatternRequiredForLikeKeyword)
 	}
 	return errors.Join(errs...)
+}
+
+func (opts *grantDatabaseRoleOptions) validateProp() error {
+	// TODO: implement me
+	panic("implement me")
+}
+
+func (opts *revokeDatabaseRoleOptions) validateProp() error {
+	// TODO: implement me
+	panic("implement me")
+}
+
+func (opts *grantDatabaseRoleToShareOptions) validateProp() error {
+	// TODO: implement me
+	panic("implement me")
+}
+
+func (opts *revokeDatabaseRoleFromShareOptions) validateProp() error {
+	// TODO: implement me
+	panic("implement me")
 }

--- a/pkg/sdk/database_role_validations.go
+++ b/pkg/sdk/database_role_validations.go
@@ -86,21 +86,57 @@ func (opts *showDatabaseRoleOptions) validateProp() error {
 }
 
 func (opts *grantDatabaseRoleOptions) validateProp() error {
-	// TODO: implement me
-	return nil
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	if ok := exactlyOneValueSet(opts.Role.DatabaseRoleName, opts.Role.AccountRoleName); !ok {
+		errs = append(errs, errOneOf("DatabaseRoleName", "AccountRoleName"))
+	}
+	return errors.Join(errs...)
 }
 
 func (opts *revokeDatabaseRoleOptions) validateProp() error {
-	// TODO: implement me
-	return nil
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	if ok := exactlyOneValueSet(opts.Role.DatabaseRoleName, opts.Role.AccountRoleName); !ok {
+		errs = append(errs, errOneOf("DatabaseRoleName", "AccountRoleName"))
+	}
+	return errors.Join(errs...)
 }
 
 func (opts *grantDatabaseRoleToShareOptions) validateProp() error {
-	// TODO: implement me
-	return nil
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	if !validObjectidentifier(opts.Share) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	return errors.Join(errs...)
 }
 
 func (opts *revokeDatabaseRoleFromShareOptions) validateProp() error {
-	// TODO: implement me
-	return nil
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	if !validObjectidentifier(opts.Share) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	return errors.Join(errs...)
 }

--- a/pkg/sdk/database_role_validations.go
+++ b/pkg/sdk/database_role_validations.go
@@ -93,7 +93,7 @@ func (opts *grantDatabaseRoleOptions) validateProp() error {
 	if !validObjectidentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if ok := exactlyOneValueSet(opts.Role.DatabaseRoleName, opts.Role.AccountRoleName); !ok {
+	if ok := exactlyOneValueSet(opts.ParentRole.DatabaseRoleName, opts.ParentRole.AccountRoleName); !ok {
 		errs = append(errs, errOneOf("DatabaseRoleName", "AccountRoleName"))
 	}
 	return errors.Join(errs...)
@@ -107,7 +107,7 @@ func (opts *revokeDatabaseRoleOptions) validateProp() error {
 	if !validObjectidentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if ok := exactlyOneValueSet(opts.Role.DatabaseRoleName, opts.Role.AccountRoleName); !ok {
+	if ok := exactlyOneValueSet(opts.ParentRole.DatabaseRoleName, opts.ParentRole.AccountRoleName); !ok {
 		errs = append(errs, errOneOf("DatabaseRoleName", "AccountRoleName"))
 	}
 	return errors.Join(errs...)

--- a/pkg/sdk/database_role_validations.go
+++ b/pkg/sdk/database_role_validations.go
@@ -87,20 +87,20 @@ func (opts *showDatabaseRoleOptions) validateProp() error {
 
 func (opts *grantDatabaseRoleOptions) validateProp() error {
 	// TODO: implement me
-	panic("implement me")
+	return nil
 }
 
 func (opts *revokeDatabaseRoleOptions) validateProp() error {
 	// TODO: implement me
-	panic("implement me")
+	return nil
 }
 
 func (opts *grantDatabaseRoleToShareOptions) validateProp() error {
 	// TODO: implement me
-	panic("implement me")
+	return nil
 }
 
 func (opts *revokeDatabaseRoleFromShareOptions) validateProp() error {
 	// TODO: implement me
-	panic("implement me")
+	return nil
 }


### PR DESCRIPTION
## Changes
* Implement database roles in SDK:
  * [grant-database-role](https://docs.snowflake.com/en/sql-reference/sql/grant-database-role)
  * [revoke-database-role](https://docs.snowflake.com/en/sql-reference/sql/revoke-database-role)
  * [grant-database-role-share](https://docs.snowflake.com/en/sql-reference/sql/grant-database-role-share)
  * [revoke-database-role-share](https://docs.snowflake.com/en/sql-reference/sql/revoke-database-role-share)

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] unit tests (sql generation and validations)
* [x] integration tests (sql invocation)
* [x] acceptance tests (nothing should break)

## References
* [GRANT DATABASE ROLE ... TO ROLE](https://docs.snowflake.com/en/sql-reference/sql/grant-database-role)
* [REVOKE DATABASE ROLE ... FROM ROLE](https://docs.snowflake.com/en/sql-reference/sql/revoke-database-role)
* [GRANT DATABASE ROLE ... TO SHARE](https://docs.snowflake.com/en/sql-reference/sql/grant-database-role-share)
* [REVOKE DATABASE ROLES ... FROM SHARE](https://docs.snowflake.com/en/sql-reference/sql/revoke-database-role-share)