### PR TITLE
fix: database grant read

### DIFF
--- a/pkg/resources/grant_helpers.go
+++ b/pkg/resources/grant_helpers.go
@@ -187,6 +187,8 @@ func readGenericGrant(
 			privileges.addString(grant.Privilege)
 			// Reassign set back
 			sharePrivileges[granteeNameStrippedAccount] = privileges
+		default:
+			log.Printf("[WARN] unexpected grantee type: %s", grant.GranteeType)
 		}
 	}
 


### PR DESCRIPTION
fixes #1863 
grantee type "database_role" was not recognized in the switch/case statement. adding a default fixes that.

before:
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: error reading database grant: unknown grantee type DATABASE_ROLE
│
│   with snowflake_database_grant.grant,
│   on main.tf line 38, in resource "snowflake_database_grant" "grant":
│   38: resource "snowflake_database_grant" "grant" {
│
╵
```

after:
```
No changes. Your infrastructure matches the configuration.
```