### PR TITLE
fix: Fix make sweep

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,19 +60,6 @@ jobs:
           SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
         run: make lint-ci
 
-      - name: make test-acceptance integration
-        if: always()
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
-          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
-          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
-          SNOWFLAKE_ROLE: ${{ secrets.SNOWFLAKE_ROLE }}
-          SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
-          SNOWFLAKE_ACCOUNT_SECOND: ${{ secrets.SNOWFLAKE_ACCOUNT_SECOND }}
-          SNOWFLAKE_ACCOUNT_THIRD: ${{ secrets.SNOWFLAKE_ACCOUNT_THIRD }}
-        run: make test-acceptance
-
       - name: sweepers cleanup
         if: always()
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,6 +60,19 @@ jobs:
           SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
         run: make lint-ci
 
+      - name: make test-acceptance integration
+        if: always()
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_ROLE: ${{ secrets.SNOWFLAKE_ROLE }}
+          SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
+          SNOWFLAKE_ACCOUNT_SECOND: ${{ secrets.SNOWFLAKE_ACCOUNT_SECOND }}
+          SNOWFLAKE_ACCOUNT_THIRD: ${{ secrets.SNOWFLAKE_ACCOUNT_THIRD }}
+        run: make test-acceptance
+
       - name: sweepers cleanup
         if: always()
         env:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ sweep: ## destroy the whole architecture; USE ONLY FOR DEVELOPMENT ACCOUNTS
 	@echo "Are you sure? [y/n]" >&2
 	@read -r REPLY; \
 		if echo "$$REPLY" | grep -qG "^[yY]$$"; then \
-			echo "answered: $$REPLY"; \
+			SNOWFLAKE_ENABLE_SWEEP=1 go test -timeout 300s -run ^TestSweepAll ./pkg/sdk -v; \
 			else echo "Aborting..."; \
 		fi;
 .PHONY: sweep

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,9 @@ sweep: ## destroy the whole architecture; USE ONLY FOR DEVELOPMENT ACCOUNTS
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
 	@echo "Are you sure? [y/n]" >&2
 	@read -r REPLY; \
-		if [[ $$REPLY =~ ^[yY]$$ ]]; then \
-		  echo "answered: $$REPLY"; \
-		  else echo "Aborting..."; \
+		if echo "$$REPLY" | grep -qG "^[yY]$$"; then \
+			echo "answered: $$REPLY"; \
+			else echo "Aborting..."; \
 		fi;
 .PHONY: sweep
 

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,10 @@ dev-cleanup: ## cleanup development dependencies
 
 sweep: ## destroy the whole architecture; USE ONLY FOR DEVELOPMENT ACCOUNTS
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
-	@read -p "Are you sure? [y/n]" -n 1 REPLY; echo; \
+	@echo "Are you sure? [y/n]" >&2
+	@read -r REPLY; \
 		if [[ $$REPLY =~ ^[yY]$$ ]]; then \
-		  SNOWFLAKE_ENABLE_SWEEP=1 go test -timeout 300s -run ^TestSweepAll ./pkg/sdk -v; \
+		  echo "answered: $$REPLY"; \
 		  else echo "Aborting..."; \
 		fi;
 .PHONY: sweep


### PR DESCRIPTION
## Changes
#### TL;DR
Fix make sweep.

#### Longer story
Syntax used for make sweep was made for bash shell which we are NOT running on CI. It resulted in errors when running sweepers:
```
/bin/sh: 1: read: Illegal option -n
/bin/sh: 2: [[: not found
```
There were few fix options to consider here:
- changing shell on CI
- changing shell inside Makefile
- rewriting it to support all shells

Last one was chosen because was the easiest one to apply without affecting other jobs and Makefile recipes.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests (nothing should break)
* [ ] check logs of `sweepers cleanup` job