### PR TITLE
fix: remove grantee error

### DIFF
--- a/pkg/resources/grant_helpers.go
+++ b/pkg/resources/grant_helpers.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"database/sql"
-	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -188,8 +187,6 @@ func readGenericGrant(
 			privileges.addString(grant.Privilege)
 			// Reassign set back
 			sharePrivileges[granteeNameStrippedAccount] = privileges
-		default:
-			return fmt.Errorf("unknown grantee type %s", grant.GranteeType)
 		}
 	}
 


### PR DESCRIPTION
Fixes:
https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/1962

Previously would get this error message:

```
│ Error: unknown grantee type APPLICATION
│
│   with snowflake_account_grant.create_user,
│   on main.tf line 18, in resource "snowflake_account_grant" "create_user":
│   18: resource "snowflake_account_grant" "create_user" {
│
```

Simply ignoring application grantee types fixes the problem.