### PR TITLE
fix: use schema object identifier in external tables

### DIFF
--- a/pkg/sdk/external_tables.go
+++ b/pkg/sdk/external_tables.go
@@ -48,8 +48,8 @@ type ExternalTable struct {
 	OwnerRoleType       string
 }
 
-func (v *ExternalTable) ID() AccountObjectIdentifier {
-	return NewAccountObjectIdentifier(v.Name)
+func (v *ExternalTable) ID() SchemaObjectIdentifier {
+	return NewSchemaObjectIdentifier(v.DatabaseName, v.SchemaName, v.Name)
 }
 
 func (v *ExternalTable) ObjectType() ObjectType {
@@ -58,12 +58,12 @@ func (v *ExternalTable) ObjectType() ObjectType {
 
 // CreateExternalTableOptions based on https://docs.snowflake.com/en/sql-reference/sql/create-external-table
 type CreateExternalTableOptions struct {
-	create              bool                    `ddl:"static" sql:"CREATE"`
-	OrReplace           *bool                   `ddl:"keyword" sql:"OR REPLACE"`
-	externalTable       bool                    `ddl:"static" sql:"EXTERNAL TABLE"`
-	IfNotExists         *bool                   `ddl:"keyword" sql:"IF NOT EXISTS"`
-	name                AccountObjectIdentifier `ddl:"identifier"`
-	Columns             []ExternalTableColumn   `ddl:"list,parentheses"`
+	create              bool                   `ddl:"static" sql:"CREATE"`
+	OrReplace           *bool                  `ddl:"keyword" sql:"OR REPLACE"`
+	externalTable       bool                   `ddl:"static" sql:"EXTERNAL TABLE"`
+	IfNotExists         *bool                  `ddl:"keyword" sql:"IF NOT EXISTS"`
+	name                SchemaObjectIdentifier `ddl:"identifier"`
+	Columns             []ExternalTableColumn  `ddl:"list,parentheses"`
 	CloudProviderParams *CloudProviderParams
 	PartitionBy         []string                  `ddl:"keyword,parentheses" sql:"PARTITION BY"`
 	Location            string                    `ddl:"parameter" sql:"LOCATION"`
@@ -192,12 +192,12 @@ var (
 
 // CreateWithManualPartitioningExternalTableOptions based on https://docs.snowflake.com/en/sql-reference/sql/create-external-table
 type CreateWithManualPartitioningExternalTableOptions struct {
-	create                     bool                    `ddl:"static" sql:"CREATE"`
-	OrReplace                  *bool                   `ddl:"keyword" sql:"OR REPLACE"`
-	externalTable              bool                    `ddl:"static" sql:"EXTERNAL TABLE"`
-	IfNotExists                *bool                   `ddl:"keyword" sql:"IF NOT EXISTS"`
-	name                       AccountObjectIdentifier `ddl:"identifier"`
-	Columns                    []ExternalTableColumn   `ddl:"list,parentheses"`
+	create                     bool                   `ddl:"static" sql:"CREATE"`
+	OrReplace                  *bool                  `ddl:"keyword" sql:"OR REPLACE"`
+	externalTable              bool                   `ddl:"static" sql:"EXTERNAL TABLE"`
+	IfNotExists                *bool                  `ddl:"keyword" sql:"IF NOT EXISTS"`
+	name                       SchemaObjectIdentifier `ddl:"identifier"`
+	Columns                    []ExternalTableColumn  `ddl:"list,parentheses"`
 	CloudProviderParams        *CloudProviderParams
 	PartitionBy                []string                  `ddl:"keyword,parentheses" sql:"PARTITION BY"`
 	Location                   string                    `ddl:"parameter" sql:"LOCATION"`
@@ -211,12 +211,12 @@ type CreateWithManualPartitioningExternalTableOptions struct {
 
 // CreateDeltaLakeExternalTableOptions based on https://docs.snowflake.com/en/sql-reference/sql/create-external-table
 type CreateDeltaLakeExternalTableOptions struct {
-	create                     bool                    `ddl:"static" sql:"CREATE"`
-	OrReplace                  *bool                   `ddl:"keyword" sql:"OR REPLACE"`
-	externalTable              bool                    `ddl:"static" sql:"EXTERNAL TABLE"`
-	IfNotExists                *bool                   `ddl:"keyword" sql:"IF NOT EXISTS"`
-	name                       AccountObjectIdentifier `ddl:"identifier"`
-	Columns                    []ExternalTableColumn   `ddl:"list,parentheses"`
+	create                     bool                   `ddl:"static" sql:"CREATE"`
+	OrReplace                  *bool                  `ddl:"keyword" sql:"OR REPLACE"`
+	externalTable              bool                   `ddl:"static" sql:"EXTERNAL TABLE"`
+	IfNotExists                *bool                  `ddl:"keyword" sql:"IF NOT EXISTS"`
+	name                       SchemaObjectIdentifier `ddl:"identifier"`
+	Columns                    []ExternalTableColumn  `ddl:"list,parentheses"`
 	CloudProviderParams        *CloudProviderParams
 	PartitionBy                []string                  `ddl:"keyword,parentheses" sql:"PARTITION BY"`
 	Location                   string                    `ddl:"parameter" sql:"LOCATION"`
@@ -233,12 +233,12 @@ type CreateDeltaLakeExternalTableOptions struct {
 
 // CreateExternalTableUsingTemplateOptions based on https://docs.snowflake.com/en/sql-reference/sql/create-external-table#variant-syntax
 type CreateExternalTableUsingTemplateOptions struct {
-	create              bool                    `ddl:"static" sql:"CREATE"`
-	OrReplace           *bool                   `ddl:"keyword" sql:"OR REPLACE"`
-	externalTable       bool                    `ddl:"static" sql:"EXTERNAL TABLE"`
-	name                AccountObjectIdentifier `ddl:"identifier"`
-	CopyGrants          *bool                   `ddl:"keyword" sql:"COPY GRANTS"`
-	Query               []string                `ddl:"parameter,no_equals,parentheses" sql:"USING TEMPLATE"`
+	create              bool                   `ddl:"static" sql:"CREATE"`
+	OrReplace           *bool                  `ddl:"keyword" sql:"OR REPLACE"`
+	externalTable       bool                   `ddl:"static" sql:"EXTERNAL TABLE"`
+	name                SchemaObjectIdentifier `ddl:"identifier"`
+	CopyGrants          *bool                  `ddl:"keyword" sql:"COPY GRANTS"`
+	Query               []string               `ddl:"parameter,no_equals,parentheses" sql:"USING TEMPLATE"`
 	CloudProviderParams *CloudProviderParams
 	PartitionBy         []string                  `ddl:"keyword,parentheses" sql:"PARTITION BY"`
 	Location            string                    `ddl:"parameter" sql:"LOCATION"`
@@ -254,9 +254,9 @@ type CreateExternalTableUsingTemplateOptions struct {
 
 // AlterExternalTableOptions based on https://docs.snowflake.com/en/sql-reference/sql/alter-external-table
 type AlterExternalTableOptions struct {
-	alterExternalTable bool                    `ddl:"static" sql:"ALTER EXTERNAL TABLE"`
-	IfExists           *bool                   `ddl:"keyword" sql:"IF EXISTS"`
-	name               AccountObjectIdentifier `ddl:"identifier"`
+	alterExternalTable bool                   `ddl:"static" sql:"ALTER EXTERNAL TABLE"`
+	IfExists           *bool                  `ddl:"keyword" sql:"IF EXISTS"`
+	name               SchemaObjectIdentifier `ddl:"identifier"`
 	// One of
 	Refresh     *RefreshExternalTable `ddl:"keyword" sql:"REFRESH"`
 	AddFiles    []ExternalTableFile   `ddl:"keyword,no_quotes,parentheses" sql:"ADD FILES"`
@@ -276,12 +276,12 @@ type ExternalTableFile struct {
 
 // AlterExternalTablePartitionOptions based on https://docs.snowflake.com/en/sql-reference/sql/alter-external-table
 type AlterExternalTablePartitionOptions struct {
-	alterExternalTable bool                    `ddl:"static" sql:"ALTER EXTERNAL TABLE"`
-	IfExists           *bool                   `ddl:"keyword" sql:"IF EXISTS"`
-	name               AccountObjectIdentifier `ddl:"identifier"`
-	AddPartitions      []Partition             `ddl:"keyword,parentheses" sql:"ADD PARTITION"`
-	DropPartition      *bool                   `ddl:"keyword" sql:"DROP PARTITION"`
-	Location           string                  `ddl:"parameter,no_equals,single_quotes" sql:"LOCATION"`
+	alterExternalTable bool                   `ddl:"static" sql:"ALTER EXTERNAL TABLE"`
+	IfExists           *bool                  `ddl:"keyword" sql:"IF EXISTS"`
+	name               SchemaObjectIdentifier `ddl:"identifier"`
+	AddPartitions      []Partition            `ddl:"keyword,parentheses" sql:"ADD PARTITION"`
+	DropPartition      *bool                  `ddl:"keyword" sql:"DROP PARTITION"`
+	Location           string                 `ddl:"parameter,no_equals,single_quotes" sql:"LOCATION"`
 }
 
 type Partition struct {
@@ -291,9 +291,9 @@ type Partition struct {
 
 // DropExternalTableOptions based on https://docs.snowflake.com/en/sql-reference/sql/drop-external-table
 type DropExternalTableOptions struct {
-	dropExternalTable bool                    `ddl:"static" sql:"DROP EXTERNAL TABLE"`
-	IfExists          *bool                   `ddl:"keyword" sql:"IF EXISTS"`
-	name              AccountObjectIdentifier `ddl:"identifier"`
+	dropExternalTable bool                   `ddl:"static" sql:"DROP EXTERNAL TABLE"`
+	IfExists          *bool                  `ddl:"keyword" sql:"IF EXISTS"`
+	name              SchemaObjectIdentifier `ddl:"identifier"`
 	DropOption        *ExternalTableDropOption
 }
 
@@ -314,25 +314,25 @@ type ShowExternalTableOptions struct {
 }
 
 type externalTableRow struct {
-	CreatedOn           time.Time
-	Name                string
-	DatabaseName        string
-	SchemaName          string
-	Invalid             bool
-	InvalidReason       sql.NullString
-	Owner               string
-	Comment             string
-	Stage               string
-	Location            string
-	FileFormatName      string
-	FileFormatType      string
-	Cloud               string
-	Region              string
-	NotificationChannel sql.NullString
-	LastRefreshedOn     sql.NullTime
-	TableFormat         string
-	LastRefreshDetails  sql.NullString
-	OwnerRoleType       string
+	CreatedOn           time.Time      `db:"created_on"`
+	Name                string         `db:"name"`
+	DatabaseName        string         `db:"database_name"`
+	SchemaName          string         `db:"schema_name"`
+	Invalid             bool           `db:"invalid"`
+	InvalidReason       sql.NullString `db:"invalid_reason"`
+	Owner               string         `db:"owner"`
+	Comment             string         `db:"comment"`
+	Stage               string         `db:"stage"`
+	Location            string         `db:"location"`
+	FileFormatName      string         `db:"file_format_name"`
+	FileFormatType      sql.NullString `db:"file_format_type"`
+	Cloud               string         `db:"cloud"`
+	Region              string         `db:"region"`
+	NotificationChannel sql.NullString `db:"notification_channel"`
+	LastRefreshedOn     sql.NullTime   `db:"last_refreshed_on"`
+	TableFormat         string         `db:"table_format"`
+	LastRefreshDetails  sql.NullString `db:"last_refresh_details"`
+	OwnerRoleType       string         `db:"owner_role_type"`
 }
 
 func (e externalTableRow) convert() *ExternalTable {
@@ -340,13 +340,12 @@ func (e externalTableRow) convert() *ExternalTable {
 		CreatedOn:      e.CreatedOn,
 		Name:           e.Name,
 		DatabaseName:   e.DatabaseName,
-		SchemaName:     e.DatabaseName,
+		SchemaName:     e.SchemaName,
 		Invalid:        e.Invalid,
 		Owner:          e.Owner,
 		Stage:          e.Stage,
 		Location:       e.Location,
 		FileFormatName: e.FileFormatName,
-		FileFormatType: e.FileFormatType,
 		Cloud:          e.Cloud,
 		Region:         e.Region,
 		TableFormat:    e.TableFormat,
@@ -365,14 +364,17 @@ func (e externalTableRow) convert() *ExternalTable {
 	if e.LastRefreshDetails.Valid {
 		et.LastRefreshDetails = e.LastRefreshDetails.String
 	}
+	if e.FileFormatType.Valid {
+		et.FileFormatType = e.FileFormatType.String
+	}
 	return et
 }
 
 // describeExternalTableColumnsOptions based on https://docs.snowflake.com/en/sql-reference/sql/desc-external-table
 type describeExternalTableColumnsOptions struct {
-	describeExternalTable bool                    `ddl:"static" sql:"DESCRIBE EXTERNAL TABLE"`
-	name                  AccountObjectIdentifier `ddl:"identifier"`
-	columnsType           bool                    `ddl:"static" sql:"TYPE = COLUMNS"`
+	describeExternalTable bool                   `ddl:"static" sql:"DESCRIBE EXTERNAL TABLE"`
+	name                  SchemaObjectIdentifier `ddl:"identifier"`
+	columnsType           bool                   `ddl:"static" sql:"TYPE = COLUMNS"`
 }
 
 type ExternalTableColumnDetails struct {
@@ -432,9 +434,9 @@ func (r externalTableColumnDetailsRow) convert() *ExternalTableColumnDetails {
 }
 
 type describeExternalTableStageOptions struct {
-	describeExternalTable bool                    `ddl:"static" sql:"DESCRIBE EXTERNAL TABLE"`
-	name                  AccountObjectIdentifier `ddl:"identifier"`
-	stageType             bool                    `ddl:"static" sql:"TYPE = STAGE"`
+	describeExternalTable bool                   `ddl:"static" sql:"DESCRIBE EXTERNAL TABLE"`
+	name                  SchemaObjectIdentifier `ddl:"identifier"`
+	stageType             bool                   `ddl:"static" sql:"TYPE = STAGE"`
 }
 
 type ExternalTableStageDetails struct {

--- a/pkg/sdk/external_tables_dto.go
+++ b/pkg/sdk/external_tables_dto.go
@@ -18,7 +18,7 @@ var (
 type CreateExternalTableRequest struct {
 	orReplace           *bool
 	ifNotExists         *bool
-	name                AccountObjectIdentifier // required
+	name                SchemaObjectIdentifier // required
 	columns             []*ExternalTableColumnRequest
 	cloudProviderParams *CloudProviderParamsRequest
 	partitionBy         []string
@@ -302,7 +302,7 @@ func (s *CreateExternalTableRequest) toOpts() *CreateExternalTableOptions {
 type CreateWithManualPartitioningExternalTableRequest struct {
 	orReplace                  *bool
 	ifNotExists                *bool
-	name                       AccountObjectIdentifier // required
+	name                       SchemaObjectIdentifier // required
 	columns                    []*ExternalTableColumnRequest
 	cloudProviderParams        *CloudProviderParamsRequest
 	partitionBy                []string
@@ -365,7 +365,7 @@ func (v *CreateWithManualPartitioningExternalTableRequest) toOpts() *CreateWithM
 type CreateDeltaLakeExternalTableRequest struct {
 	orReplace                  *bool
 	ifNotExists                *bool
-	name                       AccountObjectIdentifier // required
+	name                       SchemaObjectIdentifier // required
 	columns                    []*ExternalTableColumnRequest
 	cloudProviderParams        *CloudProviderParamsRequest
 	partitionBy                []string
@@ -433,7 +433,7 @@ func (v *CreateDeltaLakeExternalTableRequest) toOpts() *CreateDeltaLakeExternalT
 
 type CreateExternalTableUsingTemplateRequest struct {
 	orReplace           *bool
-	name                AccountObjectIdentifier // required
+	name                SchemaObjectIdentifier // required
 	copyGrants          *bool
 	query               string
 	cloudProviderParams *CloudProviderParamsRequest
@@ -493,7 +493,7 @@ func (v *CreateExternalTableUsingTemplateRequest) toOpts() *CreateExternalTableU
 
 type AlterExternalTableRequest struct {
 	ifExists    *bool
-	name        AccountObjectIdentifier // required
+	name        SchemaObjectIdentifier // required
 	refresh     *RefreshExternalTableRequest
 	addFiles    []*ExternalTableFileRequest
 	removeFiles []*ExternalTableFileRequest
@@ -557,7 +557,7 @@ func (v *AlterExternalTableRequest) toOpts() *AlterExternalTableOptions {
 
 type AlterExternalTablePartitionRequest struct {
 	ifExists      *bool
-	name          AccountObjectIdentifier // required
+	name          SchemaObjectIdentifier // required
 	addPartitions []*PartitionRequest
 	dropPartition *bool
 	location      string
@@ -590,7 +590,7 @@ func (v *AlterExternalTablePartitionRequest) toOpts() *AlterExternalTablePartiti
 
 type DropExternalTableRequest struct {
 	ifExists   *bool
-	name       AccountObjectIdentifier // required
+	name       SchemaObjectIdentifier // required
 	dropOption *ExternalTableDropOptionRequest
 }
 
@@ -681,15 +681,15 @@ func (v *ShowExternalTableRequest) toOpts() *ShowExternalTableOptions {
 }
 
 type ShowExternalTableByIDRequest struct {
-	id AccountObjectIdentifier // required
+	id SchemaObjectIdentifier // required
 }
 
 type DescribeExternalTableColumnsRequest struct {
-	id AccountObjectIdentifier // required
+	id SchemaObjectIdentifier // required
 }
 
 type DescribeExternalTableStageRequest struct {
-	id AccountObjectIdentifier // required
+	id SchemaObjectIdentifier // required
 }
 
 func (v *DescribeExternalTableColumnsRequest) toOpts() *describeExternalTableColumnsOptions {

--- a/pkg/sdk/external_tables_dto_builders_gen.go
+++ b/pkg/sdk/external_tables_dto_builders_gen.go
@@ -5,7 +5,7 @@ package sdk
 import ()
 
 func NewCreateExternalTableRequest(
-	name AccountObjectIdentifier,
+	name SchemaObjectIdentifier,
 	location string,
 	fileFormat *ExternalTableFileFormatRequest,
 ) *CreateExternalTableRequest {
@@ -402,7 +402,7 @@ func NewTagAssociationRequest(
 }
 
 func NewCreateWithManualPartitioningExternalTableRequest(
-	name AccountObjectIdentifier,
+	name SchemaObjectIdentifier,
 	location string,
 	fileFormat *ExternalTableFileFormatRequest,
 ) *CreateWithManualPartitioningExternalTableRequest {
@@ -464,7 +464,7 @@ func (s *CreateWithManualPartitioningExternalTableRequest) WithTag(tag []*TagAss
 }
 
 func NewCreateDeltaLakeExternalTableRequest(
-	name AccountObjectIdentifier,
+	name SchemaObjectIdentifier,
 	location string,
 	fileFormat *ExternalTableFileFormatRequest,
 ) *CreateDeltaLakeExternalTableRequest {
@@ -541,7 +541,7 @@ func (s *CreateDeltaLakeExternalTableRequest) WithTag(tag []*TagAssociationReque
 }
 
 func NewCreateExternalTableUsingTemplateRequest(
-	name AccountObjectIdentifier,
+	name SchemaObjectIdentifier,
 	location string,
 	fileFormat *ExternalTableFileFormatRequest,
 ) *CreateExternalTableUsingTemplateRequest {
@@ -613,7 +613,7 @@ func (s *CreateExternalTableUsingTemplateRequest) WithTag(tag []*TagAssociationR
 }
 
 func NewAlterExternalTableRequest(
-	name AccountObjectIdentifier,
+	name SchemaObjectIdentifier,
 ) *AlterExternalTableRequest {
 	s := AlterExternalTableRequest{}
 	s.name = name
@@ -672,7 +672,7 @@ func NewExternalTableFileRequest(
 }
 
 func NewAlterExternalTablePartitionRequest(
-	name AccountObjectIdentifier,
+	name SchemaObjectIdentifier,
 ) *AlterExternalTablePartitionRequest {
 	s := AlterExternalTablePartitionRequest{}
 	s.name = name
@@ -710,7 +710,7 @@ func NewPartitionRequest(
 }
 
 func NewDropExternalTableRequest(
-	name AccountObjectIdentifier,
+	name SchemaObjectIdentifier,
 ) *DropExternalTableRequest {
 	s := DropExternalTableRequest{}
 	s.name = name
@@ -804,7 +804,7 @@ func (s *LimitFromRequest) WithFrom(from *string) *LimitFromRequest {
 }
 
 func NewShowExternalTableByIDRequest(
-	id AccountObjectIdentifier,
+	id SchemaObjectIdentifier,
 ) *ShowExternalTableByIDRequest {
 	s := ShowExternalTableByIDRequest{}
 	s.id = id
@@ -812,7 +812,7 @@ func NewShowExternalTableByIDRequest(
 }
 
 func NewDescribeExternalTableColumnsRequest(
-	id AccountObjectIdentifier,
+	id SchemaObjectIdentifier,
 ) *DescribeExternalTableColumnsRequest {
 	s := DescribeExternalTableColumnsRequest{}
 	s.id = id
@@ -820,7 +820,7 @@ func NewDescribeExternalTableColumnsRequest(
 }
 
 func NewDescribeExternalTableStageRequest(
-	id AccountObjectIdentifier,
+	id SchemaObjectIdentifier,
 ) *DescribeExternalTableStageRequest {
 	s := DescribeExternalTableStageRequest{}
 	s.id = id

--- a/pkg/sdk/external_tables_impl.go
+++ b/pkg/sdk/external_tables_impl.go
@@ -55,7 +55,7 @@ func (v *externalTables) ShowByID(ctx context.Context, req *ShowExternalTableByI
 		return nil, err
 	}
 
-	return findOne(externalTables, func(t ExternalTable) bool { return t.ID() == req.id })
+	return findOne(externalTables, func(t ExternalTable) bool { return t.ID().FullyQualifiedName() == req.id.FullyQualifiedName() })
 }
 
 func (v *externalTables) DescribeColumns(ctx context.Context, req *DescribeExternalTableColumnsRequest) ([]ExternalTableColumnDetails, error) {

--- a/pkg/sdk/external_tables_test.go
+++ b/pkg/sdk/external_tables_test.go
@@ -8,7 +8,7 @@ func TestExternalTablesCreate(t *testing.T) {
 	t.Run("basic options", func(t *testing.T) {
 		opts := &CreateExternalTableOptions{
 			IfNotExists: Bool(true),
-			name:        NewAccountObjectIdentifier("external_table"),
+			name:        NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			Columns: []ExternalTableColumn{
 				{
 					Name:         "column",
@@ -31,13 +31,13 @@ func TestExternalTablesCreate(t *testing.T) {
 				},
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `CREATE EXTERNAL TABLE IF NOT EXISTS "external_table" (column varchar AS (value::column::varchar) NOT NULL CONSTRAINT my_constraint UNIQUE) INTEGRATION = '123' LOCATION = @s1/logs/ FILE_FORMAT = (TYPE = JSON)`)
+		assertOptsValidAndSQLEquals(t, opts, `CREATE EXTERNAL TABLE IF NOT EXISTS "db"."schema"."external_table" (column varchar AS (value::column::varchar) NOT NULL CONSTRAINT my_constraint UNIQUE) INTEGRATION = '123' LOCATION = @s1/logs/ FILE_FORMAT = (TYPE = JSON)`)
 	})
 
 	t.Run("every optional field", func(t *testing.T) {
 		opts := &CreateExternalTableOptions{
 			OrReplace: Bool(true),
-			name:      NewAccountObjectIdentifier("external_table"),
+			name:      NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			Columns: []ExternalTableColumn{
 				{
 					Name:         "column",
@@ -77,14 +77,14 @@ func TestExternalTablesCreate(t *testing.T) {
 			},
 			Comment: String("some_comment"),
 		}
-		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE EXTERNAL TABLE "external_table" (column varchar AS (value::column::varchar) NOT NULL CONSTRAINT my_constraint UNIQUE) INTEGRATION = '123' LOCATION = @s1/logs/ FILE_FORMAT = (TYPE = JSON) AWS_SNS_TOPIC = 'aws_sns_topic' COPY GRANTS COMMENT = 'some_comment' ROW ACCESS POLICY "db"."schema"."row_access_policy" ON (value1, value2) TAG ("tag1" = 'value1', "tag2" = 'value2')`)
+		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE EXTERNAL TABLE "db"."schema"."external_table" (column varchar AS (value::column::varchar) NOT NULL CONSTRAINT my_constraint UNIQUE) INTEGRATION = '123' LOCATION = @s1/logs/ FILE_FORMAT = (TYPE = JSON) AWS_SNS_TOPIC = 'aws_sns_topic' COPY GRANTS COMMENT = 'some_comment' ROW ACCESS POLICY "db"."schema"."row_access_policy" ON (value1, value2) TAG ("tag1" = 'value1', "tag2" = 'value2')`)
 	})
 
 	t.Run("invalid options", func(t *testing.T) {
 		opts := &CreateExternalTableOptions{
 			OrReplace:   Bool(true),
 			IfNotExists: Bool(true),
-			name:        NewAccountObjectIdentifier(""),
+			name:        NewSchemaObjectIdentifier("", "", ""),
 		}
 		assertOptsInvalidJoinedErrors(
 			t, opts,
@@ -100,7 +100,7 @@ func TestExternalTablesCreateWithManualPartitioning(t *testing.T) {
 	t.Run("valid options", func(t *testing.T) {
 		opts := &CreateWithManualPartitioningExternalTableOptions{
 			OrReplace: Bool(true),
-			name:      NewAccountObjectIdentifier("external_table"),
+			name:      NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			Columns: []ExternalTableColumn{
 				{
 					Name:         "column",
@@ -139,14 +139,14 @@ func TestExternalTablesCreateWithManualPartitioning(t *testing.T) {
 			},
 			Comment: String("some_comment"),
 		}
-		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE EXTERNAL TABLE "external_table" (column varchar AS (value::column::varchar) NOT NULL CONSTRAINT my_constraint UNIQUE) INTEGRATION = '123' LOCATION = @s1/logs/ FILE_FORMAT = (TYPE = JSON) COPY GRANTS COMMENT = 'some_comment' ROW ACCESS POLICY "db"."schema"."row_access_policy" ON (value1, value2) TAG ("tag1" = 'value1', "tag2" = 'value2')`)
+		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE EXTERNAL TABLE "db"."schema"."external_table" (column varchar AS (value::column::varchar) NOT NULL CONSTRAINT my_constraint UNIQUE) INTEGRATION = '123' LOCATION = @s1/logs/ FILE_FORMAT = (TYPE = JSON) COPY GRANTS COMMENT = 'some_comment' ROW ACCESS POLICY "db"."schema"."row_access_policy" ON (value1, value2) TAG ("tag1" = 'value1', "tag2" = 'value2')`)
 	})
 
 	t.Run("invalid options", func(t *testing.T) {
 		opts := &CreateWithManualPartitioningExternalTableOptions{
 			OrReplace:   Bool(true),
 			IfNotExists: Bool(true),
-			name:        NewAccountObjectIdentifier(""),
+			name:        NewSchemaObjectIdentifier("", "", ""),
 		}
 		assertOptsInvalidJoinedErrors(
 			t, opts,
@@ -162,7 +162,7 @@ func TestExternalTablesCreateDeltaLake(t *testing.T) {
 	t.Run("valid options", func(t *testing.T) {
 		opts := &CreateDeltaLakeExternalTableOptions{
 			OrReplace: Bool(true),
-			name:      NewAccountObjectIdentifier("external_table"),
+			name:      NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			Columns: []ExternalTableColumn{
 				{
 					Name:             "column",
@@ -199,14 +199,14 @@ func TestExternalTablesCreateDeltaLake(t *testing.T) {
 			},
 			Comment: String("some_comment"),
 		}
-		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE EXTERNAL TABLE "external_table" (column varchar AS (value::column::varchar)) INTEGRATION = '123' PARTITION BY (column) LOCATION = @s1/logs/ FILE_FORMAT = (FORMAT_NAME = 'JSON') TABLE_FORMAT = DELTA COPY GRANTS COMMENT = 'some_comment' ROW ACCESS POLICY "db"."schema"."row_access_policy" ON (value1, value2) TAG ("tag1" = 'value1', "tag2" = 'value2')`)
+		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE EXTERNAL TABLE "db"."schema"."external_table" (column varchar AS (value::column::varchar)) INTEGRATION = '123' PARTITION BY (column) LOCATION = @s1/logs/ FILE_FORMAT = (FORMAT_NAME = 'JSON') TABLE_FORMAT = DELTA COPY GRANTS COMMENT = 'some_comment' ROW ACCESS POLICY "db"."schema"."row_access_policy" ON (value1, value2) TAG ("tag1" = 'value1', "tag2" = 'value2')`)
 	})
 
 	t.Run("invalid options", func(t *testing.T) {
 		opts := &CreateDeltaLakeExternalTableOptions{
 			OrReplace:   Bool(true),
 			IfNotExists: Bool(true),
-			name:        NewAccountObjectIdentifier(""),
+			name:        NewSchemaObjectIdentifier("", "", ""),
 		}
 		assertOptsInvalidJoinedErrors(
 			t, opts,
@@ -222,7 +222,7 @@ func TestExternalTableUsingTemplateOpts(t *testing.T) {
 	t.Run("valid options", func(t *testing.T) {
 		opts := &CreateExternalTableUsingTemplateOptions{
 			OrReplace:  Bool(true),
-			name:       NewAccountObjectIdentifier("external_table"),
+			name:       NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			CopyGrants: Bool(true),
 			Query:      []string{"query statement"},
 			CloudProviderParams: &CloudProviderParams{
@@ -251,12 +251,12 @@ func TestExternalTableUsingTemplateOpts(t *testing.T) {
 				},
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE EXTERNAL TABLE "external_table" COPY GRANTS USING TEMPLATE (query statement) INTEGRATION = '123' PARTITION BY (column) LOCATION = @s1/logs/ FILE_FORMAT = (FORMAT_NAME = 'JSON') COMMENT = 'some_comment' ROW ACCESS POLICY "db"."schema"."row_access_policy" ON (value1, value2) TAG ("tag1" = 'value1', "tag2" = 'value2')`)
+		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE EXTERNAL TABLE "db"."schema"."external_table" COPY GRANTS USING TEMPLATE (query statement) INTEGRATION = '123' PARTITION BY (column) LOCATION = @s1/logs/ FILE_FORMAT = (FORMAT_NAME = 'JSON') COMMENT = 'some_comment' ROW ACCESS POLICY "db"."schema"."row_access_policy" ON (value1, value2) TAG ("tag1" = 'value1', "tag2" = 'value2')`)
 	})
 
 	t.Run("invalid options", func(t *testing.T) {
 		opts := &CreateExternalTableUsingTemplateOptions{
-			name: NewAccountObjectIdentifier(""),
+			name: NewSchemaObjectIdentifier("", "", ""),
 		}
 		assertOptsInvalidJoinedErrors(
 			t, opts,
@@ -272,56 +272,56 @@ func TestExternalTablesAlter(t *testing.T) {
 	t.Run("refresh without path", func(t *testing.T) {
 		opts := &AlterExternalTableOptions{
 			IfExists: Bool(true),
-			name:     NewAccountObjectIdentifier("external_table"),
+			name:     NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			Refresh:  &RefreshExternalTable{},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE IF EXISTS "external_table" REFRESH ''`)
+		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE IF EXISTS "db"."schema"."external_table" REFRESH ''`)
 	})
 
 	t.Run("refresh with path", func(t *testing.T) {
 		opts := &AlterExternalTableOptions{
 			IfExists: Bool(true),
-			name:     NewAccountObjectIdentifier("external_table"),
+			name:     NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			Refresh: &RefreshExternalTable{
 				Path: "some/path",
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE IF EXISTS "external_table" REFRESH 'some/path'`)
+		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE IF EXISTS "db"."schema"."external_table" REFRESH 'some/path'`)
 	})
 
 	t.Run("add files", func(t *testing.T) {
 		opts := &AlterExternalTableOptions{
-			name: NewAccountObjectIdentifier("external_table"),
+			name: NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			AddFiles: []ExternalTableFile{
 				{Name: "one/file.txt"},
 				{Name: "second/file.txt"},
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE "external_table" ADD FILES ('one/file.txt', 'second/file.txt')`)
+		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE "db"."schema"."external_table" ADD FILES ('one/file.txt', 'second/file.txt')`)
 	})
 
 	t.Run("remove files", func(t *testing.T) {
 		opts := &AlterExternalTableOptions{
-			name: NewAccountObjectIdentifier("external_table"),
+			name: NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			RemoveFiles: []ExternalTableFile{
 				{Name: "one/file.txt"},
 				{Name: "second/file.txt"},
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE "external_table" REMOVE FILES ('one/file.txt', 'second/file.txt')`)
+		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE "db"."schema"."external_table" REMOVE FILES ('one/file.txt', 'second/file.txt')`)
 	})
 
 	t.Run("set auto refresh", func(t *testing.T) {
 		opts := &AlterExternalTableOptions{
-			name:        NewAccountObjectIdentifier("external_table"),
+			name:        NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			AutoRefresh: Bool(true),
 		}
-		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE "external_table" SET AUTO_REFRESH = true`)
+		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE "db"."schema"."external_table" SET AUTO_REFRESH = true`)
 	})
 
 	t.Run("set tag", func(t *testing.T) {
 		opts := &AlterExternalTableOptions{
-			name: NewAccountObjectIdentifier("external_table"),
+			name: NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			SetTag: []TagAssociation{
 				{
 					Name:  NewAccountObjectIdentifier("tag1"),
@@ -333,23 +333,23 @@ func TestExternalTablesAlter(t *testing.T) {
 				},
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE "external_table" SET TAG "tag1" = 'tag_value1', "tag2" = 'tag_value2'`)
+		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE "db"."schema"."external_table" SET TAG "tag1" = 'tag_value1', "tag2" = 'tag_value2'`)
 	})
 
 	t.Run("unset tag", func(t *testing.T) {
 		opts := &AlterExternalTableOptions{
-			name: NewAccountObjectIdentifier("external_table"),
+			name: NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			UnsetTag: []ObjectIdentifier{
 				NewAccountObjectIdentifier("tag1"),
 				NewAccountObjectIdentifier("tag2"),
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE "external_table" UNSET TAG "tag1", "tag2"`)
+		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE "db"."schema"."external_table" UNSET TAG "tag1", "tag2"`)
 	})
 
 	t.Run("invalid options", func(t *testing.T) {
 		opts := &AlterExternalTableOptions{
-			name:        NewAccountObjectIdentifier(""),
+			name:        NewSchemaObjectIdentifier("", "", ""),
 			AddFiles:    []ExternalTableFile{{Name: "some file"}},
 			RemoveFiles: []ExternalTableFile{{Name: "some other file"}},
 		}
@@ -364,7 +364,7 @@ func TestExternalTablesAlter(t *testing.T) {
 func TestExternalTablesAlterPartitions(t *testing.T) {
 	t.Run("add partition", func(t *testing.T) {
 		opts := &AlterExternalTablePartitionOptions{
-			name:     NewAccountObjectIdentifier("external_table"),
+			name:     NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			IfExists: Bool(true),
 			AddPartitions: []Partition{
 				{
@@ -378,22 +378,22 @@ func TestExternalTablesAlterPartitions(t *testing.T) {
 			},
 			Location: "123",
 		}
-		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE IF EXISTS "external_table" ADD PARTITION (one = 'one_value', two = 'two_value') LOCATION '123'`)
+		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE IF EXISTS "db"."schema"."external_table" ADD PARTITION (one = 'one_value', two = 'two_value') LOCATION '123'`)
 	})
 
 	t.Run("remove partition", func(t *testing.T) {
 		opts := &AlterExternalTablePartitionOptions{
-			name:          NewAccountObjectIdentifier("external_table"),
+			name:          NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			IfExists:      Bool(true),
 			DropPartition: Bool(true),
 			Location:      "partition_location",
 		}
-		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE IF EXISTS "external_table" DROP PARTITION LOCATION 'partition_location'`)
+		assertOptsValidAndSQLEquals(t, opts, `ALTER EXTERNAL TABLE IF EXISTS "db"."schema"."external_table" DROP PARTITION LOCATION 'partition_location'`)
 	})
 
 	t.Run("invalid options", func(t *testing.T) {
 		opts := &AlterExternalTablePartitionOptions{
-			name:          NewAccountObjectIdentifier(""),
+			name:          NewSchemaObjectIdentifier("", "", ""),
 			AddPartitions: []Partition{{ColumnName: "colName", Value: "value"}},
 			DropPartition: Bool(true),
 		}
@@ -409,28 +409,28 @@ func TestExternalTablesDrop(t *testing.T) {
 	t.Run("restrict", func(t *testing.T) {
 		opts := &DropExternalTableOptions{
 			IfExists: Bool(true),
-			name:     NewAccountObjectIdentifier("external_table"),
+			name:     NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			DropOption: &ExternalTableDropOption{
 				Restrict: Bool(true),
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `DROP EXTERNAL TABLE IF EXISTS "external_table" RESTRICT`)
+		assertOptsValidAndSQLEquals(t, opts, `DROP EXTERNAL TABLE IF EXISTS "db"."schema"."external_table" RESTRICT`)
 	})
 
 	t.Run("cascade", func(t *testing.T) {
 		opts := &DropExternalTableOptions{
 			IfExists: Bool(true),
-			name:     NewAccountObjectIdentifier("external_table"),
+			name:     NewSchemaObjectIdentifier("db", "schema", "external_table"),
 			DropOption: &ExternalTableDropOption{
 				Cascade: Bool(true),
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `DROP EXTERNAL TABLE IF EXISTS "external_table" CASCADE`)
+		assertOptsValidAndSQLEquals(t, opts, `DROP EXTERNAL TABLE IF EXISTS "db"."schema"."external_table" CASCADE`)
 	})
 
 	t.Run("invalid options", func(t *testing.T) {
 		opts := &DropExternalTableOptions{
-			name: NewAccountObjectIdentifier(""),
+			name: NewSchemaObjectIdentifier("", "", ""),
 			DropOption: &ExternalTableDropOption{
 				Restrict: Bool(true),
 				Cascade:  Bool(true),
@@ -486,7 +486,7 @@ func TestExternalTablesShow(t *testing.T) {
 
 	t.Run("invalid options", func(t *testing.T) {
 		opts := &DropExternalTableOptions{
-			name: NewAccountObjectIdentifier(""),
+			name: NewSchemaObjectIdentifier("", "", ""),
 			DropOption: &ExternalTableDropOption{
 				Restrict: Bool(true),
 				Cascade:  Bool(true),
@@ -504,15 +504,15 @@ func TestExternalTablesShow(t *testing.T) {
 func TestExternalTablesDescribe(t *testing.T) {
 	t.Run("type columns", func(t *testing.T) {
 		opts := &describeExternalTableColumnsOptions{
-			name: NewAccountObjectIdentifier("external_table"),
+			name: NewSchemaObjectIdentifier("db", "schema", "external_table"),
 		}
-		assertOptsValidAndSQLEquals(t, opts, `DESCRIBE EXTERNAL TABLE "external_table" TYPE = COLUMNS`)
+		assertOptsValidAndSQLEquals(t, opts, `DESCRIBE EXTERNAL TABLE "db"."schema"."external_table" TYPE = COLUMNS`)
 	})
 
 	t.Run("type stage", func(t *testing.T) {
 		opts := &describeExternalTableStageOptions{
-			name: NewAccountObjectIdentifier("external_table"),
+			name: NewSchemaObjectIdentifier("db", "schema", "external_table"),
 		}
-		assertOptsValidAndSQLEquals(t, opts, `DESCRIBE EXTERNAL TABLE "external_table" TYPE = STAGE`)
+		assertOptsValidAndSQLEquals(t, opts, `DESCRIBE EXTERNAL TABLE "db"."schema"."external_table" TYPE = STAGE`)
 	})
 }

--- a/pkg/sdk/testint/external_tables_integration_test.go
+++ b/pkg/sdk/testint/external_tables_integration_test.go
@@ -18,7 +18,7 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	schema, _ := createSchema(t, client, db)
 
-	stageID := NewAccountObjectIdentifier("EXTERNAL_TABLE_STAGE")
+	stageID := sdk.NewAccountObjectIdentifier("EXTERNAL_TABLE_STAGE")
 	stageLocation := "@external_table_stage"
 	_, _ = createStageWithURL(t, client, stageID, "s3://snowflake-workshop-lab/weather-nyc")
 
@@ -39,17 +39,17 @@ func TestInt_ExternalTables(t *testing.T) {
 		sdk.NewExternalTableColumnRequest("part_date", sdk.DataTypeDate, "parse_json(metadata$external_table_partition):weather_date::date"),
 	}...)
 
-	minimalCreateExternalTableReq := func(name string) *CreateExternalTableRequest {
-		return NewCreateExternalTableRequest(
-			NewSchemaObjectIdentifier(db.Name, schema.Name, name),
+	minimalCreateExternalTableReq := func(name string) *sdk.CreateExternalTableRequest {
+		return sdk.NewCreateExternalTableRequest(
+			sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name),
 			stageLocation,
 			sdk.NewExternalTableFileFormatRequest().WithFileFormatType(&sdk.ExternalTableFileFormatTypeJSON),
 		)
 	}
 
-	createExternalTableWithManualPartitioningReq := func(name string) *CreateWithManualPartitioningExternalTableRequest {
-		return NewCreateWithManualPartitioningExternalTableRequest(
-			NewSchemaObjectIdentifier(db.Name, schema.Name, name),
+	createExternalTableWithManualPartitioningReq := func(name string) *sdk.CreateWithManualPartitioningExternalTableRequest {
+		return sdk.NewCreateWithManualPartitioningExternalTableRequest(
+			sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name),
 			stageLocation,
 			sdk.NewExternalTableFileFormatRequest().WithFileFormatType(&sdk.ExternalTableFileFormatTypeJSON),
 		).
@@ -64,7 +64,7 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Create: minimal", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		err := client.ExternalTables.Create(ctx, minimalCreateExternalTableReq(name))
 		require.NoError(t, err)
 
@@ -75,7 +75,7 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Create: complete", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		err := client.ExternalTables.Create(
 			ctx,
 			sdk.NewCreateExternalTableRequest(
@@ -109,7 +109,7 @@ func TestInt_ExternalTables(t *testing.T) {
 		require.NoError(t, err)
 
 		name := randomAlphanumericN(t, 32)
-		id := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		query := fmt.Sprintf(`SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) WITHIN GROUP (ORDER BY order_id) FROM TABLE (INFER_SCHEMA(location => '%s', FILE_FORMAT=>'%s', ignore_case => true))`, stageLocation, fileFormat.ID().FullyQualifiedName())
 		err = client.ExternalTables.CreateUsingTemplate(
 			ctx,
@@ -128,7 +128,7 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Create with manual partitioning: complete", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		err := client.ExternalTables.CreateWithManualPartitioning(ctx, createExternalTableWithManualPartitioningReq(name))
 		require.NoError(t, err)
 
@@ -139,7 +139,7 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Create delta lake: complete", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		err := client.ExternalTables.CreateDeltaLake(
 			ctx,
 			sdk.NewCreateDeltaLakeExternalTableRequest(
@@ -166,7 +166,7 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Alter: refresh", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		err := client.ExternalTables.Create(ctx, minimalCreateExternalTableReq(name))
 		require.NoError(t, err)
 
@@ -181,11 +181,11 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Alter: add files", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		err := client.ExternalTables.Create(
 			ctx,
 			minimalCreateExternalTableReq(name).
-				WithPattern(String("weather-nyc/weather_2_3_0.json.gz")),
+				WithPattern(sdk.String("weather-nyc/weather_2_3_0.json.gz")),
 		)
 		require.NoError(t, err)
 
@@ -200,11 +200,11 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Alter: remove files", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		err := client.ExternalTables.Create(
 			ctx,
 			minimalCreateExternalTableReq(name).
-				WithPattern(String("weather-nyc/weather_2_3_0.json.gz")),
+				WithPattern(sdk.String("weather-nyc/weather_2_3_0.json.gz")),
 		)
 		require.NoError(t, err)
 
@@ -227,7 +227,7 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Alter: set auto refresh", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		err := client.ExternalTables.Create(ctx, minimalCreateExternalTableReq(name))
 		require.NoError(t, err)
 
@@ -287,7 +287,7 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Alter: add partitions", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		err := client.ExternalTables.CreateWithManualPartitioning(ctx, createExternalTableWithManualPartitioningReq(name))
 		require.NoError(t, err)
 
@@ -303,7 +303,7 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Alter: drop partitions", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		err := client.ExternalTables.CreateWithManualPartitioning(ctx, createExternalTableWithManualPartitioningReq(name))
 		require.NoError(t, err)
 
@@ -328,7 +328,7 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Drop", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		err := client.ExternalTables.Create(ctx, minimalCreateExternalTableReq(name))
 		require.NoError(t, err)
 
@@ -346,7 +346,7 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Show", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		err := client.ExternalTables.Create(ctx, minimalCreateExternalTableReq(name))
 		require.NoError(t, err)
 
@@ -366,7 +366,7 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Describe: columns", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		req := minimalCreateExternalTableReq(name)
 		err := client.ExternalTables.Create(ctx, req)
 		require.NoError(t, err)
@@ -392,7 +392,7 @@ func TestInt_ExternalTables(t *testing.T) {
 
 	t.Run("Describe: stage", func(t *testing.T) {
 		name := randomAlphanumericN(t, 32)
-		externalTableID := NewSchemaObjectIdentifier(db.Name, schema.Name, name)
+		externalTableID := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, name)
 		err := client.ExternalTables.Create(ctx, minimalCreateExternalTableReq(name))
 		require.NoError(t, err)
 


### PR DESCRIPTION
Minor refactors + fixes + usage of SchemaObjectIdentifier instead of AccountObjectIdentifier