### PR TITLE
chore: Integration tests setup db once

### DIFF
--- a/pkg/sdk/testint/accounts_integration_test.go
+++ b/pkg/sdk/testint/accounts_integration_test.go
@@ -234,11 +234,9 @@ func TestInt_AccountAlter(t *testing.T) {
 	})
 
 	t.Run("set and unset password policy", func(t *testing.T) {
-		databaseTest, databaseCleanup := createDatabase(t, client)
-		t.Cleanup(databaseCleanup)
-		schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+		schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 		t.Cleanup(schemaCleanup)
-		passwordPolicyTest, passwordPolicyCleanup := createPasswordPolicy(t, client, databaseTest, schemaTest)
+		passwordPolicyTest, passwordPolicyCleanup := createPasswordPolicy(t, client, testDb(t), schemaTest)
 		t.Cleanup(passwordPolicyCleanup)
 		opts := &sdk.AlterAccountOptions{
 			Set: &sdk.AccountSet{
@@ -259,11 +257,9 @@ func TestInt_AccountAlter(t *testing.T) {
 	})
 
 	t.Run("set and unset session policy", func(t *testing.T) {
-		databaseTest, databaseCleanup := createDatabase(t, client)
-		t.Cleanup(databaseCleanup)
-		schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+		schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 		t.Cleanup(schemaCleanup)
-		sessionPolicyTest, sessionPolicyCleanup := createSessionPolicy(t, client, databaseTest, schemaTest)
+		sessionPolicyTest, sessionPolicyCleanup := createSessionPolicy(t, client, testDb(t), schemaTest)
 		t.Cleanup(sessionPolicyCleanup)
 		opts := &sdk.AlterAccountOptions{
 			Set: &sdk.AccountSet{
@@ -284,13 +280,11 @@ func TestInt_AccountAlter(t *testing.T) {
 	})
 
 	t.Run("set and unset tag", func(t *testing.T) {
-		databaseTest, databaseCleanup := createDatabase(t, client)
-		t.Cleanup(databaseCleanup)
-		schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+		schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 		t.Cleanup(schemaCleanup)
-		tagTest1, tagCleanup1 := createTag(t, client, databaseTest, schemaTest)
+		tagTest1, tagCleanup1 := createTag(t, client, testDb(t), schemaTest)
 		t.Cleanup(tagCleanup1)
-		tagTest2, tagCleanup2 := createTag(t, client, databaseTest, schemaTest)
+		tagTest2, tagCleanup2 := createTag(t, client, testDb(t), schemaTest)
 		t.Cleanup(tagCleanup2)
 
 		opts := &sdk.AlterAccountOptions{

--- a/pkg/sdk/testint/alerts_integration_test.go
+++ b/pkg/sdk/testint/alerts_integration_test.go
@@ -14,19 +14,16 @@ func TestInt_AlertsShow(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
 	testWarehouse, warehouseCleanup := createWarehouse(t, client)
 	t.Cleanup(warehouseCleanup)
 
-	alertTest, alertCleanup := createAlert(t, client, databaseTest, schemaTest, testWarehouse)
+	alertTest, alertCleanup := createAlert(t, client, testDb(t), schemaTest, testWarehouse)
 	t.Cleanup(alertCleanup)
 
-	alert2Test, alert2Cleanup := createAlert(t, client, databaseTest, schemaTest, testWarehouse)
+	alert2Test, alert2Cleanup := createAlert(t, client, testDb(t), schemaTest, testWarehouse)
 	t.Cleanup(alert2Cleanup)
 
 	t.Run("without show options", func(t *testing.T) {
@@ -54,7 +51,7 @@ func TestInt_AlertsShow(t *testing.T) {
 				Pattern: sdk.String(alertTest.Name),
 			},
 			In: &sdk.In{
-				Database: databaseTest.ID(),
+				Database: testDb(t).ID(),
 			},
 		}
 		alerts, err := client.Alerts.Show(ctx, showOptions)
@@ -90,10 +87,8 @@ func TestInt_AlertsShow(t *testing.T) {
 func TestInt_AlertCreate(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
 
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
 	testWarehouse, warehouseCleanup := createWarehouse(t, client)
@@ -105,7 +100,7 @@ func TestInt_AlertCreate(t *testing.T) {
 		condition := "SELECT 1"
 		action := "SELECT 1"
 		comment := random.Comment()
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, name)
 		err := client.Alerts.Create(ctx, id, testWarehouse.ID(), schedule, condition, action, &sdk.CreateAlertOptions{
 			OrReplace:   sdk.Bool(true),
 			IfNotExists: sdk.Bool(false),
@@ -141,7 +136,7 @@ func TestInt_AlertCreate(t *testing.T) {
 		condition := "SELECT 1"
 		action := "SELECT 1"
 		comment := random.Comment()
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, name)
 		err := client.Alerts.Create(ctx, id, testWarehouse.ID(), schedule, condition, action, &sdk.CreateAlertOptions{
 			OrReplace:   sdk.Bool(false),
 			IfNotExists: sdk.Bool(true),
@@ -176,7 +171,7 @@ func TestInt_AlertCreate(t *testing.T) {
 		schedule := "USING CRON * * * * TUE,THU UTC"
 		condition := "SELECT 1"
 		action := "SELECT 1"
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, name)
 		err := client.Alerts.Create(ctx, id, testWarehouse.ID(), schedule, condition, action, nil)
 		require.NoError(t, err)
 		alertDetails, err := client.Alerts.Describe(ctx, id)
@@ -214,7 +209,7 @@ func TestInt_AlertCreate(t *testing.T) {
 						2
 				end
 		`
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, name)
 		err := client.Alerts.Create(ctx, id, testWarehouse.ID(), schedule, condition, action, nil)
 		require.NoError(t, err)
 		alertDetails, err := client.Alerts.Describe(ctx, id)
@@ -244,16 +239,13 @@ func TestInt_AlertDescribe(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
 	warehouseTest, warehouseCleanup := createWarehouse(t, client)
 	t.Cleanup(warehouseCleanup)
 
-	alert, alertCleanup := createAlert(t, client, databaseTest, schemaTest, warehouseTest)
+	alert, alertCleanup := createAlert(t, client, testDb(t), schemaTest, warehouseTest)
 	t.Cleanup(alertCleanup)
 
 	t.Run("when alert exists", func(t *testing.T) {
@@ -263,7 +255,7 @@ func TestInt_AlertDescribe(t *testing.T) {
 	})
 
 	t.Run("when alert does not exist", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, "does_not_exist")
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, "does_not_exist")
 		_, err := client.Alerts.Describe(ctx, id)
 		assert.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
 	})
@@ -273,17 +265,14 @@ func TestInt_AlertAlter(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
 	warehouseTest, warehouseCleanup := createWarehouse(t, client)
 	t.Cleanup(warehouseCleanup)
 
 	t.Run("when setting and unsetting a value", func(t *testing.T) {
-		alert, alertCleanup := createAlert(t, client, databaseTest, schemaTest, warehouseTest)
+		alert, alertCleanup := createAlert(t, client, testDb(t), schemaTest, warehouseTest)
 		t.Cleanup(alertCleanup)
 		newSchedule := "USING CRON * * * * TUE,FRI GMT"
 
@@ -309,7 +298,7 @@ func TestInt_AlertAlter(t *testing.T) {
 	})
 
 	t.Run("when modifying condition and action", func(t *testing.T) {
-		alert, alertCleanup := createAlert(t, client, databaseTest, schemaTest, warehouseTest)
+		alert, alertCleanup := createAlert(t, client, testDb(t), schemaTest, warehouseTest)
 		t.Cleanup(alertCleanup)
 		newCondition := "select * from DUAL where false"
 
@@ -353,7 +342,7 @@ func TestInt_AlertAlter(t *testing.T) {
 	})
 
 	t.Run("resume and then suspend", func(t *testing.T) {
-		alert, alertCleanup := createAlert(t, client, databaseTest, schemaTest, warehouseTest)
+		alert, alertCleanup := createAlert(t, client, testDb(t), schemaTest, warehouseTest)
 		t.Cleanup(alertCleanup)
 
 		alterOptions := &sdk.AlterAlertOptions{
@@ -398,17 +387,14 @@ func TestInt_AlertDrop(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
 	warehouseTest, warehouseCleanup := createWarehouse(t, client)
 	t.Cleanup(warehouseCleanup)
 
 	t.Run("when alert exists", func(t *testing.T) {
-		alert, _ := createAlert(t, client, databaseTest, schemaTest, warehouseTest)
+		alert, _ := createAlert(t, client, testDb(t), schemaTest, warehouseTest)
 		id := alert.ID()
 		err := client.Alerts.Drop(ctx, id)
 		require.NoError(t, err)
@@ -417,7 +403,7 @@ func TestInt_AlertDrop(t *testing.T) {
 	})
 
 	t.Run("when alert does not exist", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, "does_not_exist")
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, "does_not_exist")
 		err := client.Alerts.Drop(ctx, id)
 		assert.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
 	})

--- a/pkg/sdk/testint/dynamic_table_integration_test.go
+++ b/pkg/sdk/testint/dynamic_table_integration_test.go
@@ -14,16 +14,14 @@ func TestInt_DynamicTableCreateAndDrop(t *testing.T) {
 
 	warehouseTest, warehouseCleanup := createWarehouse(t, client)
 	t.Cleanup(warehouseCleanup)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
-	tableTest, tableCleanup := createTable(t, client, databaseTest, schemaTest)
+	tableTest, tableCleanup := createTable(t, client, testDb(t), schemaTest)
 	t.Cleanup(tableCleanup)
 
 	ctx := testContext(t)
 	t.Run("test complete", func(t *testing.T) {
-		name := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, random.String())
+		name := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, random.String())
 		targetLag := sdk.TargetLag{
 			Lagtime: sdk.String("2 minutes"),
 		}
@@ -46,7 +44,7 @@ func TestInt_DynamicTableCreateAndDrop(t *testing.T) {
 	})
 
 	t.Run("test complete with target lag", func(t *testing.T) {
-		name := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, random.String())
+		name := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, random.String())
 		targetLag := sdk.TargetLag{
 			Downstream: sdk.Bool(true),
 		}

--- a/pkg/sdk/testint/failover_groups_integration_test.go
+++ b/pkg/sdk/testint/failover_groups_integration_test.go
@@ -19,8 +19,6 @@ func TestInt_FailoverGroupsCreate(t *testing.T) {
 	}
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
 	shareTest, shareCleanup := createShare(t, client)
 	t.Cleanup(shareCleanup)
 
@@ -37,7 +35,7 @@ func TestInt_FailoverGroupsCreate(t *testing.T) {
 		err := client.FailoverGroups.Create(ctx, id, objectTypes, allowedAccounts, &sdk.CreateFailoverGroupOptions{
 			IfNotExists: sdk.Bool(true),
 			AllowedDatabases: []sdk.AccountObjectIdentifier{
-				databaseTest.ID(),
+				testDb(t).ID(),
 			},
 			AllowedShares: []sdk.AccountObjectIdentifier{
 				shareTest.ID(),
@@ -68,7 +66,7 @@ func TestInt_FailoverGroupsCreate(t *testing.T) {
 		fgDBS, err := client.FailoverGroups.ShowDatabases(ctx, id)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(fgDBS))
-		assert.Equal(t, databaseTest.ID().Name(), fgDBS[0].Name())
+		assert.Equal(t, testDb(t).ID().Name(), fgDBS[0].Name())
 
 		fgShares, err := client.FailoverGroups.ShowShares(ctx, id)
 		require.NoError(t, err)
@@ -242,8 +240,6 @@ func TestInt_FailoverGroupsAlterSource(t *testing.T) {
 	})
 
 	t.Run("add and remove database account object", func(t *testing.T) {
-		databaseTest, cleanupDatabase := createDatabase(t, client)
-		t.Cleanup(cleanupDatabase)
 		failoverGroup, cleanupFailoverGroup := createFailoverGroup(t, client)
 		t.Cleanup(cleanupFailoverGroup)
 
@@ -266,7 +262,7 @@ func TestInt_FailoverGroupsAlterSource(t *testing.T) {
 		opts = &sdk.AlterSourceFailoverGroupOptions{
 			Add: &sdk.FailoverGroupAdd{
 				AllowedDatabases: []sdk.AccountObjectIdentifier{
-					databaseTest.ID(),
+					testDb(t).ID(),
 				},
 			},
 		}
@@ -275,13 +271,13 @@ func TestInt_FailoverGroupsAlterSource(t *testing.T) {
 		allowedDBs, err := client.FailoverGroups.ShowDatabases(ctx, failoverGroup.ID())
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(allowedDBs))
-		assert.Equal(t, databaseTest.ID().Name(), allowedDBs[0].Name())
+		assert.Equal(t, testDb(t).ID().Name(), allowedDBs[0].Name())
 
 		// now remove database from allowed databases
 		opts = &sdk.AlterSourceFailoverGroupOptions{
 			Remove: &sdk.FailoverGroupRemove{
 				AllowedDatabases: []sdk.AccountObjectIdentifier{
-					databaseTest.ID(),
+					testDb(t).ID(),
 				},
 			},
 		}
@@ -729,8 +725,6 @@ func TestInt_FailoverGroupsShowDatabases(t *testing.T) {
 	failoverGroupTest, failoverGroupCleanup := createFailoverGroup(t, client)
 	t.Cleanup(failoverGroupCleanup)
 
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
 	opts := &sdk.AlterSourceFailoverGroupOptions{
 		Set: &sdk.FailoverGroupSet{
 			ObjectTypes: []sdk.PluralObjectType{
@@ -743,7 +737,7 @@ func TestInt_FailoverGroupsShowDatabases(t *testing.T) {
 	opts = &sdk.AlterSourceFailoverGroupOptions{
 		Add: &sdk.FailoverGroupAdd{
 			AllowedDatabases: []sdk.AccountObjectIdentifier{
-				databaseTest.ID(),
+				testDb(t).ID(),
 			},
 		},
 	}
@@ -752,7 +746,7 @@ func TestInt_FailoverGroupsShowDatabases(t *testing.T) {
 	databases, err := client.FailoverGroups.ShowDatabases(ctx, failoverGroupTest.ID())
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(databases))
-	assert.Equal(t, databaseTest.ID(), databases[0])
+	assert.Equal(t, testDb(t).ID(), databases[0])
 }
 
 func TestInt_FailoverGroupsShowShares(t *testing.T) {

--- a/pkg/sdk/testint/file_format_integration_test.go
+++ b/pkg/sdk/testint/file_format_integration_test.go
@@ -13,13 +13,11 @@ import (
 func TestInt_FileFormatsCreateAndRead(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-	schema, schemaCleanup := createSchema(t, client, databaseTest)
+	schema, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
 	t.Run("CSV", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schema.Name, random.String())
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, random.String())
 		err := client.FileFormats.Create(ctx, id, &sdk.CreateFileFormatOptions{
 			Type: sdk.FileFormatTypeCSV,
 			FileFormatTypeOptions: sdk.FileFormatTypeOptions{
@@ -108,7 +106,7 @@ func TestInt_FileFormatsCreateAndRead(t *testing.T) {
 		assert.Equal(t, &sdk.CSVEncodingGB18030, describeResult.Options.CSVEncoding)
 	})
 	t.Run("JSON", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schema.Name, random.String())
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, random.String())
 		err := client.FileFormats.Create(ctx, id, &sdk.CreateFileFormatOptions{
 			Type: sdk.FileFormatTypeJSON,
 			FileFormatTypeOptions: sdk.FileFormatTypeOptions{
@@ -180,7 +178,7 @@ func TestInt_FileFormatsCreateAndRead(t *testing.T) {
 		assert.Equal(t, true, *describeResult.Options.JSONSkipByteOrderMark)
 	})
 	t.Run("AVRO", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schema.Name, random.String())
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, random.String())
 		err := client.FileFormats.Create(ctx, id, &sdk.CreateFileFormatOptions{
 			Type: sdk.FileFormatTypeAvro,
 			FileFormatTypeOptions: sdk.FileFormatTypeOptions{
@@ -222,7 +220,7 @@ func TestInt_FileFormatsCreateAndRead(t *testing.T) {
 		assert.Equal(t, []sdk.NullString{{S: "a"}, {S: "b"}}, *describeResult.Options.AvroNullIf)
 	})
 	t.Run("ORC", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schema.Name, random.String())
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, random.String())
 		err := client.FileFormats.Create(ctx, id, &sdk.CreateFileFormatOptions{
 			Type: sdk.FileFormatTypeORC,
 			FileFormatTypeOptions: sdk.FileFormatTypeOptions{
@@ -261,7 +259,7 @@ func TestInt_FileFormatsCreateAndRead(t *testing.T) {
 		assert.Equal(t, []sdk.NullString{{S: "a"}, {S: "b"}}, *describeResult.Options.ORCNullIf)
 	})
 	t.Run("PARQUET", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schema.Name, random.String())
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, random.String())
 		err := client.FileFormats.Create(ctx, id, &sdk.CreateFileFormatOptions{
 			Type: sdk.FileFormatTypeParquet,
 			FileFormatTypeOptions: sdk.FileFormatTypeOptions{
@@ -306,7 +304,7 @@ func TestInt_FileFormatsCreateAndRead(t *testing.T) {
 		assert.Equal(t, []sdk.NullString{{S: "a"}, {S: "b"}}, *describeResult.Options.ParquetNullIf)
 	})
 	t.Run("XML", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schema.Name, random.String())
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, random.String())
 		err := client.FileFormats.Create(ctx, id, &sdk.CreateFileFormatOptions{
 			Type: sdk.FileFormatTypeXML,
 			FileFormatTypeOptions: sdk.FileFormatTypeOptions{
@@ -362,9 +360,7 @@ func TestInt_FileFormatsAlter(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, cleanupDatabase := createDatabase(t, client)
-	t.Cleanup(cleanupDatabase)
-	schemaTest, cleanupSchema := createSchema(t, client, databaseTest)
+	schemaTest, cleanupSchema := createSchema(t, client, testDb(t))
 	t.Cleanup(cleanupSchema)
 
 	t.Run("rename", func(t *testing.T) {
@@ -425,9 +421,7 @@ func TestInt_FileFormatsDrop(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, cleanupDatabase := createDatabase(t, client)
-	t.Cleanup(cleanupDatabase)
-	schemaTest, cleanupSchema := createSchema(t, client, databaseTest)
+	schemaTest, cleanupSchema := createSchema(t, client, testDb(t))
 	t.Cleanup(cleanupSchema)
 	t.Run("no options", func(t *testing.T) {
 		fileFormat, _ := createFileFormat(t, client, schemaTest.ID())
@@ -454,9 +448,7 @@ func TestInt_FileFormatsShow(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, cleanupDatabase := createDatabase(t, client)
-	t.Cleanup(cleanupDatabase)
-	schemaTest, cleanupSchema := createSchema(t, client, databaseTest)
+	schemaTest, cleanupSchema := createSchema(t, client, testDb(t))
 	t.Cleanup(cleanupSchema)
 	fileFormatTest, cleanupFileFormat := createFileFormat(t, client, schemaTest.ID())
 	t.Cleanup(cleanupFileFormat)
@@ -499,9 +491,7 @@ func TestInt_FileFormatsShowById(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, cleanupDatabase := createDatabase(t, client)
-	t.Cleanup(cleanupDatabase)
-	schemaTest, cleanupSchema := createSchema(t, client, databaseTest)
+	schemaTest, cleanupSchema := createSchema(t, client, testDb(t))
 	t.Cleanup(cleanupSchema)
 	fileFormatTest, cleanupFileFormat := createFileFormat(t, client, schemaTest.ID())
 	t.Cleanup(cleanupFileFormat)
@@ -519,7 +509,7 @@ func TestInt_FileFormatsShowById(t *testing.T) {
 
 		fileFormat, err := client.FileFormats.ShowByID(ctx, fileFormatTest.ID())
 		require.NoError(t, err)
-		assert.Equal(t, databaseTest.Name, fileFormat.Name.DatabaseName())
+		assert.Equal(t, testDb(t).Name, fileFormat.Name.DatabaseName())
 		assert.Equal(t, schemaTest.Name, fileFormat.Name.SchemaName())
 		assert.Equal(t, fileFormatTest.Name.Name(), fileFormat.Name.Name())
 	})

--- a/pkg/sdk/testint/grants_integration_test.go
+++ b/pkg/sdk/testint/grants_integration_test.go
@@ -97,9 +97,7 @@ func TestInt_GrantAndRevokePrivilegesToAccountRole(t *testing.T) {
 	t.Run("on schema", func(t *testing.T) {
 		roleTest, roleCleanup := createRole(t, client)
 		t.Cleanup(roleCleanup)
-		databaseTest, databaseCleanup := createDatabase(t, client)
-		t.Cleanup(databaseCleanup)
-		schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+		schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 		t.Cleanup(schemaCleanup)
 		privileges := &sdk.AccountRoleGrantPrivileges{
 			SchemaPrivileges: []sdk.SchemaPrivilege{sdk.SchemaPrivilegeCreateAlert},
@@ -135,11 +133,9 @@ func TestInt_GrantAndRevokePrivilegesToAccountRole(t *testing.T) {
 	t.Run("on schema object", func(t *testing.T) {
 		roleTest, roleCleanup := createRole(t, client)
 		t.Cleanup(roleCleanup)
-		databaseTest, databaseCleanup := createDatabase(t, client)
-		t.Cleanup(databaseCleanup)
-		schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+		schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 		t.Cleanup(schemaCleanup)
-		tableTest, tableTestCleanup := createTable(t, client, databaseTest, schemaTest)
+		tableTest, tableTestCleanup := createTable(t, client, testDb(t), schemaTest)
 		t.Cleanup(tableTestCleanup)
 		privileges := &sdk.AccountRoleGrantPrivileges{
 			SchemaObjectPrivileges: []sdk.SchemaObjectPrivilege{sdk.SchemaObjectPrivilegeSelect},
@@ -179,8 +175,6 @@ func TestInt_GrantAndRevokePrivilegesToAccountRole(t *testing.T) {
 	t.Run("on future schema object", func(t *testing.T) {
 		roleTest, roleCleanup := createRole(t, client)
 		t.Cleanup(roleCleanup)
-		databaseTest, databaseCleanup := createDatabase(t, client)
-		t.Cleanup(databaseCleanup)
 		privileges := &sdk.AccountRoleGrantPrivileges{
 			SchemaObjectPrivileges: []sdk.SchemaObjectPrivilege{sdk.SchemaObjectPrivilegeSelect},
 		}
@@ -188,7 +182,7 @@ func TestInt_GrantAndRevokePrivilegesToAccountRole(t *testing.T) {
 			SchemaObject: &sdk.GrantOnSchemaObject{
 				Future: &sdk.GrantOnSchemaObjectIn{
 					PluralObjectType: sdk.PluralObjectTypeExternalTables,
-					InDatabase:       sdk.Pointer(databaseTest.ID()),
+					InDatabase:       sdk.Pointer(testDb(t).ID()),
 				},
 			},
 		}
@@ -221,18 +215,15 @@ func TestInt_GrantAndRevokePrivilegesToDatabaseRole(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	database, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
 	t.Run("on database", func(t *testing.T) {
-		databaseRole, _ := createDatabaseRole(t, client, database)
-		databaseRoleId := sdk.NewDatabaseObjectIdentifier(database.Name, databaseRole.Name)
+		databaseRole, _ := createDatabaseRole(t, client, testDb(t))
+		databaseRoleId := sdk.NewDatabaseObjectIdentifier(testDb(t).Name, databaseRole.Name)
 
 		privileges := &sdk.DatabaseRoleGrantPrivileges{
 			DatabasePrivileges: []sdk.AccountObjectPrivilege{sdk.AccountObjectPrivilegeCreateSchema},
 		}
 		on := &sdk.DatabaseRoleGrantOn{
-			Database: sdk.Pointer(database.ID()),
+			Database: sdk.Pointer(testDb(t).ID()),
 		}
 
 		err := client.Grants.GrantPrivilegesToDatabaseRole(ctx, privileges, on, databaseRoleId, nil)
@@ -271,9 +262,9 @@ func TestInt_GrantAndRevokePrivilegesToDatabaseRole(t *testing.T) {
 	})
 
 	t.Run("on schema", func(t *testing.T) {
-		databaseRole, _ := createDatabaseRole(t, client, database)
-		databaseRoleId := sdk.NewDatabaseObjectIdentifier(database.Name, databaseRole.Name)
-		schema, _ := createSchema(t, client, database)
+		databaseRole, _ := createDatabaseRole(t, client, testDb(t))
+		databaseRoleId := sdk.NewDatabaseObjectIdentifier(testDb(t).Name, databaseRole.Name)
+		schema, _ := createSchema(t, client, testDb(t))
 
 		privileges := &sdk.DatabaseRoleGrantPrivileges{
 			SchemaPrivileges: []sdk.SchemaPrivilege{sdk.SchemaPrivilegeCreateAlert},
@@ -320,10 +311,10 @@ func TestInt_GrantAndRevokePrivilegesToDatabaseRole(t *testing.T) {
 	})
 
 	t.Run("on schema object", func(t *testing.T) {
-		databaseRole, _ := createDatabaseRole(t, client, database)
-		databaseRoleId := sdk.NewDatabaseObjectIdentifier(database.Name, databaseRole.Name)
-		schema, _ := createSchema(t, client, database)
-		table, _ := createTable(t, client, database, schema)
+		databaseRole, _ := createDatabaseRole(t, client, testDb(t))
+		databaseRoleId := sdk.NewDatabaseObjectIdentifier(testDb(t).Name, databaseRole.Name)
+		schema, _ := createSchema(t, client, testDb(t))
+		table, _ := createTable(t, client, testDb(t), schema)
 
 		privileges := &sdk.DatabaseRoleGrantPrivileges{
 			SchemaObjectPrivileges: []sdk.SchemaObjectPrivilege{sdk.SchemaObjectPrivilegeSelect},
@@ -374,8 +365,8 @@ func TestInt_GrantAndRevokePrivilegesToDatabaseRole(t *testing.T) {
 	})
 
 	t.Run("on future schema object", func(t *testing.T) {
-		databaseRole, _ := createDatabaseRole(t, client, database)
-		databaseRoleId := sdk.NewDatabaseObjectIdentifier(database.Name, databaseRole.Name)
+		databaseRole, _ := createDatabaseRole(t, client, testDb(t))
+		databaseRoleId := sdk.NewDatabaseObjectIdentifier(testDb(t).Name, databaseRole.Name)
 
 		privileges := &sdk.DatabaseRoleGrantPrivileges{
 			SchemaObjectPrivileges: []sdk.SchemaObjectPrivilege{sdk.SchemaObjectPrivilegeSelect},
@@ -384,7 +375,7 @@ func TestInt_GrantAndRevokePrivilegesToDatabaseRole(t *testing.T) {
 			SchemaObject: &sdk.GrantOnSchemaObject{
 				Future: &sdk.GrantOnSchemaObjectIn{
 					PluralObjectType: sdk.PluralObjectTypeExternalTables,
-					InDatabase:       sdk.Pointer(database.ID()),
+					InDatabase:       sdk.Pointer(testDb(t).ID()),
 				},
 			},
 		}
@@ -424,22 +415,20 @@ func TestInt_GrantPrivilegeToShare(t *testing.T) {
 	ctx := testContext(t)
 	shareTest, shareCleanup := createShare(t, client)
 	t.Cleanup(shareCleanup)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
 	t.Run("without options", func(t *testing.T) {
 		err := client.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, nil, shareTest.ID())
 		require.Error(t, err)
 	})
 	t.Run("with options", func(t *testing.T) {
 		err := client.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
-			Database: databaseTest.ID(),
+			Database: testDb(t).ID(),
 		}, shareTest.ID())
 		require.NoError(t, err)
 		grants, err := client.Grants.Show(ctx, &sdk.ShowGrantOptions{
 			On: &sdk.ShowGrantsOn{
 				Object: &sdk.Object{
 					ObjectType: sdk.ObjectTypeDatabase,
-					Name:       databaseTest.ID(),
+					Name:       testDb(t).ID(),
 				},
 			},
 		})
@@ -456,9 +445,9 @@ func TestInt_GrantPrivilegeToShare(t *testing.T) {
 		assert.Equal(t, string(sdk.ObjectPrivilegeUsage), shareGrant.Privilege)
 		assert.Equal(t, sdk.ObjectTypeDatabase, shareGrant.GrantedOn)
 		assert.Equal(t, sdk.ObjectTypeShare, shareGrant.GrantedTo)
-		assert.Equal(t, databaseTest.ID().Name(), shareGrant.Name.Name())
+		assert.Equal(t, testDb(t).ID().Name(), shareGrant.Name.Name())
 		err = client.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
-			Database: databaseTest.ID(),
+			Database: testDb(t).ID(),
 		}, shareTest.ID())
 		require.NoError(t, err)
 	})
@@ -469,10 +458,8 @@ func TestInt_RevokePrivilegeToShare(t *testing.T) {
 	ctx := testContext(t)
 	shareTest, shareCleanup := createShare(t, client)
 	t.Cleanup(shareCleanup)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
 	err := client.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
-		Database: databaseTest.ID(),
+		Database: testDb(t).ID(),
 	}, shareTest.ID())
 	require.NoError(t, err)
 	t.Run("without options", func(t *testing.T) {
@@ -481,7 +468,7 @@ func TestInt_RevokePrivilegeToShare(t *testing.T) {
 	})
 	t.Run("with options", func(t *testing.T) {
 		err = client.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
-			Database: databaseTest.ID(),
+			Database: testDb(t).ID(),
 		}, shareTest.ID())
 		require.NoError(t, err)
 	})
@@ -491,14 +478,11 @@ func TestInt_GrantOwnership(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	database, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
 	t.Run("on schema object to database role", func(t *testing.T) {
-		databaseRole, _ := createDatabaseRole(t, client, database)
-		databaseRoleId := sdk.NewDatabaseObjectIdentifier(database.Name, databaseRole.Name)
-		schema, _ := createSchema(t, client, database)
-		table, _ := createTable(t, client, database, schema)
+		databaseRole, _ := createDatabaseRole(t, client, testDb(t))
+		databaseRoleId := sdk.NewDatabaseObjectIdentifier(testDb(t).Name, databaseRole.Name)
+		schema, _ := createSchema(t, client, testDb(t))
+		table, _ := createTable(t, client, testDb(t), schema)
 
 		on := sdk.OwnershipGrantOn{
 			Object: &sdk.Object{
@@ -541,7 +525,7 @@ func TestInt_GrantOwnership(t *testing.T) {
 		on := sdk.OwnershipGrantOn{
 			Future: &sdk.GrantOnSchemaObjectIn{
 				PluralObjectType: sdk.PluralObjectTypeExternalTables,
-				InDatabase:       sdk.Pointer(database.ID()),
+				InDatabase:       sdk.Pointer(testDb(t).ID()),
 			},
 		}
 		to := sdk.OwnershipGrantTo{
@@ -613,15 +597,13 @@ func TestInt_ShowGrants(t *testing.T) {
 	ctx := testContext(t)
 	shareTest, shareCleanup := createShare(t, client)
 	t.Cleanup(shareCleanup)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
 	err := client.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
-		Database: databaseTest.ID(),
+		Database: testDb(t).ID(),
 	}, shareTest.ID())
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err = client.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
-			Database: databaseTest.ID(),
+			Database: testDb(t).ID(),
 		}, shareTest.ID())
 		require.NoError(t, err)
 	})
@@ -634,7 +616,7 @@ func TestInt_ShowGrants(t *testing.T) {
 			On: &sdk.ShowGrantsOn{
 				Object: &sdk.Object{
 					ObjectType: sdk.ObjectTypeDatabase,
-					Name:       databaseTest.ID(),
+					Name:       testDb(t).ID(),
 				},
 			},
 		})

--- a/pkg/sdk/testint/helpers.go
+++ b/pkg/sdk/testint/helpers.go
@@ -105,11 +105,6 @@ func createDatabase(t *testing.T, client *sdk.Client) (*sdk.Database, func()) {
 	return createDatabaseWithOptions(t, client, sdk.RandomAccountObjectIdentifier(), &sdk.CreateDatabaseOptions{})
 }
 
-func createDatabaseWithIdentifier(t *testing.T, client *sdk.Client, id sdk.AccountObjectIdentifier) (*sdk.Database, func()) {
-	t.Helper()
-	return createDatabaseWithOptions(t, client, id, &sdk.CreateDatabaseOptions{})
-}
-
 func createDatabaseWithOptions(t *testing.T, client *sdk.Client, id sdk.AccountObjectIdentifier, _ *sdk.CreateDatabaseOptions) (*sdk.Database, func()) {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/sdk/testint/masking_policy_integration_test.go
+++ b/pkg/sdk/testint/masking_policy_integration_test.go
@@ -13,20 +13,18 @@ import (
 func TestInt_MaskingPoliciesShow(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
 
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
-	maskingPolicyTest, maskingPolicyCleanup := createMaskingPolicy(t, client, databaseTest, schemaTest)
+	maskingPolicyTest, maskingPolicyCleanup := createMaskingPolicy(t, client, testDb(t), schemaTest)
 	t.Cleanup(maskingPolicyCleanup)
 
-	maskingPolicy2Test, maskingPolicy2Cleanup := createMaskingPolicy(t, client, databaseTest, schemaTest)
+	maskingPolicy2Test, maskingPolicy2Cleanup := createMaskingPolicy(t, client, testDb(t), schemaTest)
 	t.Cleanup(maskingPolicy2Cleanup)
 
 	t.Run("without show options", func(t *testing.T) {
-		useDatabaseCleanup := useDatabase(t, client, databaseTest.ID())
+		useDatabaseCleanup := useDatabase(t, client, testDb(t).ID())
 		t.Cleanup(useDatabaseCleanup)
 		useSchemaCleanup := useSchema(t, client, schemaTest.ID())
 		t.Cleanup(useSchemaCleanup)
@@ -55,7 +53,7 @@ func TestInt_MaskingPoliciesShow(t *testing.T) {
 				Pattern: sdk.String(maskingPolicyTest.Name),
 			},
 			In: &sdk.In{
-				Database: databaseTest.ID(),
+				Database: testDb(t).ID(),
 			},
 		}
 		maskingPolicies, err := client.MaskingPolicies.Show(ctx, showOptions)
@@ -94,15 +92,13 @@ func TestInt_MaskingPoliciesShow(t *testing.T) {
 func TestInt_MaskingPolicyCreate(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
 
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
 	t.Run("test complete case", func(t *testing.T) {
 		name := random.String()
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, name)
 		signature := []sdk.TableColumnSignature{
 			{
 				Name: "col1",
@@ -147,7 +143,7 @@ func TestInt_MaskingPolicyCreate(t *testing.T) {
 
 	t.Run("test if_not_exists", func(t *testing.T) {
 		name := random.String()
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, name)
 		signature := []sdk.TableColumnSignature{
 			{
 				Name: "col1",
@@ -191,7 +187,7 @@ func TestInt_MaskingPolicyCreate(t *testing.T) {
 
 	t.Run("test no options", func(t *testing.T) {
 		name := random.String()
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, name)
 		signature := []sdk.TableColumnSignature{
 			{
 				Name: "col1",
@@ -225,7 +221,7 @@ func TestInt_MaskingPolicyCreate(t *testing.T) {
 
 	t.Run("test multiline expression", func(t *testing.T) {
 		name := random.String()
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, name)
 		signature := []sdk.TableColumnSignature{
 			{
 				Name: "val",
@@ -257,13 +253,10 @@ func TestInt_MaskingPolicyDescribe(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
-	maskingPolicy, maskingPolicyCleanup := createMaskingPolicy(t, client, databaseTest, schemaTest)
+	maskingPolicy, maskingPolicyCleanup := createMaskingPolicy(t, client, testDb(t), schemaTest)
 	t.Cleanup(maskingPolicyCleanup)
 
 	t.Run("when masking policy exists", func(t *testing.T) {
@@ -273,7 +266,7 @@ func TestInt_MaskingPolicyDescribe(t *testing.T) {
 	})
 
 	t.Run("when masking policy does not exist", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, "does_not_exist")
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, "does_not_exist")
 		_, err := client.MaskingPolicies.Describe(ctx, id)
 		assert.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
 	})
@@ -283,14 +276,11 @@ func TestInt_MaskingPolicyAlter(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
 	t.Run("when setting and unsetting a value", func(t *testing.T) {
-		maskingPolicy, maskingPolicyCleanup := createMaskingPolicy(t, client, databaseTest, schemaTest)
+		maskingPolicy, maskingPolicyCleanup := createMaskingPolicy(t, client, testDb(t), schemaTest)
 		t.Cleanup(maskingPolicyCleanup)
 		comment := random.Comment()
 		alterOptions := &sdk.AlterMaskingPolicyOptions{
@@ -335,11 +325,11 @@ func TestInt_MaskingPolicyAlter(t *testing.T) {
 	})
 
 	t.Run("when renaming", func(t *testing.T) {
-		maskingPolicy, maskingPolicyCleanup := createMaskingPolicy(t, client, databaseTest, schemaTest)
+		maskingPolicy, maskingPolicyCleanup := createMaskingPolicy(t, client, testDb(t), schemaTest)
 		oldID := maskingPolicy.ID()
 		t.Cleanup(maskingPolicyCleanup)
 		newName := random.String()
-		newID := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, newName)
+		newID := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, newName)
 		alterOptions := &sdk.AlterMaskingPolicyOptions{
 			NewName: newID,
 		}
@@ -357,14 +347,14 @@ func TestInt_MaskingPolicyAlter(t *testing.T) {
 	})
 
 	t.Run("setting and unsetting tags", func(t *testing.T) {
-		maskingPolicy, maskingPolicyCleanup := createMaskingPolicy(t, client, databaseTest, schemaTest)
+		maskingPolicy, maskingPolicyCleanup := createMaskingPolicy(t, client, testDb(t), schemaTest)
 		id := maskingPolicy.ID()
 		t.Cleanup(maskingPolicyCleanup)
 
-		tag, tagCleanup := createTag(t, client, databaseTest, schemaTest)
+		tag, tagCleanup := createTag(t, client, testDb(t), schemaTest)
 		t.Cleanup(tagCleanup)
 
-		tag2, tag2Cleanup := createTag(t, client, databaseTest, schemaTest)
+		tag2, tag2Cleanup := createTag(t, client, testDb(t), schemaTest)
 		t.Cleanup(tag2Cleanup)
 
 		tagAssociations := []sdk.TagAssociation{{Name: tag.ID(), Value: "value1"}, {Name: tag2.ID(), Value: "value2"}}
@@ -399,14 +389,11 @@ func TestInt_MaskingPolicyDrop(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
 	t.Run("when masking policy exists", func(t *testing.T) {
-		maskingPolicy, _ := createMaskingPolicy(t, client, databaseTest, schemaTest)
+		maskingPolicy, _ := createMaskingPolicy(t, client, testDb(t), schemaTest)
 		id := maskingPolicy.ID()
 		err := client.MaskingPolicies.Drop(ctx, id)
 		require.NoError(t, err)
@@ -415,7 +402,7 @@ func TestInt_MaskingPolicyDrop(t *testing.T) {
 	})
 
 	t.Run("when masking policy does not exist", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, "does_not_exist")
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, "does_not_exist")
 		err := client.MaskingPolicies.Drop(ctx, id)
 		assert.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
 	})

--- a/pkg/sdk/testint/password_policy_integration_test.go
+++ b/pkg/sdk/testint/password_policy_integration_test.go
@@ -12,16 +12,14 @@ import (
 func TestInt_PasswordPoliciesShow(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
 
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
-	passwordPolicyTest, passwordPolicyCleanup := createPasswordPolicy(t, client, databaseTest, schemaTest)
+	passwordPolicyTest, passwordPolicyCleanup := createPasswordPolicy(t, client, testDb(t), schemaTest)
 	t.Cleanup(passwordPolicyCleanup)
 
-	passwordPolicy2Test, passwordPolicy2Cleanup := createPasswordPolicy(t, client, databaseTest, schemaTest)
+	passwordPolicy2Test, passwordPolicy2Cleanup := createPasswordPolicy(t, client, testDb(t), schemaTest)
 	t.Cleanup(passwordPolicy2Cleanup)
 
 	t.Run("without show options", func(t *testing.T) {
@@ -49,7 +47,7 @@ func TestInt_PasswordPoliciesShow(t *testing.T) {
 				Pattern: sdk.String(passwordPolicyTest.Name),
 			},
 			In: &sdk.In{
-				Database: databaseTest.ID(),
+				Database: testDb(t).ID(),
 			},
 		}
 		passwordPolicies, err := client.PasswordPolicies.Show(ctx, showOptions)
@@ -86,14 +84,12 @@ func TestInt_PasswordPoliciesShow(t *testing.T) {
 func TestInt_PasswordPolicyCreate(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
 
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 	t.Run("test complete", func(t *testing.T) {
 		name := random.UUID()
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, name)
 		err := client.PasswordPolicies.Create(ctx, id, &sdk.CreatePasswordPolicyOptions{
 			OrReplace:                 sdk.Bool(true),
 			PasswordMinLength:         sdk.Int(10),
@@ -127,7 +123,7 @@ func TestInt_PasswordPolicyCreate(t *testing.T) {
 
 	t.Run("test if_not_exists", func(t *testing.T) {
 		name := random.UUID()
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, name)
 		err := client.PasswordPolicies.Create(ctx, id, &sdk.CreatePasswordPolicyOptions{
 			OrReplace:                 sdk.Bool(false),
 			IfNotExists:               sdk.Bool(true),
@@ -150,7 +146,7 @@ func TestInt_PasswordPolicyCreate(t *testing.T) {
 
 	t.Run("test no options", func(t *testing.T) {
 		name := random.UUID()
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, name)
 		err := client.PasswordPolicies.Create(ctx, id, nil)
 		require.NoError(t, err)
 		passwordPolicyDetails, err := client.PasswordPolicies.Describe(ctx, id)
@@ -173,13 +169,10 @@ func TestInt_PasswordPolicyDescribe(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
-	passwordPolicy, passwordPolicyCleanup := createPasswordPolicy(t, client, databaseTest, schemaTest)
+	passwordPolicy, passwordPolicyCleanup := createPasswordPolicy(t, client, testDb(t), schemaTest)
 	t.Cleanup(passwordPolicyCleanup)
 
 	t.Run("when password policy exists", func(t *testing.T) {
@@ -190,7 +183,7 @@ func TestInt_PasswordPolicyDescribe(t *testing.T) {
 	})
 
 	t.Run("when password policy does not exist", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, "does_not_exist")
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, "does_not_exist")
 		_, err := client.PasswordPolicies.Describe(ctx, id)
 		assert.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
 	})
@@ -200,14 +193,11 @@ func TestInt_PasswordPolicyAlter(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
 	t.Run("when setting new values", func(t *testing.T) {
-		passwordPolicy, passwordPolicyCleanup := createPasswordPolicy(t, client, databaseTest, schemaTest)
+		passwordPolicy, passwordPolicyCleanup := createPasswordPolicy(t, client, testDb(t), schemaTest)
 		t.Cleanup(passwordPolicyCleanup)
 		alterOptions := &sdk.AlterPasswordPolicyOptions{
 			Set: &sdk.PasswordPolicySet{
@@ -227,11 +217,11 @@ func TestInt_PasswordPolicyAlter(t *testing.T) {
 	})
 
 	t.Run("when renaming", func(t *testing.T) {
-		passwordPolicy, passwordPolicyCleanup := createPasswordPolicy(t, client, databaseTest, schemaTest)
+		passwordPolicy, passwordPolicyCleanup := createPasswordPolicy(t, client, testDb(t), schemaTest)
 		oldID := passwordPolicy.ID()
 		t.Cleanup(passwordPolicyCleanup)
 		newName := random.UUID()
-		newID := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, newName)
+		newID := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, newName)
 		alterOptions := &sdk.AlterPasswordPolicyOptions{
 			NewName: newID,
 		}
@@ -255,7 +245,7 @@ func TestInt_PasswordPolicyAlter(t *testing.T) {
 			// todo [SNOW-928909]: uncomment this once comments are working again
 			// Comment: String("test comment")
 		}
-		passwordPolicy, passwordPolicyCleanup := createPasswordPolicyWithOptions(t, client, databaseTest, schemaTest, createOptions)
+		passwordPolicy, passwordPolicyCleanup := createPasswordPolicyWithOptions(t, client, testDb(t), schemaTest, createOptions)
 		id := passwordPolicy.ID()
 		t.Cleanup(passwordPolicyCleanup)
 		alterOptions := &sdk.AlterPasswordPolicyOptions{
@@ -288,7 +278,7 @@ func TestInt_PasswordPolicyAlter(t *testing.T) {
 			// todo [SNOW-928909]: uncomment this once comments are working again
 			// Comment: String("test comment")
 		}
-		passwordPolicy, passwordPolicyCleanup := createPasswordPolicyWithOptions(t, client, databaseTest, schemaTest, createOptions)
+		passwordPolicy, passwordPolicyCleanup := createPasswordPolicyWithOptions(t, client, testDb(t), schemaTest, createOptions)
 		id := passwordPolicy.ID()
 		t.Cleanup(passwordPolicyCleanup)
 		alterOptions := &sdk.AlterPasswordPolicyOptions{
@@ -308,14 +298,11 @@ func TestInt_PasswordPolicyDrop(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
 	t.Run("when password policy exists", func(t *testing.T) {
-		passwordPolicy, _ := createPasswordPolicy(t, client, databaseTest, schemaTest)
+		passwordPolicy, _ := createPasswordPolicy(t, client, testDb(t), schemaTest)
 		id := passwordPolicy.ID()
 		err := client.PasswordPolicies.Drop(ctx, id, nil)
 		require.NoError(t, err)
@@ -324,13 +311,13 @@ func TestInt_PasswordPolicyDrop(t *testing.T) {
 	})
 
 	t.Run("when password policy does not exist", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(databaseTest.Name, schemaTest.Name, "does_not_exist")
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schemaTest.Name, "does_not_exist")
 		err := client.PasswordPolicies.Drop(ctx, id, nil)
 		assert.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
 	})
 
 	t.Run("when password policy exists and if exists is true", func(t *testing.T) {
-		passwordPolicy, _ := createPasswordPolicy(t, client, databaseTest, schemaTest)
+		passwordPolicy, _ := createPasswordPolicy(t, client, testDb(t), schemaTest)
 		id := passwordPolicy.ID()
 		dropOptions := &sdk.DropPasswordPolicyOptions{IfExists: sdk.Bool(true)}
 		err := client.PasswordPolicies.Drop(ctx, id, dropOptions)

--- a/pkg/sdk/testint/roles_integration_test.go
+++ b/pkg/sdk/testint/roles_integration_test.go
@@ -13,11 +13,9 @@ func TestInt_Roles(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	database, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-	schema, _ := createSchema(t, client, database)
-	tag, _ := createTag(t, client, database, schema)
-	tag2, _ := createTag(t, client, database, schema)
+	schema, _ := createSchema(t, client, testDb(t))
+	tag, _ := createTag(t, client, testDb(t), schema)
+	tag2, _ := createTag(t, client, testDb(t), schema)
 
 	t.Run("create no options", func(t *testing.T) {
 		roleID := sdk.RandomAccountObjectIdentifier()

--- a/pkg/sdk/testint/session_policies_gen_integration_test.go
+++ b/pkg/sdk/testint/session_policies_gen_integration_test.go
@@ -14,10 +14,7 @@ func TestInt_SessionPolicies(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	database, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
-	schema, schemaCleanup := createSchema(t, client, database)
+	schema, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
 	assertSessionPolicy := func(t *testing.T, sessionPolicy *sdk.SessionPolicy, id sdk.SchemaObjectIdentifier, expectedComment string) {
@@ -55,7 +52,7 @@ func TestInt_SessionPolicies(t *testing.T) {
 	createSessionPolicy := func(t *testing.T) *sdk.SessionPolicy {
 		t.Helper()
 		name := random.String()
-		id := sdk.NewSchemaObjectIdentifier(database.Name, schema.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, name)
 
 		err := client.SessionPolicies.Create(ctx, sdk.NewCreateSessionPolicyRequest(id))
 		require.NoError(t, err)
@@ -69,7 +66,7 @@ func TestInt_SessionPolicies(t *testing.T) {
 
 	t.Run("create session_policy: complete case", func(t *testing.T) {
 		name := random.String()
-		id := sdk.NewSchemaObjectIdentifier(database.Name, schema.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, name)
 		comment := random.Comment()
 
 		request := sdk.NewCreateSessionPolicyRequest(id).
@@ -90,7 +87,7 @@ func TestInt_SessionPolicies(t *testing.T) {
 
 	t.Run("create session_policy: no optionals", func(t *testing.T) {
 		name := random.String()
-		id := sdk.NewSchemaObjectIdentifier(database.Name, schema.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, name)
 
 		request := sdk.NewCreateSessionPolicyRequest(id)
 
@@ -106,7 +103,7 @@ func TestInt_SessionPolicies(t *testing.T) {
 
 	t.Run("drop session_policy: existing", func(t *testing.T) {
 		name := random.String()
-		id := sdk.NewSchemaObjectIdentifier(database.Name, schema.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, name)
 
 		err := client.SessionPolicies.Create(ctx, sdk.NewCreateSessionPolicyRequest(id))
 		require.NoError(t, err)
@@ -119,7 +116,7 @@ func TestInt_SessionPolicies(t *testing.T) {
 	})
 
 	t.Run("drop session_policy: non-existing", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(database.Name, schema.Name, "does_not_exist")
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, "does_not_exist")
 
 		err := client.SessionPolicies.Drop(ctx, sdk.NewDropSessionPolicyRequest(id))
 		assert.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
@@ -127,7 +124,7 @@ func TestInt_SessionPolicies(t *testing.T) {
 
 	t.Run("alter session_policy: set value and unset value", func(t *testing.T) {
 		name := random.String()
-		id := sdk.NewSchemaObjectIdentifier(database.Name, schema.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, name)
 
 		err := client.SessionPolicies.Create(ctx, sdk.NewCreateSessionPolicyRequest(id))
 		require.NoError(t, err)
@@ -153,11 +150,11 @@ func TestInt_SessionPolicies(t *testing.T) {
 	})
 
 	t.Run("set and unset tag", func(t *testing.T) {
-		tag, tagCleanup := createTag(t, client, database, schema)
+		tag, tagCleanup := createTag(t, client, testDb(t), schema)
 		t.Cleanup(tagCleanup)
 
 		name := random.String()
-		id := sdk.NewSchemaObjectIdentifier(database.Name, schema.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, name)
 
 		err := client.SessionPolicies.Create(ctx, sdk.NewCreateSessionPolicyRequest(id))
 		require.NoError(t, err)
@@ -194,13 +191,13 @@ func TestInt_SessionPolicies(t *testing.T) {
 
 	t.Run("alter session_policy: rename", func(t *testing.T) {
 		name := random.String()
-		id := sdk.NewSchemaObjectIdentifier(database.Name, schema.Name, name)
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, name)
 
 		err := client.SessionPolicies.Create(ctx, sdk.NewCreateSessionPolicyRequest(id))
 		require.NoError(t, err)
 
 		newName := random.String()
-		newId := sdk.NewSchemaObjectIdentifier(database.Name, schema.Name, newName)
+		newId := sdk.NewSchemaObjectIdentifier(testDb(t).Name, schema.Name, newName)
 		alterRequest := sdk.NewAlterSessionPolicyRequest(id).WithRenameTo(&newId)
 
 		err = client.SessionPolicies.Alter(ctx, alterRequest)

--- a/pkg/sdk/testint/sessions_integration_test.go
+++ b/pkg/sdk/testint/sessions_integration_test.go
@@ -80,9 +80,7 @@ func TestInt_ShowSessionParameter(t *testing.T) {
 func TestInt_ShowObjectParameter(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-	parameter, err := client.Parameters.ShowObjectParameter(ctx, sdk.ObjectParameterDataRetentionTimeInDays, sdk.Object{ObjectType: databaseTest.ObjectType(), Name: databaseTest.ID()})
+	parameter, err := client.Parameters.ShowObjectParameter(ctx, sdk.ObjectParameterDataRetentionTimeInDays, sdk.Object{ObjectType: testDb(t).ObjectType(), Name: testDb(t).ID()})
 	require.NoError(t, err)
 	assert.NotEmpty(t, parameter)
 }
@@ -134,22 +132,18 @@ func TestInt_UseDatabase(t *testing.T) {
 		err := client.Sessions.UseDatabase(ctx, originalDBIdentifier)
 		require.NoError(t, err)
 	})
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-	err = client.Sessions.UseDatabase(ctx, databaseTest.ID())
+	err = client.Sessions.UseDatabase(ctx, testDb(t).ID())
 	require.NoError(t, err)
 	actual, err := client.ContextFunctions.CurrentDatabase(ctx)
 	require.NoError(t, err)
-	expected := databaseTest.Name
+	expected := testDb(t).Name
 	assert.Equal(t, expected, actual)
 }
 
 func TestInt_UseSchema(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 	originalSchema, err := client.ContextFunctions.CurrentSchema(ctx)
 	require.NoError(t, err)

--- a/pkg/sdk/testint/setup_integration_test.go
+++ b/pkg/sdk/testint/setup_integration_test.go
@@ -55,7 +55,11 @@ type integrationTestContext struct {
 func (itc *integrationTestContext) initialize() error {
 	log.Println("Initializing integration test context")
 	var err error
-	itc.client, err = sdk.NewDefaultClient()
+	c, err := sdk.NewDefaultClient()
+	if err != nil {
+		return err
+	}
+	itc.client = c
 	itc.ctx = context.Background()
 
 	db, dbCleanup, err := createDb(itc.client, itc.ctx)

--- a/pkg/sdk/testint/shares_integration_test.go
+++ b/pkg/sdk/testint/shares_integration_test.go
@@ -127,19 +127,16 @@ func TestInt_SharesAlter(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-
 	t.Run("add and remove accounts", func(t *testing.T) {
 		shareTest, shareCleanup := createShare(t, client)
 		t.Cleanup(shareCleanup)
 		err := client.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
-			Database: databaseTest.ID(),
+			Database: testDb(t).ID(),
 		}, shareTest.ID())
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = client.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
-				Database: databaseTest.ID(),
+				Database: testDb(t).ID(),
 			}, shareTest.ID())
 		})
 		require.NoError(t, err)
@@ -189,12 +186,12 @@ func TestInt_SharesAlter(t *testing.T) {
 		shareTest, shareCleanup := createShare(t, client)
 		t.Cleanup(shareCleanup)
 		err := client.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
-			Database: databaseTest.ID(),
+			Database: testDb(t).ID(),
 		}, shareTest.ID())
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = client.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
-				Database: databaseTest.ID(),
+				Database: testDb(t).ID(),
 			}, shareTest.ID())
 		})
 		require.NoError(t, err)
@@ -225,12 +222,12 @@ func TestInt_SharesAlter(t *testing.T) {
 		shareTest, shareCleanup := createShare(t, client)
 		t.Cleanup(shareCleanup)
 		err := client.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
-			Database: databaseTest.ID(),
+			Database: testDb(t).ID(),
 		}, shareTest.ID())
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = client.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
-				Database: databaseTest.ID(),
+				Database: testDb(t).ID(),
 			}, shareTest.ID())
 			require.NoError(t, err)
 		})
@@ -276,21 +273,21 @@ func TestInt_SharesAlter(t *testing.T) {
 		shareTest, shareCleanup := createShare(t, client)
 		t.Cleanup(shareCleanup)
 		err := client.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
-			Database: databaseTest.ID(),
+			Database: testDb(t).ID(),
 		}, shareTest.ID())
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = client.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
-				Database: databaseTest.ID(),
+				Database: testDb(t).ID(),
 			}, shareTest.ID())
 			require.NoError(t, err)
 		})
 
-		schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+		schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 		t.Cleanup(schemaCleanup)
-		tagTest, tagCleanup := createTag(t, client, databaseTest, schemaTest)
+		tagTest, tagCleanup := createTag(t, client, testDb(t), schemaTest)
 		t.Cleanup(tagCleanup)
-		tagTest2, tagCleanup2 := createTag(t, client, databaseTest, schemaTest)
+		tagTest2, tagCleanup2 := createTag(t, client, testDb(t), schemaTest)
 		t.Cleanup(tagCleanup2)
 		tagAssociations := []sdk.TagAssociation{
 			{
@@ -342,16 +339,13 @@ func TestInt_ShareDescribeProvider(t *testing.T) {
 		shareTest, shareCleanup := createShare(t, client)
 		t.Cleanup(shareCleanup)
 
-		databaseTest, databaseCleanup := createDatabase(t, client)
-		t.Cleanup(databaseCleanup)
-
 		err := client.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
-			Database: databaseTest.ID(),
+			Database: testDb(t).ID(),
 		}, shareTest.ID())
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = client.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
-				Database: databaseTest.ID(),
+				Database: testDb(t).ID(),
 			}, shareTest.ID())
 			require.NoError(t, err)
 		})
@@ -362,7 +356,7 @@ func TestInt_ShareDescribeProvider(t *testing.T) {
 			assert.Equal(t, 1, len(shareDetails.SharedObjects))
 			sharedObject := shareDetails.SharedObjects[0]
 			assert.Equal(t, sdk.ObjectTypeDatabase, sharedObject.Kind)
-			assert.Equal(t, databaseTest.ID(), sharedObject.Name)
+			assert.Equal(t, testDb(t).ID(), sharedObject.Name)
 		})
 	})
 }
@@ -376,16 +370,13 @@ func TestInt_ShareDescribeConsumer(t *testing.T) {
 		shareTest, shareCleanup := createShare(t, providerClient)
 		t.Cleanup(shareCleanup)
 
-		databaseTest, databaseCleanup := createDatabase(t, providerClient)
-		t.Cleanup(databaseCleanup)
-
 		err := providerClient.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
-			Database: databaseTest.ID(),
+			Database: testDb(t).ID(),
 		}, shareTest.ID())
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = providerClient.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
-				Database: databaseTest.ID(),
+				Database: testDb(t).ID(),
 			}, shareTest.ID())
 			require.NoError(t, err)
 		})

--- a/pkg/sdk/testint/system_functions_integration_test.go
+++ b/pkg/sdk/testint/system_functions_integration_test.go
@@ -12,17 +12,15 @@ import (
 func TestInt_GetTag(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
 
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
-	tagTest, tagCleanup := createTag(t, client, databaseTest, schemaTest)
+	tagTest, tagCleanup := createTag(t, client, testDb(t), schemaTest)
 	t.Cleanup(tagCleanup)
 
 	t.Run("masking policy tag", func(t *testing.T) {
-		maskingPolicyTest, maskingPolicyCleanup := createMaskingPolicy(t, client, databaseTest, schemaTest)
+		maskingPolicyTest, maskingPolicyCleanup := createMaskingPolicy(t, client, testDb(t), schemaTest)
 		t.Cleanup(maskingPolicyCleanup)
 
 		tagValue := random.String()
@@ -43,7 +41,7 @@ func TestInt_GetTag(t *testing.T) {
 	})
 
 	t.Run("masking policy with no set tag", func(t *testing.T) {
-		maskingPolicyTest, maskingPolicyCleanup := createMaskingPolicy(t, client, databaseTest, schemaTest)
+		maskingPolicyTest, maskingPolicyCleanup := createMaskingPolicy(t, client, testDb(t), schemaTest)
 		t.Cleanup(maskingPolicyCleanup)
 
 		s, err := client.SystemFunctions.GetTag(ctx, tagTest.ID(), maskingPolicyTest.ID(), sdk.ObjectTypeMaskingPolicy)

--- a/pkg/sdk/testint/users_integration_test.go
+++ b/pkg/sdk/testint/users_integration_test.go
@@ -79,13 +79,11 @@ func TestInt_UsersShow(t *testing.T) {
 func TestInt_UserCreate(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
 
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
 
-	tag, tagCleanup := createTag(t, client, databaseTest, schemaTest)
+	tag, tagCleanup := createTag(t, client, testDb(t), schemaTest)
 	t.Cleanup(tagCleanup)
 
 	t.Run("test complete case", func(t *testing.T) {

--- a/pkg/sdk/testint/warehouses_integration_test.go
+++ b/pkg/sdk/testint/warehouses_integration_test.go
@@ -54,13 +54,11 @@ func TestInt_WarehousesShow(t *testing.T) {
 func TestInt_WarehouseCreate(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
-	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
+	schemaTest, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
-	tagTest, tagCleanup := createTag(t, client, databaseTest, schemaTest)
+	tagTest, tagCleanup := createTag(t, client, testDb(t), schemaTest)
 	t.Cleanup(tagCleanup)
-	tag2Test, tag2Cleanup := createTag(t, client, databaseTest, schemaTest)
+	tag2Test, tag2Cleanup := createTag(t, client, testDb(t), schemaTest)
 	t.Cleanup(tag2Cleanup)
 
 	t.Run("test complete", func(t *testing.T) {
@@ -187,13 +185,11 @@ func TestInt_WarehouseAlter(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	database, dbCleanup := createDatabase(t, client)
-	t.Cleanup(dbCleanup)
-	schema, schemaCleanup := createSchema(t, client, database)
+	schema, schemaCleanup := createSchema(t, client, testDb(t))
 	t.Cleanup(schemaCleanup)
-	tag, tagCleanup := createTag(t, client, database, schema)
+	tag, tagCleanup := createTag(t, client, testDb(t), schema)
 	t.Cleanup(tagCleanup)
-	tag2, tagCleanup2 := createTag(t, client, database, schema)
+	tag2, tagCleanup2 := createTag(t, client, testDb(t), schema)
 	t.Cleanup(tagCleanup2)
 
 	t.Run("terraform acc test", func(t *testing.T) {


### PR DESCRIPTION
After moving integration tests to a separate package in #2111 and #2115, it is possible now to reuse a common setup. This PR is about setting up a database only once for all integration tests and cleaning it up at the end.

## Changes
* Create a database in integration tests setup; clean it up in cleanup.
* Not every test uses the created database (database tests, renames, and tests specifically needing two databases are still creating their own database).
* Database id is the same string with added UUID so that different test runs do not interfere with each other.