### PR TITLE
fix: Ignore two flaky table tests and disable comment unset for password policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ export GO111MODULE=on
 export TF_ACC_TERRAFORM_VERSION=1.4.1
 export SKIP_EXTERNAL_TABLE_TESTS=true
 export SKIP_SCIM_INTEGRATION_TESTS=true
+export SKIP_TABLE_DATA_RETENTION_TESTS=true
 
 BASE_BINARY_NAME=terraform-provider-snowflake
 TERRAFORM_PLUGINS_DIR=$(HOME)/.terraform.d/plugins

--- a/pkg/resources/password_policy.go
+++ b/pkg/resources/password_policy.go
@@ -357,9 +357,13 @@ func UpdatePasswordPolicy(d *schema.ResourceData, meta interface{}) error {
 				Comment: sdk.String(v.(string)),
 			}
 		} else {
+			alterOptions.Set = &sdk.PasswordPolicySet{
+				Comment: sdk.String(""),
+			}
+			/* todo: uncomment this once comments are working again
 			alterOptions.Unset = &sdk.PasswordPolicyUnset{
 				Comment: sdk.Bool(true),
-			}
+			}*/
 		}
 		err := client.PasswordPolicies.Alter(ctx, objectIdentifier, alterOptions)
 		if err != nil {

--- a/pkg/resources/table_acceptance_test.go
+++ b/pkg/resources/table_acceptance_test.go
@@ -2,6 +2,7 @@ package resources_test
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -10,6 +11,10 @@ import (
 )
 
 func TestAcc_TableWithSeparateDataRetentionObjectParameterWithoutLifecycle(t *testing.T) {
+	if _, ok := os.LookupEnv("SKIP_TABLE_DATA_RETENTION_TESTS"); ok {
+		t.Skip("Skipping TestAcc_TableWithSeparateDataRetentionObjectParameterWithoutLifecycle")
+	}
+
 	accName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    providers(),
@@ -54,6 +59,10 @@ func TestAcc_TableWithSeparateDataRetentionObjectParameterWithoutLifecycle(t *te
 }
 
 func TestAcc_TableWithSeparateDataRetentionObjectParameterWithLifecycle(t *testing.T) {
+	if _, ok := os.LookupEnv("SKIP_TABLE_DATA_RETENTION_TESTS"); ok {
+		t.Skip("Skipping TestAcc_TableWithSeparateDataRetentionObjectParameterWithLifecycle")
+	}
+
 	accName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    providers(),

--- a/pkg/sdk/password_policy_integration_test.go
+++ b/pkg/sdk/password_policy_integration_test.go
@@ -212,6 +212,7 @@ func TestInt_PasswordPolicyAlter(t *testing.T) {
 			Set: &PasswordPolicySet{
 				PasswordMinLength: Int(10),
 				PasswordMaxLength: Int(20),
+				Comment:           String("new comment"),
 			},
 		}
 		err := client.PasswordPolicies.Alter(ctx, passwordPolicy.ID(), alterOptions)
@@ -221,6 +222,7 @@ func TestInt_PasswordPolicyAlter(t *testing.T) {
 		assert.Equal(t, passwordPolicy.Name, passwordPolicyDetails.Name.Value)
 		assert.Equal(t, 10, *passwordPolicyDetails.PasswordMinLength.Value)
 		assert.Equal(t, 20, *passwordPolicyDetails.PasswordMaxLength.Value)
+		assert.Equal(t, "new comment", passwordPolicyDetails.Comment.Value)
 	})
 
 	t.Run("when renaming", func(t *testing.T) {
@@ -247,8 +249,10 @@ func TestInt_PasswordPolicyAlter(t *testing.T) {
 
 	t.Run("when unsetting values", func(t *testing.T) {
 		createOptions := &CreatePasswordPolicyOptions{
-			Comment:            String("test comment"),
+			PasswordMaxAgeDays: Int(20),
 			PasswordMaxRetries: Int(10),
+			// todo: uncomment this once comments are working again
+			// Comment: String("test comment")
 		}
 		passwordPolicy, passwordPolicyCleanup := createPasswordPolicyWithOptions(t, client, databaseTest, schemaTest, createOptions)
 		id := passwordPolicy.ID()
@@ -262,7 +266,9 @@ func TestInt_PasswordPolicyAlter(t *testing.T) {
 		require.NoError(t, err)
 		alterOptions = &AlterPasswordPolicyOptions{
 			Unset: &PasswordPolicyUnset{
-				Comment: Bool(true),
+				PasswordMaxAgeDays: Bool(true),
+				// todo: uncomment this once comments are working again
+				// Comment: Bool("true")
 			},
 		}
 		err = client.PasswordPolicies.Alter(ctx, id, alterOptions)
@@ -276,16 +282,20 @@ func TestInt_PasswordPolicyAlter(t *testing.T) {
 
 	t.Run("when unsetting multiple values at same time", func(t *testing.T) {
 		createOptions := &CreatePasswordPolicyOptions{
-			Comment:            String("test comment"),
+			PasswordMaxAgeDays: Int(20),
 			PasswordMaxRetries: Int(10),
+			// todo: uncomment this once comments are working again
+			// Comment: String("test comment")
 		}
 		passwordPolicy, passwordPolicyCleanup := createPasswordPolicyWithOptions(t, client, databaseTest, schemaTest, createOptions)
 		id := passwordPolicy.ID()
 		t.Cleanup(passwordPolicyCleanup)
 		alterOptions := &AlterPasswordPolicyOptions{
 			Unset: &PasswordPolicyUnset{
-				Comment:            Bool(true),
+				PasswordMaxAgeDays: Bool(true),
 				PasswordMaxRetries: Bool(true),
+				// todo: uncomment this once comments are working again
+				// Comment: Bool("true")
 			},
 		}
 		err := client.PasswordPolicies.Alter(ctx, id, alterOptions)


### PR DESCRIPTION
- Temporarily ignore two flaky tests which fail most often.
- Disable unsetting comments on password policies temporarily

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
```
=== RUN   TestAcc_TableWithSeparateDataRetentionObjectParameterWithoutLifecycle
    table_acceptance_test.go:15: Skipping TestAcc_TableWithSeparateDataRetentionObjectParameterWithoutLifecycle
--- SKIP: TestAcc_TableWithSeparateDataRetentionObjectParameterWithoutLifecycle (0.00s)
=== RUN   TestAcc_TableWithSeparateDataRetentionObjectParameterWithLifecycle
    table_acceptance_test.go:63: Skipping TestAcc_TableWithSeparateDataRetentionObjectParameterWithLifecycle
--- SKIP: TestAcc_TableWithSeparateDataRetentionObjectParameterWithLifecycle (0.00s)
```

## Resources
* Failing tests for password policy unset comment:
```
=== RUN   TestInt_PasswordPolicyAlter/when_unsetting_multiple_values_at_same_time
2023/10/02 11:35:15 [DEBUG] sql-conn-exec: [query CREATE PASSWORD POLICY "yHne}Rhh2;ZR"."q>FPFaQx2wlbIls5c;jR;"."25f2da28-7c94-4f93-1d85-e9817a5c5809" PASSWORD_MAX_RETRIES = 10 COMMENT = 'test comment' err 001420 (22023): SQL compilation error:
invalid property 'COMMENT' for 'PASSWORD_POLICY' duration 94.97594ms args {}] (***)
2023/10/02 11:35:15 [DEBUG] err: 001420 (22023): SQL compilation error:
invalid property 'COMMENT' for 'PASSWORD_POLICY'
    password_policy_integration_test.go:282: 
        	Error Trace:	/home/runner/work/terraform-provider-snowflake/terraform-provider-snowflake/pkg/sdk/helper_test.go:424
        	            				/home/runner/work/terraform-provider-snowflake/terraform-provider-snowflake/pkg/sdk/password_policy_integration_test.go:282
        	Error:      	Received unexpected error:
        	            	001420 (22023): SQL compilation error:
        	            	invalid property 'COMMENT' for 'PASSWORD_POLICY'
        	Test:       	TestInt_PasswordPolicyAlter/when_unsetting_multiple_values_at_same_time
```