### PR TITLE
feat: Add task clone to sdk

### DIFF
--- a/pkg/sdk/tasks_def.go
+++ b/pkg/sdk/tasks_def.go
@@ -86,6 +86,20 @@ var TasksDef = g.NewInterface(
 			WithValidation(g.ValidIdentifier, "name").
 			WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists"),
 	).
+	CustomOperation(
+		"Clone",
+		"https://docs.snowflake.com/en/sql-reference/sql/create-task#variant-syntax",
+		g.QueryStruct("CloneTask").
+			Create().
+			OrReplace().
+			SQL("TASK").
+			Name().
+			SQL("CLONE").
+			Identifier("sourceTask", g.KindOfT[SchemaObjectIdentifier](), g.IdentifierOptions().Required()).
+			OptionalSQL("COPY GRANTS").
+			WithValidation(g.ValidIdentifier, "name").
+			WithValidation(g.ValidIdentifier, "sourceTask"),
+	).
 	AlterOperation(
 		"https://docs.snowflake.com/en/sql-reference/sql/alter-task",
 		g.QueryStruct("AlterTask").

--- a/pkg/sdk/tasks_dto_builders_gen.go
+++ b/pkg/sdk/tasks_dto_builders_gen.go
@@ -103,6 +103,26 @@ func (s *CreateTaskWarehouseRequest) WithUserTaskManagedInitialWarehouseSize(Use
 	return s
 }
 
+func NewCloneTaskRequest(
+	name SchemaObjectIdentifier,
+	sourceTask SchemaObjectIdentifier,
+) *CloneTaskRequest {
+	s := CloneTaskRequest{}
+	s.name = name
+	s.sourceTask = sourceTask
+	return &s
+}
+
+func (s *CloneTaskRequest) WithOrReplace(OrReplace *bool) *CloneTaskRequest {
+	s.OrReplace = OrReplace
+	return s
+}
+
+func (s *CloneTaskRequest) WithCopyGrants(CopyGrants *bool) *CloneTaskRequest {
+	s.CopyGrants = CopyGrants
+	return s
+}
+
 func NewAlterTaskRequest(
 	name SchemaObjectIdentifier,
 ) *AlterTaskRequest {

--- a/pkg/sdk/tasks_dto_gen.go
+++ b/pkg/sdk/tasks_dto_gen.go
@@ -4,6 +4,7 @@ package sdk
 
 var (
 	_ optionsProvider[CreateTaskOptions]   = new(CreateTaskRequest)
+	_ optionsProvider[CloneTaskOptions]    = new(CloneTaskRequest)
 	_ optionsProvider[AlterTaskOptions]    = new(AlterTaskRequest)
 	_ optionsProvider[DropTaskOptions]     = new(DropTaskRequest)
 	_ optionsProvider[ShowTaskOptions]     = new(ShowTaskRequest)
@@ -34,6 +35,13 @@ type CreateTaskRequest struct {
 type CreateTaskWarehouseRequest struct {
 	Warehouse                           *AccountObjectIdentifier
 	UserTaskManagedInitialWarehouseSize *WarehouseSize
+}
+
+type CloneTaskRequest struct {
+	OrReplace  *bool
+	name       SchemaObjectIdentifier // required
+	sourceTask SchemaObjectIdentifier // required
+	CopyGrants *bool
 }
 
 type AlterTaskRequest struct {

--- a/pkg/sdk/tasks_gen.go
+++ b/pkg/sdk/tasks_gen.go
@@ -7,6 +7,7 @@ import (
 
 type Tasks interface {
 	Create(ctx context.Context, request *CreateTaskRequest) error
+	Clone(ctx context.Context, request *CloneTaskRequest) error
 	Alter(ctx context.Context, request *AlterTaskRequest) error
 	Drop(ctx context.Context, request *DropTaskRequest) error
 	Show(ctx context.Context, request *ShowTaskRequest) ([]Task, error)
@@ -42,6 +43,17 @@ type CreateTaskOptions struct {
 type CreateTaskWarehouse struct {
 	Warehouse                           *AccountObjectIdentifier `ddl:"identifier,equals" sql:"WAREHOUSE"`
 	UserTaskManagedInitialWarehouseSize *WarehouseSize           `ddl:"parameter,single_quotes" sql:"USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE"`
+}
+
+// CloneTaskOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-task#variant-syntax.
+type CloneTaskOptions struct {
+	create     bool                   `ddl:"static" sql:"CREATE"`
+	OrReplace  *bool                  `ddl:"keyword" sql:"OR REPLACE"`
+	task       bool                   `ddl:"static" sql:"TASK"`
+	name       SchemaObjectIdentifier `ddl:"identifier"`
+	clone      bool                   `ddl:"static" sql:"CLONE"`
+	sourceTask SchemaObjectIdentifier `ddl:"identifier"`
+	CopyGrants *bool                  `ddl:"keyword" sql:"COPY GRANTS"`
 }
 
 // AlterTaskOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-task.

--- a/pkg/sdk/tasks_gen_integration_test.go
+++ b/pkg/sdk/tasks_gen_integration_test.go
@@ -235,6 +235,24 @@ func TestInt_Tasks(t *testing.T) {
 		assert.Equal(t, "v1", returnedTagValue)
 	})
 
+	t.Run("clone task: default", func(t *testing.T) {
+		sourceTask := createTask(t)
+
+		name := randomString(t)
+		id := NewSchemaObjectIdentifier(database.Name, schema.Name, name)
+
+		request := NewCloneTaskRequest(id, sourceTask.ID())
+
+		err := client.Tasks.Clone(ctx, request)
+		require.NoError(t, err)
+		t.Cleanup(cleanupTaskProvider(id))
+
+		task, err := client.Tasks.ShowByID(ctx, id)
+		require.NoError(t, err)
+
+		assertTask(t, task, request.name)
+	})
+
 	t.Run("drop task: existing", func(t *testing.T) {
 		request := createTaskBasicRequest(t)
 		id := request.name

--- a/pkg/sdk/tasks_gen_test.go
+++ b/pkg/sdk/tasks_gen_test.go
@@ -90,6 +90,48 @@ func TestTasks_Create(t *testing.T) {
 	})
 }
 
+func TestTasks_Clone(t *testing.T) {
+	id := randomSchemaObjectIdentifier(t)
+	sourceId := randomSchemaObjectIdentifier(t)
+
+	// Minimal valid CloneTaskOptions
+	defaultOpts := func() *CloneTaskOptions {
+		return &CloneTaskOptions{
+			name:       id,
+			sourceTask: sourceId,
+		}
+	}
+
+	t.Run("validation: nil options", func(t *testing.T) {
+		var opts *CloneTaskOptions = nil
+		assertOptsInvalidJoinedErrors(t, opts, errNilOptions)
+	})
+
+	t.Run("validation: valid identifier for [opts.name]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.name = NewSchemaObjectIdentifier("", "", "")
+		assertOptsInvalidJoinedErrors(t, opts, errInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: valid identifier for [opts.sourceTask]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.sourceTask = NewSchemaObjectIdentifier("", "", "")
+		assertOptsInvalidJoinedErrors(t, opts, errInvalidObjectIdentifier)
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		opts := defaultOpts()
+		assertOptsValidAndSQLEquals(t, opts, "CREATE TASK %s CLONE %s", id.FullyQualifiedName(), sourceId.FullyQualifiedName())
+	})
+
+	t.Run("all options", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.OrReplace = Bool(true)
+		opts.CopyGrants = Bool(true)
+		assertOptsValidAndSQLEquals(t, opts, "CREATE OR REPLACE TASK %s CLONE %s COPY GRANTS", id.FullyQualifiedName(), sourceId.FullyQualifiedName())
+	})
+}
+
 func TestTasks_Alter(t *testing.T) {
 	id := randomSchemaObjectIdentifier(t)
 	otherTaskId := randomSchemaObjectIdentifier(t)

--- a/pkg/sdk/tasks_impl_gen.go
+++ b/pkg/sdk/tasks_impl_gen.go
@@ -15,6 +15,11 @@ func (v *tasks) Create(ctx context.Context, request *CreateTaskRequest) error {
 	return validateAndExec(v.client, ctx, opts)
 }
 
+func (v *tasks) Clone(ctx context.Context, request *CloneTaskRequest) error {
+	opts := request.toOpts()
+	return validateAndExec(v.client, ctx, opts)
+}
+
 func (v *tasks) Alter(ctx context.Context, request *AlterTaskRequest) error {
 	opts := request.toOpts()
 	return validateAndExec(v.client, ctx, opts)
@@ -80,6 +85,16 @@ func (r *CreateTaskRequest) toOpts() *CreateTaskOptions {
 			Warehouse:                           r.Warehouse.Warehouse,
 			UserTaskManagedInitialWarehouseSize: r.Warehouse.UserTaskManagedInitialWarehouseSize,
 		}
+	}
+	return opts
+}
+
+func (r *CloneTaskRequest) toOpts() *CloneTaskOptions {
+	opts := &CloneTaskOptions{
+		OrReplace:  r.OrReplace,
+		name:       r.name,
+		sourceTask: r.sourceTask,
+		CopyGrants: r.CopyGrants,
 	}
 	return opts
 }

--- a/pkg/sdk/tasks_validations_gen.go
+++ b/pkg/sdk/tasks_validations_gen.go
@@ -4,6 +4,7 @@ import "errors"
 
 var (
 	_ validatable = new(CreateTaskOptions)
+	_ validatable = new(CloneTaskOptions)
 	_ validatable = new(AlterTaskOptions)
 	_ validatable = new(DropTaskOptions)
 	_ validatable = new(ShowTaskOptions)
@@ -31,6 +32,20 @@ func (opts *CreateTaskOptions) validate() error {
 		if err := opts.SessionParameters.validate(); err != nil {
 			errs = append(errs, err)
 		}
+	}
+	return errors.Join(errs...)
+}
+
+func (opts *CloneTaskOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
+	}
+	if !validObjectidentifier(opts.sourceTask) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	return errors.Join(errs...)
 }


### PR DESCRIPTION
## Changes
* Add task clone to SDK:
  * Add implementation based on references
  * Update task definition in `tasks_def.go`

## Test Plan
* [x] unit tests (SQL generation and validations)
* [x] integration tests (SQL invocation)
* [x] acceptance tests (nothing should break yet)

## References
* [CREATE TASK ... CLONE](https://docs.snowflake.com/en/sql-reference/sql/create-task#variant-syntax)