### PR TITLE
chore: Cleanup comments

### DIFF
--- a/pkg/sdk/accounts.go
+++ b/pkg/sdk/accounts.go
@@ -36,6 +36,7 @@ var (
 	EditionBusinessCritical AccountEdition = "BUSINESS_CRITICAL"
 )
 
+// CreateAccountOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-account.
 type CreateAccountOptions struct {
 	create  bool                    `ddl:"static" sql:"CREATE"`
 	account bool                    `ddl:"static" sql:"ACCOUNT"`
@@ -79,6 +80,7 @@ func (c *accounts) Create(ctx context.Context, id AccountObjectIdentifier, opts 
 	return validateAndExec(c.client, ctx, opts)
 }
 
+// AlterAccountOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-account.
 type AlterAccountOptions struct {
 	alter   bool `ddl:"static" sql:"ALTER"`
 	account bool `ddl:"static" sql:"ACCOUNT"`
@@ -270,6 +272,7 @@ func (c *accounts) Alter(ctx context.Context, opts *AlterAccountOptions) error {
 	return validateAndExec(c.client, ctx, opts)
 }
 
+// ShowAccountOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-organisation-accounts.
 type ShowAccountOptions struct {
 	show     bool  `ddl:"static" sql:"SHOW"`
 	accounts bool  `ddl:"static" sql:"ORGANIZATION ACCOUNTS"`
@@ -386,6 +389,7 @@ func (c *accounts) ShowByID(ctx context.Context, id AccountObjectIdentifier) (*A
 	return nil, errObjectNotExistOrAuthorized
 }
 
+// DropAccountOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-account.
 type DropAccountOptions struct {
 	drop              bool                    `ddl:"static" sql:"DROP"`
 	account           bool                    `ddl:"static" sql:"ACCOUNT"`
@@ -413,6 +417,7 @@ func (c *accounts) Drop(ctx context.Context, id AccountObjectIdentifier, gracePe
 	return validateAndExec(c.client, ctx, opts)
 }
 
+// undropAccountOptions is based on https://docs.snowflake.com/en/sql-reference/sql/undrop-account.
 type undropAccountOptions struct {
 	undrop  bool                    `ddl:"static" sql:"UNDROP"`
 	account bool                    `ddl:"static" sql:"ACCOUNT"`

--- a/pkg/sdk/alerts.go
+++ b/pkg/sdk/alerts.go
@@ -18,25 +18,19 @@ var (
 )
 
 type Alerts interface {
-	// Create creates a new alert.
 	Create(ctx context.Context, id SchemaObjectIdentifier, warehouse AccountObjectIdentifier, schedule string, condition string, action string, opts *CreateAlertOptions) error
-	// Alter modifies an existing alert.
 	Alter(ctx context.Context, id SchemaObjectIdentifier, opts *AlterAlertOptions) error
-	// Drop removes an alert.
 	Drop(ctx context.Context, id SchemaObjectIdentifier) error
-	// Show returns a list of alerts
 	Show(ctx context.Context, opts *ShowAlertOptions) ([]Alert, error)
-	// ShowByID returns an alert by ID
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Alert, error)
-	// Describe returns the details of an alert.
 	Describe(ctx context.Context, id SchemaObjectIdentifier) (*AlertDetails, error)
 }
 
-// alerts implements Alerts
 type alerts struct {
 	client *Client
 }
 
+// CreateAlertOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-alert.
 type CreateAlertOptions struct {
 	create      bool                   `ddl:"static" sql:"CREATE"`
 	OrReplace   *bool                  `ddl:"keyword" sql:"OR REPLACE"`
@@ -105,6 +99,7 @@ var (
 	AlertStateSuspended AlertState = "suspended"
 )
 
+// AlterAlertOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-alert.
 type AlterAlertOptions struct {
 	alter    bool                   `ddl:"static" sql:"ALTER"`
 	alert    bool                   `ddl:"static" sql:"ALERT"`
@@ -172,6 +167,7 @@ func (v *alerts) Alter(ctx context.Context, id SchemaObjectIdentifier, opts *Alt
 	return err
 }
 
+// DropAlertOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-alert.
 type dropAlertOptions struct {
 	drop  bool                   `ddl:"static" sql:"DROP"`
 	alert bool                   `ddl:"static" sql:"ALERT"`
@@ -204,6 +200,7 @@ func (v *alerts) Drop(ctx context.Context, id SchemaObjectIdentifier) error {
 	return err
 }
 
+// ShowAlertOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-alerts.
 type ShowAlertOptions struct {
 	show   bool  `ddl:"static" sql:"SHOW"`
 	Terse  *bool `ddl:"keyword" sql:"TERSE"`
@@ -303,6 +300,7 @@ func (v *alerts) ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Aler
 	return nil, errObjectNotExistOrAuthorized
 }
 
+// describeAlertOptions is based on https://docs.snowflake.com/en/sql-reference/sql/desc-alert.
 type describeAlertOptions struct {
 	describe bool                   `ddl:"static" sql:"DESCRIBE"`
 	alert    bool                   `ddl:"static" sql:"ALERT"`

--- a/pkg/sdk/comments.go
+++ b/pkg/sdk/comments.go
@@ -20,6 +20,7 @@ type comments struct {
 
 var _ Comments = (*comments)(nil)
 
+// SetCommentOptions is based on https://docs.snowflake.com/en/sql-reference/sql/comment.
 type SetCommentOptions struct {
 	comment    bool             `ddl:"static" sql:"COMMENT"`
 	IfExists   *bool            `ddl:"keyword" sql:"IF EXISTS"`
@@ -49,6 +50,7 @@ func (c *comments) Set(ctx context.Context, opts *SetCommentOptions) error {
 	return err
 }
 
+// SetColumnCommentOptions is based on https://docs.snowflake.com/en/sql-reference/sql/comment.
 type SetColumnCommentOptions struct {
 	comment  bool             `ddl:"static" sql:"COMMENT"`
 	IfExists *bool            `ddl:"keyword" sql:"IF EXISTS"`

--- a/pkg/sdk/databases.go
+++ b/pkg/sdk/databases.go
@@ -23,29 +23,17 @@ var (
 )
 
 type Databases interface {
-	// Create creates a database.
 	Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateDatabaseOptions) error
-	// CreateShared creates a database from a shared database.
 	CreateShared(ctx context.Context, id AccountObjectIdentifier, shareID ExternalObjectIdentifier, opts *CreateSharedDatabaseOptions) error
-	// CreateSecondary creates a secondary database.
 	CreateSecondary(ctx context.Context, id AccountObjectIdentifier, primaryID ExternalObjectIdentifier, opts *CreateSecondaryDatabaseOptions) error
-	// Alter modifies an existing database
 	Alter(ctx context.Context, id AccountObjectIdentifier, opts *AlterDatabaseOptions) error
-	// AlterReplication modifies an existing database replica
 	AlterReplication(ctx context.Context, id AccountObjectIdentifier, opts *AlterDatabaseReplicationOptions) error
-	// AlterFailover modifies an existing database failover group
 	AlterFailover(ctx context.Context, id AccountObjectIdentifier, opts *AlterDatabaseFailoverOptions) error
-	// Drop removes a database.
 	Drop(ctx context.Context, id AccountObjectIdentifier, opts *DropDatabaseOptions) error
-	// Undrop restores the most recent version of a dropped database
 	Undrop(ctx context.Context, id AccountObjectIdentifier) error
-	// Show returns a list of databases.
 	Show(ctx context.Context, opts *ShowDatabasesOptions) ([]Database, error)
-	// ShowByID returns a database by ID
 	ShowByID(ctx context.Context, id AccountObjectIdentifier) (*Database, error)
-	// Describe returns the details of a database.
 	Describe(ctx context.Context, id AccountObjectIdentifier) (*DatabaseDetails, error)
-	// Use sets the active database for the current session.
 	Use(ctx context.Context, id AccountObjectIdentifier) error
 }
 
@@ -144,6 +132,7 @@ func (row databaseRow) convert() *Database {
 	return database
 }
 
+// CreateDatabaseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-database.
 type CreateDatabaseOptions struct {
 	create                     bool                    `ddl:"static" sql:"CREATE"`
 	OrReplace                  *bool                   `ddl:"keyword" sql:"OR REPLACE"`
@@ -186,6 +175,7 @@ func (v *databases) Create(ctx context.Context, id AccountObjectIdentifier, opts
 	return err
 }
 
+// CreateSharedDatabaseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-database.
 type CreateSharedDatabaseOptions struct {
 	create    bool                     `ddl:"static" sql:"CREATE"`
 	database  bool                     `ddl:"static" sql:"DATABASE"`
@@ -223,6 +213,7 @@ func (v *databases) CreateShared(ctx context.Context, id AccountObjectIdentifier
 	return err
 }
 
+// CreateSecondaryDatabaseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-database.
 type CreateSecondaryDatabaseOptions struct {
 	create                  bool                     `ddl:"static" sql:"CREATE"`
 	database                bool                     `ddl:"static" sql:"DATABASE"`
@@ -258,6 +249,7 @@ func (v *databases) CreateSecondary(ctx context.Context, id AccountObjectIdentif
 	return err
 }
 
+// AlterDatabaseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-database.
 type AlterDatabaseOptions struct {
 	alter    bool                    `ddl:"static" sql:"ALTER"`
 	database bool                    `ddl:"static" sql:"DATABASE"`
@@ -341,6 +333,7 @@ func (v *databases) Alter(ctx context.Context, id AccountObjectIdentifier, opts 
 	return err
 }
 
+// AlterDatabaseReplicationOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-database.
 type AlterDatabaseReplicationOptions struct {
 	alter              bool                    `ddl:"static" sql:"ALTER"`
 	database           bool                    `ddl:"static" sql:"DATABASE"`
@@ -406,6 +399,7 @@ func (v *databases) AlterReplication(ctx context.Context, id AccountObjectIdenti
 	return err
 }
 
+// AlterDatabaseFailoverOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-database.
 type AlterDatabaseFailoverOptions struct {
 	alter           bool                    `ddl:"static" sql:"ALTER"`
 	database        bool                    `ddl:"static" sql:"DATABASE"`
@@ -470,6 +464,7 @@ func (v *databases) AlterFailover(ctx context.Context, id AccountObjectIdentifie
 	return err
 }
 
+// DropDatabaseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-database.
 type DropDatabaseOptions struct {
 	drop     bool                    `ddl:"static" sql:"DROP"`
 	database bool                    `ddl:"static" sql:"DATABASE"`
@@ -500,6 +495,7 @@ func (v *databases) Drop(ctx context.Context, id AccountObjectIdentifier, opts *
 	return err
 }
 
+// undropDatabaseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/undrop-database.
 type undropDatabaseOptions struct {
 	undrop   bool                    `ddl:"static" sql:"UNDROP"`
 	database bool                    `ddl:"static" sql:"DATABASE"`
@@ -528,6 +524,7 @@ func (v *databases) Undrop(ctx context.Context, id AccountObjectIdentifier) erro
 	return err
 }
 
+// ShowDatabasesOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-databases.
 type ShowDatabasesOptions struct {
 	show       bool       `ddl:"static" sql:"SHOW"`
 	Terse      *bool      `ddl:"keyword" sql:"TERSE"`
@@ -579,6 +576,7 @@ type DatabaseDetailsRow struct {
 	Kind      string
 }
 
+// describeDatabaseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/desc-database.
 type describeDatabaseOptions struct {
 	describe bool                    `ddl:"static" sql:"DESCRIBE"`
 	database bool                    `ddl:"static" sql:"DATABASE"`
@@ -614,6 +612,7 @@ func (v *databases) Describe(ctx context.Context, id AccountObjectIdentifier) (*
 	return &details, err
 }
 
+// Use is based on https://docs.snowflake.com/en/sql-reference/sql/use-database.
 func (v *databases) Use(ctx context.Context, id AccountObjectIdentifier) error {
 	// proxy to sessions
 	return v.client.Sessions.UseDatabase(ctx, id)

--- a/pkg/sdk/failover_groups.go
+++ b/pkg/sdk/failover_groups.go
@@ -10,7 +10,6 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// Compile-time proof of interface implementation.
 var _ FailoverGroups = (*failoverGroups)(nil)
 
 var (
@@ -26,26 +25,15 @@ var (
 	_ validatable = new(describeDatabaseOptions)
 )
 
-// FailoverGroups describes all the failover group related methods that the
-// Snowflake API supports.
 type FailoverGroups interface {
-	// Create creates a new failover group.
 	Create(ctx context.Context, id AccountObjectIdentifier, objectTypes []PluralObjectType, allowedAccounts []AccountIdentifier, opts *CreateFailoverGroupOptions) error
-	// CreateSecondaryReplicationGroup creates a new secondary replication group.
 	CreateSecondaryReplicationGroup(ctx context.Context, id AccountObjectIdentifier, primaryFailoverGroupID ExternalObjectIdentifier, opts *CreateSecondaryReplicationGroupOptions) error
-	// Alter modifies an existing failover group in a source acount.
 	AlterSource(ctx context.Context, id AccountObjectIdentifier, opts *AlterSourceFailoverGroupOptions) error
-	// AlterTarget modifies an existing failover group in a target acount.
 	AlterTarget(ctx context.Context, id AccountObjectIdentifier, opts *AlterTargetFailoverGroupOptions) error
-	// Drop removes a failover group.
 	Drop(ctx context.Context, id AccountObjectIdentifier, opts *DropFailoverGroupOptions) error
-	// Show returns a list of failover groups.
 	Show(ctx context.Context, opts *ShowFailoverGroupOptions) ([]FailoverGroup, error)
-	// ShowByID returns a failover group by ID
 	ShowByID(ctx context.Context, id AccountObjectIdentifier) (*FailoverGroup, error)
-	// ShowDatabases returns a list of databases in a failover group.
 	ShowDatabases(ctx context.Context, id AccountObjectIdentifier) ([]AccountObjectIdentifier, error)
-	// ShowShares returns a list of shares in a failover group.
 	ShowShares(ctx context.Context, id AccountObjectIdentifier) ([]AccountObjectIdentifier, error)
 }
 
@@ -63,6 +51,7 @@ const (
 	IntegrationTypeNotificationIntegrations IntegrationType = "NOTIFICATION INTEGRATIONS"
 )
 
+// CreateFailoverGroupOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-failover-group.
 type CreateFailoverGroupOptions struct {
 	create        bool                    `ddl:"static" sql:"CREATE"`
 	failoverGroup bool                    `ddl:"static" sql:"FAILOVER GROUP"`
@@ -103,6 +92,7 @@ func (v *failoverGroups) Create(ctx context.Context, id AccountObjectIdentifier,
 	return err
 }
 
+// CreateSecondaryReplicationGroupOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-failover-group.
 type CreateSecondaryReplicationGroupOptions struct {
 	create               bool                     `ddl:"static" sql:"CREATE"`
 	failoverGroup        bool                     `ddl:"static" sql:"FAILOVER GROUP"`
@@ -138,6 +128,7 @@ func (v *failoverGroups) CreateSecondaryReplicationGroup(ctx context.Context, id
 	return err
 }
 
+// AlterSourceFailoverGroupOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-failover-group.
 type AlterSourceFailoverGroupOptions struct {
 	alter         bool                    `ddl:"static" sql:"ALTER"`
 	failoverGroup bool                    `ddl:"static" sql:"FAILOVER GROUP"`
@@ -244,6 +235,7 @@ func (v *failoverGroups) AlterSource(ctx context.Context, id AccountObjectIdenti
 	return err
 }
 
+// AlterTargetFailoverGroupOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-failover-group.
 type AlterTargetFailoverGroupOptions struct {
 	alter         bool                    `ddl:"static" sql:"ALTER"`
 	failoverGroup bool                    `ddl:"static" sql:"FAILOVER GROUP"`
@@ -281,6 +273,7 @@ func (v *failoverGroups) AlterTarget(ctx context.Context, id AccountObjectIdenti
 	return err
 }
 
+// DropFailoverGroupOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-failover-group.
 type DropFailoverGroupOptions struct {
 	drop          bool                    `ddl:"static" sql:"DROP"`
 	failoverGroup bool                    `ddl:"static" sql:"FAILOVER GROUP"`
@@ -314,7 +307,7 @@ func (v *failoverGroups) Drop(ctx context.Context, id AccountObjectIdentifier, o
 	return err
 }
 
-// ShowFailoverGroupOptions represents the options for listing failover groups.
+// ShowFailoverGroupOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-failover-groups.
 type ShowFailoverGroupOptions struct {
 	show           bool              `ddl:"static" sql:"SHOW"`
 	failoverGroups bool              `ddl:"static" sql:"FAILOVER GROUPS"`
@@ -485,6 +478,7 @@ func (v *failoverGroups) ShowByID(ctx context.Context, id AccountObjectIdentifie
 	return nil, errObjectNotExistOrAuthorized
 }
 
+// showFailoverGroupDatabasesOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-databases-in-failover-group.
 type showFailoverGroupDatabasesOptions struct {
 	show      bool                    `ddl:"static" sql:"SHOW"`
 	databases bool                    `ddl:"static" sql:"DATABASES"`
@@ -523,6 +517,7 @@ func (v *failoverGroups) ShowDatabases(ctx context.Context, id AccountObjectIden
 	return resultList, nil
 }
 
+// showFailoverGroupSharesOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-shares-in-failover-group.
 type showFailoverGroupSharesOptions struct {
 	show      bool                    `ddl:"static" sql:"SHOW"`
 	databases bool                    `ddl:"static" sql:"SHARES"`

--- a/pkg/sdk/file_format.go
+++ b/pkg/sdk/file_format.go
@@ -21,17 +21,11 @@ var (
 )
 
 type FileFormats interface {
-	// Create creates a FileFormat.
 	Create(ctx context.Context, id SchemaObjectIdentifier, opts *CreateFileFormatOptions) error
-	// Alter modifies an existing FileFormat
 	Alter(ctx context.Context, id SchemaObjectIdentifier, opts *AlterFileFormatOptions) error
-	// Drop removes a FileFormat.
 	Drop(ctx context.Context, id SchemaObjectIdentifier, opts *DropFileFormatOptions) error
-	// Show returns a list of fileFormats.
 	Show(ctx context.Context, opts *ShowFileFormatsOptions) ([]FileFormat, error)
-	// ShowByID returns a FileFormat by ID
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*FileFormat, error)
-	// Describe returns the details of a FileFormat.
 	Describe(ctx context.Context, id SchemaObjectIdentifier) (*FileFormatDetails, error)
 }
 
@@ -326,6 +320,7 @@ type NullString struct {
 	S string `ddl:"parameter,no_equals,single_quotes"`
 }
 
+// CreateFileFormatOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-file-format.
 type CreateFileFormatOptions struct {
 	create      bool                   `ddl:"static" sql:"CREATE"`
 	OrReplace   *bool                  `ddl:"keyword" sql:"OR REPLACE"`
@@ -374,6 +369,7 @@ func (v *fileFormats) Create(ctx context.Context, id SchemaObjectIdentifier, opt
 	return err
 }
 
+// AlterFileFormatOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-file-format.
 type AlterFileFormatOptions struct {
 	alter      bool                   `ddl:"static" sql:"ALTER"`
 	fileFormat bool                   `ddl:"static" sql:"FILE FORMAT"`
@@ -600,6 +596,7 @@ func (v *fileFormats) Alter(ctx context.Context, id SchemaObjectIdentifier, opts
 	return err
 }
 
+// DropFileFormatOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-file-format.
 type DropFileFormatOptions struct {
 	drop       bool                   `ddl:"static" sql:"DROP"`
 	fileFormat string                 `ddl:"static" sql:"FILE FORMAT"`
@@ -627,6 +624,7 @@ func (v *fileFormats) Drop(ctx context.Context, id SchemaObjectIdentifier, opts 
 	return err
 }
 
+// ShowFileFormatsOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-file-formats.
 type ShowFileFormatsOptions struct {
 	show        bool  `ddl:"static" sql:"SHOW"`
 	fileFormats bool  `ddl:"static" sql:"FILE FORMATS"`
@@ -680,6 +678,7 @@ type FileFormatDetailsRow struct {
 	Property_Default string
 }
 
+// describeFileFormatOptions is based on https://docs.snowflake.com/en/sql-reference/sql/desc-file-format.
 type describeFileFormatOptions struct {
 	describe   bool                   `ddl:"static" sql:"DESCRIBE"`
 	fileFormat string                 `ddl:"static" sql:"FILE FORMAT"`

--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -115,6 +115,7 @@ type RevokePrivilegesFromDatabaseRoleOptions struct {
 	Cascade        *bool                        `ddl:"keyword" sql:"CASCADE"`
 }
 
+// grantPrivilegeToShareOptions is based on https://docs.snowflake.com/en/sql-reference/sql/grant-privilege-share.
 type grantPrivilegeToShareOptions struct {
 	grant     bool                     `ddl:"static" sql:"GRANT"`
 	privilege ObjectPrivilege          `ddl:"keyword"`
@@ -135,6 +136,7 @@ type OnTable struct {
 	AllInSchema DatabaseObjectIdentifier `ddl:"identifier" sql:"ALL TABLES IN SCHEMA"`
 }
 
+// revokePrivilegeFromShareOptions is based on https://docs.snowflake.com/en/sql-reference/sql/revoke-privilege-share.
 type revokePrivilegeFromShareOptions struct {
 	revoke    bool                        `ddl:"static" sql:"REVOKE"`
 	privilege ObjectPrivilege             `ddl:"keyword"`
@@ -154,6 +156,7 @@ type OnView struct {
 	AllInSchema DatabaseObjectIdentifier `ddl:"identifier" sql:"ALL VIEWS IN SCHEMA"`
 }
 
+// ShowGrantOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-grants.
 type ShowGrantOptions struct {
 	show   bool          `ddl:"static" sql:"SHOW"`
 	Future *bool         `ddl:"keyword" sql:"FUTURE"`

--- a/pkg/sdk/helper_test.go
+++ b/pkg/sdk/helper_test.go
@@ -19,7 +19,7 @@ func getAccountIdentifier(t *testing.T, client *Client) AccountIdentifier {
 	ctx := context.Background()
 	currentAccountLocator, err := client.ContextFunctions.CurrentAccount(ctx)
 	require.NoError(t, err)
-	replicationAccounts, err := client.ReplicationFunctions.ShowReplicationAcccounts(ctx)
+	replicationAccounts, err := client.ReplicationFunctions.ShowReplicationAccounts(ctx)
 	require.NoError(t, err)
 	for _, replicationAccount := range replicationAccounts {
 		if replicationAccount.AccountLocator == currentAccountLocator {

--- a/pkg/sdk/masking_policy.go
+++ b/pkg/sdk/masking_policy.go
@@ -10,7 +10,6 @@ import (
 	"github.com/buger/jsonparser"
 )
 
-// Compile-time proof of interface implementation.
 var _ MaskingPolicies = (*maskingPolicies)(nil)
 
 var (
@@ -21,28 +20,20 @@ var (
 	_ validatable = new(describeMaskingPolicyOptions)
 )
 
-// MaskingPolicies describes all the masking policy related methods that the
-// Snowflake API supports.
 type MaskingPolicies interface {
-	// Create creates a new masking policy.
 	Create(ctx context.Context, id SchemaObjectIdentifier, signature []TableColumnSignature, returns DataType, expression string, opts *CreateMaskingPolicyOptions) error
-	// Alter modifies an existing masking policy.
 	Alter(ctx context.Context, id SchemaObjectIdentifier, opts *AlterMaskingPolicyOptions) error
-	// Drop removes a masking policy.
 	Drop(ctx context.Context, id SchemaObjectIdentifier) error
-	// Show returns a list of masking policies.
 	Show(ctx context.Context, opts *ShowMaskingPolicyOptions) ([]MaskingPolicy, error)
-	// ShowByID returns a masking policy by ID
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*MaskingPolicy, error)
-	// Describe returns the details of a masking policy.
 	Describe(ctx context.Context, id SchemaObjectIdentifier) (*MaskingPolicyDetails, error)
 }
 
-// maskingPolicies implements MaskingPolicies.
 type maskingPolicies struct {
 	client *Client
 }
 
+// CreateMaskingPolicyOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-masking-policy.
 type CreateMaskingPolicyOptions struct {
 	create        bool                   `ddl:"static" sql:"CREATE"`
 	OrReplace     *bool                  `ddl:"keyword" sql:"OR REPLACE"`
@@ -87,6 +78,7 @@ func (v *maskingPolicies) Create(ctx context.Context, id SchemaObjectIdentifier,
 	return err
 }
 
+// AlterMaskingPolicyOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-masking-policy.
 type AlterMaskingPolicyOptions struct {
 	alter         bool                   `ddl:"static" sql:"ALTER"`
 	maskingPolicy bool                   `ddl:"static" sql:"MASKING POLICY"`
@@ -168,6 +160,7 @@ func (v *maskingPolicies) Alter(ctx context.Context, id SchemaObjectIdentifier, 
 	return err
 }
 
+// DropMaskingPolicyOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-masking-policy.
 type DropMaskingPolicyOptions struct {
 	drop          bool                   `ddl:"static" sql:"DROP"`
 	maskingPolicy bool                   `ddl:"static" sql:"MASKING POLICY"`
@@ -200,7 +193,7 @@ func (v *maskingPolicies) Drop(ctx context.Context, id SchemaObjectIdentifier) e
 	return err
 }
 
-// ShowMaskingPolicyOptions represents the options for listing masking policies.
+// ShowMaskingPolicyOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-masking-policies.
 type ShowMaskingPolicyOptions struct {
 	show            bool  `ddl:"static" sql:"SHOW"`
 	maskingPolicies bool  `ddl:"static" sql:"MASKING POLICIES"`
@@ -295,6 +288,7 @@ func (v *maskingPolicies) ShowByID(ctx context.Context, id SchemaObjectIdentifie
 	return nil, errObjectNotExistOrAuthorized
 }
 
+// describeMaskingPolicyOptions is based on https://docs.snowflake.com/en/sql-reference/sql/desc-masking-policy.
 type describeMaskingPolicyOptions struct {
 	describe      bool                   `ddl:"static" sql:"DESCRIBE"`
 	maskingPolicy bool                   `ddl:"static" sql:"MASKING POLICY"`

--- a/pkg/sdk/parameters.go
+++ b/pkg/sdk/parameters.go
@@ -783,6 +783,7 @@ const (
 	UserParameterWeekStart                             UserParameter = "WEEK_START"
 )
 
+// AccountParameters is based on https://docs.snowflake.com/en/sql-reference/parameters#account-parameters.
 type AccountParameters struct {
 	// Account Parameters
 	AllowClientMFACaching                        *bool    `ddl:"parameter" sql:"ALLOW_CLIENT_MFA_CACHING"`
@@ -880,6 +881,7 @@ const (
 	UnsupportedDDLActionFail   UnsupportedDDLAction = "FAIL"
 )
 
+// SessionParameters is based on https://docs.snowflake.com/en/sql-reference/parameters#session-parameters.
 type SessionParameters struct {
 	AbortDetachedQuery                    *bool                             `ddl:"parameter" sql:"ABORT_DETACHED_QUERY"`
 	Autocommit                            *bool                             `ddl:"parameter" sql:"AUTOCOMMIT"`
@@ -1021,6 +1023,7 @@ const (
 	TraceLevelOff     TraceLevel = "OFF"
 )
 
+// ObjectParameters is based on https://docs.snowflake.com/en/sql-reference/parameters#object-parameters.
 type ObjectParameters struct {
 	DataRetentionTimeInDays             *int           `ddl:"parameter" sql:"DATA_RETENTION_TIME_IN_DAYS"`
 	DefaultDDLCollation                 *string        `ddl:"parameter,single_quotes" sql:"DEFAULT_DDL_COLLATION"`
@@ -1106,6 +1109,7 @@ type UserParametersUnset struct {
 	EnableUnredactedQuerySyntaxError *bool `ddl:"keyword" sql:"ENABLE_UNREDACTED_QUERY_SYNTAX_ERROR"`
 }
 
+// ShowParametersOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-parameters.
 type ShowParametersOptions struct {
 	show       bool          `ddl:"static" sql:"SHOW"`       //lint:ignore U1000 This is used in the ddl tag
 	parameters bool          `ddl:"static" sql:"PARAMETERS"` //lint:ignore U1000 This is used in the ddl tag

--- a/pkg/sdk/password_policy.go
+++ b/pkg/sdk/password_policy.go
@@ -7,7 +7,6 @@ import (
 	"time"
 )
 
-// Compile-time proof of interface implementation.
 var _ PasswordPolicies = (*passwordPolicies)(nil)
 
 var (
@@ -18,20 +17,12 @@ var (
 	_ validatable = new(describePasswordPolicyOptions)
 )
 
-// PasswordPolicies describes all the password policy related methods that the
-// Snowflake API supports.
 type PasswordPolicies interface {
-	// Create creates a new password policy.
 	Create(ctx context.Context, id SchemaObjectIdentifier, opts *CreatePasswordPolicyOptions) error
-	// Alter modifies an existing password policy.
 	Alter(ctx context.Context, id SchemaObjectIdentifier, opts *AlterPasswordPolicyOptions) error
-	// Drop removes a password policy.
 	Drop(ctx context.Context, id SchemaObjectIdentifier, opts *DropPasswordPolicyOptions) error
-	// Show returns a list of password policies.
 	Show(ctx context.Context, opts *ShowPasswordPolicyOptions) ([]PasswordPolicy, error)
-	// ShowByID returns a password policy by ID.
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*PasswordPolicy, error)
-	// Describe returns the details of a password policy.
 	Describe(ctx context.Context, id SchemaObjectIdentifier) (*PasswordPolicyDetails, error)
 }
 
@@ -40,6 +31,7 @@ type passwordPolicies struct {
 	client *Client
 }
 
+// CreatePasswordPolicyOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-password-policy.
 type CreatePasswordPolicyOptions struct {
 	create         bool                   `ddl:"static" sql:"CREATE"`
 	OrReplace      *bool                  `ddl:"keyword" sql:"OR REPLACE"`
@@ -84,6 +76,7 @@ func (v *passwordPolicies) Create(ctx context.Context, id SchemaObjectIdentifier
 	return err
 }
 
+// AlterPasswordPolicyOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-password-policy.
 type AlterPasswordPolicyOptions struct {
 	alter          bool                   `ddl:"static" sql:"ALTER"`
 	passwordPolicy bool                   `ddl:"static" sql:"PASSWORD POLICY"`
@@ -212,6 +205,7 @@ func (v *passwordPolicies) Alter(ctx context.Context, id SchemaObjectIdentifier,
 	return err
 }
 
+// DropPasswordPolicyOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-password-policy.
 type DropPasswordPolicyOptions struct {
 	drop           bool                   `ddl:"static" sql:"DROP"`
 	passwordPolicy bool                   `ddl:"static" sql:"PASSWORD POLICY"`
@@ -242,7 +236,7 @@ func (v *passwordPolicies) Drop(ctx context.Context, id SchemaObjectIdentifier, 
 	return err
 }
 
-// ShowPasswordPolicyOptions represents the options for listing password policies.
+// ShowPasswordPolicyOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-password-policies.
 type ShowPasswordPolicyOptions struct {
 	show             bool  `ddl:"static" sql:"SHOW"`
 	passwordPolicies bool  `ddl:"static" sql:"PASSWORD POLICIES"`
@@ -343,6 +337,7 @@ func (v *passwordPolicies) ShowByID(ctx context.Context, id SchemaObjectIdentifi
 	return nil, errObjectNotExistOrAuthorized
 }
 
+// describePasswordPolicyOptions is based on https://docs.snowflake.com/en/sql-reference/sql/desc-password-policy.
 type describePasswordPolicyOptions struct {
 	describe       bool                   `ddl:"static" sql:"DESCRIBE"`
 	passwordPolicy bool                   `ddl:"static" sql:"PASSWORD POLICY"`

--- a/pkg/sdk/pipes.go
+++ b/pkg/sdk/pipes.go
@@ -8,24 +8,15 @@ import (
 var _ convertibleRow[Pipe] = new(pipeDBRow)
 
 type Pipes interface {
-	// Create creates a pipe.
 	Create(ctx context.Context, id SchemaObjectIdentifier, copyStatement string, opts *CreatePipeOptions) error
-	// Alter modifies an existing pipe.
 	Alter(ctx context.Context, id SchemaObjectIdentifier, opts *AlterPipeOptions) error
-	// Drop removes a pipe.
 	Drop(ctx context.Context, id SchemaObjectIdentifier) error
-	// Show returns a list of pipes.
 	Show(ctx context.Context, opts *ShowPipeOptions) ([]Pipe, error)
-	// ShowByID returns a pipe by ID.
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Pipe, error)
-	// Describe returns the details of a pipe.
 	Describe(ctx context.Context, id SchemaObjectIdentifier) (*Pipe, error)
 }
 
-// CreatePipeOptions contains options for creating a new pipe in the system for defining the COPY INTO <table> statement
-// used by Snowpipe to load data from an ingestion queue into tables.
-//
-// Based on https://docs.snowflake.com/en/sql-reference/sql/create-pipe.
+// CreatePipeOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-pipe.
 type CreatePipeOptions struct {
 	create      bool                   `ddl:"static" sql:"CREATE"`
 	OrReplace   *bool                  `ddl:"keyword" sql:"OR REPLACE"`
@@ -43,9 +34,7 @@ type CreatePipeOptions struct {
 	copyStatement string `ddl:"keyword,no_quotes"`
 }
 
-// AlterPipeOptions contains options for modifying a limited set of properties for an existing pipe object.
-//
-// Based on https://docs.snowflake.com/en/sql-reference/sql/alter-pipe.
+// AlterPipeOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-pipe.
 type AlterPipeOptions struct {
 	alter    bool                   `ddl:"static" sql:"ALTER"`
 	role     bool                   `ddl:"static" sql:"PIPE"`
@@ -84,9 +73,7 @@ type PipeRefresh struct {
 	ModifiedAfter *string `ddl:"parameter,single_quotes" sql:"MODIFIED_AFTER"`
 }
 
-// DropPipeOptions contains options for removing the specified pipe from the current/specified schema.
-//
-// Based on https://docs.snowflake.com/en/sql-reference/sql/drop-pipe.
+// DropPipeOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-pipe.
 type DropPipeOptions struct {
 	drop     bool                   `ddl:"static" sql:"DROP"`
 	pipe     bool                   `ddl:"static" sql:"PIPE"`
@@ -94,9 +81,7 @@ type DropPipeOptions struct {
 	name     SchemaObjectIdentifier `ddl:"identifier"`
 }
 
-// ShowPipeOptions contains options for showing pipes which user has access privilege to.
-//
-// https://docs.snowflake.com/en/sql-reference/sql/show-pipes
+// ShowPipeOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-pipes.
 type ShowPipeOptions struct {
 	show  bool  `ddl:"static" sql:"SHOW"`
 	pipes bool  `ddl:"static" sql:"PIPES"`
@@ -181,9 +166,7 @@ func (row pipeDBRow) convert() *Pipe {
 	return &pipe
 }
 
-// describePipeOptions contains options for describing the properties specified for a pipe, as well as the default values of the properties.
-//
-// Based on https://docs.snowflake.com/en/sql-reference/sql/desc-pipe.
+// describePipeOptions is based on https://docs.snowflake.com/en/sql-reference/sql/desc-pipe.
 type describePipeOptions struct {
 	describe bool                   `ddl:"static" sql:"DESCRIBE"`
 	pipe     bool                   `ddl:"static" sql:"PIPE"`

--- a/pkg/sdk/replication_functions.go
+++ b/pkg/sdk/replication_functions.go
@@ -8,7 +8,7 @@ import (
 var _ validatable = new(ShowRegionsOptions)
 
 type ReplicationFunctions interface {
-	ShowReplicationAcccounts(ctx context.Context) ([]*ReplicationAccount, error)
+	ShowReplicationAccounts(ctx context.Context) ([]*ReplicationAccount, error)
 	// todo: ShowReplicationDatabases(ctx context.Context, opts *ShowReplicationDatabasesOptions) ([]*ReplicationDatabase, error)
 	ShowRegions(ctx context.Context, opts *ShowRegionsOptions) ([]*Region, error)
 }
@@ -37,7 +37,8 @@ func (v *ReplicationAccount) ID() AccountIdentifier {
 	}
 }
 
-func (c *replicationFunctions) ShowReplicationAcccounts(ctx context.Context) ([]*ReplicationAccount, error) {
+// ShowReplicationAccounts is based on https://docs.snowflake.com/en/sql-reference/sql/show-replication-accounts.
+func (c *replicationFunctions) ShowReplicationAccounts(ctx context.Context) ([]*ReplicationAccount, error) {
 	rows := []ReplicationAccount{}
 	sql := "SHOW REPLICATION ACCOUNTS"
 	err := c.client.query(ctx, &rows, sql)
@@ -96,6 +97,7 @@ func (opts *ShowRegionsOptions) validate() error {
 	return nil
 }
 
+// ShowRegions is based on https://docs.snowflake.com/en/sql-reference/sql/show-regions.
 func (c *replicationFunctions) ShowRegions(ctx context.Context, opts *ShowRegionsOptions) ([]*Region, error) {
 	if opts == nil {
 		opts = &ShowRegionsOptions{}

--- a/pkg/sdk/replication_functions_integration_test.go
+++ b/pkg/sdk/replication_functions_integration_test.go
@@ -11,7 +11,7 @@ import (
 func TestInt_ShowReplicationFunctions(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
-	accounts, err := client.ReplicationFunctions.ShowReplicationAcccounts(ctx)
+	accounts, err := client.ReplicationFunctions.ShowReplicationAccounts(ctx)
 	if err != nil {
 		t.Skip("replication not enabled in this account")
 	}

--- a/pkg/sdk/resource_monitors.go
+++ b/pkg/sdk/resource_monitors.go
@@ -17,15 +17,10 @@ var (
 )
 
 type ResourceMonitors interface {
-	// Create creates a resource monitor.
 	Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateResourceMonitorOptions) error
-	// Alter modifies an existing resource monitor
 	Alter(ctx context.Context, id AccountObjectIdentifier, opts *AlterResourceMonitorOptions) error
-	// Drop removes a resource monitor.
 	Drop(ctx context.Context, id AccountObjectIdentifier) error
-	// Show returns a list of resource monitor.
 	Show(ctx context.Context, opts *ShowResourceMonitorOptions) ([]ResourceMonitor, error)
-	// ShowByID returns a resource monitor by ID
 	ShowByID(ctx context.Context, id AccountObjectIdentifier) (*ResourceMonitor, error)
 }
 
@@ -182,7 +177,7 @@ func (v *ResourceMonitor) ObjectType() ObjectType {
 	return ObjectTypeResourceMonitor
 }
 
-// CreateResourceMonitorOptions contains options for creating a resource monitor.
+// CreateResourceMonitorOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-resource-monitor.
 type CreateResourceMonitorOptions struct {
 	create          bool                    `ddl:"static" sql:"CREATE"`
 	OrReplace       *bool                   `ddl:"keyword" sql:"OR REPLACE"`
@@ -274,7 +269,7 @@ const (
 	FrequencyNever   Frequency = "NEVER"
 )
 
-// AlterResourceMonitorOptions contains options for altering a resource monitor.
+// AlterResourceMonitorOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-resource-monitor.
 type AlterResourceMonitorOptions struct {
 	alter           bool                    `ddl:"static" sql:"ALTER"`
 	resourceMonitor bool                    `ddl:"static" sql:"RESOURCE MONITOR"`
@@ -324,7 +319,7 @@ type ResourceMonitorSet struct {
 	EndTimestamp   *string    `ddl:"parameter,equals,single_quotes" sql:"END_TIMESTAMP"`
 }
 
-// resourceMonitorDropOptions contains options for dropping a resource monitor.
+// dropResourceMonitorOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-resource-monitor.
 type dropResourceMonitorOptions struct {
 	drop            bool                    `ddl:"static" sql:"DROP"`
 	resourceMonitor bool                    `ddl:"static" sql:"RESOURCE MONITOR"`
@@ -353,7 +348,7 @@ func (v *resourceMonitors) Drop(ctx context.Context, id AccountObjectIdentifier)
 	return err
 }
 
-// ShowResourceMonitorOptions contains options for listing resource monitors.
+// ShowResourceMonitorOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-resource-monitors.
 type ShowResourceMonitorOptions struct {
 	show             bool  `ddl:"static" sql:"SHOW"`
 	resourceMonitors bool  `ddl:"static" sql:"RESOURCE MONITORS"`

--- a/pkg/sdk/roles.go
+++ b/pkg/sdk/roles.go
@@ -7,23 +7,14 @@ import (
 )
 
 type Roles interface {
-	// Create creates a role.
 	Create(ctx context.Context, req *CreateRoleRequest) error
-	// Alter modifies an existing role
 	Alter(ctx context.Context, req *AlterRoleRequest) error
-	// Drop removes a role.
 	Drop(ctx context.Context, req *DropRoleRequest) error
-	// Show returns a list of roles.
 	Show(ctx context.Context, req *ShowRoleRequest) ([]Role, error)
-	// ShowByID returns a user by ID
 	ShowByID(ctx context.Context, req *ShowRoleByIdRequest) (*Role, error)
-	// Grant grants privileges on a role.
 	Grant(ctx context.Context, req *GrantRoleRequest) error
-	// Revoke revokes privileges on a role.
 	Revoke(ctx context.Context, req *RevokeRoleRequest) error
-	// Use sets the active role for the current session.
 	Use(ctx context.Context, req *UseRoleRequest) error
-	// UseSecondary specifies the active/current secondary roles for the session.
 	UseSecondary(ctx context.Context, req *UseSecondaryRolesRequest) error
 }
 

--- a/pkg/sdk/schemas.go
+++ b/pkg/sdk/schemas.go
@@ -17,21 +17,13 @@ var (
 )
 
 type Schemas interface {
-	// Create creates a schema.
 	Create(ctx context.Context, id DatabaseObjectIdentifier, opts *CreateSchemaOptions) error
-	// Alter modifies an existing schema.
 	Alter(ctx context.Context, id DatabaseObjectIdentifier, opts *AlterSchemaOptions) error
-	// Drop removes a schema.
 	Drop(ctx context.Context, id DatabaseObjectIdentifier, opts *DropSchemaOptions) error
-	// Undrop restores the most recent version of a dropped schema.
 	Undrop(ctx context.Context, id DatabaseObjectIdentifier) error
-	// Describe lists objects in the schema.
 	Describe(ctx context.Context, id DatabaseObjectIdentifier) ([]SchemaDetails, error)
-	// Show returns a list of schemas.
 	Show(ctx context.Context, opts *ShowSchemaOptions) ([]Schema, error)
-	// ShowByID returns a schema by ID.
 	ShowByID(ctx context.Context, id DatabaseObjectIdentifier) (*Schema, error)
-	// Use sets the active schema for the current session.
 	Use(ctx context.Context, id DatabaseObjectIdentifier) error
 }
 
@@ -265,6 +257,7 @@ func (v *schemas) Drop(ctx context.Context, id DatabaseObjectIdentifier, opts *D
 	return err
 }
 
+// undropSchemaOptions is based on https://docs.snowflake.com/en/sql-reference/sql/undrop-schema.
 type undropSchemaOptions struct {
 	undrop bool                     `ddl:"static" sql:"UNDROP"`
 	schema bool                     `ddl:"static" sql:"SCHEMA"`
@@ -293,6 +286,7 @@ func (v *schemas) Undrop(ctx context.Context, id DatabaseObjectIdentifier) error
 	return err
 }
 
+// describeSchemaOptions is based on https://docs.snowflake.com/en/sql-reference/sql/desc-schema.
 type describeSchemaOptions struct {
 	describe bool                     `ddl:"static" sql:"DESCRIBE"`
 	database bool                     `ddl:"static" sql:"SCHEMA"`

--- a/pkg/sdk/sessions.go
+++ b/pkg/sdk/sessions.go
@@ -28,6 +28,7 @@ type sessions struct {
 	client *Client
 }
 
+// AlterSessionOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-session.
 type AlterSessionOptions struct {
 	alter   bool          `ddl:"static" sql:"ALTER"`
 	session bool          `ddl:"static" sql:"SESSION"`
@@ -118,6 +119,7 @@ func (v *sessions) UseRole(ctx context.Context, role AccountObjectIdentifier) er
 	return err
 }
 
+// SecondaryRoleOption is based on https://docs.snowflake.com/en/sql-reference/sql/use-secondary-roles.
 type SecondaryRoleOption string
 
 const (

--- a/pkg/sdk/shares.go
+++ b/pkg/sdk/shares.go
@@ -16,19 +16,12 @@ var (
 )
 
 type Shares interface {
-	// Create creates a share.
 	Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateShareOptions) error
-	// Alter modifies an existing share
 	Alter(ctx context.Context, id AccountObjectIdentifier, opts *AlterShareOptions) error
-	// Drop removes a share.
 	Drop(ctx context.Context, id AccountObjectIdentifier) error
-	// Show returns a list of shares.
 	Show(ctx context.Context, opts *ShowShareOptions) ([]Share, error)
-	// ShowByID returns a share by ID.
 	ShowByID(ctx context.Context, id AccountObjectIdentifier) (*Share, error)
-	// Describe returns the details of an outbound share.
 	DescribeProvider(ctx context.Context, id AccountObjectIdentifier) (*ShareDetails, error)
-	// Describe returns the details of an inbound share.
 	DescribeConsumer(ctx context.Context, id ExternalObjectIdentifier) (*ShareDetails, error)
 }
 
@@ -108,6 +101,7 @@ func (r shareRow) convert() *Share {
 	}
 }
 
+// CreateShareOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-share.
 type CreateShareOptions struct {
 	create    bool                    `ddl:"static" sql:"CREATE"`
 	OrReplace *bool                   `ddl:"keyword" sql:"OR REPLACE"`
@@ -139,6 +133,7 @@ func (v *shares) Create(ctx context.Context, id AccountObjectIdentifier, opts *C
 	return err
 }
 
+// dropShareOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-share.
 type dropShareOptions struct {
 	drop  bool                    `ddl:"static" sql:"DROP"`
 	share bool                    `ddl:"static" sql:"SHARE"`
@@ -164,6 +159,7 @@ func (v *shares) Drop(ctx context.Context, id AccountObjectIdentifier) error {
 	return err
 }
 
+// AlterShareOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-share.
 type AlterShareOptions struct {
 	alter    bool                    `ddl:"static" sql:"ALTER"`
 	share    bool                    `ddl:"static" sql:"SHARE"`
@@ -269,6 +265,7 @@ func (v *shares) Alter(ctx context.Context, id AccountObjectIdentifier, opts *Al
 	return err
 }
 
+// ShowShareOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-shares.
 type ShowShareOptions struct {
 	show       bool       `ddl:"static" sql:"SHOW"`
 	shares     bool       `ddl:"static" sql:"SHARES"`
@@ -343,6 +340,7 @@ func shareDetailsFromRows(rows []shareDetailsRow) *ShareDetails {
 	return v
 }
 
+// describeShareOptions is based on https://docs.snowflake.com/en/sql-reference/sql/desc-share.
 type describeShareOptions struct {
 	describe bool             `ddl:"static" sql:"DESCRIBE"`
 	share    bool             `ddl:"static" sql:"SHARE"`

--- a/pkg/sdk/users.go
+++ b/pkg/sdk/users.go
@@ -17,17 +17,11 @@ var (
 )
 
 type Users interface {
-	// Create creates a user.
 	Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateUserOptions) error
-	// Alter modifies an existing user
 	Alter(ctx context.Context, id AccountObjectIdentifier, opts *AlterUserOptions) error
-	// Drop removes a user.
 	Drop(ctx context.Context, id AccountObjectIdentifier) error
-	// Describe returns the details of a user.
 	Describe(ctx context.Context, id AccountObjectIdentifier) (*UserDetails, error)
-	// Show returns a list of users.
 	Show(ctx context.Context, opts *ShowUserOptions) ([]User, error)
-	// ShowByID returns a user by ID
 	ShowByID(ctx context.Context, id AccountObjectIdentifier) (*User, error)
 }
 
@@ -156,8 +150,7 @@ func (v *User) ObjectType() ObjectType {
 	return ObjectTypeUser
 }
 
-// CreateUserOptions contains options for creating a user.
-// Based on https://docs.snowflake.com/en/sql-reference/sql/create-user.
+// CreateUserOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-user.
 type CreateUserOptions struct {
 	create            bool                    `ddl:"static" sql:"CREATE"`
 	OrReplace         *bool                   `ddl:"keyword" sql:"OR REPLACE"`
@@ -262,8 +255,7 @@ type UserObjectParametersUnset struct {
 	NetworkPolicy                    *bool `ddl:"keyword" sql:"NETWORK_POLICY"`
 }
 
-// AlterUserOptions contains options for altering a user.
-// Based on https://docs.snowflake.com/en/sql-reference/sql/alter-user.
+// AlterUserOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-user.
 type AlterUserOptions struct {
 	alter    bool                    `ddl:"static" sql:"ALTER"`
 	user     bool                    `ddl:"static" sql:"USER"`
@@ -392,8 +384,7 @@ func (opts *UserUnset) validate() error {
 	return nil
 }
 
-// DropUserOptions contains options for dropping a user.
-// Based on https://docs.snowflake.com/en/sql-reference/sql/drop-user.
+// DropUserOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-user.
 type DropUserOptions struct {
 	drop bool                    `ddl:"static" sql:"DROP"`
 	user bool                    `ddl:"static" sql:"USER"`
@@ -528,8 +519,7 @@ func userDetailsFromRows(rows []propertyRow) *UserDetails {
 	return v
 }
 
-// describeUserOptions contains options for describing the properties specified for users, as well as the default values of the properties.
-// Based on https://docs.snowflake.com/en/sql-reference/sql/desc-user.
+// describeUserOptions is based on https://docs.snowflake.com/en/sql-reference/sql/desc-user.
 type describeUserOptions struct {
 	describe bool                    `ddl:"static" sql:"DESCRIBE"`
 	user     bool                    `ddl:"static" sql:"USER"`
@@ -564,8 +554,7 @@ func (v *users) Describe(ctx context.Context, id AccountObjectIdentifier) (*User
 	return userDetailsFromRows(dest), nil
 }
 
-// ShowUserOptions contains options for listing users.
-// Based on https://docs.snowflake.com/en/sql-reference/sql/show-users.
+// ShowUserOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-users.
 type ShowUserOptions struct {
 	show       bool    `ddl:"static" sql:"SHOW"`
 	Terse      *bool   `ddl:"static" sql:"TERSE"`

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -18,17 +18,11 @@ var (
 )
 
 type Warehouses interface {
-	// Create creates a warehouse.
 	Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateWarehouseOptions) error
-	// Alter modifies an existing warehouse
 	Alter(ctx context.Context, id AccountObjectIdentifier, opts *AlterWarehouseOptions) error
-	// Drop removes a warehouse.
 	Drop(ctx context.Context, id AccountObjectIdentifier, opts *DropWarehouseOptions) error
-	// Show returns a list of warehouses.
 	Show(ctx context.Context, opts *ShowWarehouseOptions) ([]Warehouse, error)
-	// ShowByID returns a warehouse by ID
 	ShowByID(ctx context.Context, id AccountObjectIdentifier) (*Warehouse, error)
-	// Describe returns the details of a warehouse.
 	Describe(ctx context.Context, id AccountObjectIdentifier) (*WarehouseDetails, error)
 }
 
@@ -95,6 +89,7 @@ var (
 	ScalingPolicyEconomy  ScalingPolicy = "ECONOMY"
 )
 
+// CreateWarehouseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-warehouse.
 type CreateWarehouseOptions struct {
 	create      bool                    `ddl:"static" sql:"CREATE"`
 	OrReplace   *bool                   `ddl:"keyword" sql:"OR REPLACE"`
@@ -152,6 +147,7 @@ func (c *warehouses) Create(ctx context.Context, id AccountObjectIdentifier, opt
 	return err
 }
 
+// AlterWarehouseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-warehouse.
 type AlterWarehouseOptions struct {
 	alter     bool                    `ddl:"static" sql:"ALTER"`
 	warehouse bool                    `ddl:"static" sql:"WAREHOUSE"`
@@ -293,6 +289,7 @@ func (c *warehouses) Alter(ctx context.Context, id AccountObjectIdentifier, opts
 	return err
 }
 
+// DropWarehouseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-warehouse.
 type DropWarehouseOptions struct {
 	drop      bool                    `ddl:"static" sql:"DROP"`
 	warehouse bool                    `ddl:"static" sql:"WAREHOUSE"`
@@ -328,6 +325,7 @@ func (c *warehouses) Drop(ctx context.Context, id AccountObjectIdentifier, opts 
 	return err
 }
 
+// ShowWarehouseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-warehouses.
 type ShowWarehouseOptions struct {
 	show       bool  `ddl:"static" sql:"SHOW"`
 	warehouses bool  `ddl:"static" sql:"WAREHOUSES"`
@@ -481,6 +479,7 @@ func (c *warehouses) ShowByID(ctx context.Context, id AccountObjectIdentifier) (
 	return nil, errObjectNotExistOrAuthorized
 }
 
+// describeWarehouseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/desc-warehouse.
 type describeWarehouseOptions struct {
 	describe  bool                    `ddl:"static" sql:"DESCRIBE"`
 	warehouse bool                    `ddl:"static" sql:"WAREHOUSE"`


### PR DESCRIPTION
- Remove interface methods comments
- Add a link to Snowflake doc for every SDK Options struct

Because of the two conclusions we had about SDK:
- We will get rid of meaningless comments, e.g. comments on interface methods. We will not be adding them with new objects.
- We will keep adding documentation comments on struct level (...Options). We are adding them with new objects.
