### PR TITLE
chore: Make options naming consistent

### DIFF
--- a/pkg/datasources/pipes.go
+++ b/pkg/datasources/pipes.go
@@ -69,7 +69,7 @@ func ReadPipes(d *schema.ResourceData, meta interface{}) error {
 	databaseName := d.Get("database").(string)
 	schemaName := d.Get("schema").(string)
 
-	extractedPipes, err := client.Pipes.Show(ctx, &sdk.PipeShowOptions{
+	extractedPipes, err := client.Pipes.Show(ctx, &sdk.ShowPipeOptions{
 		In: &sdk.In{
 			Schema: sdk.NewDatabaseObjectIdentifier(databaseName, schemaName),
 		},

--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -117,7 +117,7 @@ func CreatePipe(d *schema.ResourceData, meta interface{}) error {
 	ctx := context.Background()
 	objectIdentifier := sdk.NewSchemaObjectIdentifier(databaseName, schemaName, name)
 
-	opts := &sdk.PipeCreateOptions{}
+	opts := &sdk.CreatePipeOptions{}
 
 	copyStatement := d.Get("copy_statement").(string)
 
@@ -244,7 +244,7 @@ func UpdatePipe(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if runSetStatement {
-		options := &sdk.PipeAlterOptions{Set: pipeSet}
+		options := &sdk.AlterPipeOptions{Set: pipeSet}
 		err := client.Pipes.Alter(ctx, objectIdentifier, options)
 		if err != nil {
 			return fmt.Errorf("error updating pipe %v: %w", objectIdentifier.Name(), err)
@@ -252,7 +252,7 @@ func UpdatePipe(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if runUnsetStatement {
-		options := &sdk.PipeAlterOptions{Unset: pipeUnset}
+		options := &sdk.AlterPipeOptions{Unset: pipeUnset}
 		err := client.Pipes.Alter(ctx, objectIdentifier, options)
 		if err != nil {
 			return fmt.Errorf("error updating pipe %v: %w", objectIdentifier.Name(), err)

--- a/pkg/sdk/database_role_test.go
+++ b/pkg/sdk/database_role_test.go
@@ -195,7 +195,7 @@ func TestDatabaseRolesShow(t *testing.T) {
 	}
 
 	t.Run("validation: nil options", func(t *testing.T) {
-		var opts *PipeShowOptions = nil
+		var opts *ShowPipeOptions = nil
 		assertOptsInvalidJoinedErrors(t, opts, errNilOptions)
 	})
 

--- a/pkg/sdk/external_tables.go
+++ b/pkg/sdk/external_tables.go
@@ -368,8 +368,8 @@ func (e externalTableRow) convert() *ExternalTable {
 	return et
 }
 
-// describeExternalTableColumns based on https://docs.snowflake.com/en/sql-reference/sql/desc-external-table
-type describeExternalTableColumns struct {
+// describeExternalTableColumnsOptions based on https://docs.snowflake.com/en/sql-reference/sql/desc-external-table
+type describeExternalTableColumnsOptions struct {
 	describeExternalTable bool                    `ddl:"static" sql:"DESCRIBE EXTERNAL TABLE"`
 	name                  AccountObjectIdentifier `ddl:"identifier"`
 	columnsType           bool                    `ddl:"static" sql:"TYPE = COLUMNS"`
@@ -431,7 +431,7 @@ func (r externalTableColumnDetailsRow) convert() *ExternalTableColumnDetails {
 	return details
 }
 
-type describeExternalTableStage struct {
+type describeExternalTableStageOptions struct {
 	describeExternalTable bool                    `ddl:"static" sql:"DESCRIBE EXTERNAL TABLE"`
 	name                  AccountObjectIdentifier `ddl:"identifier"`
 	stageType             bool                    `ddl:"static" sql:"TYPE = STAGE"`

--- a/pkg/sdk/external_tables_dto.go
+++ b/pkg/sdk/external_tables_dto.go
@@ -2,6 +2,19 @@ package sdk
 
 //go:generate go run ./dto-builder-generator/main.go
 
+var (
+	_ optionsProvider[CreateExternalTableOptions]                       = new(CreateExternalTableRequest)
+	_ optionsProvider[CreateWithManualPartitioningExternalTableOptions] = new(CreateWithManualPartitioningExternalTableRequest)
+	_ optionsProvider[CreateDeltaLakeExternalTableOptions]              = new(CreateDeltaLakeExternalTableRequest)
+	_ optionsProvider[CreateExternalTableUsingTemplateOptions]          = new(CreateExternalTableUsingTemplateRequest)
+	_ optionsProvider[AlterExternalTableOptions]                        = new(AlterExternalTableRequest)
+	_ optionsProvider[AlterExternalTablePartitionOptions]               = new(AlterExternalTablePartitionRequest)
+	_ optionsProvider[DropExternalTableOptions]                         = new(DropExternalTableRequest)
+	_ optionsProvider[ShowExternalTableOptions]                         = new(ShowExternalTableRequest)
+	_ optionsProvider[describeExternalTableColumnsOptions]              = new(DescribeExternalTableColumnsRequest)
+	_ optionsProvider[describeExternalTableStageOptions]                = new(DescribeExternalTableStageRequest)
+)
+
 type CreateExternalTableRequest struct {
 	orReplace           *bool
 	ifNotExists         *bool
@@ -677,4 +690,16 @@ type DescribeExternalTableColumnsRequest struct {
 
 type DescribeExternalTableStageRequest struct {
 	id AccountObjectIdentifier // required
+}
+
+func (v *DescribeExternalTableColumnsRequest) toOpts() *describeExternalTableColumnsOptions {
+	return &describeExternalTableColumnsOptions{
+		name: v.id,
+	}
+}
+
+func (v *DescribeExternalTableStageRequest) toOpts() *describeExternalTableStageOptions {
+	return &describeExternalTableStageOptions{
+		name: v.id,
+	}
 }

--- a/pkg/sdk/external_tables_impl.go
+++ b/pkg/sdk/external_tables_impl.go
@@ -59,9 +59,7 @@ func (v *externalTables) ShowByID(ctx context.Context, req *ShowExternalTableByI
 }
 
 func (v *externalTables) DescribeColumns(ctx context.Context, req *DescribeExternalTableColumnsRequest) ([]ExternalTableColumnDetails, error) {
-	rows, err := validateAndQuery[externalTableColumnDetailsRow](v.client, ctx, &describeExternalTableColumns{
-		name: req.id,
-	})
+	rows, err := validateAndQuery[externalTableColumnDetailsRow](v.client, ctx, req.toOpts())
 	if err != nil {
 		return nil, err
 	}
@@ -69,9 +67,7 @@ func (v *externalTables) DescribeColumns(ctx context.Context, req *DescribeExter
 }
 
 func (v *externalTables) DescribeStage(ctx context.Context, req *DescribeExternalTableStageRequest) ([]ExternalTableStageDetails, error) {
-	rows, err := validateAndQuery[externalTableStageDetailsRow](v.client, ctx, &describeExternalTableStage{
-		name: req.id,
-	})
+	rows, err := validateAndQuery[externalTableStageDetailsRow](v.client, ctx, req.toOpts())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sdk/external_tables_test.go
+++ b/pkg/sdk/external_tables_test.go
@@ -503,14 +503,14 @@ func TestExternalTablesShow(t *testing.T) {
 
 func TestExternalTablesDescribe(t *testing.T) {
 	t.Run("type columns", func(t *testing.T) {
-		opts := &describeExternalTableColumns{
+		opts := &describeExternalTableColumnsOptions{
 			name: NewAccountObjectIdentifier("external_table"),
 		}
 		assertOptsValidAndSQLEquals(t, opts, `DESCRIBE EXTERNAL TABLE "external_table" TYPE = COLUMNS`)
 	})
 
 	t.Run("type stage", func(t *testing.T) {
-		opts := &describeExternalTableStage{
+		opts := &describeExternalTableStageOptions{
 			name: NewAccountObjectIdentifier("external_table"),
 		}
 		assertOptsValidAndSQLEquals(t, opts, `DESCRIBE EXTERNAL TABLE "external_table" TYPE = STAGE`)

--- a/pkg/sdk/external_tables_validations.go
+++ b/pkg/sdk/external_tables_validations.go
@@ -14,8 +14,8 @@ var (
 	_ validatable = (*AlterExternalTablePartitionOptions)(nil)
 	_ validatable = (*DropExternalTableOptions)(nil)
 	_ validatable = (*ShowExternalTableOptions)(nil)
-	_ validatable = (*describeExternalTableColumns)(nil)
-	_ validatable = (*describeExternalTableStage)(nil)
+	_ validatable = (*describeExternalTableColumnsOptions)(nil)
+	_ validatable = (*describeExternalTableStageOptions)(nil)
 )
 
 func (opts *CreateExternalTableOptions) validate() error {
@@ -162,14 +162,14 @@ func (opts *ShowExternalTableOptions) validate() error {
 	return nil
 }
 
-func (v *describeExternalTableColumns) validate() error {
+func (v *describeExternalTableColumnsOptions) validate() error {
 	if !validObjectidentifier(v.name) {
 		return errInvalidObjectIdentifier
 	}
 	return nil
 }
 
-func (v *describeExternalTableStage) validate() error {
+func (v *describeExternalTableStageOptions) validate() error {
 	if !validObjectidentifier(v.name) {
 		return errInvalidObjectIdentifier
 	}

--- a/pkg/sdk/helper_test.go
+++ b/pkg/sdk/helper_test.go
@@ -388,10 +388,10 @@ func createTable(t *testing.T, client *Client, database *Database, schema *Schem
 
 func createTag(t *testing.T, client *Client, database *Database, schema *Schema) (*Tag, func()) {
 	t.Helper()
-	return createTagWithOptions(t, client, database, schema, &TagCreateOptions{})
+	return createTagWithOptions(t, client, database, schema, &CreateTagOptions{})
 }
 
-func createTagWithOptions(t *testing.T, client *Client, database *Database, schema *Schema, _ *TagCreateOptions) (*Tag, func()) {
+func createTagWithOptions(t *testing.T, client *Client, database *Database, schema *Schema, _ *CreateTagOptions) (*Tag, func()) {
 	t.Helper()
 	name := randomStringRange(t, 8, 28)
 	ctx := context.Background()

--- a/pkg/sdk/helper_test.go
+++ b/pkg/sdk/helper_test.go
@@ -423,7 +423,7 @@ func createPasswordPolicyWithOptions(t *testing.T, client *Client, database *Dat
 	err := client.PasswordPolicies.Create(ctx, id, options)
 	require.NoError(t, err)
 
-	showOptions := &PasswordPolicyShowOptions{
+	showOptions := &ShowPasswordPolicyOptions{
 		Like: &Like{
 			Pattern: String(name),
 		},

--- a/pkg/sdk/helper_test.go
+++ b/pkg/sdk/helper_test.go
@@ -655,7 +655,7 @@ func createPipe(t *testing.T, client *Client, database *Database, schema *Schema
 		require.NoError(t, err)
 	}
 
-	err := client.Pipes.Create(ctx, id, copyStatement, &PipeCreateOptions{})
+	err := client.Pipes.Create(ctx, id, copyStatement, &CreatePipeOptions{})
 	if err != nil {
 		return nil, pipeCleanup
 	}

--- a/pkg/sdk/password_policy.go
+++ b/pkg/sdk/password_policy.go
@@ -14,7 +14,7 @@ var (
 	_ validatable = new(CreatePasswordPolicyOptions)
 	_ validatable = new(AlterPasswordPolicyOptions)
 	_ validatable = new(DropPasswordPolicyOptions)
-	_ validatable = new(PasswordPolicyShowOptions)
+	_ validatable = new(ShowPasswordPolicyOptions)
 	_ validatable = new(describePasswordPolicyOptions)
 )
 
@@ -28,7 +28,7 @@ type PasswordPolicies interface {
 	// Drop removes a password policy.
 	Drop(ctx context.Context, id SchemaObjectIdentifier, opts *DropPasswordPolicyOptions) error
 	// Show returns a list of password policies.
-	Show(ctx context.Context, opts *PasswordPolicyShowOptions) ([]PasswordPolicy, error)
+	Show(ctx context.Context, opts *ShowPasswordPolicyOptions) ([]PasswordPolicy, error)
 	// ShowByID returns a password policy by ID.
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*PasswordPolicy, error)
 	// Describe returns the details of a password policy.
@@ -242,8 +242,8 @@ func (v *passwordPolicies) Drop(ctx context.Context, id SchemaObjectIdentifier, 
 	return err
 }
 
-// PasswordPolicyShowOptions represents the options for listing password policies.
-type PasswordPolicyShowOptions struct {
+// ShowPasswordPolicyOptions represents the options for listing password policies.
+type ShowPasswordPolicyOptions struct {
 	show             bool  `ddl:"static" sql:"SHOW"`
 	passwordPolicies bool  `ddl:"static" sql:"PASSWORD POLICIES"`
 	Like             *Like `ddl:"keyword" sql:"LIKE"`
@@ -251,11 +251,11 @@ type PasswordPolicyShowOptions struct {
 	Limit            *int  `ddl:"parameter,no_equals" sql:"LIMIT"`
 }
 
-func (input *PasswordPolicyShowOptions) validate() error {
+func (input *ShowPasswordPolicyOptions) validate() error {
 	return nil
 }
 
-// PasswordPolicys is a user friendly result for a CREATE PASSWORD POLICY query.
+// PasswordPolicy is a user-friendly result for a CREATE PASSWORD POLICY query.
 type PasswordPolicy struct {
 	CreatedOn    time.Time
 	Name         string
@@ -300,7 +300,7 @@ func (row passwordPolicyDBRow) convert() PasswordPolicy {
 }
 
 // List all the password policies by pattern.
-func (v *passwordPolicies) Show(ctx context.Context, opts *PasswordPolicyShowOptions) ([]PasswordPolicy, error) {
+func (v *passwordPolicies) Show(ctx context.Context, opts *ShowPasswordPolicyOptions) ([]PasswordPolicy, error) {
 	opts = createIfNil(opts)
 	if err := opts.validate(); err != nil {
 		return nil, err
@@ -323,7 +323,7 @@ func (v *passwordPolicies) Show(ctx context.Context, opts *PasswordPolicyShowOpt
 }
 
 func (v *passwordPolicies) ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*PasswordPolicy, error) {
-	passwordPolicies, err := v.Show(ctx, &PasswordPolicyShowOptions{
+	passwordPolicies, err := v.Show(ctx, &ShowPasswordPolicyOptions{
 		Like: &Like{
 			Pattern: String(id.Name()),
 		},

--- a/pkg/sdk/password_policy_integration_test.go
+++ b/pkg/sdk/password_policy_integration_test.go
@@ -30,7 +30,7 @@ func TestInt_PasswordPoliciesShow(t *testing.T) {
 	})
 
 	t.Run("with show options", func(t *testing.T) {
-		showOptions := &PasswordPolicyShowOptions{
+		showOptions := &ShowPasswordPolicyOptions{
 			In: &In{
 				Schema: schemaTest.ID(),
 			},
@@ -43,7 +43,7 @@ func TestInt_PasswordPoliciesShow(t *testing.T) {
 	})
 
 	t.Run("with show options and like", func(t *testing.T) {
-		showOptions := &PasswordPolicyShowOptions{
+		showOptions := &ShowPasswordPolicyOptions{
 			Like: &Like{
 				Pattern: String(passwordPolicyTest.Name),
 			},
@@ -58,7 +58,7 @@ func TestInt_PasswordPoliciesShow(t *testing.T) {
 	})
 
 	t.Run("when searching a non-existent password policy", func(t *testing.T) {
-		showOptions := &PasswordPolicyShowOptions{
+		showOptions := &ShowPasswordPolicyOptions{
 			Like: &Like{
 				Pattern: String("non-existent"),
 			},
@@ -70,7 +70,7 @@ func TestInt_PasswordPoliciesShow(t *testing.T) {
 
 	/* there appears to be a bug in the Snowflake API. LIMIT is not actually limiting the number of results
 	t.Run("when limiting the number of results", func(t *testing.T) {
-		showOptions := &PasswordPolicyShowOptions{
+		showOptions := &ShowPasswordPolicyOptions{
 			In: &In{
 				Schema: String(schemaTest.FullyQualifiedName()),
 			},

--- a/pkg/sdk/password_policy_test.go
+++ b/pkg/sdk/password_policy_test.go
@@ -152,7 +152,7 @@ func TestPasswordPolicyShow(t *testing.T) {
 	id := randomSchemaObjectIdentifier(t)
 
 	t.Run("empty options", func(t *testing.T) {
-		opts := &PasswordPolicyShowOptions{}
+		opts := &ShowPasswordPolicyOptions{}
 		actual, err := structToSQL(opts)
 		require.NoError(t, err)
 		expected := "SHOW PASSWORD POLICIES"
@@ -160,7 +160,7 @@ func TestPasswordPolicyShow(t *testing.T) {
 	})
 
 	t.Run("with like", func(t *testing.T) {
-		opts := &PasswordPolicyShowOptions{
+		opts := &ShowPasswordPolicyOptions{
 			Like: &Like{
 				Pattern: String(id.Name()),
 			},
@@ -172,7 +172,7 @@ func TestPasswordPolicyShow(t *testing.T) {
 	})
 
 	t.Run("with like and in account", func(t *testing.T) {
-		opts := &PasswordPolicyShowOptions{
+		opts := &ShowPasswordPolicyOptions{
 			Like: &Like{
 				Pattern: String(id.Name()),
 			},
@@ -188,7 +188,7 @@ func TestPasswordPolicyShow(t *testing.T) {
 
 	t.Run("with like and in database", func(t *testing.T) {
 		databaseIdentifier := NewAccountObjectIdentifier(id.DatabaseName())
-		opts := &PasswordPolicyShowOptions{
+		opts := &ShowPasswordPolicyOptions{
 			Like: &Like{
 				Pattern: String(id.Name()),
 			},
@@ -204,7 +204,7 @@ func TestPasswordPolicyShow(t *testing.T) {
 
 	t.Run("with like and in schema", func(t *testing.T) {
 		schemaIdentifier := NewDatabaseObjectIdentifier(id.DatabaseName(), id.SchemaName())
-		opts := &PasswordPolicyShowOptions{
+		opts := &ShowPasswordPolicyOptions{
 			Like: &Like{
 				Pattern: String(id.Name()),
 			},
@@ -219,7 +219,7 @@ func TestPasswordPolicyShow(t *testing.T) {
 	})
 
 	t.Run("with limit", func(t *testing.T) {
-		opts := &PasswordPolicyShowOptions{
+		opts := &ShowPasswordPolicyOptions{
 			Limit: Int(10),
 		}
 		actual, err := structToSQL(opts)

--- a/pkg/sdk/pipes.go
+++ b/pkg/sdk/pipes.go
@@ -9,24 +9,24 @@ var _ convertibleRow[Pipe] = new(pipeDBRow)
 
 type Pipes interface {
 	// Create creates a pipe.
-	Create(ctx context.Context, id SchemaObjectIdentifier, copyStatement string, opts *PipeCreateOptions) error
+	Create(ctx context.Context, id SchemaObjectIdentifier, copyStatement string, opts *CreatePipeOptions) error
 	// Alter modifies an existing pipe.
-	Alter(ctx context.Context, id SchemaObjectIdentifier, opts *PipeAlterOptions) error
+	Alter(ctx context.Context, id SchemaObjectIdentifier, opts *AlterPipeOptions) error
 	// Drop removes a pipe.
 	Drop(ctx context.Context, id SchemaObjectIdentifier) error
 	// Show returns a list of pipes.
-	Show(ctx context.Context, opts *PipeShowOptions) ([]Pipe, error)
+	Show(ctx context.Context, opts *ShowPipeOptions) ([]Pipe, error)
 	// ShowByID returns a pipe by ID.
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Pipe, error)
 	// Describe returns the details of a pipe.
 	Describe(ctx context.Context, id SchemaObjectIdentifier) (*Pipe, error)
 }
 
-// PipeCreateOptions contains options for creating a new pipe in the system for defining the COPY INTO <table> statement
+// CreatePipeOptions contains options for creating a new pipe in the system for defining the COPY INTO <table> statement
 // used by Snowpipe to load data from an ingestion queue into tables.
 //
 // Based on https://docs.snowflake.com/en/sql-reference/sql/create-pipe.
-type PipeCreateOptions struct {
+type CreatePipeOptions struct {
 	create      bool                   `ddl:"static" sql:"CREATE"`
 	OrReplace   *bool                  `ddl:"keyword" sql:"OR REPLACE"`
 	pipe        bool                   `ddl:"static" sql:"PIPE"`
@@ -43,10 +43,10 @@ type PipeCreateOptions struct {
 	copyStatement string `ddl:"keyword,no_quotes"`
 }
 
-// PipeAlterOptions contains options for modifying a limited set of properties for an existing pipe object.
+// AlterPipeOptions contains options for modifying a limited set of properties for an existing pipe object.
 //
 // Based on https://docs.snowflake.com/en/sql-reference/sql/alter-pipe.
-type PipeAlterOptions struct {
+type AlterPipeOptions struct {
 	alter    bool                   `ddl:"static" sql:"ALTER"`
 	role     bool                   `ddl:"static" sql:"PIPE"`
 	IfExists *bool                  `ddl:"keyword" sql:"IF EXISTS"`
@@ -84,20 +84,20 @@ type PipeRefresh struct {
 	ModifiedAfter *string `ddl:"parameter,single_quotes" sql:"MODIFIED_AFTER"`
 }
 
-// PipeDropOptions contains options for removing the specified pipe from the current/specified schema.
+// DropPipeOptions contains options for removing the specified pipe from the current/specified schema.
 //
 // Based on https://docs.snowflake.com/en/sql-reference/sql/drop-pipe.
-type PipeDropOptions struct {
+type DropPipeOptions struct {
 	drop     bool                   `ddl:"static" sql:"DROP"`
 	pipe     bool                   `ddl:"static" sql:"PIPE"`
 	IfExists *bool                  `ddl:"keyword" sql:"IF EXISTS"`
 	name     SchemaObjectIdentifier `ddl:"identifier"`
 }
 
-// PipeShowOptions contains options for showing pipes which user has access privilege to.
+// ShowPipeOptions contains options for showing pipes which user has access privilege to.
 //
 // https://docs.snowflake.com/en/sql-reference/sql/show-pipes
-type PipeShowOptions struct {
+type ShowPipeOptions struct {
 	show  bool  `ddl:"static" sql:"SHOW"`
 	pipes bool  `ddl:"static" sql:"PIPES"`
 	Like  *Like `ddl:"keyword" sql:"LIKE"`

--- a/pkg/sdk/pipes_impl.go
+++ b/pkg/sdk/pipes_impl.go
@@ -8,27 +8,27 @@ type pipes struct {
 	client *Client
 }
 
-func (v *pipes) Create(ctx context.Context, id SchemaObjectIdentifier, copyStatement string, opts *PipeCreateOptions) error {
-	opts = createIfNil[PipeCreateOptions](opts)
+func (v *pipes) Create(ctx context.Context, id SchemaObjectIdentifier, copyStatement string, opts *CreatePipeOptions) error {
+	opts = createIfNil[CreatePipeOptions](opts)
 	opts.name = id
 	opts.copyStatement = copyStatement
 	return validateAndExec(v.client, ctx, opts)
 }
 
-func (v *pipes) Alter(ctx context.Context, id SchemaObjectIdentifier, opts *PipeAlterOptions) error {
-	opts = createIfNil[PipeAlterOptions](opts)
+func (v *pipes) Alter(ctx context.Context, id SchemaObjectIdentifier, opts *AlterPipeOptions) error {
+	opts = createIfNil[AlterPipeOptions](opts)
 	opts.name = id
 	return validateAndExec(v.client, ctx, opts)
 }
 
 func (v *pipes) Drop(ctx context.Context, id SchemaObjectIdentifier) error {
-	opts := &PipeDropOptions{
+	opts := &DropPipeOptions{
 		name: id,
 	}
 	return validateAndExec(v.client, ctx, opts)
 }
 
-func (v *pipes) Show(ctx context.Context, opts *PipeShowOptions) ([]Pipe, error) {
+func (v *pipes) Show(ctx context.Context, opts *ShowPipeOptions) ([]Pipe, error) {
 	dbRows, err := validateAndQuery[pipeDBRow](v.client, ctx, opts)
 	if err != nil {
 		return nil, err
@@ -40,7 +40,7 @@ func (v *pipes) Show(ctx context.Context, opts *PipeShowOptions) ([]Pipe, error)
 }
 
 func (v *pipes) ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Pipe, error) {
-	pipes, err := v.Show(ctx, &PipeShowOptions{
+	pipes, err := v.Show(ctx, &ShowPipeOptions{
 		Like: &Like{
 			Pattern: String(id.Name()),
 		},

--- a/pkg/sdk/pipes_integration_test.go
+++ b/pkg/sdk/pipes_integration_test.go
@@ -39,7 +39,7 @@ func TestInt_IncorrectCreatePipeBehaviour(t *testing.T) {
 			ctx,
 			NewSchemaObjectIdentifier(database.Name, schema.Name, randomAlphanumericN(t, 20)),
 			createPipeCopyStatement(t, table, stage),
-			&PipeCreateOptions{},
+			&CreatePipeOptions{},
 		)
 
 		require.ErrorContains(t, err, "(42000): SQL compilation error:\nsyntax error line")
@@ -64,7 +64,7 @@ func TestInt_IncorrectCreatePipeBehaviour(t *testing.T) {
 			ctx,
 			NewSchemaObjectIdentifier(database.Name, schema.Name, randomAlphanumericN(t, 20)),
 			createCopyStatementWithoutQualifiersForStage(t, table, stage),
-			&PipeCreateOptions{},
+			&CreatePipeOptions{},
 		)
 
 		require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestInt_PipesShowAndDescribe(t *testing.T) {
 	t.Cleanup(pipe2Cleanup)
 
 	t.Run("show: without options", func(t *testing.T) {
-		pipes, err := client.Pipes.Show(ctx, &PipeShowOptions{})
+		pipes, err := client.Pipes.Show(ctx, &ShowPipeOptions{})
 
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(pipes))
@@ -112,7 +112,7 @@ func TestInt_PipesShowAndDescribe(t *testing.T) {
 	})
 
 	t.Run("show: in schema", func(t *testing.T) {
-		showOptions := &PipeShowOptions{
+		showOptions := &ShowPipeOptions{
 			In: &In{
 				Schema: schema.ID(),
 			},
@@ -126,7 +126,7 @@ func TestInt_PipesShowAndDescribe(t *testing.T) {
 	})
 
 	t.Run("show: like", func(t *testing.T) {
-		showOptions := &PipeShowOptions{
+		showOptions := &ShowPipeOptions{
 			Like: &Like{
 				Pattern: String(pipe1Name),
 			},
@@ -139,7 +139,7 @@ func TestInt_PipesShowAndDescribe(t *testing.T) {
 	})
 
 	t.Run("show: non-existent pipe", func(t *testing.T) {
-		showOptions := &PipeShowOptions{
+		showOptions := &ShowPipeOptions{
 			Like: &Like{
 				Pattern: String("non-existent"),
 			},
@@ -208,7 +208,7 @@ func TestInt_PipeCreate(t *testing.T) {
 		id := NewSchemaObjectIdentifier(database.Name, schema.Name, name)
 		comment := randomComment(t)
 
-		err := client.Pipes.Create(ctx, id, copyStatement, &PipeCreateOptions{
+		err := client.Pipes.Create(ctx, id, copyStatement, &CreatePipeOptions{
 			OrReplace:   Bool(false),
 			IfNotExists: Bool(true),
 			AutoIngest:  Bool(false),
@@ -226,7 +226,7 @@ func TestInt_PipeCreate(t *testing.T) {
 		name := randomString(t)
 		id := NewSchemaObjectIdentifier(database.Name, schema.Name, name)
 
-		err := client.Pipes.Create(ctx, id, copyStatement, &PipeCreateOptions{
+		err := client.Pipes.Create(ctx, id, copyStatement, &CreatePipeOptions{
 			OrReplace:   Bool(true),
 			IfNotExists: Bool(true),
 		})
@@ -311,7 +311,7 @@ func TestInt_PipeAlter(t *testing.T) {
 		pipe, pipeCleanup := createPipe(t, client, database, schema, pipeName, pipeCopyStatement)
 		t.Cleanup(pipeCleanup)
 
-		alterOptions := &PipeAlterOptions{
+		alterOptions := &AlterPipeOptions{
 			Set: &PipeSet{
 				Comment:             String("new comment"),
 				PipeExecutionPaused: Bool(true),
@@ -326,7 +326,7 @@ func TestInt_PipeAlter(t *testing.T) {
 
 		assert.Equal(t, "new comment", alteredPipe.Comment)
 
-		alterOptions = &PipeAlterOptions{
+		alterOptions = &AlterPipeOptions{
 			Unset: &PipeUnset{
 				Comment:             Bool(true),
 				PipeExecutionPaused: Bool(true),
@@ -351,7 +351,7 @@ func TestInt_PipeAlter(t *testing.T) {
 		t.Cleanup(pipeCleanup)
 
 		tagValue := "abc"
-		alterOptions := &PipeAlterOptions{
+		alterOptions := &AlterPipeOptions{
 			SetTags: &PipeSetTags{
 				Tag: []TagAssociation{
 					{
@@ -370,7 +370,7 @@ func TestInt_PipeAlter(t *testing.T) {
 
 		assert.Equal(t, tagValue, returnedTagValue)
 
-		alterOptions = &PipeAlterOptions{
+		alterOptions = &AlterPipeOptions{
 			UnsetTags: &PipeUnsetTags{
 				Tag: []ObjectIdentifier{
 					tag.ID(),
@@ -390,7 +390,7 @@ func TestInt_PipeAlter(t *testing.T) {
 		pipe, pipeCleanup := createPipe(t, client, database, schema, pipeName, pipeCopyStatement)
 		t.Cleanup(pipeCleanup)
 
-		alterOptions := &PipeAlterOptions{
+		alterOptions := &AlterPipeOptions{
 			Refresh: &PipeRefresh{
 				Prefix:        String("/d1"),
 				ModifiedAfter: String("2018-07-30T13:56:46-07:00"),

--- a/pkg/sdk/pipes_test.go
+++ b/pkg/sdk/pipes_test.go
@@ -7,15 +7,15 @@ import (
 func TestPipesCreate(t *testing.T) {
 	id := randomSchemaObjectIdentifier(t)
 
-	defaultOpts := func() *PipeCreateOptions {
-		return &PipeCreateOptions{
+	defaultOpts := func() *CreatePipeOptions {
+		return &CreatePipeOptions{
 			name:          id,
 			copyStatement: "<copy_statement>",
 		}
 	}
 
 	t.Run("validation: nil options", func(t *testing.T) {
-		var opts *PipeCreateOptions = nil
+		var opts *CreatePipeOptions = nil
 		assertOptsInvalid(t, opts, errNilOptions)
 	})
 
@@ -51,14 +51,14 @@ func TestPipesCreate(t *testing.T) {
 func TestPipesAlter(t *testing.T) {
 	id := randomSchemaObjectIdentifier(t)
 
-	defaultOpts := func() *PipeAlterOptions {
-		return &PipeAlterOptions{
+	defaultOpts := func() *AlterPipeOptions {
+		return &AlterPipeOptions{
 			name: id,
 		}
 	}
 
 	t.Run("validation: nil options", func(t *testing.T) {
-		var opts *PipeAlterOptions = nil
+		var opts *AlterPipeOptions = nil
 		assertOptsInvalid(t, opts, errNilOptions)
 	})
 
@@ -204,14 +204,14 @@ func TestPipesAlter(t *testing.T) {
 func TestPipesDrop(t *testing.T) {
 	id := randomSchemaObjectIdentifier(t)
 
-	defaultOpts := func() *PipeDropOptions {
-		return &PipeDropOptions{
+	defaultOpts := func() *DropPipeOptions {
+		return &DropPipeOptions{
 			name: id,
 		}
 	}
 
 	t.Run("validation: nil options", func(t *testing.T) {
-		var opts *PipeDropOptions = nil
+		var opts *DropPipeOptions = nil
 		assertOptsInvalid(t, opts, errNilOptions)
 	})
 
@@ -238,12 +238,12 @@ func TestPipesShow(t *testing.T) {
 	databaseIdentifier := NewAccountObjectIdentifier(id.DatabaseName())
 	schemaIdentifier := NewDatabaseObjectIdentifier(id.DatabaseName(), id.SchemaName())
 
-	defaultOpts := func() *PipeShowOptions {
-		return &PipeShowOptions{}
+	defaultOpts := func() *ShowPipeOptions {
+		return &ShowPipeOptions{}
 	}
 
 	t.Run("validation: nil options", func(t *testing.T) {
-		var opts *PipeShowOptions = nil
+		var opts *ShowPipeOptions = nil
 		assertOptsInvalid(t, opts, errNilOptions)
 	})
 

--- a/pkg/sdk/pipes_validations.go
+++ b/pkg/sdk/pipes_validations.go
@@ -5,14 +5,14 @@ import (
 )
 
 var (
-	_ validatable = new(PipeCreateOptions)
-	_ validatable = new(PipeAlterOptions)
-	_ validatable = new(PipeDropOptions)
-	_ validatable = new(PipeShowOptions)
+	_ validatable = new(CreatePipeOptions)
+	_ validatable = new(AlterPipeOptions)
+	_ validatable = new(DropPipeOptions)
+	_ validatable = new(ShowPipeOptions)
 	_ validatable = new(describePipeOptions)
 )
 
-func (opts *PipeCreateOptions) validate() error {
+func (opts *CreatePipeOptions) validate() error {
 	if opts == nil {
 		return errNilOptions
 	}
@@ -25,7 +25,7 @@ func (opts *PipeCreateOptions) validate() error {
 	return nil
 }
 
-func (opts *PipeAlterOptions) validate() error {
+func (opts *AlterPipeOptions) validate() error {
 	if opts == nil {
 		return errNilOptions
 	}
@@ -64,7 +64,7 @@ func (opts *PipeAlterOptions) validate() error {
 	return nil
 }
 
-func (opts *PipeDropOptions) validate() error {
+func (opts *DropPipeOptions) validate() error {
 	if opts == nil {
 		return errNilOptions
 	}
@@ -74,7 +74,7 @@ func (opts *PipeDropOptions) validate() error {
 	return nil
 }
 
-func (opts *PipeShowOptions) validate() error {
+func (opts *ShowPipeOptions) validate() error {
 	if opts == nil {
 		return errNilOptions
 	}

--- a/pkg/sdk/roles_dto.go
+++ b/pkg/sdk/roles_dto.go
@@ -1,5 +1,14 @@
 package sdk
 
+var (
+	_ optionsProvider[CreateRoleOptions] = new(CreateRoleRequest)
+	_ optionsProvider[AlterRoleOptions]  = new(AlterRoleRequest)
+	_ optionsProvider[DropRoleOptions]   = new(DropRoleRequest)
+	_ optionsProvider[ShowRoleOptions]   = new(ShowRoleRequest)
+	_ optionsProvider[GrantRoleOptions]  = new(GrantRoleRequest)
+	_ optionsProvider[RevokeRoleOptions] = new(RevokeRoleRequest)
+)
+
 type CreateRoleRequest struct {
 	OrReplace   *bool
 	IfNotExists *bool
@@ -34,7 +43,7 @@ func (s *CreateRoleRequest) WithTag(tag []TagAssociation) *CreateRoleRequest {
 	return s
 }
 
-func (s *CreateRoleRequest) ToOpts() *CreateRoleOptions {
+func (s *CreateRoleRequest) toOpts() *CreateRoleOptions {
 	return &CreateRoleOptions{
 		OrReplace:   s.OrReplace,
 		IfNotExists: s.IfNotExists,
@@ -90,7 +99,7 @@ func (s *AlterRoleRequest) WithUnsetTags(unsetTags []ObjectIdentifier) *AlterRol
 	return s
 }
 
-func (s *AlterRoleRequest) ToOpts() *AlterRoleOptions {
+func (s *AlterRoleRequest) toOpts() *AlterRoleOptions {
 	return &AlterRoleOptions{
 		IfExists:     s.IfExists,
 		name:         s.name,
@@ -118,7 +127,7 @@ func (s *DropRoleRequest) WithIfExists(ifExists bool) *DropRoleRequest {
 	return s
 }
 
-func (s *DropRoleRequest) ToOpts() *DropRoleOptions {
+func (s *DropRoleRequest) toOpts() *DropRoleOptions {
 	return &DropRoleOptions{
 		IfExists: s.IfExists,
 		name:     s.name,
@@ -156,7 +165,7 @@ func NewLikeRequest(pattern string) *LikeRequest {
 	}
 }
 
-func (s *ShowRoleRequest) ToOpts() *ShowRoleOptions {
+func (s *ShowRoleRequest) toOpts() *ShowRoleOptions {
 	return &ShowRoleOptions{
 		Like:    s.Like,
 		InClass: s.InClass,
@@ -185,7 +194,7 @@ func NewGrantRoleRequest(name AccountObjectIdentifier, grant GrantRole) *GrantRo
 	}
 }
 
-func (s *GrantRoleRequest) ToOpts() *GrantRoleOptions {
+func (s *GrantRoleRequest) toOpts() *GrantRoleOptions {
 	return &GrantRoleOptions{
 		name:  s.name,
 		Grant: s.Grant,
@@ -204,7 +213,7 @@ func NewRevokeRoleRequest(name AccountObjectIdentifier, revoke RevokeRole) *Revo
 	}
 }
 
-func (s *RevokeRoleRequest) ToOpts() *RevokeRoleOptions {
+func (s *RevokeRoleRequest) toOpts() *RevokeRoleOptions {
 	return &RevokeRoleOptions{
 		name:   s.name,
 		Revoke: s.Revoke,

--- a/pkg/sdk/roles_impl.go
+++ b/pkg/sdk/roles_impl.go
@@ -14,19 +14,19 @@ type roles struct {
 }
 
 func (v *roles) Create(ctx context.Context, req *CreateRoleRequest) error {
-	return validateAndExec(v.client, ctx, req.ToOpts())
+	return validateAndExec(v.client, ctx, req.toOpts())
 }
 
 func (v *roles) Alter(ctx context.Context, req *AlterRoleRequest) error {
-	return validateAndExec(v.client, ctx, req.ToOpts())
+	return validateAndExec(v.client, ctx, req.toOpts())
 }
 
 func (v *roles) Drop(ctx context.Context, req *DropRoleRequest) error {
-	return validateAndExec(v.client, ctx, req.ToOpts())
+	return validateAndExec(v.client, ctx, req.toOpts())
 }
 
 func (v *roles) Show(ctx context.Context, req *ShowRoleRequest) ([]Role, error) {
-	dbRows, err := validateAndQuery[roleDBRow](v.client, ctx, req.ToOpts())
+	dbRows, err := validateAndQuery[roleDBRow](v.client, ctx, req.toOpts())
 	if err != nil {
 		return nil, err
 	}
@@ -43,11 +43,11 @@ func (v *roles) ShowByID(ctx context.Context, req *ShowRoleByIdRequest) (*Role, 
 }
 
 func (v *roles) Grant(ctx context.Context, req *GrantRoleRequest) error {
-	return validateAndExec(v.client, ctx, req.ToOpts())
+	return validateAndExec(v.client, ctx, req.toOpts())
 }
 
 func (v *roles) Revoke(ctx context.Context, req *RevokeRoleRequest) error {
-	return validateAndExec(v.client, ctx, req.ToOpts())
+	return validateAndExec(v.client, ctx, req.toOpts())
 }
 
 func (v *roles) Use(ctx context.Context, req *UseRoleRequest) error {

--- a/pkg/sdk/session_policies.go
+++ b/pkg/sdk/session_policies.go
@@ -8,7 +8,7 @@ var (
 	_ validatable = new(CreateSessionPolicyOptions)
 	_ validatable = new(AlterSessionPolicyOptions)
 	_ validatable = new(DropSessionPolicyOptions)
-	_ validatable = new(sessionPolicyShowOptions)
+	_ validatable = new(showSessionPolicyOptions)
 )
 
 type SessionPolicies interface {
@@ -132,18 +132,18 @@ func (v *sessionPolicies) Drop(ctx context.Context, id SchemaObjectIdentifier, o
 	return err
 }
 
-// sessionPolicyShowOptions contains options for listing session policies.
-type sessionPolicyShowOptions struct {
+// showSessionPolicyOptions contains options for listing session policies.
+type showSessionPolicyOptions struct {
 	show            bool `ddl:"static" sql:"SHOW"`
 	sessionPolicies bool `ddl:"static" sql:"SESSION POLICIES"`
 }
 
-func (opts *sessionPolicyShowOptions) validate() error {
+func (opts *showSessionPolicyOptions) validate() error {
 	return nil
 }
 
 func (v *sessionPolicies) Show(ctx context.Context) ([]SessionPolicy, error) {
-	opts := &sessionPolicyShowOptions{}
+	opts := &showSessionPolicyOptions{}
 	if err := opts.validate(); err != nil {
 		return nil, err
 	}

--- a/pkg/sdk/shares.go
+++ b/pkg/sdk/shares.go
@@ -10,9 +10,9 @@ import (
 var (
 	_ validatable = new(CreateShareOptions)
 	_ validatable = new(AlterShareOptions)
-	_ validatable = new(shareDropOptions)
+	_ validatable = new(dropShareOptions)
 	_ validatable = new(ShowShareOptions)
-	_ validatable = new(shareDescribeOptions)
+	_ validatable = new(describeShareOptions)
 )
 
 type Shares interface {
@@ -139,18 +139,18 @@ func (v *shares) Create(ctx context.Context, id AccountObjectIdentifier, opts *C
 	return err
 }
 
-type shareDropOptions struct {
+type dropShareOptions struct {
 	drop  bool                    `ddl:"static" sql:"DROP"`
 	share bool                    `ddl:"static" sql:"SHARE"`
 	name  AccountObjectIdentifier `ddl:"identifier"`
 }
 
-func (opts *shareDropOptions) validate() error {
+func (opts *dropShareOptions) validate() error {
 	return nil
 }
 
 func (v *shares) Drop(ctx context.Context, id AccountObjectIdentifier) error {
-	opts := &shareDropOptions{
+	opts := &dropShareOptions{
 		name: id,
 	}
 	if err := opts.validate(); err != nil {
@@ -343,13 +343,13 @@ func shareDetailsFromRows(rows []shareDetailsRow) *ShareDetails {
 	return v
 }
 
-type shareDescribeOptions struct {
+type describeShareOptions struct {
 	describe bool             `ddl:"static" sql:"DESCRIBE"`
 	share    bool             `ddl:"static" sql:"SHARE"`
 	name     ObjectIdentifier `ddl:"identifier"`
 }
 
-func (opts *shareDescribeOptions) validate() error {
+func (opts *describeShareOptions) validate() error {
 	if ok := validObjectidentifier(opts.name); !ok {
 		return errInvalidObjectIdentifier
 	}
@@ -357,7 +357,7 @@ func (opts *shareDescribeOptions) validate() error {
 }
 
 func (c *shares) DescribeProvider(ctx context.Context, id AccountObjectIdentifier) (*ShareDetails, error) {
-	opts := &shareDescribeOptions{
+	opts := &describeShareOptions{
 		name: id,
 	}
 	sql, err := structToSQL(opts)
@@ -373,7 +373,7 @@ func (c *shares) DescribeProvider(ctx context.Context, id AccountObjectIdentifie
 }
 
 func (c *shares) DescribeConsumer(ctx context.Context, id ExternalObjectIdentifier) (*ShareDetails, error) {
-	opts := &shareDescribeOptions{
+	opts := &describeShareOptions{
 		name: id,
 	}
 	sql, err := structToSQL(opts)

--- a/pkg/sdk/shares_test.go
+++ b/pkg/sdk/shares_test.go
@@ -162,7 +162,7 @@ func TestShareShow(t *testing.T) {
 
 func TestShareDrop(t *testing.T) {
 	t.Run("only name", func(t *testing.T) {
-		opts := &shareDropOptions{
+		opts := &dropShareOptions{
 			name: NewAccountObjectIdentifier("myshare"),
 		}
 		actual, err := structToSQL(opts)
@@ -174,7 +174,7 @@ func TestShareDrop(t *testing.T) {
 
 func TestShareDescribe(t *testing.T) {
 	t.Run("describe provider", func(t *testing.T) {
-		opts := &shareDescribeOptions{
+		opts := &describeShareOptions{
 			name: NewAccountObjectIdentifier("myprovider"),
 		}
 		actual, err := structToSQL(opts)
@@ -183,7 +183,7 @@ func TestShareDescribe(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 	t.Run("describe consumer", func(t *testing.T) {
-		opts := &shareDescribeOptions{
+		opts := &describeShareOptions{
 			name: NewAccountObjectIdentifier("myconsumer"),
 		}
 		actual, err := structToSQL(opts)

--- a/pkg/sdk/tables.go
+++ b/pkg/sdk/tables.go
@@ -1,7 +1,7 @@
 package sdk
 
 // placeholder for the real implementation.
-type TableCreateOptions struct{}
+type CreateTableOptions struct{}
 
 type Table struct {
 	DatabaseName string

--- a/pkg/sdk/tags.go
+++ b/pkg/sdk/tags.go
@@ -1,7 +1,7 @@
 package sdk
 
 // placeholder for the real implementation.
-type TagCreateOptions struct{}
+type CreateTagOptions struct{}
 
 type Tag struct {
 	DatabaseName string

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -14,7 +14,7 @@ var (
 	_ validatable = new(AlterWarehouseOptions)
 	_ validatable = new(DropWarehouseOptions)
 	_ validatable = new(ShowWarehouseOptions)
-	_ validatable = new(warehouseDescribeOptions)
+	_ validatable = new(describeWarehouseOptions)
 )
 
 type Warehouses interface {
@@ -481,13 +481,13 @@ func (c *warehouses) ShowByID(ctx context.Context, id AccountObjectIdentifier) (
 	return nil, errObjectNotExistOrAuthorized
 }
 
-type warehouseDescribeOptions struct {
+type describeWarehouseOptions struct {
 	describe  bool                    `ddl:"static" sql:"DESCRIBE"`
 	warehouse bool                    `ddl:"static" sql:"WAREHOUSE"`
 	name      AccountObjectIdentifier `ddl:"identifier"`
 }
 
-func (opts *warehouseDescribeOptions) validate() error {
+func (opts *describeWarehouseOptions) validate() error {
 	if !validObjectidentifier(opts.name) {
 		return errInvalidObjectIdentifier
 	}
@@ -515,7 +515,7 @@ type WarehouseDetails struct {
 }
 
 func (c *warehouses) Describe(ctx context.Context, id AccountObjectIdentifier) (*WarehouseDetails, error) {
-	opts := &warehouseDescribeOptions{
+	opts := &describeWarehouseOptions{
 		name: id,
 	}
 	if err := opts.validate(); err != nil {

--- a/pkg/sdk/warehouses_test.go
+++ b/pkg/sdk/warehouses_test.go
@@ -303,7 +303,7 @@ func TestWarehouseShow(t *testing.T) {
 
 func TestWarehouseDescribe(t *testing.T) {
 	t.Run("only name", func(t *testing.T) {
-		opts := &warehouseDescribeOptions{
+		opts := &describeWarehouseOptions{
 			name: NewAccountObjectIdentifier("mywarehouse"),
 		}
 		actual, err := structToSQL(opts)


### PR DESCRIPTION
We want to align the naming of all options to `ActionObjectOptions`, e.g. `CreatePipeOptions`. New options are already being named accordingly. Existing options are renamed in this PR.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] tests should not break