### PR TITLE
fix: removes default value for data_retention_time_in_days parameter

### DIFF
--- a/docs/resources/function.md
+++ b/docs/resources/function.md
@@ -26,14 +26,14 @@ provider "snowflake" {
 // Create database
 resource "snowflake_database" "db" {
   name                = "MY_DB"
-  data_retention_days = 1
+  data_retention_time_in_days = 1
 }
 
 // Create schema
 resource "snowflake_schema" "schema" {
   database            = snowflake_database.db.name
   name                = "MY_SCHEMA"
-  data_retention_days = 1
+  data_retention_time_in_days = 1
 }
 
 // Example for Java language

--- a/docs/resources/procedure.md
+++ b/docs/resources/procedure.md
@@ -15,13 +15,13 @@ description: |-
 ```terraform
 resource "snowflake_database" "db" {
   name                = "MYDB"
-  data_retention_days = 1
+  data_retention_time_in_days = 1
 }
 
 resource "snowflake_schema" "schema" {
   database            = snowflake_database.db.name
   name                = "MYSCHEMA"
-  data_retention_days = 1
+  data_retention_time_in_days = 1
 }
 
 resource "snowflake_procedure" "proc" {

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -20,7 +20,7 @@ resource "snowflake_schema" "schema" {
 
   is_transient        = false
   is_managed          = false
-  data_retention_days = 1
+  data_retention_time_in_days = 1
 }
 ```
 
@@ -35,7 +35,7 @@ resource "snowflake_schema" "schema" {
 ### Optional
 
 - `comment` (String) Specifies a comment for the schema.
-- `data_retention_days` (Number) Specifies the number of days for which Time Travel actions (CLONE and UNDROP) can be performed on the schema, as well as specifying the default Time Travel retention time for all tables created in the schema.
+- `data_retention_time_in_days` (Number) Specifies the number of days for which Time Travel actions (CLONE and UNDROP) can be performed on the schema, as well as specifying the default Time Travel retention time for all tables created in the schema.
 - `is_managed` (Boolean) Specifies a managed schema. Managed access schemas centralize privilege management with the schema owner.
 - `is_transient` (Boolean) Specifies a schema as transient. Transient schemas do not have a Fail-safe period so they do not incur additional storage costs once they leave Time Travel; however, this means they are also not protected by Fail-safe in the event of a data loss.
 - `tag` (Block List, Deprecated) Definitions of a tag to associate with the resource. (see [below for nested schema](#nestedblock--tag))

--- a/docs/resources/table.md
+++ b/docs/resources/table.md
@@ -16,7 +16,7 @@ description: |-
 resource "snowflake_schema" "schema" {
   database            = "database"
   name                = "schema"
-  data_retention_days = 1
+  data_retention_time_in_days = 1
 }
 
 resource "snowflake_sequence" "sequence" {
@@ -31,7 +31,7 @@ resource "snowflake_table" "table" {
   name                = "table"
   comment             = "A table."
   cluster_by          = ["to_date(DATE)"]
-  data_retention_days = snowflake_schema.schema.data_retention_days
+  data_retention_time_in_days = snowflake_schema.schema.data_retention_time_in_days
   change_tracking     = false
 
   column {
@@ -94,7 +94,7 @@ resource "snowflake_table" "table" {
 - `change_tracking` (Boolean) Specifies whether to enable change tracking on the table. Default false.
 - `cluster_by` (List of String) A list of one or more table columns/expressions to be used as clustering key(s) for the table
 - `comment` (String) Specifies a comment for the table.
-- `data_retention_days` (Number, Deprecated) Specifies the retention period for the table so that Time Travel actions (SELECT, CLONE, UNDROP) can be performed on historical data in the table. Default value is 1, if you wish to inherit the parent schema setting then pass in the schema attribute to this argument.
+- `data_retention_time_in_days` (Number, Deprecated) Specifies the retention period for the table so that Time Travel actions (SELECT, CLONE, UNDROP) can be performed on historical data in the table. Default value is 1, if you wish to inherit the parent schema setting then pass in the schema attribute to this argument.
 - `primary_key` (Block List, Max: 1, Deprecated) Definitions of primary key constraint to create on table (see [below for nested schema](#nestedblock--primary_key))
 - `tag` (Block List, Deprecated) Definitions of a tag to associate with the resource. (see [below for nested schema](#nestedblock--tag))
 

--- a/docs/resources/table.md
+++ b/docs/resources/table.md
@@ -94,7 +94,7 @@ resource "snowflake_table" "table" {
 - `change_tracking` (Boolean) Specifies whether to enable change tracking on the table. Default false.
 - `cluster_by` (List of String) A list of one or more table columns/expressions to be used as clustering key(s) for the table
 - `comment` (String) Specifies a comment for the table.
-- `data_retention_time_in_days` (Number, Deprecated) Specifies the retention period for the table so that Time Travel actions (SELECT, CLONE, UNDROP) can be performed on historical data in the table. Default value is 1, if you wish to inherit the parent schema setting then pass in the schema attribute to this argument.
+- `data_retention_time_in_days` (Number) Specifies the retention period for the table so that Time Travel actions (SELECT, CLONE, UNDROP) can be performed on historical data in the table. Default value is 1, if you wish to inherit the parent schema setting then pass in the schema attribute to this argument.
 - `primary_key` (Block List, Max: 1, Deprecated) Definitions of primary key constraint to create on table (see [below for nested schema](#nestedblock--primary_key))
 - `tag` (Block List, Deprecated) Definitions of a tag to associate with the resource. (see [below for nested schema](#nestedblock--tag))
 

--- a/docs/resources/tag_masking_policy_association.md
+++ b/docs/resources/tag_masking_policy_association.md
@@ -29,13 +29,13 @@ resource "snowflake_database" "test2" {
 resource "snowflake_schema" "test2" {
   database            = snowflake_database.test2.name
   name                = "FOOBAR2"
-  data_retention_days = snowflake_database.test2.data_retention_time_in_days
+  data_retention_time_in_days = snowflake_database.test2.data_retention_time_in_days
 }
 
 resource "snowflake_schema" "test" {
   database            = snowflake_database.test.name
   name                = "FOOBAR"
-  data_retention_days = snowflake_database.test.data_retention_time_in_days
+  data_retention_time_in_days = snowflake_database.test.data_retention_time_in_days
 }
 
 resource "snowflake_tag" "this" {

--- a/examples/resources/snowflake_function/resource.tf
+++ b/examples/resources/snowflake_function/resource.tf
@@ -11,14 +11,14 @@ provider "snowflake" {
 // Create database
 resource "snowflake_database" "db" {
   name                = "MY_DB"
-  data_retention_days = 1
+  data_retention_time_in_days = 1
 }
 
 // Create schema
 resource "snowflake_schema" "schema" {
   database            = snowflake_database.db.name
   name                = "MY_SCHEMA"
-  data_retention_days = 1
+  data_retention_time_in_days = 1
 }
 
 // Example for Java language

--- a/examples/resources/snowflake_procedure/resource.tf
+++ b/examples/resources/snowflake_procedure/resource.tf
@@ -1,12 +1,12 @@
 resource "snowflake_database" "db" {
   name                = "MYDB"
-  data_retention_days = 1
+  data_retention_time_in_days = 1
 }
 
 resource "snowflake_schema" "schema" {
   database            = snowflake_database.db.name
   name                = "MYSCHEMA"
-  data_retention_days = 1
+  data_retention_time_in_days = 1
 }
 
 resource "snowflake_procedure" "proc" {

--- a/examples/resources/snowflake_schema/resource.tf
+++ b/examples/resources/snowflake_schema/resource.tf
@@ -5,5 +5,5 @@ resource "snowflake_schema" "schema" {
 
   is_transient        = false
   is_managed          = false
-  data_retention_days = 1
+  data_retention_time_in_days = 1
 }

--- a/examples/resources/snowflake_table/resource.tf
+++ b/examples/resources/snowflake_table/resource.tf
@@ -1,7 +1,7 @@
 resource "snowflake_schema" "schema" {
   database            = "database"
   name                = "schema"
-  data_retention_days = 1
+  data_retention_time_in_days = 1
 }
 
 resource "snowflake_sequence" "sequence" {
@@ -16,7 +16,7 @@ resource "snowflake_table" "table" {
   name                = "table"
   comment             = "A table."
   cluster_by          = ["to_date(DATE)"]
-  data_retention_days = snowflake_schema.schema.data_retention_days
+  data_retention_time_in_days = snowflake_schema.schema.data_retention_time_in_days
   change_tracking     = false
 
   column {

--- a/examples/resources/snowflake_tag_masking_policy_association/resource.tf
+++ b/examples/resources/snowflake_tag_masking_policy_association/resource.tf
@@ -14,13 +14,13 @@ resource "snowflake_database" "test2" {
 resource "snowflake_schema" "test2" {
   database            = snowflake_database.test2.name
   name                = "FOOBAR2"
-  data_retention_days = snowflake_database.test2.data_retention_time_in_days
+  data_retention_time_in_days = snowflake_database.test2.data_retention_time_in_days
 }
 
 resource "snowflake_schema" "test" {
   database            = snowflake_database.test.name
   name                = "FOOBAR"
-  data_retention_days = snowflake_database.test.data_retention_time_in_days
+  data_retention_time_in_days = snowflake_database.test.data_retention_time_in_days
 }
 
 resource "snowflake_tag" "this" {

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -52,7 +52,7 @@ var schemaSchema = map[string]*schema.Schema{
 		Default:     false,
 		Description: "Specifies a managed schema. Managed access schemas centralize privilege management with the schema owner.",
 	},
-	"data_retention_days": {
+	"data_retention_time_in_days": {
 		Type:         schema.TypeInt,
 		Optional:     true,
 		Default:      1,
@@ -141,7 +141,7 @@ func CreateSchema(d *schema.ResourceData, meta interface{}) error {
 		builder.Managed()
 	}
 
-	if v, ok := d.GetOk("data_retention_days"); ok {
+	if v, ok := d.GetOk("data_retention_time_in_days"); ok {
 		builder.WithDataRetentionDays(v.(int))
 	}
 
@@ -225,7 +225,7 @@ func ReadSchema(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		if err := d.Set("data_retention_days", i); err != nil {
+		if err := d.Set("data_retention_time_in_days", i); err != nil {
 			return err
 		}
 	}
@@ -310,8 +310,8 @@ func UpdateSchema(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if d.HasChange("data_retention_days") {
-		days := d.Get("data_retention_days")
+	if d.HasChange("data_retention_time_in_days") {
+		days := d.Get("data_retention_time_in_days")
 
 		q := builder.ChangeDataRetentionDays(days.(int))
 		if err := snowflake.Exec(db, q); err != nil {

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -177,13 +177,11 @@ var tableSchema = map[string]*schema.Schema{
 			},
 		},
 	},
-	"data_retention_days": {
+	"data_retention_time_in_days": {
 		Type:         schema.TypeInt,
 		Optional:     true,
-		Default:      1,
 		Description:  "Specifies the retention period for the table so that Time Travel actions (SELECT, CLONE, UNDROP) can be performed on historical data in the table. Default value is 1, if you wish to inherit the parent schema setting then pass in the schema attribute to this argument.",
 		ValidateFunc: validation.IntBetween(0, 90),
-		Deprecated:   "Use snowflake_object_parameter instead",
 	},
 	"change_tracking": {
 		Type:        schema.TypeBool,
@@ -508,7 +506,7 @@ func CreateTable(d *schema.ResourceData, meta interface{}) error {
 		builder.WithPrimaryKey(pk.toSnowflakePrimaryKey())
 	}
 
-	if v, ok := d.GetOk("data_retention_days"); ok {
+	if v, ok := d.GetOk("data_retention_time_in_days"); ok {
 		builder.WithDataRetentionTimeInDays(v.(int))
 	}
 
@@ -594,9 +592,9 @@ func ReadTable(d *schema.ResourceData, meta interface{}) error {
 		"column":     snowflake.NewColumns(tableDescription).Flatten(),
 		"cluster_by": snowflake.ClusterStatementToList(table.ClusterBy.String),
 		// "primary_key":         snowflake.FlattenTablePrimaryKey(pkDescription),
-		"data_retention_days": table.RetentionTime.Int32,
-		"change_tracking":     (table.ChangeTracking.String == "ON"),
-		"qualified_name":      fmt.Sprintf(`"%s"."%s"."%s"`, tableID.DatabaseName, tableID.SchemaName, table.TableName.String),
+		"data_retention_time_in_days": table.RetentionTime.Int32,
+		"change_tracking":             (table.ChangeTracking.String == "ON"),
+		"qualified_name":              fmt.Sprintf(`"%s"."%s"."%s"`, tableID.DatabaseName, tableID.SchemaName, table.TableName.String),
 	}
 
 	for key, val := range toSet {
@@ -743,8 +741,8 @@ func UpdateTable(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 	}
-	if d.HasChange("data_retention_days") {
-		ndr := d.Get("data_retention_days")
+	if d.HasChange("data_retention_time_in_days") {
+		ndr := d.Get("data_retention_time_in_days")
 
 		q := builder.ChangeDataRetention(ndr.(int))
 		if err := snowflake.Exec(db, q); err != nil {

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -180,7 +180,7 @@ var tableSchema = map[string]*schema.Schema{
 	"data_retention_time_in_days": {
 		Type:         schema.TypeInt,
 		Optional:     true,
-		Description:  "Specifies the retention period for the table so that Time Travel actions (SELECT, CLONE, UNDROP) can be performed on historical data in the table. Default value is 1, if you wish to inherit the parent schema setting then pass in the schema attribute to this argument.",
+		Description:  "Previously: data_retention_days. Specifies the retention period for the table so that Time Travel actions (SELECT, CLONE, UNDROP) can be performed on historical data in the table. Default value is 1, if you wish to inherit the parent schema setting then pass in the schema attribute to this argument.",
 		ValidateFunc: validation.IntBetween(0, 90),
 	},
 	"change_tracking": {

--- a/pkg/resources/table_acceptance_test.go
+++ b/pkg/resources/table_acceptance_test.go
@@ -25,7 +25,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.#", "2"),
@@ -42,7 +42,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.#", "2"),
@@ -61,7 +61,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "name", table2Name),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table2", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table2", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "column.#", "2"),
@@ -78,7 +78,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "name", table2Name),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table2", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table2", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "column.#", "2"),
@@ -94,7 +94,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "name", table2Name),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table2", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table2", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "column.#", "2"),
@@ -110,7 +110,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.#", "2"),
@@ -129,7 +129,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.#", "2"),
@@ -149,7 +149,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.#", "2"),
@@ -170,7 +170,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "name", table2Name),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table2", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table2", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "column.#", "2"),
@@ -191,7 +191,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "name", table2Name),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table2", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table2", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "column.#", "2"),
@@ -212,7 +212,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "name", table2Name),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table2", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table2", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table2", "column.#", "3"),
@@ -237,7 +237,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "name", table3Name),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table3", "data_retention_days", "10"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table3", "data_retention_time_in_days", "10"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "column.#", "2"),
@@ -254,7 +254,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "name", table3Name),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table3", "data_retention_days", "0"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table3", "data_retention_time_in_days", "0"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "column.#", "2"),
@@ -271,7 +271,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "name", table3Name),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table3", "data_retention_days", "0"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table3", "data_retention_time_in_days", "0"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "change_tracking", "true"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table3", "column.#", "2"),
@@ -288,7 +288,7 @@ func TestAcc_Table(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "change_tracking", "true"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.#", "2"),
@@ -688,7 +688,7 @@ resource "snowflake_table" "test_table3" {
 	schema              = snowflake_schema.test_schema.name
 	name                = "%s"
 	comment             = "Terraform acceptance test"
-	data_retention_days = 10
+	data_retention_time_in_days = 10
 	column {
 		name = "column1"
 		type = "VARIANT"
@@ -720,7 +720,7 @@ resource "snowflake_table" "test_table3" {
 	schema              = snowflake_schema.test_schema.name
 	name                = "%s"
 	comment             = "Terraform acceptance test"
-	data_retention_days = 0
+	data_retention_time_in_days = 0
 	column {
 		name = "column1"
 		type = "VARIANT"
@@ -752,7 +752,7 @@ resource "snowflake_table" "test_table3" {
 	schema              = snowflake_schema.test_schema.name
 	name                = "%s"
 	comment             = "Terraform acceptance test"
-	data_retention_days = 0
+	data_retention_time_in_days = 0
 	change_tracking     = true
 	column {
 		name = "column1"
@@ -812,7 +812,7 @@ func TestAcc_TableDefaults(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.#", "3"),
@@ -840,7 +840,7 @@ func TestAcc_TableDefaults(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.#", "3"),
@@ -1057,7 +1057,7 @@ func TestAcc_TableIdentity(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.#", "3"),
@@ -1084,7 +1084,7 @@ func TestAcc_TableIdentity(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "comment", "Terraform acceptance test"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.#", "3"),
@@ -1215,7 +1215,7 @@ func TestAcc_TableRename(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "name", oldTableName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.0.name", "column1"),
@@ -1229,7 +1229,7 @@ func TestAcc_TableRename(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "name", newTableName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "database", accName),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "schema", accName),
-					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_days", "1"),
+					resource.TestCheckResourceAttr("snowflake_table.test_table", "data_retention_time_in_days", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "change_tracking", "false"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_table.test_table", "column.0.name", "column1"),


### PR DESCRIPTION
- removes default value for data_retention_time_in_days
Having a default value caused problems when value for `data_retention_time_in_days` was set with a separate resource.
Terraform would read the current value set by the dedicated parameter resource, compare it to the default value for the table resource and plan to update it since the two values don't match. This gave the illusion that creating another table somehow interferes with the first one, where in fact any `terraform update` would give a similar result
- (BREAKING) renames `data_retention_days` -> `data_retention_time_in_days` for consistency
- marks `data_retention_time_in_days` as not deprecated

fixes #1938 
