### PR TITLE
chore: Extract reviewdog job from integration workflow

### DIFF
--- a/.github/workflows/go-fmt.yml
+++ b/.github/workflows/go-fmt.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Install golangci-lint
         run: make dev-setup
 
-      - name: Run golangci-lint
-        run: make lint-check
-
       - name: make lint-ci integration
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make lint-ci
+
+      - name: Run golangci-lint
+        run: make lint-check

--- a/.github/workflows/go-fmt.yml
+++ b/.github/workflows/go-fmt.yml
@@ -36,3 +36,8 @@ jobs:
 
       - name: Run golangci-lint
         run: make lint-check
+
+      - name: make lint-ci integration
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make lint-ci

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,20 +50,9 @@ jobs:
       - name: Install dependencies
         run: make dev-setup
 
-      - name: make lint-ci integration
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
-          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
-          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
-          SNOWFLAKE_ROLE: ${{ secrets.SNOWFLAKE_ROLE }}
-          SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
-        run: make lint-ci
-
       - name: make test-acceptance integration
         if: always()
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
           SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
@@ -76,7 +65,6 @@ jobs:
       - name: sweepers cleanup
         if: always()
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
           SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}

--- a/pkg/sdk/database_role_integration_test.go
+++ b/pkg/sdk/database_role_integration_test.go
@@ -2,10 +2,9 @@ package sdk
 
 import (
 	"context"
-	"testing"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestInt_DatabaseRoles(t *testing.T) {

--- a/pkg/sdk/database_role_integration_test.go
+++ b/pkg/sdk/database_role_integration_test.go
@@ -2,9 +2,10 @@ package sdk
 
 import (
 	"context"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestInt_DatabaseRoles(t *testing.T) {


### PR DESCRIPTION
## Changes
* Remove unneccesary environment variable.
* Extract `make lint-ci` from integration workflow.

Step `make lint-ci integration` was wasting over 2 minutes of time of the integration workflow, delaying acceptance tests start (which is the longest part of our build). This should make our builds 2-3 minutes faster.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests (nothing should break)
* [x] check that reviewdog works after extraction (file was formatted badly to receive comment: [this one](https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/2027#discussion_r1301227927))