### PR TITLE
chore: Rename and reuse validatableOpts interface

### DIFF
--- a/pkg/sdk/accounts.go
+++ b/pkg/sdk/accounts.go
@@ -7,6 +7,12 @@ import (
 	"time"
 )
 
+var (
+	_ validatable = new(CreateAccountOptions)
+	_ validatable = new(AlterAccountOptions)
+	_ validatable = new(ShowAccountOptions)
+)
+
 type Accounts interface {
 	// Create creates an account.
 	Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateAccountOptions) error

--- a/pkg/sdk/alerts.go
+++ b/pkg/sdk/alerts.go
@@ -10,6 +10,13 @@ import (
 // Compile-time proof of interface implementation.
 var _ Alerts = (*alerts)(nil)
 
+var (
+	_ validatable = new(CreateAlertOptions)
+	_ validatable = new(AlterAlertOptions)
+	_ validatable = new(dropAlertOptions)
+	_ validatable = new(ShowAlertOptions)
+)
+
 type Alerts interface {
 	// Create creates a new alert.
 	Create(ctx context.Context, id SchemaObjectIdentifier, warehouse AccountObjectIdentifier, schedule string, condition string, action string, opts *CreateAlertOptions) error

--- a/pkg/sdk/assertions_test.go
+++ b/pkg/sdk/assertions_test.go
@@ -10,17 +10,17 @@ import (
 )
 
 // assertOptsInvalid could be reused in tests for other interfaces in sdk package.
-func assertOptsInvalid(t *testing.T, opts validatableOpts, expectedError error) {
+func assertOptsInvalid(t *testing.T, opts validatable, expectedError error) {
 	t.Helper()
-	err := opts.validateProp()
+	err := opts.validate()
 	assert.Error(t, err)
 	assert.Equal(t, expectedError, err)
 }
 
 // assertOptsInvalidJoinedErrors could be reused in tests for other interfaces in sdk package.
-func assertOptsInvalidJoinedErrors(t *testing.T, opts validatableOpts, expectedErrors ...error) {
+func assertOptsInvalidJoinedErrors(t *testing.T, opts validatable, expectedErrors ...error) {
 	t.Helper()
-	err := opts.validateProp()
+	err := opts.validate()
 	assert.Error(t, err)
 	for _, expectedError := range expectedErrors {
 		assert.Contains(t, err.Error(), expectedError.Error())
@@ -28,9 +28,9 @@ func assertOptsInvalidJoinedErrors(t *testing.T, opts validatableOpts, expectedE
 }
 
 // assertOptsValid could be reused in tests for other interfaces in sdk package.
-func assertOptsValid(t *testing.T, opts validatableOpts) {
+func assertOptsValid(t *testing.T, opts validatable) {
 	t.Helper()
-	err := opts.validateProp()
+	err := opts.validate()
 	assert.NoError(t, err)
 }
 
@@ -44,7 +44,7 @@ func assertSQLEquals(t *testing.T, opts any, format string, args ...any) {
 
 // assertOptsValidAndSQLEquals could be reused in tests for other interfaces in sdk package.
 // It's a shorthand for assertOptsValid and assertSQLEquals.
-func assertOptsValidAndSQLEquals(t *testing.T, opts validatableOpts, format string, args ...any) {
+func assertOptsValidAndSQLEquals(t *testing.T, opts validatable, format string, args ...any) {
 	t.Helper()
 	assertOptsValid(t, opts)
 	assertSQLEquals(t, opts, format, args...)

--- a/pkg/sdk/comments.go
+++ b/pkg/sdk/comments.go
@@ -4,6 +4,11 @@ import (
 	"context"
 )
 
+var (
+	_ validatable = new(SetCommentOptions)
+	_ validatable = new(SetColumnCommentOptions)
+)
+
 type Comments interface {
 	Set(ctx context.Context, opts *SetCommentOptions) error
 	SetColumn(ctx context.Context, opts *SetColumnCommentOptions) error

--- a/pkg/sdk/common_types.go
+++ b/pkg/sdk/common_types.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+var (
+	_ validatable = new(TimeTravel)
+	_ validatable = new(Clone)
+)
+
 type TimeTravel struct {
 	Timestamp *time.Time `ddl:"parameter,single_quotes,arrow_equals" sql:"TIMESTAMP"`
 	Offset    *int       `ddl:"parameter,arrow_equals" sql:"OFFSET"`

--- a/pkg/sdk/database_role_validations.go
+++ b/pkg/sdk/database_role_validations.go
@@ -3,19 +3,19 @@ package sdk
 import "errors"
 
 var (
-	_ validatableOpts = new(createDatabaseRoleOptions)
-	_ validatableOpts = new(alterDatabaseRoleOptions)
-	_ validatableOpts = new(dropDatabaseRoleOptions)
-	_ validatableOpts = new(showDatabaseRoleOptions)
-	_ validatableOpts = new(grantDatabaseRoleOptions)
-	_ validatableOpts = new(revokeDatabaseRoleOptions)
-	_ validatableOpts = new(grantDatabaseRoleToShareOptions)
-	_ validatableOpts = new(revokeDatabaseRoleFromShareOptions)
+	_ validatable = new(createDatabaseRoleOptions)
+	_ validatable = new(alterDatabaseRoleOptions)
+	_ validatable = new(dropDatabaseRoleOptions)
+	_ validatable = new(showDatabaseRoleOptions)
+	_ validatable = new(grantDatabaseRoleOptions)
+	_ validatable = new(revokeDatabaseRoleOptions)
+	_ validatable = new(grantDatabaseRoleToShareOptions)
+	_ validatable = new(revokeDatabaseRoleFromShareOptions)
 )
 
 var errDifferentDatabase = errors.New("database must be the same")
 
-func (opts *createDatabaseRoleOptions) validateProp() error {
+func (opts *createDatabaseRoleOptions) validate() error {
 	if opts == nil {
 		return errors.Join(errNilOptions)
 	}
@@ -29,7 +29,7 @@ func (opts *createDatabaseRoleOptions) validateProp() error {
 	return errors.Join(errs...)
 }
 
-func (opts *alterDatabaseRoleOptions) validateProp() error {
+func (opts *alterDatabaseRoleOptions) validate() error {
 	if opts == nil {
 		return errors.Join(errNilOptions)
 	}
@@ -60,7 +60,7 @@ func (opts *alterDatabaseRoleOptions) validateProp() error {
 	return errors.Join(errs...)
 }
 
-func (opts *dropDatabaseRoleOptions) validateProp() error {
+func (opts *dropDatabaseRoleOptions) validate() error {
 	if opts == nil {
 		return errors.Join(errNilOptions)
 	}
@@ -71,7 +71,7 @@ func (opts *dropDatabaseRoleOptions) validateProp() error {
 	return errors.Join(errs...)
 }
 
-func (opts *showDatabaseRoleOptions) validateProp() error {
+func (opts *showDatabaseRoleOptions) validate() error {
 	if opts == nil {
 		return errors.Join(errNilOptions)
 	}
@@ -85,7 +85,7 @@ func (opts *showDatabaseRoleOptions) validateProp() error {
 	return errors.Join(errs...)
 }
 
-func (opts *grantDatabaseRoleOptions) validateProp() error {
+func (opts *grantDatabaseRoleOptions) validate() error {
 	if opts == nil {
 		return errors.Join(errNilOptions)
 	}
@@ -99,7 +99,7 @@ func (opts *grantDatabaseRoleOptions) validateProp() error {
 	return errors.Join(errs...)
 }
 
-func (opts *revokeDatabaseRoleOptions) validateProp() error {
+func (opts *revokeDatabaseRoleOptions) validate() error {
 	if opts == nil {
 		return errors.Join(errNilOptions)
 	}
@@ -113,7 +113,7 @@ func (opts *revokeDatabaseRoleOptions) validateProp() error {
 	return errors.Join(errs...)
 }
 
-func (opts *grantDatabaseRoleToShareOptions) validateProp() error {
+func (opts *grantDatabaseRoleToShareOptions) validate() error {
 	if opts == nil {
 		return errors.Join(errNilOptions)
 	}
@@ -127,7 +127,7 @@ func (opts *grantDatabaseRoleToShareOptions) validateProp() error {
 	return errors.Join(errs...)
 }
 
-func (opts *revokeDatabaseRoleFromShareOptions) validateProp() error {
+func (opts *revokeDatabaseRoleFromShareOptions) validate() error {
 	if opts == nil {
 		return errors.Join(errNilOptions)
 	}

--- a/pkg/sdk/databases.go
+++ b/pkg/sdk/databases.go
@@ -9,6 +9,19 @@ import (
 	"time"
 )
 
+var (
+	_ validatable = new(CreateDatabaseOptions)
+	_ validatable = new(CreateSharedDatabaseOptions)
+	_ validatable = new(CreateSecondaryDatabaseOptions)
+	_ validatable = new(AlterDatabaseOptions)
+	_ validatable = new(AlterDatabaseReplicationOptions)
+	_ validatable = new(AlterDatabaseFailoverOptions)
+	_ validatable = new(DropDatabaseOptions)
+	_ validatable = new(undropDatabaseOptions)
+	_ validatable = new(ShowDatabasesOptions)
+	_ validatable = new(describeDatabaseOptions)
+)
+
 type Databases interface {
 	// Create creates a database.
 	Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateDatabaseOptions) error

--- a/pkg/sdk/failover_groups.go
+++ b/pkg/sdk/failover_groups.go
@@ -13,6 +13,19 @@ import (
 // Compile-time proof of interface implementation.
 var _ FailoverGroups = (*failoverGroups)(nil)
 
+var (
+	_ validatable = new(CreateDatabaseOptions)
+	_ validatable = new(CreateSharedDatabaseOptions)
+	_ validatable = new(CreateSecondaryDatabaseOptions)
+	_ validatable = new(AlterDatabaseOptions)
+	_ validatable = new(AlterDatabaseReplicationOptions)
+	_ validatable = new(AlterDatabaseFailoverOptions)
+	_ validatable = new(DropDatabaseOptions)
+	_ validatable = new(undropDatabaseOptions)
+	_ validatable = new(ShowDatabasesOptions)
+	_ validatable = new(describeDatabaseOptions)
+)
+
 // FailoverGroups describes all the failover group related methods that the
 // Snowflake API supports.
 type FailoverGroups interface {

--- a/pkg/sdk/file_format.go
+++ b/pkg/sdk/file_format.go
@@ -12,6 +12,14 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+var (
+	_ validatable = new(CreateFileFormatOptions)
+	_ validatable = new(AlterFileFormatOptions)
+	_ validatable = new(DropFileFormatOptions)
+	_ validatable = new(ShowFileFormatsOptions)
+	_ validatable = new(describeFileFormatOptions)
+)
+
 type FileFormats interface {
 	// Create creates a FileFormat.
 	Create(ctx context.Context, id SchemaObjectIdentifier, opts *CreateFileFormatOptions) error

--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -7,6 +7,14 @@ import (
 	"time"
 )
 
+var (
+	_ validatable = new(GrantPrivilegesToAccountRoleOptions)
+	_ validatable = new(RevokePrivilegesFromAccountRoleOptions)
+	_ validatable = new(grantPrivilegeToShareOptions)
+	_ validatable = new(revokePrivilegeFromShareOptions)
+	_ validatable = new(ShowGrantOptions)
+)
+
 type Grants interface {
 	GrantPrivilegesToAccountRole(ctx context.Context, privileges *AccountRoleGrantPrivileges, on *AccountRoleGrantOn, role AccountObjectIdentifier, opts *GrantPrivilegesToAccountRoleOptions) error
 	RevokePrivilegesFromAccountRole(ctx context.Context, privileges *AccountRoleGrantPrivileges, on *AccountRoleGrantOn, role AccountObjectIdentifier, opts *RevokePrivilegesFromAccountRoleOptions) error

--- a/pkg/sdk/helpers_proposal.go
+++ b/pkg/sdk/helpers_proposal.go
@@ -4,16 +4,15 @@ import (
 	"context"
 )
 
-// validatableOpts is just a proposal how we can remove some of the boilerplate.
-type validatableOpts interface {
-	// validateProp will be renamed if accepted.
-	// Having the name `validate` now would make all other `...Opts` structs validatableOpts because of Go nature.
-	validateProp() error
+// validatable is our sdk interface for anything that can be validated (e.g. CreateXxxOptions).
+type validatable interface {
+	// validate is a method which should contain all rules for checking validity of the implementing type.
+	validate() error
 }
 
 // validateAndExec is just a proposal how we can remove some of the boilerplate.
-func validateAndExec(client *Client, ctx context.Context, opts validatableOpts) error {
-	if err := opts.validateProp(); err != nil {
+func validateAndExec(client *Client, ctx context.Context, opts validatable) error {
+	if err := opts.validate(); err != nil {
 		return err
 	}
 	sql, err := structToSQL(opts)
@@ -25,8 +24,8 @@ func validateAndExec(client *Client, ctx context.Context, opts validatableOpts) 
 }
 
 // validateAndQuery is just a proposal how we can remove some of the boilerplate.
-func validateAndQuery[T any](client *Client, ctx context.Context, opts validatableOpts) (*[]T, error) {
-	if err := opts.validateProp(); err != nil {
+func validateAndQuery[T any](client *Client, ctx context.Context, opts validatable) (*[]T, error) {
+	if err := opts.validate(); err != nil {
 		return nil, err
 	}
 	sql, err := structToSQL(opts)
@@ -43,8 +42,8 @@ func validateAndQuery[T any](client *Client, ctx context.Context, opts validatab
 }
 
 // validateAndQueryOne is just a proposal how we can remove some of the boilerplate.
-func validateAndQueryOne[T any](client *Client, ctx context.Context, opts validatableOpts) (*T, error) {
-	if err := opts.validateProp(); err != nil {
+func validateAndQueryOne[T any](client *Client, ctx context.Context, opts validatable) (*T, error) {
+	if err := opts.validate(); err != nil {
 		return nil, err
 	}
 	sql, err := structToSQL(opts)

--- a/pkg/sdk/masking_policy.go
+++ b/pkg/sdk/masking_policy.go
@@ -13,6 +13,14 @@ import (
 // Compile-time proof of interface implementation.
 var _ MaskingPolicies = (*maskingPolicies)(nil)
 
+var (
+	_ validatable = new(CreateMaskingPolicyOptions)
+	_ validatable = new(AlterMaskingPolicyOptions)
+	_ validatable = new(DropMaskingPolicyOptions)
+	_ validatable = new(ShowMaskingPolicyOptions)
+	_ validatable = new(describeMaskingPolicyOptions)
+)
+
 // MaskingPolicies describes all the masking policy related methods that the
 // Snowflake API supports.
 type MaskingPolicies interface {

--- a/pkg/sdk/parameters.go
+++ b/pkg/sdk/parameters.go
@@ -2,6 +2,13 @@ package sdk
 
 import "fmt"
 
+var (
+	_ validatable = new(AccountParameters)
+	_ validatable = new(SessionParameters)
+	_ validatable = new(ObjectParameters)
+	_ validatable = new(UserParameters)
+)
+
 type AccountParameter string
 
 // There is a hierarchical relationship between the different parameter types. Account parameters can set any of account, user, session or object parameters

--- a/pkg/sdk/password_policy.go
+++ b/pkg/sdk/password_policy.go
@@ -10,6 +10,14 @@ import (
 // Compile-time proof of interface implementation.
 var _ PasswordPolicies = (*passwordPolicies)(nil)
 
+var (
+	_ validatable = new(CreatePasswordPolicyOptions)
+	_ validatable = new(AlterPasswordPolicyOptions)
+	_ validatable = new(DropPasswordPolicyOptions)
+	_ validatable = new(PasswordPolicyShowOptions)
+	_ validatable = new(describePasswordPolicyOptions)
+)
+
 // PasswordPolicies describes all the password policy related methods that the
 // Snowflake API supports.
 type PasswordPolicies interface {

--- a/pkg/sdk/pipes_validations.go
+++ b/pkg/sdk/pipes_validations.go
@@ -5,14 +5,14 @@ import (
 )
 
 var (
-	_ validatableOpts = &PipeCreateOptions{}
-	_ validatableOpts = &PipeAlterOptions{}
-	_ validatableOpts = &PipeDropOptions{}
-	_ validatableOpts = &PipeShowOptions{}
-	_ validatableOpts = &describePipeOptions{}
+	_ validatable = new(PipeCreateOptions)
+	_ validatable = new(PipeAlterOptions)
+	_ validatable = new(PipeDropOptions)
+	_ validatable = new(PipeShowOptions)
+	_ validatable = new(describePipeOptions)
 )
 
-func (opts *PipeCreateOptions) validateProp() error {
+func (opts *PipeCreateOptions) validate() error {
 	if opts == nil {
 		return errNilOptions
 	}
@@ -25,7 +25,7 @@ func (opts *PipeCreateOptions) validateProp() error {
 	return nil
 }
 
-func (opts *PipeAlterOptions) validateProp() error {
+func (opts *PipeAlterOptions) validate() error {
 	if opts == nil {
 		return errNilOptions
 	}
@@ -64,7 +64,7 @@ func (opts *PipeAlterOptions) validateProp() error {
 	return nil
 }
 
-func (opts *PipeDropOptions) validateProp() error {
+func (opts *PipeDropOptions) validate() error {
 	if opts == nil {
 		return errNilOptions
 	}
@@ -74,7 +74,7 @@ func (opts *PipeDropOptions) validateProp() error {
 	return nil
 }
 
-func (opts *PipeShowOptions) validateProp() error {
+func (opts *PipeShowOptions) validate() error {
 	if opts == nil {
 		return errNilOptions
 	}
@@ -87,7 +87,7 @@ func (opts *PipeShowOptions) validateProp() error {
 	return nil
 }
 
-func (opts *describePipeOptions) validateProp() error {
+func (opts *describePipeOptions) validate() error {
 	if opts == nil {
 		return errNilOptions
 	}

--- a/pkg/sdk/replication_functions.go
+++ b/pkg/sdk/replication_functions.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+var _ validatable = new(ShowRegionsOptions)
+
 type ReplicationFunctions interface {
 	ShowReplicationAcccounts(ctx context.Context) ([]*ReplicationAccount, error)
 	// todo: ShowReplicationDatabases(ctx context.Context, opts *ShowReplicationDatabasesOptions) ([]*ReplicationDatabase, error)

--- a/pkg/sdk/resource_monitors.go
+++ b/pkg/sdk/resource_monitors.go
@@ -9,6 +9,13 @@ import (
 	"strings"
 )
 
+var (
+	_ validatable = new(CreateResourceMonitorOptions)
+	_ validatable = new(AlterResourceMonitorOptions)
+	_ validatable = new(dropResourceMonitorOptions)
+	_ validatable = new(ShowResourceMonitorOptions)
+)
+
 type ResourceMonitors interface {
 	// Create creates a resource monitor.
 	Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateResourceMonitorOptions) error

--- a/pkg/sdk/schemas.go
+++ b/pkg/sdk/schemas.go
@@ -7,6 +7,15 @@ import (
 	"time"
 )
 
+var (
+	_ validatable = new(CreateSchemaOptions)
+	_ validatable = new(AlterSchemaOptions)
+	_ validatable = new(DropSchemaOptions)
+	_ validatable = new(undropSchemaOptions)
+	_ validatable = new(describeSchemaOptions)
+	_ validatable = new(ShowSchemaOptions)
+)
+
 type Schemas interface {
 	// Create creates a schema.
 	Create(ctx context.Context, id DatabaseObjectIdentifier, opts *CreateSchemaOptions) error

--- a/pkg/sdk/session_policies.go
+++ b/pkg/sdk/session_policies.go
@@ -4,6 +4,13 @@ import (
 	"context"
 )
 
+var (
+	_ validatable = new(CreateSessionPolicyOptions)
+	_ validatable = new(AlterSessionPolicyOptions)
+	_ validatable = new(DropSessionPolicyOptions)
+	_ validatable = new(sessionPolicyShowOptions)
+)
+
 type SessionPolicies interface {
 	// Create creates a session policy.
 	Create(ctx context.Context, id SchemaObjectIdentifier, opts *CreateSessionPolicyOptions) error
@@ -85,6 +92,10 @@ func (v *sessionPolicies) Create(ctx context.Context, id SchemaObjectIdentifier,
 
 // AlterSessionPolicyOptions contains options for altering a session policy.
 type AlterSessionPolicyOptions struct{}
+
+func (opts *AlterSessionPolicyOptions) validate() error {
+	return nil
+}
 
 func (v *sessionPolicies) Alter(ctx context.Context, id SchemaObjectIdentifier, opts *AlterSessionPolicyOptions) error {
 	return nil

--- a/pkg/sdk/sessions.go
+++ b/pkg/sdk/sessions.go
@@ -6,6 +6,11 @@ import (
 	"fmt"
 )
 
+var (
+	_ validatable = new(AlterSessionOptions)
+	_ validatable = new(ShowParametersOptions)
+)
+
 type Sessions interface {
 	// Parameters
 	AlterSession(ctx context.Context, opts *AlterSessionOptions) error

--- a/pkg/sdk/shares.go
+++ b/pkg/sdk/shares.go
@@ -7,6 +7,14 @@ import (
 	"time"
 )
 
+var (
+	_ validatable = new(CreateShareOptions)
+	_ validatable = new(AlterShareOptions)
+	_ validatable = new(shareDropOptions)
+	_ validatable = new(ShowShareOptions)
+	_ validatable = new(shareDescribeOptions)
+)
+
 type Shares interface {
 	// Create creates a share.
 	Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateShareOptions) error
@@ -136,9 +144,16 @@ type shareDropOptions struct {
 	name  AccountObjectIdentifier `ddl:"identifier"`
 }
 
+func (opts *shareDropOptions) validate() error {
+	return nil
+}
+
 func (v *shares) Drop(ctx context.Context, id AccountObjectIdentifier) error {
 	opts := &shareDropOptions{
 		name: id,
+	}
+	if err := opts.validate(); err != nil {
+		return err
 	}
 	sql, err := structToSQL(opts)
 	if err != nil {

--- a/pkg/sdk/users.go
+++ b/pkg/sdk/users.go
@@ -8,6 +8,14 @@ import (
 	"time"
 )
 
+var (
+	_ validatable = new(CreateUserOptions)
+	_ validatable = new(AlterUserOptions)
+	_ validatable = new(DropUserOptions)
+	_ validatable = new(describeUserOptions)
+	_ validatable = new(ShowUserOptions)
+)
+
 type Users interface {
 	// Create creates a user.
 	Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateUserOptions) error

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -9,6 +9,14 @@ import (
 	"time"
 )
 
+var (
+	_ validatable = new(CreateWarehouseOptions)
+	_ validatable = new(AlterWarehouseOptions)
+	_ validatable = new(DropWarehouseOptions)
+	_ validatable = new(ShowWarehouseOptions)
+	_ validatable = new(warehouseDescribeOptions)
+)
+
 type Warehouses interface {
 	// Create creates a warehouse.
 	Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateWarehouseOptions) error


### PR DESCRIPTION
## Description
Reuse `validatableOpts` interface:
- rename it to `validatable`
- rename method to `validate()`
- add implementation guards for all `XxxOptions` structs

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests (should not break)