### PR TITLE
chore: Return multiple errors in existing validations

### DIFF
--- a/pkg/sdk/accounts.go
+++ b/pkg/sdk/accounts.go
@@ -388,7 +388,7 @@ func (opts *DropAccountOptions) validate() error {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !validateIntGreaterThanOrEqual(opts.gracePeriodInDays, 3) {
-		errs = append(errs, errIntValue(IntErrGreaterOrEqual, "DropAccountOptions", "gracePeriodInDays", 3))
+		errs = append(errs, errIntValue("DropAccountOptions", "gracePeriodInDays", IntErrGreaterOrEqual, 3))
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/accounts.go
+++ b/pkg/sdk/accounts.go
@@ -105,16 +105,24 @@ func (opts *AlterAccountOptions) validate() error {
 		errs = append(errs, errExactlyOneOf("CreateAccountOptions", "Set", "Unset", "Drop", "Rename"))
 	}
 	if valueSet(opts.Set) {
-		errs = append(errs, opts.Set.validate())
+		if err := opts.Set.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if valueSet(opts.Unset) {
-		errs = append(errs, opts.Unset.validate())
+		if err := opts.Unset.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if valueSet(opts.Drop) {
-		errs = append(errs, opts.Drop.validate())
+		if err := opts.Drop.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if valueSet(opts.Rename) {
-		errs = append(errs, opts.Rename.validate())
+		if err := opts.Rename.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/accounts.go
+++ b/pkg/sdk/accounts.go
@@ -59,7 +59,7 @@ type CreateAccountOptions struct {
 
 func (opts *CreateAccountOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if opts.AdminName == "" {
@@ -98,7 +98,7 @@ type AlterAccountOptions struct {
 
 func (opts *AlterAccountOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if !exactlyOneValueSet(opts.Set, opts.Unset, opts.Drop, opts.Rename) {
@@ -215,7 +215,7 @@ type AccountRename struct {
 func (opts *AccountRename) validate() error {
 	var errs []error
 	if !ValidObjectIdentifier(opts.Name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !ValidObjectIdentifier(opts.NewName) {
 		errs = append(errs, errInvalidIdentifier("AccountRename", "NewName"))
@@ -231,7 +231,7 @@ type AccountDrop struct {
 func (opts *AccountDrop) validate() error {
 	var errs []error
 	if !ValidObjectIdentifier(opts.Name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if valueSet(opts.OldURL) {
 		// TODO: Should this really be validated to be true ?
@@ -260,7 +260,7 @@ type ShowAccountOptions struct {
 
 func (opts *ShowAccountOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	return nil
 }
@@ -381,15 +381,14 @@ type DropAccountOptions struct {
 
 func (opts *DropAccountOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !validateIntGreaterThanOrEqual(opts.gracePeriodInDays, 3) {
 		errs = append(errs, errIntValue(IntErrGreaterOrEqual, "DropAccountOptions", "gracePeriodInDays", 3))
-		return fmt.Errorf("gracePeriodInDays must be greater than or equal to 3")
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/accounts.go
+++ b/pkg/sdk/accounts.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -57,11 +58,15 @@ type CreateAccountOptions struct {
 }
 
 func (opts *CreateAccountOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	var errs []error
 	if opts.AdminName == "" {
-		return fmt.Errorf("AdminName is required")
+		errs = append(errs, errNotSet("CreateAccountOptions", "AdminName"))
 	}
 	if !anyValueSet(opts.AdminPassword, opts.AdminRSAPublicKey) {
-		return fmt.Errorf("at least one of AdminPassword or AdminRSAPublicKey must be set")
+		errs = append(errs, errAtLeastOneOf("CreateAccountOptions", "AdminPassword", "AdminRSAPublicKey"))
 	}
 	if opts.Email == "" {
 		return fmt.Errorf("email is required")
@@ -69,7 +74,7 @@ func (opts *CreateAccountOptions) validate() error {
 	if opts.Edition == "" {
 		return fmt.Errorf("edition is required")
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (c *accounts) Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateAccountOptions) error {
@@ -92,6 +97,9 @@ type AlterAccountOptions struct {
 }
 
 func (opts *AlterAccountOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	if ok := exactlyOneValueSet(
 		opts.Set,
 		opts.Unset,
@@ -280,6 +288,9 @@ type ShowAccountOptions struct {
 }
 
 func (opts *ShowAccountOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	return nil
 }
 
@@ -399,6 +410,9 @@ type DropAccountOptions struct {
 }
 
 func (opts *DropAccountOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	if !ValidObjectIdentifier(opts.name) {
 		return fmt.Errorf("Name must be set")
 	}

--- a/pkg/sdk/alerts.go
+++ b/pkg/sdk/alerts.go
@@ -55,10 +55,12 @@ type AlertCondition struct {
 }
 
 func (opts *CreateAlertOptions) validate() error {
-	if !ValidObjectIdentifier(opts.name) {
-		return errors.New("invalid object identifier")
+	if opts == nil {
+		return errors.Join(errNilOptions)
 	}
-
+	if !validObjectidentifier(opts.name) {
+		return errors.Join(errInvalidObjectIdentifier)
+	}
 	return nil
 }
 
@@ -115,15 +117,17 @@ type AlterAlertOptions struct {
 }
 
 func (opts *AlterAlertOptions) validate() error {
-	if !ValidObjectIdentifier(opts.name) {
-		return errors.New("invalid object identifier")
+	if opts == nil {
+		return errors.Join(errNilOptions)
 	}
-
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
+	}
 	if !exactlyOneValueSet(opts.Action, opts.Set, opts.Unset, opts.ModifyCondition, opts.ModifyAction) {
-		return errExactlyOneOf("Action", "Set", "Unset", "ModifyCondition", "ModifyAction")
+		errs = append(errs, errExactlyOneOf("AlterAlertOptions", "Action", "Set", "Unset", "ModifyCondition", "ModifyAction"))
 	}
-
-	return nil
+	return errors.Join(errs...)
 }
 
 type AlertSet struct {
@@ -163,8 +167,11 @@ type dropAlertOptions struct {
 }
 
 func (opts *dropAlertOptions) validate() error {
-	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	if !validObjectidentifier(opts.name) {
+		return errors.Join(errInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -254,6 +261,9 @@ func (row alertDBRow) convert() *Alert {
 }
 
 func (opts *ShowAlertOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	return nil
 }
 
@@ -285,7 +295,7 @@ func (v *alerts) ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Aler
 			return &alert, nil
 		}
 	}
-	return nil, ErrObjectNotExistOrAuthorized
+	return nil, errObjectNotExistOrAuthorized
 }
 
 // describeAlertOptions is based on https://docs.snowflake.com/en/sql-reference/sql/desc-alert.
@@ -295,9 +305,12 @@ type describeAlertOptions struct {
 	name     SchemaObjectIdentifier `ddl:"identifier"`
 }
 
-func (v *describeAlertOptions) validate() error {
-	if !ValidObjectIdentifier(v.name) {
-		return ErrInvalidObjectIdentifier
+func (opts *describeAlertOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	if !validObjectidentifier(opts.name) {
+		return errors.Join(errInvalidObjectIdentifier)
 	}
 	return nil
 }

--- a/pkg/sdk/alerts.go
+++ b/pkg/sdk/alerts.go
@@ -56,10 +56,10 @@ type AlertCondition struct {
 
 func (opts *CreateAlertOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -118,11 +118,11 @@ type AlterAlertOptions struct {
 
 func (opts *AlterAlertOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !exactlyOneValueSet(opts.Action, opts.Set, opts.Unset, opts.ModifyCondition, opts.ModifyAction) {
 		errs = append(errs, errExactlyOneOf("AlterAlertOptions", "Action", "Set", "Unset", "ModifyCondition", "ModifyAction"))
@@ -168,10 +168,10 @@ type dropAlertOptions struct {
 
 func (opts *dropAlertOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -262,7 +262,7 @@ func (row alertDBRow) convert() *Alert {
 
 func (opts *ShowAlertOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	return nil
 }
@@ -295,7 +295,7 @@ func (v *alerts) ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Aler
 			return &alert, nil
 		}
 	}
-	return nil, errObjectNotExistOrAuthorized
+	return nil, ErrObjectNotExistOrAuthorized
 }
 
 // describeAlertOptions is based on https://docs.snowflake.com/en/sql-reference/sql/desc-alert.
@@ -307,10 +307,10 @@ type describeAlertOptions struct {
 
 func (opts *describeAlertOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }

--- a/pkg/sdk/alerts_test.go
+++ b/pkg/sdk/alerts_test.go
@@ -37,7 +37,7 @@ func TestAlertAlter(t *testing.T) {
 		opts := &AlterAlertOptions{
 			name: id,
 		}
-		assertOptsInvalid(t, opts, errExactlyOneOf("Action", "Set", "Unset", "ModifyCondition", "ModifyAction"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterAlertOptions", "Action", "Set", "Unset", "ModifyCondition", "ModifyAction"))
 	})
 
 	t.Run("fail when 2 alter actions specified", func(t *testing.T) {
@@ -49,7 +49,7 @@ func TestAlertAlter(t *testing.T) {
 				Comment: String(newComment),
 			},
 		}
-		assertOptsInvalid(t, opts, errExactlyOneOf("Action", "Set", "Unset", "ModifyCondition", "ModifyAction"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterAlertOptions", "Action", "Set", "Unset", "ModifyCondition", "ModifyAction"))
 	})
 
 	t.Run("with resume", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestAlertDrop(t *testing.T) {
 
 	t.Run("empty options", func(t *testing.T) {
 		opts := &dropAlertOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("only name", func(t *testing.T) {
@@ -210,7 +210,7 @@ func TestAlertDescribe(t *testing.T) {
 
 	t.Run("empty options", func(t *testing.T) {
 		opts := &describeAlertOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("only name", func(t *testing.T) {

--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -3,12 +3,12 @@ package sdk
 import (
 	"context"
 	"database/sql"
-	"encoding/pem"
 	"fmt"
+	"log"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/luna-duclos/instrumentedsql"
 	"golang.org/x/exp/slices"
-	"log"
 
 	"github.com/snowflakedb/gosnowflake"
 )
@@ -100,8 +100,6 @@ func NewClient(cfg *gosnowflake.Config) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open snowflake connection: %w", err)
 	}
-
-	pem.Decode()
 
 	client = &Client{
 		// snowflake does not adhere to the normal sql driver interface, so we have to use unsafe

--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -3,12 +3,12 @@ package sdk
 import (
 	"context"
 	"database/sql"
+	"encoding/pem"
 	"fmt"
-	"log"
-
 	"github.com/jmoiron/sqlx"
 	"github.com/luna-duclos/instrumentedsql"
 	"golang.org/x/exp/slices"
+	"log"
 
 	"github.com/snowflakedb/gosnowflake"
 )
@@ -100,6 +100,8 @@ func NewClient(cfg *gosnowflake.Config) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open snowflake connection: %w", err)
 	}
+
+	pem.Decode()
 
 	client = &Client{
 		// snowflake does not adhere to the normal sql driver interface, so we have to use unsafe

--- a/pkg/sdk/comments.go
+++ b/pkg/sdk/comments.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"errors"
 )
 
 var (
@@ -31,6 +32,9 @@ type SetCommentOptions struct {
 }
 
 func (opts *SetCommentOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	return nil
 }
 
@@ -60,6 +64,9 @@ type SetColumnCommentOptions struct {
 }
 
 func (opts *SetColumnCommentOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	return nil
 }
 

--- a/pkg/sdk/comments.go
+++ b/pkg/sdk/comments.go
@@ -33,7 +33,7 @@ type SetCommentOptions struct {
 
 func (opts *SetCommentOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	return nil
 }
@@ -65,7 +65,7 @@ type SetColumnCommentOptions struct {
 
 func (opts *SetColumnCommentOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	return nil
 }

--- a/pkg/sdk/database_role_test.go
+++ b/pkg/sdk/database_role_test.go
@@ -30,7 +30,7 @@ func TestDatabaseRoleCreate(t *testing.T) {
 		opts := defaultOpts()
 		opts.IfNotExists = Bool(true)
 		opts.OrReplace = Bool(true)
-		assertOptsInvalidJoinedErrors(t, opts, errOneOf("OrReplace", "IfNotExists"))
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("createDatabaseRoleOptions", "OrReplace", "IfNotExists"))
 	})
 
 	t.Run("validation: multiple errors", func(t *testing.T) {
@@ -38,7 +38,7 @@ func TestDatabaseRoleCreate(t *testing.T) {
 		opts.name = NewDatabaseObjectIdentifier("", "")
 		opts.IfNotExists = Bool(true)
 		opts.OrReplace = Bool(true)
-		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier, errOneOf("OrReplace", "IfNotExists"))
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier, errOneOf("createDatabaseRoleOptions", "OrReplace", "IfNotExists"))
 	})
 
 	t.Run("basic", func(t *testing.T) {

--- a/pkg/sdk/database_role_test.go
+++ b/pkg/sdk/database_role_test.go
@@ -77,7 +77,7 @@ func TestDatabaseRoleAlter(t *testing.T) {
 
 	t.Run("validation: no alter action", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errAlterNeedsExactlyOneAction)
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("alterDatabaseRoleOptions", "Rename", "Set", "Unset"))
 	})
 
 	t.Run("validation: multiple alter actions", func(t *testing.T) {
@@ -88,7 +88,7 @@ func TestDatabaseRoleAlter(t *testing.T) {
 		opts.Unset = &DatabaseRoleUnset{
 			Comment: true,
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errAlterNeedsExactlyOneAction)
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("alterDatabaseRoleOptions", "Rename", "Set", "Unset"))
 	})
 
 	t.Run("validation: invalid new name", func(t *testing.T) {
@@ -114,7 +114,7 @@ func TestDatabaseRoleAlter(t *testing.T) {
 		opts.Unset = &DatabaseRoleUnset{
 			Comment: false,
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errAlterNeedsAtLeastOneProperty)
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("alterDatabaseRoleOptions.Unset", "Comment"))
 	})
 
 	t.Run("rename", func(t *testing.T) {

--- a/pkg/sdk/database_role_validations.go
+++ b/pkg/sdk/database_role_validations.go
@@ -35,12 +35,8 @@ func (opts *alterDatabaseRoleOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if ok := exactlyOneValueSet(
-		opts.Rename,
-		opts.Set,
-		opts.Unset,
-	); !ok {
-		errs = append(errs, errAlterNeedsExactlyOneAction)
+	if !exactlyOneValueSet(opts.Rename, opts.Set, opts.Unset) {
+		errs = append(errs, errExactlyOneOf("alterDatabaseRoleOptions", "Rename", "Set", "Unset"))
 	}
 	if rename := opts.Rename; valueSet(rename) {
 		if !ValidObjectIdentifier(rename.Name) {
@@ -52,7 +48,7 @@ func (opts *alterDatabaseRoleOptions) validate() error {
 	}
 	if unset := opts.Unset; valueSet(unset) {
 		if !unset.Comment {
-			errs = append(errs, errAlterNeedsAtLeastOneProperty)
+			errs = append(errs, errAtLeastOneOf("alterDatabaseRoleOptions.Unset", "Comment"))
 		}
 	}
 	return errors.Join(errs...)

--- a/pkg/sdk/database_role_validations.go
+++ b/pkg/sdk/database_role_validations.go
@@ -22,7 +22,7 @@ func (opts *createDatabaseRoleOptions) validate() error {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) && *opts.OrReplace && *opts.IfNotExists {
-		errs = append(errs, errOneOf("OrReplace", "IfNotExists"))
+		errs = append(errs, errOneOf("createDatabaseRoleOptions", "OrReplace", "IfNotExists"))
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/databases.go
+++ b/pkg/sdk/databases.go
@@ -281,7 +281,7 @@ func (opts *AlterDatabaseOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if exactlyOneValueSet(opts.NewName, opts.Set, opts.Unset, opts.SwapWith) {
+	if !exactlyOneValueSet(opts.NewName, opts.Set, opts.Unset, opts.SwapWith) {
 		errs = append(errs, errExactlyOneOf("AlterDatabaseOptions", "NewName", "Set", "Unset", "SwapWith"))
 	}
 	if valueSet(opts.Set) {

--- a/pkg/sdk/databases.go
+++ b/pkg/sdk/databases.go
@@ -149,7 +149,7 @@ type CreateDatabaseOptions struct {
 
 func (opts *CreateDatabaseOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if valueSet(opts.Clone) {
@@ -190,14 +190,14 @@ type CreateSharedDatabaseOptions struct {
 
 func (opts *CreateSharedDatabaseOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !validObjectidentifier(opts.fromShare) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.fromShare) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	return errors.Join(errs...)
 }
@@ -232,16 +232,16 @@ type CreateSecondaryDatabaseOptions struct {
 
 func (opts *CreateSecondaryDatabaseOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !validObjectidentifier(opts.primaryDatabase) {
+	if !ValidObjectIdentifier(opts.primaryDatabase) {
 		errs = append(errs, errInvalidIdentifier("CreateSecondaryDatabaseOptions", "primaryDatabase"))
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *databases) CreateSecondary(ctx context.Context, id AccountObjectIdentifier, primaryID ExternalObjectIdentifier, opts *CreateSecondaryDatabaseOptions) error {
@@ -275,11 +275,11 @@ type AlterDatabaseOptions struct {
 
 func (opts *AlterDatabaseOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if exactlyOneValueSet(opts.NewName, opts.Set, opts.Unset, opts.SwapWith) {
 		errs = append(errs, errExactlyOneOf("AlterDatabaseOptions", "NewName", "Set", "Unset", "SwapWith"))
@@ -353,11 +353,11 @@ type AlterDatabaseReplicationOptions struct {
 
 func (opts *AlterDatabaseReplicationOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !exactlyOneValueSet(opts.EnableReplication, opts.DisableReplication, opts.Refresh) {
 		errs = append(errs, errExactlyOneOf("AlterDatabaseReplicationOptions", "EnableReplication", "DisableReplication", "Refresh"))
@@ -420,11 +420,11 @@ type AlterDatabaseFailoverOptions struct {
 
 func (opts *AlterDatabaseFailoverOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !exactlyOneValueSet(opts.EnableFailover, opts.DisableFailover, opts.Primary) {
 		errs = append(errs, errExactlyOneOf("AlterDatabaseFailoverOptions", "EnableFailover", "DisableFailover", "Primary"))
@@ -484,10 +484,10 @@ type DropDatabaseOptions struct {
 
 func (opts *DropDatabaseOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errInvalidObjectIdentifier
+	if !ValidObjectIdentifier(opts.name) {
+		return ErrInvalidObjectIdentifier
 	}
 	return nil
 }
@@ -517,10 +517,10 @@ type undropDatabaseOptions struct {
 
 func (opts *undropDatabaseOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -553,7 +553,7 @@ type ShowDatabasesOptions struct {
 
 func (opts *ShowDatabasesOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	return nil
 }
@@ -582,7 +582,7 @@ func (v *databases) ShowByID(ctx context.Context, id AccountObjectIdentifier) (*
 			return &database, nil
 		}
 	}
-	return nil, errObjectNotExistOrAuthorized
+	return nil, ErrObjectNotExistOrAuthorized
 }
 
 type DatabaseDetails struct {
@@ -604,10 +604,10 @@ type describeDatabaseOptions struct {
 
 func (opts *describeDatabaseOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }

--- a/pkg/sdk/databases.go
+++ b/pkg/sdk/databases.go
@@ -161,7 +161,7 @@ func (opts *CreateDatabaseOptions) validate() error {
 		}
 	}
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
-		errs = append(errs, errOneOf("OrReplace", "IfNotExists"))
+		errs = append(errs, errOneOf("CreateDatabaseOptions", "OrReplace", "IfNotExists"))
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/databases_test.go
+++ b/pkg/sdk/databases_test.go
@@ -8,6 +8,7 @@ import (
 func TestDatabasesCreate(t *testing.T) {
 	t.Run("clone", func(t *testing.T) {
 		opts := &CreateDatabaseOptions{
+			name: NewAccountObjectIdentifier("db"),
 			Clone: &Clone{
 				SourceObject: NewAccountObjectIdentifier("db1"),
 				At: &TimeTravel{
@@ -15,11 +16,12 @@ func TestDatabasesCreate(t *testing.T) {
 				},
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `CREATE DATABASE CLONE "db1" AT (TIMESTAMP => '2021-01-01 00:00:00 +0000 UTC')`)
+		assertOptsValidAndSQLEquals(t, opts, `CREATE DATABASE "db" CLONE "db1" AT (TIMESTAMP => '2021-01-01 00:00:00 +0000 UTC')`)
 	})
 
 	t.Run("complete", func(t *testing.T) {
 		opts := &CreateDatabaseOptions{
+			name:                       NewAccountObjectIdentifier("db"),
 			OrReplace:                  Bool(true),
 			Transient:                  Bool(true),
 			Comment:                    String("comment"),
@@ -32,7 +34,7 @@ func TestDatabasesCreate(t *testing.T) {
 				},
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE TRANSIENT DATABASE DATA_RETENTION_TIME_IN_DAYS = 1 MAX_DATA_EXTENSION_TIME_IN_DAYS = 1 COMMENT = 'comment' TAG ("db1"."schema1"."tag1" = 'v1')`)
+		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE TRANSIENT DATABASE "db" DATA_RETENTION_TIME_IN_DAYS = 1 MAX_DATA_EXTENSION_TIME_IN_DAYS = 1 COMMENT = 'comment' TAG ("db1"."schema1"."tag1" = 'v1')`)
 	})
 }
 

--- a/pkg/sdk/dynamic_table_test.go
+++ b/pkg/sdk/dynamic_table_test.go
@@ -64,19 +64,19 @@ func TestDynamicTableAlter(t *testing.T) {
 
 	t.Run("validation: no alter action", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errAlterNeedsExactlyOneAction)
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("alterDynamicTableOptions", "Suspend", "Resume", "Refresh", "Set"))
 	})
 
 	t.Run("validation: multiple alter actions", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Resume = Bool(true)
 		opts.Suspend = Bool(true)
-		assertOptsInvalidJoinedErrors(t, opts, errAlterNeedsExactlyOneAction)
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("alterDynamicTableOptions", "Suspend", "Resume", "Refresh", "Set"))
 	})
 
 	t.Run("validation: no property to unset", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errAlterNeedsAtLeastOneProperty)
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("alterDynamicTableOptions", "Suspend", "Resume", "Refresh", "Set"))
 	})
 
 	t.Run("suspend", func(t *testing.T) {

--- a/pkg/sdk/dynamic_table_validations.go
+++ b/pkg/sdk/dynamic_table_validations.go
@@ -15,25 +15,25 @@ var (
 
 func (tl *TargetLag) validate() error {
 	if tl == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if everyValueSet(tl.Lagtime, tl.Downstream) {
-		errs = append(errs, errOneOf("TargetLag", "Lagtime", "Downstream"))
+	if everyValueSet(tl.MaximumDuration, tl.Downstream) {
+		errs = append(errs, errOneOf("TargetLag", "MaximumDuration", "Downstream"))
 	}
 	return errors.Join(errs...)
 }
 
 func (opts *createDynamicTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !validObjectidentifier(opts.warehouse) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.warehouse) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	return errors.Join(errs...)
 }
@@ -45,8 +45,8 @@ func (dts *DynamicTableSet) validate() error {
 	}
 
 	if valueSet(dts.Warehouse) {
-		if !validObjectidentifier(*dts.Warehouse) {
-			errs = append(errs, errInvalidObjectIdentifier)
+		if !ValidObjectIdentifier(*dts.Warehouse) {
+			errs = append(errs, ErrInvalidObjectIdentifier)
 		}
 	}
 	return errors.Join(errs...)
@@ -54,17 +54,14 @@ func (dts *DynamicTableSet) validate() error {
 
 func (opts *alterDynamicTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if ok := exactlyOneValueSet(opts.Suspend, opts.Resume, opts.Refresh, opts.Set); !ok {
 		errs = append(errs, errExactlyOneOf("alterDynamicTableOptions", "Suspend", "Resume", "Refresh", "Set"))
-	}
-	if !anyValueSet(opts.Suspend, opts.Resume, opts.Refresh, opts.Set) {
-		errs = append(errs, errAtLeastOneOf("alterDynamicTableOptions", "Suspend", "Resume", "Refresh", "Set"))
 	}
 	if valueSet(opts.Set) && valueSet(opts.Set.TargetLag) {
 		errs = append(errs, opts.Set.TargetLag.validate())
@@ -74,11 +71,11 @@ func (opts *alterDynamicTableOptions) validate() error {
 
 func (opts *showDynamicTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if valueSet(opts.Like) && !valueSet(opts.Like.Pattern) {
-		errs = append(errs, errPatternRequiredForLikeKeyword)
+		errs = append(errs, ErrPatternRequiredForLikeKeyword)
 	}
 	if valueSet(opts.In) && !exactlyOneValueSet(opts.In.Account, opts.In.Database, opts.In.Schema) {
 		errs = append(errs, errExactlyOneOf("showDynamicTableOptions.In", "Account", "Database", "Schema"))
@@ -88,23 +85,23 @@ func (opts *showDynamicTableOptions) validate() error {
 
 func (opts *dropDynamicTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	return errors.Join(errs...)
 }
 
 func (opts *describeDynamicTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/dynamic_table_validations.go
+++ b/pkg/sdk/dynamic_table_validations.go
@@ -15,25 +15,25 @@ var (
 
 func (tl *TargetLag) validate() error {
 	if tl == nil {
-		return errors.Join(ErrNilOptions)
+		return errors.Join(errNilOptions)
 	}
 	var errs []error
-	if everyValueSet(tl.MaximumDuration, tl.Downstream) {
-		errs = append(errs, errOneOf("MaximumDuration", "Downstream"))
+	if everyValueSet(tl.Lagtime, tl.Downstream) {
+		errs = append(errs, errOneOf("TargetLag", "Lagtime", "Downstream"))
 	}
 	return errors.Join(errs...)
 }
 
 func (opts *createDynamicTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(ErrNilOptions)
+		return errors.Join(errNilOptions)
 	}
 	var errs []error
-	if !ValidObjectIdentifier(opts.name) {
-		errs = append(errs, ErrInvalidObjectIdentifier)
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
-	if !ValidObjectIdentifier(opts.warehouse) {
-		errs = append(errs, ErrInvalidObjectIdentifier)
+	if !validObjectidentifier(opts.warehouse) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	return errors.Join(errs...)
 }
@@ -45,8 +45,8 @@ func (dts *DynamicTableSet) validate() error {
 	}
 
 	if valueSet(dts.Warehouse) {
-		if !ValidObjectIdentifier(*dts.Warehouse) {
-			errs = append(errs, ErrInvalidObjectIdentifier)
+		if !validObjectidentifier(*dts.Warehouse) {
+			errs = append(errs, errInvalidObjectIdentifier)
 		}
 	}
 	return errors.Join(errs...)
@@ -54,22 +54,17 @@ func (dts *DynamicTableSet) validate() error {
 
 func (opts *alterDynamicTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(ErrNilOptions)
+		return errors.Join(errNilOptions)
 	}
 	var errs []error
-	if !ValidObjectIdentifier(opts.name) {
-		errs = append(errs, ErrInvalidObjectIdentifier)
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
-	if ok := exactlyOneValueSet(
-		opts.Suspend,
-		opts.Resume,
-		opts.Refresh,
-		opts.Set,
-	); !ok {
-		errs = append(errs, errAlterNeedsExactlyOneAction)
+	if ok := exactlyOneValueSet(opts.Suspend, opts.Resume, opts.Refresh, opts.Set); !ok {
+		errs = append(errs, errExactlyOneOf("alterDynamicTableOptions", "Suspend", "Resume", "Refresh", "Set"))
 	}
 	if !anyValueSet(opts.Suspend, opts.Resume, opts.Refresh, opts.Set) {
-		errs = append(errs, errAlterNeedsAtLeastOneProperty)
+		errs = append(errs, errAtLeastOneOf("alterDynamicTableOptions", "Suspend", "Resume", "Refresh", "Set"))
 	}
 	if valueSet(opts.Set) && valueSet(opts.Set.TargetLag) {
 		errs = append(errs, opts.Set.TargetLag.validate())
@@ -79,37 +74,37 @@ func (opts *alterDynamicTableOptions) validate() error {
 
 func (opts *showDynamicTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(ErrNilOptions)
+		return errors.Join(errNilOptions)
 	}
 	var errs []error
 	if valueSet(opts.Like) && !valueSet(opts.Like.Pattern) {
-		errs = append(errs, ErrPatternRequiredForLikeKeyword)
+		errs = append(errs, errPatternRequiredForLikeKeyword)
 	}
 	if valueSet(opts.In) && !exactlyOneValueSet(opts.In.Account, opts.In.Database, opts.In.Schema) {
-		errs = append(errs, errScopeRequiredForInKeyword)
+		errs = append(errs, errExactlyOneOf("showDynamicTableOptions.In", "Account", "Database", "Schema"))
 	}
 	return errors.Join(errs...)
 }
 
 func (opts *dropDynamicTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(ErrNilOptions)
+		return errors.Join(errNilOptions)
 	}
 	var errs []error
 
-	if !ValidObjectIdentifier(opts.name) {
-		errs = append(errs, ErrInvalidObjectIdentifier)
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	return errors.Join(errs...)
 }
 
 func (opts *describeDynamicTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(ErrNilOptions)
+		return errors.Join(errNilOptions)
 	}
 	var errs []error
-	if !ValidObjectIdentifier(opts.name) {
-		errs = append(errs, ErrInvalidObjectIdentifier)
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/errors.go
+++ b/pkg/sdk/errors.go
@@ -30,8 +30,12 @@ const (
 	IntErrLess           IntErrType = "less than"
 )
 
-func errIntValue(intErrType IntErrType, structName string, fieldName string, limit int) error {
+func errIntValue(structName string, fieldName string, intErrType IntErrType, limit int) error {
 	return fmt.Errorf("%s field: %s must be %s %d", structName, fieldName, string(intErrType), limit)
+}
+
+func errIntBetween(structName string, fieldName string, from int, to int) error {
+	return fmt.Errorf("%s field: %s must be between %d and %d", structName, fieldName, from, to)
 }
 
 func errInvalidIdentifier(structName string, identifierField string) error {

--- a/pkg/sdk/errors.go
+++ b/pkg/sdk/errors.go
@@ -20,8 +20,22 @@ var (
 	ErrDifferentDatabase       = errors.New("database must be the same")
 )
 
-func errInvalidIdentifier(identifierField string) error {
-	return fmt.Errorf("invalid object identifier in field: %s", identifierField)
+type IntErrType string
+
+const (
+	IntErrEqual          IntErrType = "equal to"
+	IntErrGreaterOrEqual IntErrType = "greater than or equal to"
+	IntErrGreater        IntErrType = "greater than"
+	IntErrLessOrEqual    IntErrType = "less than or equal to"
+	IntErrLess           IntErrType = "less than"
+)
+
+func errIntValue(intErrType IntErrType, structName string, fieldName string, limit int) error {
+	return fmt.Errorf("%s field: %s must be %s %d", structName, fieldName, string(intErrType), limit)
+}
+
+func errInvalidIdentifier(structName string, identifierField string) error {
+	return fmt.Errorf("invalid object identifier of %s field: %s", structName, identifierField)
 }
 
 func errOneOf(structName string, fieldNames ...string) error {

--- a/pkg/sdk/errors.go
+++ b/pkg/sdk/errors.go
@@ -20,6 +20,10 @@ var (
 	ErrDifferentDatabase       = errors.New("database must be the same")
 )
 
+func errInvalidIdentifier(identifierField string) error {
+	return fmt.Errorf("invalid object identifier in field: %s", identifierField)
+}
+
 func errOneOf(structName string, fieldNames ...string) error {
 	return fmt.Errorf("%v fields: %v are incompatible and cannot be set at the same time", structName, fieldNames)
 }
@@ -28,12 +32,12 @@ func errNotSet(structName string, fieldNames ...string) error {
 	return fmt.Errorf("%v fields: %v should be set", structName, fieldNames)
 }
 
-func errExactlyOneOf(fieldNames ...string) error {
-	return fmt.Errorf("exactly one of %v must be set", fieldNames)
+func errExactlyOneOf(structName string, fieldNames ...string) error {
+	return fmt.Errorf("exactly one of %s fileds %v must be set", structName, fieldNames)
 }
 
-func errAtLeastOneOf(fieldNames ...string) error {
-	return fmt.Errorf("at least one of %v must be set", fieldNames)
+func errAtLeastOneOf(structName string, fieldNames ...string) error {
+	return fmt.Errorf("at least one of %s fields %v must be set", structName, fieldNames)
 }
 
 func decodeDriverError(err error) error {

--- a/pkg/sdk/external_tables_test.go
+++ b/pkg/sdk/external_tables_test.go
@@ -356,7 +356,7 @@ func TestExternalTablesAlter(t *testing.T) {
 		assertOptsInvalidJoinedErrors(
 			t, opts,
 			ErrInvalidObjectIdentifier,
-			errOneOf("AlterExternalTableOptions", "Refresh", "AddFiles", "RemoveFiles", "AutoRefresh", "SetTag", "UnsetTag"),
+			errExactlyOneOf("AlterExternalTableOptions", "Refresh", "AddFiles", "RemoveFiles", "AutoRefresh", "SetTag", "UnsetTag"),
 		)
 	})
 }

--- a/pkg/sdk/external_tables_validations.go
+++ b/pkg/sdk/external_tables_validations.go
@@ -19,12 +19,15 @@ var (
 )
 
 func (opts *CreateExternalTableOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	var errs []error
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateExternalTableOptions", "OrReplace", "IfNotExists"))
 	}
-	if !ValidObjectIdentifier(opts.name) {
-		errs = append(errs, ErrInvalidObjectIdentifier)
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if !valueSet(opts.Location) {
 		errs = append(errs, errNotSet("CreateExternalTableOptions", "Location"))
@@ -45,12 +48,15 @@ func (opts *CreateExternalTableOptions) validate() error {
 }
 
 func (opts *CreateWithManualPartitioningExternalTableOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	var errs []error
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateWithManualPartitioningExternalTableOptions", "OrReplace", "IfNotExists"))
 	}
-	if !ValidObjectIdentifier(opts.name) {
-		errs = append(errs, ErrInvalidObjectIdentifier)
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if !valueSet(opts.Location) {
 		errs = append(errs, errNotSet("CreateWithManualPartitioningExternalTableOptions", "Location"))
@@ -71,12 +77,15 @@ func (opts *CreateWithManualPartitioningExternalTableOptions) validate() error {
 }
 
 func (opts *CreateDeltaLakeExternalTableOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	var errs []error
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateDeltaLakeExternalTableOptions", "OrReplace", "IfNotExists"))
 	}
-	if !ValidObjectIdentifier(opts.name) {
-		errs = append(errs, ErrInvalidObjectIdentifier)
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if !valueSet(opts.Location) {
 		errs = append(errs, errNotSet("CreateDeltaLakeExternalTableOptions", "Location"))
@@ -97,9 +106,12 @@ func (opts *CreateDeltaLakeExternalTableOptions) validate() error {
 }
 
 func (opts *CreateExternalTableUsingTemplateOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	var errs []error
-	if !ValidObjectIdentifier(opts.name) {
-		errs = append(errs, ErrInvalidObjectIdentifier)
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if !valueSet(opts.Query) {
 		errs = append(errs, errNotSet("CreateExternalTableUsingTemplateOptions", "Query"))
@@ -123,21 +135,26 @@ func (opts *CreateExternalTableUsingTemplateOptions) validate() error {
 }
 
 func (opts *AlterExternalTableOptions) validate() error {
-	var errs []error
-	if !ValidObjectIdentifier(opts.name) {
-		errs = append(errs, ErrInvalidObjectIdentifier)
+	if opts == nil {
+		return errors.Join(errNilOptions)
 	}
-	if anyValueSet(opts.Refresh, opts.AddFiles, opts.RemoveFiles, opts.AutoRefresh, opts.SetTag, opts.UnsetTag) &&
-		!exactlyOneValueSet(opts.Refresh, opts.AddFiles, opts.RemoveFiles, opts.AutoRefresh, opts.SetTag, opts.UnsetTag) {
-		errs = append(errs, errOneOf("AlterExternalTableOptions", "Refresh", "AddFiles", "RemoveFiles", "AutoRefresh", "SetTag", "UnsetTag"))
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
+	}
+	if !exactlyOneValueSet(opts.Refresh, opts.AddFiles, opts.RemoveFiles, opts.AutoRefresh, opts.SetTag, opts.UnsetTag) {
+		errs = append(errs, errExactlyOneOf("AlterExternalTableOptions", "Refresh", "AddFiles", "RemoveFiles", "AutoRefresh", "SetTag", "UnsetTag"))
 	}
 	return errors.Join(errs...)
 }
 
 func (opts *AlterExternalTablePartitionOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	var errs []error
-	if !ValidObjectIdentifier(opts.name) {
-		errs = append(errs, ErrInvalidObjectIdentifier)
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if everyValueSet(opts.AddPartitions, opts.DropPartition) {
 		errs = append(errs, errOneOf("AlterExternalTablePartitionOptions", "AddPartitions", "DropPartition"))
@@ -146,9 +163,12 @@ func (opts *AlterExternalTablePartitionOptions) validate() error {
 }
 
 func (opts *DropExternalTableOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	var errs []error
-	if !ValidObjectIdentifier(opts.name) {
-		errs = append(errs, ErrInvalidObjectIdentifier)
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if valueSet(opts.DropOption) {
 		if err := opts.DropOption.validate(); err != nil {
@@ -159,25 +179,34 @@ func (opts *DropExternalTableOptions) validate() error {
 }
 
 func (opts *ShowExternalTableOptions) validate() error {
-	return nil
-}
-
-func (v *describeExternalTableColumnsOptions) validate() error {
-	if !ValidObjectIdentifier(v.name) {
-		return ErrInvalidObjectIdentifier
+	if opts == nil {
+		return errors.Join(errNilOptions)
 	}
 	return nil
 }
 
-func (v *describeExternalTableStageOptions) validate() error {
-	if !ValidObjectIdentifier(v.name) {
-		return ErrInvalidObjectIdentifier
+func (opts *describeExternalTableColumnsOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	if !validObjectidentifier(opts.name) {
+		return errors.Join(errInvalidObjectIdentifier)
+	}
+	return nil
+}
+
+func (opts *describeExternalTableStageOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	if !validObjectidentifier(opts.name) {
+		return errors.Join(errInvalidObjectIdentifier)
 	}
 	return nil
 }
 
 func (cpp *CloudProviderParams) validate() error {
-	if anyValueSet(cpp.GoogleCloudStorageIntegration, cpp.MicrosoftAzureIntegration) && exactlyOneValueSet(cpp.GoogleCloudStorageIntegration, cpp.MicrosoftAzureIntegration) {
+	if anyValueSet(cpp.GoogleCloudStorageIntegration, cpp.MicrosoftAzureIntegration) && !exactlyOneValueSet(cpp.GoogleCloudStorageIntegration, cpp.MicrosoftAzureIntegration) {
 		return errOneOf("CloudProviderParams", "GoogleCloudStorageIntegration", "MicrosoftAzureIntegration")
 	}
 	return nil
@@ -201,8 +230,11 @@ func (opts *ExternalTableFileFormat) validate() error {
 }
 
 func (opts *ExternalTableDropOption) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	if anyValueSet(opts.Restrict, opts.Cascade) && !exactlyOneValueSet(opts.Restrict, opts.Cascade) {
-		return errOneOf("ExternalTableDropOption", "Restrict", "Cascade")
+		return errors.Join(errOneOf("ExternalTableDropOption", "Restrict", "Cascade"))
 	}
 	return nil
 }

--- a/pkg/sdk/external_tables_validations.go
+++ b/pkg/sdk/external_tables_validations.go
@@ -20,14 +20,14 @@ var (
 
 func (opts *CreateExternalTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateExternalTableOptions", "OrReplace", "IfNotExists"))
 	}
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !valueSet(opts.Location) {
 		errs = append(errs, errNotSet("CreateExternalTableOptions", "Location"))
@@ -49,14 +49,14 @@ func (opts *CreateExternalTableOptions) validate() error {
 
 func (opts *CreateWithManualPartitioningExternalTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateWithManualPartitioningExternalTableOptions", "OrReplace", "IfNotExists"))
 	}
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !valueSet(opts.Location) {
 		errs = append(errs, errNotSet("CreateWithManualPartitioningExternalTableOptions", "Location"))
@@ -78,14 +78,14 @@ func (opts *CreateWithManualPartitioningExternalTableOptions) validate() error {
 
 func (opts *CreateDeltaLakeExternalTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateDeltaLakeExternalTableOptions", "OrReplace", "IfNotExists"))
 	}
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !valueSet(opts.Location) {
 		errs = append(errs, errNotSet("CreateDeltaLakeExternalTableOptions", "Location"))
@@ -107,11 +107,11 @@ func (opts *CreateDeltaLakeExternalTableOptions) validate() error {
 
 func (opts *CreateExternalTableUsingTemplateOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !valueSet(opts.Query) {
 		errs = append(errs, errNotSet("CreateExternalTableUsingTemplateOptions", "Query"))
@@ -136,11 +136,11 @@ func (opts *CreateExternalTableUsingTemplateOptions) validate() error {
 
 func (opts *AlterExternalTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !exactlyOneValueSet(opts.Refresh, opts.AddFiles, opts.RemoveFiles, opts.AutoRefresh, opts.SetTag, opts.UnsetTag) {
 		errs = append(errs, errExactlyOneOf("AlterExternalTableOptions", "Refresh", "AddFiles", "RemoveFiles", "AutoRefresh", "SetTag", "UnsetTag"))
@@ -150,11 +150,11 @@ func (opts *AlterExternalTableOptions) validate() error {
 
 func (opts *AlterExternalTablePartitionOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if everyValueSet(opts.AddPartitions, opts.DropPartition) {
 		errs = append(errs, errOneOf("AlterExternalTablePartitionOptions", "AddPartitions", "DropPartition"))
@@ -164,11 +164,11 @@ func (opts *AlterExternalTablePartitionOptions) validate() error {
 
 func (opts *DropExternalTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if valueSet(opts.DropOption) {
 		if err := opts.DropOption.validate(); err != nil {
@@ -180,27 +180,27 @@ func (opts *DropExternalTableOptions) validate() error {
 
 func (opts *ShowExternalTableOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	return nil
 }
 
 func (opts *describeExternalTableColumnsOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
 
 func (opts *describeExternalTableStageOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -231,7 +231,7 @@ func (opts *ExternalTableFileFormat) validate() error {
 
 func (opts *ExternalTableDropOption) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	if anyValueSet(opts.Restrict, opts.Cascade) && !exactlyOneValueSet(opts.Restrict, opts.Cascade) {
 		return errors.Join(errOneOf("ExternalTableDropOption", "Restrict", "Cascade"))

--- a/pkg/sdk/failover_groups.go
+++ b/pkg/sdk/failover_groups.go
@@ -69,10 +69,10 @@ type CreateFailoverGroupOptions struct {
 
 func (opts *CreateFailoverGroupOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -106,13 +106,13 @@ type CreateSecondaryReplicationGroupOptions struct {
 
 func (opts *CreateSecondaryReplicationGroupOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !validObjectidentifier(opts.primaryFailoverGroup) {
+	if !ValidObjectIdentifier(opts.primaryFailoverGroup) {
 		errs = append(errs, errInvalidIdentifier("CreateSecondaryReplicationGroupOptions", "primaryFailoverGroup"))
 	}
 	return errors.Join(errs...)
@@ -150,11 +150,11 @@ type AlterSourceFailoverGroupOptions struct {
 
 func (opts *AlterSourceFailoverGroupOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !exactlyOneValueSet(opts.Set, opts.Add, opts.Move, opts.Remove, opts.NewName) {
 		errs = append(errs, errExactlyOneOf("AlterSourceFailoverGroupOptions", "Set", "Add", "Move", "Remove", "NewName"))
@@ -260,11 +260,11 @@ type AlterTargetFailoverGroupOptions struct {
 
 func (opts *AlterTargetFailoverGroupOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !exactlyOneValueSet(opts.Refresh, opts.Primary, opts.Suspend, opts.Resume) {
 		errs = append(errs, errExactlyOneOf("Refresh", "Primary", "Suspend", "Resume"))
@@ -298,10 +298,10 @@ type DropFailoverGroupOptions struct {
 
 func (opts *DropFailoverGroupOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -334,7 +334,7 @@ type ShowFailoverGroupOptions struct {
 
 func (opts *ShowFailoverGroupOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	return nil
 }
@@ -496,7 +496,7 @@ func (v *failoverGroups) ShowByID(ctx context.Context, id AccountObjectIdentifie
 			return &failoverGroup, nil
 		}
 	}
-	return nil, errObjectNotExistOrAuthorized
+	return nil, ErrObjectNotExistOrAuthorized
 }
 
 // showFailoverGroupDatabasesOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-databases-in-failover-group.
@@ -508,10 +508,10 @@ type showFailoverGroupDatabasesOptions struct {
 
 func (opts *showFailoverGroupDatabasesOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.in) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.in) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -550,10 +550,10 @@ type showFailoverGroupSharesOptions struct {
 
 func (opts *showFailoverGroupSharesOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.in) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.in) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }

--- a/pkg/sdk/failover_groups.go
+++ b/pkg/sdk/failover_groups.go
@@ -68,8 +68,11 @@ type CreateFailoverGroupOptions struct {
 }
 
 func (opts *CreateFailoverGroupOptions) validate() error {
-	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	if !validObjectidentifier(opts.name) {
+		return errors.Join(errInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -102,13 +105,17 @@ type CreateSecondaryReplicationGroupOptions struct {
 }
 
 func (opts *CreateSecondaryReplicationGroupOptions) validate() error {
-	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+	if opts == nil {
+		return errors.Join(errNilOptions)
 	}
-	if !ValidObjectIdentifier(opts.primaryFailoverGroup) {
-		return ErrInvalidObjectIdentifier
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
-	return nil
+	if !validObjectidentifier(opts.primaryFailoverGroup) {
+		errs = append(errs, errInvalidIdentifier("CreateSecondaryReplicationGroupOptions", "primaryFailoverGroup"))
+	}
+	return errors.Join(errs...)
 }
 
 func (v *failoverGroups) CreateSecondaryReplicationGroup(ctx context.Context, id AccountObjectIdentifier, primaryFailoverGroupID ExternalObjectIdentifier, opts *CreateSecondaryReplicationGroupOptions) error {
@@ -142,33 +149,37 @@ type AlterSourceFailoverGroupOptions struct {
 }
 
 func (opts *AlterSourceFailoverGroupOptions) validate() error {
-	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if !exactlyOneValueSet(opts.Set, opts.Add, opts.Move, opts.Remove, opts.NewName) {
-		return errors.New("exactly one of SET, ADD, MOVE, REMOVE, or NewName must be specified")
+		errs = append(errs, errExactlyOneOf("AlterSourceFailoverGroupOptions", "Set", "Add", "Move", "Remove", "NewName"))
 	}
 	if valueSet(opts.Set) {
 		if err := opts.Set.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 	if valueSet(opts.Add) {
 		if err := opts.Add.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 	if valueSet(opts.Move) {
 		if err := opts.Move.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 	if valueSet(opts.Remove) {
 		if err := opts.Remove.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 type FailoverGroupSet struct {
@@ -248,13 +259,17 @@ type AlterTargetFailoverGroupOptions struct {
 }
 
 func (opts *AlterTargetFailoverGroupOptions) validate() error {
-	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if !exactlyOneValueSet(opts.Refresh, opts.Primary, opts.Suspend, opts.Resume) {
-		return errors.New("must set one of [Refresh, Primary, Suspend, Resume]")
+		errs = append(errs, errExactlyOneOf("Refresh", "Primary", "Suspend", "Resume"))
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *failoverGroups) AlterTarget(ctx context.Context, id AccountObjectIdentifier, opts *AlterTargetFailoverGroupOptions) error {
@@ -282,8 +297,11 @@ type DropFailoverGroupOptions struct {
 }
 
 func (opts *DropFailoverGroupOptions) validate() error {
-	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	if !validObjectidentifier(opts.name) {
+		return errors.Join(errInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -315,6 +333,9 @@ type ShowFailoverGroupOptions struct {
 }
 
 func (opts *ShowFailoverGroupOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
 	return nil
 }
 
@@ -475,7 +496,7 @@ func (v *failoverGroups) ShowByID(ctx context.Context, id AccountObjectIdentifie
 			return &failoverGroup, nil
 		}
 	}
-	return nil, ErrObjectNotExistOrAuthorized
+	return nil, errObjectNotExistOrAuthorized
 }
 
 // showFailoverGroupDatabasesOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-databases-in-failover-group.
@@ -486,8 +507,11 @@ type showFailoverGroupDatabasesOptions struct {
 }
 
 func (opts *showFailoverGroupDatabasesOptions) validate() error {
-	if !ValidObjectIdentifier(opts.in) {
-		return ErrInvalidObjectIdentifier
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	if !validObjectidentifier(opts.in) {
+		return errors.Join(errInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -525,8 +549,11 @@ type showFailoverGroupSharesOptions struct {
 }
 
 func (opts *showFailoverGroupSharesOptions) validate() error {
-	if !ValidObjectIdentifier(opts.in) {
-		return ErrInvalidObjectIdentifier
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	if !validObjectidentifier(opts.in) {
+		return errors.Join(errInvalidObjectIdentifier)
 	}
 	return nil
 }

--- a/pkg/sdk/failover_groups.go
+++ b/pkg/sdk/failover_groups.go
@@ -267,7 +267,7 @@ func (opts *AlterTargetFailoverGroupOptions) validate() error {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !exactlyOneValueSet(opts.Refresh, opts.Primary, opts.Suspend, opts.Resume) {
-		errs = append(errs, errExactlyOneOf("Refresh", "Primary", "Suspend", "Resume"))
+		errs = append(errs, errExactlyOneOf("AlterTargetFailoverGroupOptions", "Refresh", "Primary", "Suspend", "Resume"))
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/grants_test.go
+++ b/pkg/sdk/grants_test.go
@@ -326,16 +326,16 @@ func TestGrants_GrantPrivilegesToDatabaseRole(t *testing.T) {
 		}
 	}
 
-	t.Run("validation: no privileges set", func(t *testing.T) {
+	t.Run("validation: nil privileges set", func(t *testing.T) {
 		opts := defaultGrantsForDb()
 		opts.privileges = nil
-		assertOptsInvalid(t, opts, fmt.Errorf("privileges must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("GrantPrivilegesToDatabaseRoleOptions", "privileges"))
 	})
 
 	t.Run("validation: no privileges set", func(t *testing.T) {
 		opts := defaultGrantsForDb()
 		opts.privileges = &DatabaseRoleGrantPrivileges{}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of DatabasePrivileges, SchemaPrivileges, or SchemaObjectPrivileges must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("DatabaseRoleGrantPrivileges", "DatabasePrivileges", "SchemaPrivileges", "SchemaObjectPrivileges"))
 	})
 
 	t.Run("validation: too many privileges set", func(t *testing.T) {
@@ -344,19 +344,19 @@ func TestGrants_GrantPrivilegesToDatabaseRole(t *testing.T) {
 			DatabasePrivileges: []AccountObjectPrivilege{AccountObjectPrivilegeCreateSchema},
 			SchemaPrivileges:   []SchemaPrivilege{SchemaPrivilegeCreateAlert},
 		}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of DatabasePrivileges, SchemaPrivileges, or SchemaObjectPrivileges must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("DatabaseRoleGrantPrivileges", "DatabasePrivileges", "SchemaPrivileges", "SchemaObjectPrivileges"))
 	})
 
 	t.Run("validation: no on set", func(t *testing.T) {
 		opts := defaultGrantsForDb()
 		opts.on = nil
-		assertOptsInvalid(t, opts, fmt.Errorf("on must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("GrantPrivilegesToDatabaseRoleOptions", "on"))
 	})
 
 	t.Run("validation: no on set", func(t *testing.T) {
 		opts := defaultGrantsForDb()
 		opts.on = &DatabaseRoleGrantOn{}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of Database, Schema, or SchemaObject must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("DatabaseRoleGrantOn", "Database", "Schema", "SchemaObject"))
 	})
 
 	t.Run("validation: too many ons set", func(t *testing.T) {
@@ -367,19 +367,19 @@ func TestGrants_GrantPrivilegesToDatabaseRole(t *testing.T) {
 				Schema: Pointer(NewDatabaseObjectIdentifier("db1", "schema1")),
 			},
 		}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of Database, Schema, or SchemaObject must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("DatabaseRoleGrantOn", "Database", "Schema", "SchemaObject"))
 	})
 
 	t.Run("validation: grant on schema", func(t *testing.T) {
 		opts := defaultGrantsForSchema()
 		opts.on.Schema = &GrantOnSchema{}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of Schema, AllSchemasInDatabase, or FutureSchemasInDatabase must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("GrantOnSchema", "Schema", "AllSchemasInDatabase", "FutureSchemasInDatabase"))
 	})
 
 	t.Run("validation: grant on schema object", func(t *testing.T) {
 		opts := defaultGrantsForSchemaObject()
 		opts.on.SchemaObject = &GrantOnSchemaObject{}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of Object, AllIn or Future must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("GrantOnSchemaObject", "SchemaObject", "All", "Future"))
 	})
 
 	t.Run("validation: grant on schema object - all", func(t *testing.T) {
@@ -391,7 +391,7 @@ func TestGrants_GrantPrivilegesToDatabaseRole(t *testing.T) {
 				},
 			},
 		}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of InDatabase, or InSchema must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("GrantOnSchemaObjectIn", "InDatabase", "InSchema"))
 	})
 
 	t.Run("validation: grant on schema object - future", func(t *testing.T) {
@@ -403,13 +403,13 @@ func TestGrants_GrantPrivilegesToDatabaseRole(t *testing.T) {
 				},
 			},
 		}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of InDatabase, or InSchema must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("GrantOnSchemaObjectIn", "InDatabase", "InSchema"))
 	})
 
 	t.Run("validation: unsupported database privilege", func(t *testing.T) {
 		opts := defaultGrantsForDb()
 		opts.privileges.DatabasePrivileges = []AccountObjectPrivilege{AccountObjectPrivilegeCreateDatabaseRole}
-		assertOptsInvalid(t, opts, fmt.Errorf("privilege CREATE DATABASE ROLE is not allowed"))
+		assertOptsInvalidJoinedErrors(t, opts, fmt.Errorf("privilege CREATE DATABASE ROLE is not allowed"))
 	})
 
 	t.Run("on database", func(t *testing.T) {
@@ -512,16 +512,16 @@ func TestGrants_RevokePrivilegesFromDatabaseRoleRole(t *testing.T) {
 		}
 	}
 
-	t.Run("validation: no privileges set", func(t *testing.T) {
+	t.Run("validation: nil privileges set", func(t *testing.T) {
 		opts := defaultGrantsForDb()
 		opts.privileges = nil
-		assertOptsInvalid(t, opts, fmt.Errorf("privileges must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("RevokePrivilegesFromDatabaseRoleOptions", "privileges"))
 	})
 
 	t.Run("validation: no privileges set", func(t *testing.T) {
 		opts := defaultGrantsForDb()
 		opts.privileges = &DatabaseRoleGrantPrivileges{}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of DatabasePrivileges, SchemaPrivileges, or SchemaObjectPrivileges must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("DatabaseRoleGrantPrivileges", "DatabasePrivileges", "SchemaPrivileges", "SchemaObjectPrivileges"))
 	})
 
 	t.Run("validation: too many privileges set", func(t *testing.T) {
@@ -530,19 +530,19 @@ func TestGrants_RevokePrivilegesFromDatabaseRoleRole(t *testing.T) {
 			DatabasePrivileges: []AccountObjectPrivilege{AccountObjectPrivilegeCreateSchema},
 			SchemaPrivileges:   []SchemaPrivilege{SchemaPrivilegeCreateAlert},
 		}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of DatabasePrivileges, SchemaPrivileges, or SchemaObjectPrivileges must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("DatabaseRoleGrantPrivileges", "DatabasePrivileges", "SchemaPrivileges", "SchemaObjectPrivileges"))
 	})
 
-	t.Run("validation: no on set", func(t *testing.T) {
+	t.Run("validation: nil on set", func(t *testing.T) {
 		opts := defaultGrantsForDb()
 		opts.on = nil
-		assertOptsInvalid(t, opts, fmt.Errorf("on must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("RevokePrivilegesFromDatabaseRoleOptions", "on"))
 	})
 
 	t.Run("validation: no on set", func(t *testing.T) {
 		opts := defaultGrantsForDb()
 		opts.on = &DatabaseRoleGrantOn{}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of Database, Schema, or SchemaObject must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("DatabaseRoleGrantOn", "Database", "Schema", "SchemaObject"))
 	})
 
 	t.Run("validation: too many ons set", func(t *testing.T) {
@@ -553,19 +553,19 @@ func TestGrants_RevokePrivilegesFromDatabaseRoleRole(t *testing.T) {
 				Schema: Pointer(NewDatabaseObjectIdentifier("db1", "schema1")),
 			},
 		}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of Database, Schema, or SchemaObject must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("DatabaseRoleGrantOn", "Database", "Schema", "SchemaObject"))
 	})
 
 	t.Run("validation: grant on schema", func(t *testing.T) {
 		opts := defaultGrantsForSchema()
 		opts.on.Schema = &GrantOnSchema{}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of Schema, AllSchemasInDatabase, or FutureSchemasInDatabase must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("GrantOnSchema", "Schema", "AllSchemasInDatabase", "FutureSchemasInDatabase"))
 	})
 
 	t.Run("validation: grant on schema object", func(t *testing.T) {
 		opts := defaultGrantsForSchemaObject()
 		opts.on.SchemaObject = &GrantOnSchemaObject{}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of Object, AllIn or Future must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("GrantOnSchemaObject", "SchemaObject", "All", "Future"))
 	})
 
 	t.Run("validation: grant on schema object - all", func(t *testing.T) {
@@ -577,7 +577,7 @@ func TestGrants_RevokePrivilegesFromDatabaseRoleRole(t *testing.T) {
 				},
 			},
 		}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of InDatabase, or InSchema must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("GrantOnSchemaObjectIn", "InDatabase", "InSchema"))
 	})
 
 	t.Run("validation: grant on schema object - future", func(t *testing.T) {
@@ -589,13 +589,13 @@ func TestGrants_RevokePrivilegesFromDatabaseRoleRole(t *testing.T) {
 				},
 			},
 		}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of InDatabase, or InSchema must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("GrantOnSchemaObjectIn", "InDatabase", "InSchema"))
 	})
 
 	t.Run("validation: unsupported database privilege", func(t *testing.T) {
 		opts := defaultGrantsForDb()
 		opts.privileges.DatabasePrivileges = []AccountObjectPrivilege{AccountObjectPrivilegeCreateDatabaseRole}
-		assertOptsInvalid(t, opts, errors.New("privilege CREATE DATABASE ROLE is not allowed"))
+		assertOptsInvalidJoinedErrors(t, opts, errors.New("privilege CREATE DATABASE ROLE is not allowed"))
 	})
 
 	t.Run("on database", func(t *testing.T) {
@@ -828,7 +828,7 @@ func TestGrants_GrantOwnership(t *testing.T) {
 	t.Run("validation: grant on empty", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.On = OwnershipGrantOn{}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of [Object AllIn Future] must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("OwnershipGrantOn", "Object", "AllIn", "Future"))
 	})
 
 	t.Run("validation: grant on too many", func(t *testing.T) {
@@ -843,7 +843,7 @@ func TestGrants_GrantOwnership(t *testing.T) {
 				InDatabase:       Pointer(dbId),
 			},
 		}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of [Object AllIn Future] must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("OwnershipGrantOn", "Object", "AllIn", "Future"))
 	})
 
 	t.Run("validation: grant on schema object - all", func(t *testing.T) {
@@ -853,7 +853,7 @@ func TestGrants_GrantOwnership(t *testing.T) {
 				PluralObjectType: PluralObjectTypeTables,
 			},
 		}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of InDatabase, or InSchema must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("GrantOnSchemaObjectIn", "InDatabase", "InSchema"))
 	})
 
 	t.Run("validation: grant on schema object - future", func(t *testing.T) {
@@ -863,13 +863,13 @@ func TestGrants_GrantOwnership(t *testing.T) {
 				PluralObjectType: PluralObjectTypeTables,
 			},
 		}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of InDatabase, or InSchema must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("GrantOnSchemaObjectIn", "InDatabase", "InSchema"))
 	})
 
 	t.Run("validation: grant to empty", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.To = OwnershipGrantTo{}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of [databaseRoleName accountRoleName] must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("OwnershipGrantTo", "databaseRoleName", "accountRoleName"))
 	})
 
 	t.Run("validation: grant to role and database role", func(t *testing.T) {
@@ -878,7 +878,7 @@ func TestGrants_GrantOwnership(t *testing.T) {
 			DatabaseRoleName: Pointer(databaseRoleId),
 			AccountRoleName:  Pointer(roleId),
 		}
-		assertOptsInvalid(t, opts, fmt.Errorf("exactly one of [databaseRoleName accountRoleName] must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("OwnershipGrantTo", "databaseRoleName", "accountRoleName"))
 	})
 
 	t.Run("on schema object to role", func(t *testing.T) {

--- a/pkg/sdk/grants_validations.go
+++ b/pkg/sdk/grants_validations.go
@@ -277,10 +277,10 @@ func (opts *revokePrivilegeFromShareOptions) validate() error {
 	if !valueSet(opts.On) || opts.privilege == "" {
 		errs = append(errs, errNotSet("revokePrivilegeFromShareOptions", "On", "privilege"))
 	}
-	if !exactlyOneValueSet(opts.On.Database, opts.On.Schema, opts.On.Table, opts.On.View) {
-		errs = append(errs, errExactlyOneOf("revokePrivilegeFromShareOptions", "On.Database", "On.Schema", "On.Table", "On.View"))
-	}
 	if valueSet(opts.On) {
+		if !exactlyOneValueSet(opts.On.Database, opts.On.Schema, opts.On.Table, opts.On.View) {
+			errs = append(errs, errExactlyOneOf("revokePrivilegeFromShareOptions", "On.Database", "On.Schema", "On.Table", "On.View"))
+		}
 		if err := opts.On.validate(); err != nil {
 			errs = append(errs, err)
 		}

--- a/pkg/sdk/grants_validations.go
+++ b/pkg/sdk/grants_validations.go
@@ -28,7 +28,7 @@ func (opts *GrantPrivilegesToAccountRoleOptions) validate() error {
 		errs = append(errs, errNotSet("GrantPrivilegesToAccountRoleOptions", "privileges"))
 	} else {
 		if err := opts.privileges.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 	if !valueSet(opts.on) {

--- a/pkg/sdk/grants_validations.go
+++ b/pkg/sdk/grants_validations.go
@@ -358,15 +358,8 @@ func (v *OwnershipGrantTo) validate() error {
 
 // TODO: add validations for ShowGrantsOn, ShowGrantsTo, ShowGrantsOf and ShowGrantsIn
 func (opts *ShowGrantOptions) validate() error {
-	if opts == nil {
-		return errors.Join(ErrNilOptions)
-	}
-	var errs []error
-	if everyValueNil(opts.On, opts.To, opts.Of, opts.In) {
-		errs = append(errs, errExactlyOneOf("ShowGrantOptions", "On", "To", "Of", "In"))
-	}
 	if moreThanOneValueSet(opts.On, opts.To, opts.Of, opts.In) {
-		errs = append(errs, errOneOf("ShowGrantOptions", "On", "To", "Of", "In"))
+		return errOneOf("ShowGrantOptions", "On", "To", "Of", "In")
 	}
-	return errors.Join(errs...)
+	return nil
 }

--- a/pkg/sdk/grants_validations.go
+++ b/pkg/sdk/grants_validations.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"errors"
 	"fmt"
 
 	// TODO: change to slices with go 1.21
@@ -19,129 +20,150 @@ var (
 )
 
 func (opts *GrantPrivilegesToAccountRoleOptions) validate() error {
-	if !valueSet(opts.privileges) {
-		return fmt.Errorf("privileges must be set")
+	if opts == nil {
+		return errors.Join(errNilOptions)
 	}
-	if err := opts.privileges.validate(); err != nil {
-		return err
+	var errs []error
+	if !valueSet(opts.privileges) {
+		errs = append(errs, errNotSet("GrantPrivilegesToAccountRoleOptions", "privileges"))
+	} else {
+		if err := opts.privileges.validate(); err != nil {
+			return err
+		}
 	}
 	if !valueSet(opts.on) {
-		return fmt.Errorf("on must be set")
+		errs = append(errs, errNotSet("GrantPrivilegesToAccountRoleOptions", "on"))
+	} else {
+		if err := opts.on.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	if err := opts.on.validate(); err != nil {
-		return err
-	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *AccountRoleGrantPrivileges) validate() error {
 	if !exactlyOneValueSet(v.AllPrivileges, v.GlobalPrivileges, v.AccountObjectPrivileges, v.SchemaPrivileges, v.SchemaObjectPrivileges) {
-		return fmt.Errorf("exactly one of AllPrivileges, GlobalPrivileges, AccountObjectPrivileges, SchemaPrivileges, or SchemaObjectPrivileges must be set")
+		return errExactlyOneOf("AccountRoleGrantPrivileges", "AllPrivileges", "GlobalPrivileges", "AccountObjectPrivileges", "SchemaPrivileges", "SchemaObjectPrivileges")
 	}
 	return nil
 }
 
 func (v *AccountRoleGrantOn) validate() error {
+	var errs []error
 	if !exactlyOneValueSet(v.Account, v.AccountObject, v.Schema, v.SchemaObject) {
-		return fmt.Errorf("exactly one of Account, AccountObject, Schema, or SchemaObject must be set")
+		errs = append(errs, errExactlyOneOf("AccountRoleGrantOn", "Account", "AccountObject", "Schema", "SchemaObject"))
 	}
 	if valueSet(v.AccountObject) {
 		if err := v.AccountObject.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 	if valueSet(v.Schema) {
 		if err := v.Schema.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 	if valueSet(v.SchemaObject) {
 		if err := v.SchemaObject.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *GrantOnAccountObject) validate() error {
 	if !exactlyOneValueSet(v.User, v.ResourceMonitor, v.Warehouse, v.Database, v.Integration, v.FailoverGroup, v.ReplicationGroup) {
-		return fmt.Errorf("exactly one of User, ResourceMonitor, Warehouse, Database, Integration, FailoverGroup, or ReplicationGroup must be set")
+		return errExactlyOneOf("GrantOnAccountObject", "User", "ResourceMonitor", "Warehouse", "Database", "Integration", "FailoverGroup", "ReplicationGroup")
 	}
 	return nil
 }
 
 func (v *GrantOnSchema) validate() error {
 	if !exactlyOneValueSet(v.Schema, v.AllSchemasInDatabase, v.FutureSchemasInDatabase) {
-		return fmt.Errorf("exactly one of Schema, AllSchemasInDatabase, or FutureSchemasInDatabase must be set")
+		return errExactlyOneOf("GrantOnSchema", "Schema", "AllSchemasInDatabase", "FutureSchemasInDatabase")
 	}
 	return nil
 }
 
 func (v *GrantOnSchemaObject) validate() error {
+	var errs []error
 	if !exactlyOneValueSet(v.SchemaObject, v.All, v.Future) {
-		return fmt.Errorf("exactly one of Object, AllIn or Future must be set")
+		errs = append(errs, errExactlyOneOf("GrantOnSchemaObject", "SchemaObject", "All", "Future"))
 	}
 	if valueSet(v.All) {
 		if err := v.All.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 	if valueSet(v.Future) {
 		if err := v.Future.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *GrantOnSchemaObjectIn) validate() error {
 	if !exactlyOneValueSet(v.InDatabase, v.InSchema) {
-		return fmt.Errorf("exactly one of InDatabase, or InSchema must be set")
+		return errExactlyOneOf("GrantOnSchemaObjectIn", "InDatabase", "InSchema")
 	}
 	return nil
 }
 
 func (opts *RevokePrivilegesFromAccountRoleOptions) validate() error {
-	if !valueSet(opts.privileges) {
-		return fmt.Errorf("privileges must be set")
+	if opts == nil {
+		return errors.Join(errNilOptions)
 	}
-	if err := opts.privileges.validate(); err != nil {
-		return err
+	var errs []error
+	if !valueSet(opts.privileges) {
+		errs = append(errs, errNotSet("RevokePrivilegesFromAccountRoleOptions", "privileges"))
+	} else {
+		if err := opts.privileges.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if !valueSet(opts.on) {
-		return fmt.Errorf("on must be set")
+		errs = append(errs, errNotSet("RevokePrivilegesFromAccountRoleOptions", "on"))
+	} else {
+		if err := opts.on.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	if err := opts.on.validate(); err != nil {
-		return err
-	}
-	if !ValidObjectIdentifier(opts.accountRole) {
-		return ErrInvalidObjectIdentifier
+	if !validObjectidentifier(opts.accountRole) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if everyValueSet(opts.Restrict, opts.Cascade) {
-		return fmt.Errorf("either Restrict or Cascade can be set, or neither but not both")
+		errs = append(errs, errOneOf("RevokePrivilegesFromAccountRoleOptions", "Restrict", "Cascade"))
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (opts *GrantPrivilegesToDatabaseRoleOptions) validate() error {
-	if !valueSet(opts.privileges) {
-		return fmt.Errorf("privileges must be set")
+	if opts == nil {
+		return errors.Join(errNilOptions)
 	}
-	if err := opts.privileges.validate(); err != nil {
-		return err
+	var errs []error
+	if !valueSet(opts.privileges) {
+		errs = append(errs, errNotSet("GrantPrivilegesToDatabaseRoleOptions", "privileges"))
+	} else {
+		if err := opts.privileges.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if !valueSet(opts.on) {
-		return fmt.Errorf("on must be set")
+		errs = append(errs, errNotSet("GrantPrivilegesToDatabaseRoleOptions", "on"))
+	} else {
+		if err := opts.on.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	if err := opts.on.validate(); err != nil {
-		return err
-	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *DatabaseRoleGrantPrivileges) validate() error {
+	var errs []error
 	if !exactlyOneValueSet(v.DatabasePrivileges, v.SchemaPrivileges, v.SchemaObjectPrivileges) {
-		return fmt.Errorf("exactly one of DatabasePrivileges, SchemaPrivileges, or SchemaObjectPrivileges must be set")
+		errs = append(errs, errExactlyOneOf("DatabaseRoleGrantPrivileges", "DatabasePrivileges", "SchemaPrivileges", "SchemaObjectPrivileges"))
 	}
 	if valueSet(v.DatabasePrivileges) {
 		allowedPrivileges := []AccountObjectPrivilege{
@@ -152,163 +174,199 @@ func (v *DatabaseRoleGrantPrivileges) validate() error {
 		}
 		for _, p := range v.DatabasePrivileges {
 			if !slices.Contains(allowedPrivileges, p) {
-				return fmt.Errorf("privilege %s is not allowed", p.String())
+				errs = append(errs, fmt.Errorf("privilege %s is not allowed", p.String()))
 			}
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *DatabaseRoleGrantOn) validate() error {
+	var errs []error
 	if !exactlyOneValueSet(v.Database, v.Schema, v.SchemaObject) {
-		return fmt.Errorf("exactly one of Database, Schema, or SchemaObject must be set")
+		errs = append(errs, errExactlyOneOf("DatabaseRoleGrantOn", "Database", "Schema", "SchemaObject"))
 	}
 	if valueSet(v.Schema) {
 		if err := v.Schema.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 	if valueSet(v.SchemaObject) {
 		if err := v.SchemaObject.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (opts *RevokePrivilegesFromDatabaseRoleOptions) validate() error {
-	if !valueSet(opts.privileges) {
-		return fmt.Errorf("privileges must be set")
+	if opts == nil {
+		return errors.Join(errNilOptions)
 	}
-	if err := opts.privileges.validate(); err != nil {
-		return err
+	var errs []error
+	if !valueSet(opts.privileges) {
+		errs = append(errs, errNotSet("RevokePrivilegesFromDatabaseRoleOptions", "privileges"))
+	} else {
+		if err := opts.privileges.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if !valueSet(opts.on) {
-		return fmt.Errorf("on must be set")
+		errs = append(errs, errNotSet("RevokePrivilegesFromDatabaseRoleOptions", "on"))
+	} else {
+		if err := opts.on.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	if err := opts.on.validate(); err != nil {
-		return err
-	}
-	if !ValidObjectIdentifier(opts.databaseRole) {
-		return ErrInvalidObjectIdentifier
+	if !validObjectidentifier(opts.databaseRole) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if everyValueSet(opts.Restrict, opts.Cascade) {
-		return fmt.Errorf("either Restrict or Cascade can be set, or neither but not both")
+		errs = append(errs, errOneOf("RevokePrivilegesFromDatabaseRoleOptions", "Restrict", "Cascade"))
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (opts *grantPrivilegeToShareOptions) validate() error {
-	if !ValidObjectIdentifier(opts.to) {
-		return ErrInvalidObjectIdentifier
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	var errs []error
+	if !validObjectidentifier(opts.to) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if !valueSet(opts.On) || opts.privilege == "" {
-		return fmt.Errorf("on and privilege are required")
+		errs = append(errs, fmt.Errorf("on and privilege are required"))
 	}
-	if err := opts.On.validate(); err != nil {
-		return err
+	if valueSet(opts.On) {
+		if err := opts.On.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *GrantPrivilegeToShareOn) validate() error {
+	var errs []error
 	if !exactlyOneValueSet(v.Database, v.Schema, v.Function, v.Table, v.View) {
-		return fmt.Errorf("only one of database, schema, function, table, or view can be set")
+		errs = append(errs, errExactlyOneOf("GrantPrivilegeToShareOn", "Database", "Schema", "Function", "Table", "View"))
 	}
 	if valueSet(v.Table) {
 		if err := v.Table.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *OnTable) validate() error {
 	if !exactlyOneValueSet(v.Name, v.AllInSchema) {
-		return fmt.Errorf("only one of name or allInSchema can be set")
+		return errExactlyOneOf("OnTable", "Name", "AllInSchema")
 	}
 	return nil
 }
 
 func (opts *revokePrivilegeFromShareOptions) validate() error {
-	if !ValidObjectIdentifier(opts.from) {
-		return ErrInvalidObjectIdentifier
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	var errs []error
+	if !validObjectidentifier(opts.from) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if !valueSet(opts.On) || opts.privilege == "" {
-		return fmt.Errorf("on and privilege are required")
+		errs = append(errs, errNotSet("revokePrivilegeFromShareOptions", "On", "privilege"))
 	}
 	if !exactlyOneValueSet(opts.On.Database, opts.On.Schema, opts.On.Table, opts.On.View) {
-		return fmt.Errorf("only one of database, schema, function, table, or view can be set")
+		errs = append(errs, errExactlyOneOf("revokePrivilegeFromShareOptions", "On.Database", "On.Schema", "On.Table", "On.View"))
 	}
-
-	if err := opts.On.validate(); err != nil {
-		return err
+	if valueSet(opts.On) {
+		if err := opts.On.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
-
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *RevokePrivilegeFromShareOn) validate() error {
+	var errs []error
 	if !exactlyOneValueSet(v.Database, v.Schema, v.Table, v.View) {
-		return fmt.Errorf("only one of database, schema, table, or view can be set")
+		errs = append(errs, errExactlyOneOf("RevokePrivilegeFromShareOn", "Database", "Schema", "Table", "View"))
 	}
 	if valueSet(v.Table) {
-		return v.Table.validate()
+		if err := v.Table.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if valueSet(v.View) {
-		return v.View.validate()
+		if err := v.View.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *OnView) validate() error {
 	if !exactlyOneValueSet(v.Name, v.AllInSchema) {
-		return fmt.Errorf("only one of name or allInSchema can be set")
+		return errExactlyOneOf("OnView", "Name", "AllInSchema")
 	}
 	return nil
 }
 
 func (opts *GrantOwnershipOptions) validate() error {
-	if err := opts.On.validate(); err != nil {
-		return err
+	if opts == nil {
+		return errors.Join(errNilOptions)
 	}
-	if err := opts.To.validate(); err != nil {
-		return err
+	var errs []error
+	if valueSet(opts.On) {
+		if err := opts.On.validate(); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return nil
+	if valueSet(opts.To) {
+		if err := opts.To.validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (v *OwnershipGrantOn) validate() error {
+	var errs []error
 	if !exactlyOneValueSet(v.Object, v.All, v.Future) {
-		return errExactlyOneOf("Object", "AllIn", "Future")
+		errs = append(errs, errExactlyOneOf("OwnershipGrantOn", "Object", "AllIn", "Future"))
 	}
 	if valueSet(v.All) {
 		if err := v.All.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 	if valueSet(v.Future) {
 		if err := v.Future.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *OwnershipGrantTo) validate() error {
 	if !exactlyOneValueSet(v.DatabaseRoleName, v.AccountRoleName) {
-		return errExactlyOneOf("databaseRoleName", "accountRoleName")
+		return errExactlyOneOf("OwnershipGrantTo", "databaseRoleName", "accountRoleName")
 	}
 	return nil
 }
 
 // TODO: add validations for ShowGrantsOn, ShowGrantsTo, ShowGrantsOf and ShowGrantsIn
 func (opts *ShowGrantOptions) validate() error {
+	if opts == nil {
+		return errors.Join(errNilOptions)
+	}
+	var errs []error
 	if everyValueNil(opts.On, opts.To, opts.Of, opts.In) {
-		return nil
+		errs = append(errs, errExactlyOneOf("ShowGrantOptions", "On", "To", "Of", "In"))
 	}
-	if !exactlyOneValueSet(opts.On, opts.To, opts.Of, opts.In) {
-		return fmt.Errorf("only one of [on, to, of, in] can be set")
+	if moreThanOneValueSet(opts.On, opts.To, opts.Of, opts.In) {
+		errs = append(errs, errOneOf("ShowGrantOptions", "On", "To", "Of", "In"))
 	}
-	return nil
+	return errors.Join(errs...)
 }

--- a/pkg/sdk/grants_validations.go
+++ b/pkg/sdk/grants_validations.go
@@ -21,7 +21,7 @@ var (
 
 func (opts *GrantPrivilegesToAccountRoleOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if !valueSet(opts.privileges) {
@@ -112,7 +112,7 @@ func (v *GrantOnSchemaObjectIn) validate() error {
 
 func (opts *RevokePrivilegesFromAccountRoleOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if !valueSet(opts.privileges) {
@@ -129,8 +129,8 @@ func (opts *RevokePrivilegesFromAccountRoleOptions) validate() error {
 			errs = append(errs, err)
 		}
 	}
-	if !validObjectidentifier(opts.accountRole) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.accountRole) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if everyValueSet(opts.Restrict, opts.Cascade) {
 		errs = append(errs, errOneOf("RevokePrivilegesFromAccountRoleOptions", "Restrict", "Cascade"))
@@ -140,7 +140,7 @@ func (opts *RevokePrivilegesFromAccountRoleOptions) validate() error {
 
 func (opts *GrantPrivilegesToDatabaseRoleOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if !valueSet(opts.privileges) {
@@ -201,7 +201,7 @@ func (v *DatabaseRoleGrantOn) validate() error {
 
 func (opts *RevokePrivilegesFromDatabaseRoleOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if !valueSet(opts.privileges) {
@@ -218,8 +218,8 @@ func (opts *RevokePrivilegesFromDatabaseRoleOptions) validate() error {
 			errs = append(errs, err)
 		}
 	}
-	if !validObjectidentifier(opts.databaseRole) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.databaseRole) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if everyValueSet(opts.Restrict, opts.Cascade) {
 		errs = append(errs, errOneOf("RevokePrivilegesFromDatabaseRoleOptions", "Restrict", "Cascade"))
@@ -229,11 +229,11 @@ func (opts *RevokePrivilegesFromDatabaseRoleOptions) validate() error {
 
 func (opts *grantPrivilegeToShareOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.to) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.to) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !valueSet(opts.On) || opts.privilege == "" {
 		errs = append(errs, fmt.Errorf("on and privilege are required"))
@@ -268,11 +268,11 @@ func (v *OnTable) validate() error {
 
 func (opts *revokePrivilegeFromShareOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.from) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.from) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if !valueSet(opts.On) || opts.privilege == "" {
 		errs = append(errs, errNotSet("revokePrivilegeFromShareOptions", "On", "privilege"))
@@ -315,7 +315,7 @@ func (v *OnView) validate() error {
 
 func (opts *GrantOwnershipOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if valueSet(opts.On) {
@@ -359,7 +359,7 @@ func (v *OwnershipGrantTo) validate() error {
 // TODO: add validations for ShowGrantsOn, ShowGrantsTo, ShowGrantsOf and ShowGrantsIn
 func (opts *ShowGrantOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if everyValueNil(opts.On, opts.To, opts.Of, opts.In) {

--- a/pkg/sdk/integration_test_imports.go
+++ b/pkg/sdk/integration_test_imports.go
@@ -19,3 +19,7 @@ func (c *Client) ExecForTests(ctx context.Context, sql string) (sql.Result, erro
 func ErrExactlyOneOf(structName string, fieldNames ...string) error {
 	return errExactlyOneOf(structName, fieldNames...)
 }
+
+func ErrOneOf(structName string, fieldNames ...string) error {
+	return errOneOf(structName, fieldNames...)
+}

--- a/pkg/sdk/integration_test_imports.go
+++ b/pkg/sdk/integration_test_imports.go
@@ -15,3 +15,7 @@ func (c *Client) ExecForTests(ctx context.Context, sql string) (sql.Result, erro
 	result, err := c.db.ExecContext(ctx, sql)
 	return result, decodeDriverError(err)
 }
+
+func ErrExactlyOneOf(structName string, fieldNames ...string) error {
+	return errExactlyOneOf(structName, fieldNames...)
+}

--- a/pkg/sdk/masking_policy.go
+++ b/pkg/sdk/masking_policy.go
@@ -55,19 +55,20 @@ func (opts *CreateMaskingPolicyOptions) validate() error {
 	if opts == nil {
 		return errors.Join(ErrNilOptions)
 	}
+	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
-		return errors.Join(ErrInvalidObjectIdentifier)
+		errs = append(errs, errors.Join(ErrInvalidObjectIdentifier))
 	}
 	if !valueSet(opts.signature) {
-		return errNotSet("CreateMaskingPolicyOptions", "signature")
+		errs = append(errs, errNotSet("CreateMaskingPolicyOptions", "signature"))
 	}
 	if !valueSet(opts.returns) {
-		return errNotSet("CreateMaskingPolicyOptions", "returns")
+		errs = append(errs, errNotSet("CreateMaskingPolicyOptions", "returns"))
 	}
 	if !valueSet(opts.body) {
-		return errNotSet("CreateMaskingPolicyOptions", "body")
+		errs = append(errs, errNotSet("CreateMaskingPolicyOptions", "body"))
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *maskingPolicies) Create(ctx context.Context, id SchemaObjectIdentifier, signature []TableColumnSignature, returns DataType, body string, opts *CreateMaskingPolicyOptions) error {
@@ -108,7 +109,7 @@ func (opts *AlterMaskingPolicyOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if valueSet(opts.NewName) && !ValidObjectIdentifier(opts.NewName) {
+	if opts.NewName != nil && !ValidObjectIdentifier(opts.NewName) {
 		errs = append(errs, errInvalidIdentifier("AlterMaskingPolicyOptions", "NewName"))
 	}
 	if !exactlyOneValueSet(opts.NewName, opts.Set, opts.Unset) {

--- a/pkg/sdk/masking_policy.go
+++ b/pkg/sdk/masking_policy.go
@@ -58,6 +58,15 @@ func (opts *CreateMaskingPolicyOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		return errors.Join(ErrInvalidObjectIdentifier)
 	}
+	if !valueSet(opts.signature) {
+		return errNotSet("CreateMaskingPolicyOptions", "signature")
+	}
+	if !valueSet(opts.returns) {
+		return errNotSet("CreateMaskingPolicyOptions", "returns")
+	}
+	if !valueSet(opts.body) {
+		return errNotSet("CreateMaskingPolicyOptions", "body")
+	}
 	return nil
 }
 
@@ -102,7 +111,7 @@ func (opts *AlterMaskingPolicyOptions) validate() error {
 	if valueSet(opts.NewName) && !ValidObjectIdentifier(opts.NewName) {
 		errs = append(errs, errInvalidIdentifier("AlterMaskingPolicyOptions", "NewName"))
 	}
-	if exactlyOneValueSet(opts.NewName, opts.Set, opts.Unset) {
+	if !exactlyOneValueSet(opts.NewName, opts.Set, opts.Unset) {
 		errs = append(errs, errExactlyOneOf("AlterMaskingPolicyOptions", "NewName", "Set", "Unset"))
 	}
 	if valueSet(opts.Set) {

--- a/pkg/sdk/masking_policy.go
+++ b/pkg/sdk/masking_policy.go
@@ -53,10 +53,10 @@ type CreateMaskingPolicyOptions struct {
 
 func (opts *CreateMaskingPolicyOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -93,13 +93,13 @@ type AlterMaskingPolicyOptions struct {
 
 func (opts *AlterMaskingPolicyOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if valueSet(opts.NewName) && !validObjectidentifier(opts.NewName) {
+	if valueSet(opts.NewName) && !ValidObjectIdentifier(opts.NewName) {
 		errs = append(errs, errInvalidIdentifier("AlterMaskingPolicyOptions", "NewName"))
 	}
 	if exactlyOneValueSet(opts.NewName, opts.Set, opts.Unset) {
@@ -168,10 +168,10 @@ type DropMaskingPolicyOptions struct {
 
 func (opts *DropMaskingPolicyOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -206,7 +206,7 @@ type ShowMaskingPolicyOptions struct {
 
 func (opts *ShowMaskingPolicyOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	return nil
 }
@@ -290,7 +290,7 @@ func (v *maskingPolicies) ShowByID(ctx context.Context, id SchemaObjectIdentifie
 			return &maskingPolicy, nil
 		}
 	}
-	return nil, errObjectNotExistOrAuthorized
+	return nil, ErrObjectNotExistOrAuthorized
 }
 
 // describeMaskingPolicyOptions is based on https://docs.snowflake.com/en/sql-reference/sql/desc-masking-policy.
@@ -302,10 +302,10 @@ type describeMaskingPolicyOptions struct {
 
 func (opts *describeMaskingPolicyOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }

--- a/pkg/sdk/masking_policy_test.go
+++ b/pkg/sdk/masking_policy_test.go
@@ -26,7 +26,7 @@ func TestMaskingPolicyCreate(t *testing.T) {
 			signature: signature,
 			returns:   DataTypeVARCHAR,
 		}
-		assertOptsInvalid(t, opts, errNotSet("CreateMaskingPolicyOptions", "body"))
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("CreateMaskingPolicyOptions", "body"))
 	})
 
 	t.Run("validation: no signature", func(t *testing.T) {
@@ -35,7 +35,7 @@ func TestMaskingPolicyCreate(t *testing.T) {
 			body:    expression,
 			returns: DataTypeVARCHAR,
 		}
-		assertOptsInvalid(t, opts, errNotSet("CreateMaskingPolicyOptions", "signature"))
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("CreateMaskingPolicyOptions", "signature"))
 	})
 
 	t.Run("validation: no returns", func(t *testing.T) {
@@ -44,7 +44,7 @@ func TestMaskingPolicyCreate(t *testing.T) {
 			signature: signature,
 			body:      expression,
 		}
-		assertOptsInvalid(t, opts, errNotSet("CreateMaskingPolicyOptions", "returns"))
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("CreateMaskingPolicyOptions", "returns"))
 	})
 
 	t.Run("only required options", func(t *testing.T) {
@@ -81,15 +81,14 @@ func TestMaskingPolicyAlter(t *testing.T) {
 
 	t.Run("validation: empty options", func(t *testing.T) {
 		opts := &AlterMaskingPolicyOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("validation: no option", func(t *testing.T) {
 		opts := &AlterMaskingPolicyOptions{
 			name: id,
 		}
-
-		assertOptsInvalid(t, opts, errExactlyOneOf("Set", "Unset", "NewName"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterMaskingPolicyOptions", "NewName", "Set", "Unset"))
 	})
 
 	t.Run("with set", func(t *testing.T) {
@@ -128,7 +127,7 @@ func TestMaskingPolicyDrop(t *testing.T) {
 
 	t.Run("validation: empty options", func(t *testing.T) {
 		opts := &DropMaskingPolicyOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("only name", func(t *testing.T) {
@@ -207,7 +206,7 @@ func TestMaskingPolicyDescribe(t *testing.T) {
 
 	t.Run("validation: empty options", func(t *testing.T) {
 		opts := &describeMaskingPolicyOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("only name", func(t *testing.T) {

--- a/pkg/sdk/network_policies_gen_test.go
+++ b/pkg/sdk/network_policies_gen_test.go
@@ -60,13 +60,13 @@ func TestNetworkPolicies_Alter(t *testing.T) {
 
 	t.Run("validation: exactly one field from [opts.Set opts.UnsetComment opts.RenameTo] should be present", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("Set", "UnsetComment", "RenameTo"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterNetworkPolicyOptions", "Set", "UnsetComment", "RenameTo"))
 	})
 
 	t.Run("validation: at least one of the fields [opts.Set.AllowedIpList opts.Set.BlockedIpList opts.Set.Comment] should be set", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Set = &NetworkPolicySet{}
-		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AllowedIpList", "BlockedIpList", "Comment"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterNetworkPolicyOptions.Set", "AllowedIpList", "BlockedIpList", "Comment"))
 	})
 
 	t.Run("set allowed ip list", func(t *testing.T) {

--- a/pkg/sdk/network_policies_validations_gen.go
+++ b/pkg/sdk/network_policies_validations_gen.go
@@ -30,14 +30,14 @@ func (opts *AlterNetworkPolicyOptions) validate() error {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if ok := exactlyOneValueSet(opts.Set, opts.UnsetComment, opts.RenameTo); !ok {
-		errs = append(errs, errExactlyOneOf("Set", "UnsetComment", "RenameTo"))
+		errs = append(errs, errExactlyOneOf("AlterNetworkPolicyOptions", "Set", "UnsetComment", "RenameTo"))
 	}
 	if valueSet(opts.RenameTo) && !ValidObjectIdentifier(opts.RenameTo) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if valueSet(opts.Set) {
 		if ok := anyValueSet(opts.Set.AllowedIpList, opts.Set.BlockedIpList, opts.Set.Comment); !ok {
-			errs = append(errs, errAtLeastOneOf("AllowedIpList", "BlockedIpList", "Comment"))
+			errs = append(errs, errAtLeastOneOf("AlterNetworkPolicyOptions.Set", "AllowedIpList", "BlockedIpList", "Comment"))
 		}
 	}
 	return errors.Join(errs...)

--- a/pkg/sdk/parameters.go
+++ b/pkg/sdk/parameters.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strconv"
 )
@@ -815,24 +816,24 @@ type AccountParameters struct {
 }
 
 func (v *AccountParameters) validate() error {
+	var errs []error
 	if valueSet(v.ClientEncryptionKeySize) {
 		if !(*v.ClientEncryptionKeySize == 128 || *v.ClientEncryptionKeySize == 256) {
-			return fmt.Errorf("CLIENT_ENCRYPTION_KEY_SIZE must be either 128 or 256")
+			errs = append(errs, fmt.Errorf("CLIENT_ENCRYPTION_KEY_SIZE must be either 128 or 256"))
 		}
 	}
 	if valueSet(v.InitialReplicationSizeLimitInTB) {
 		l := *v.InitialReplicationSizeLimitInTB
 		if l < 0.0 || (l < 0.0 && l < 1.0) {
-			return fmt.Errorf("%v must be 0.0 and above with a scale of at least 1 (e.g. 20.5, 32.25, 33.333, etc.)", l)
+			errs = append(errs, fmt.Errorf("%v must be 0.0 and above with a scale of at least 1 (e.g. 20.5, 32.25, 33.333, etc.)", l))
 		}
-		return nil
 	}
 	if valueSet(v.MinDataRetentionTimeInDays) {
 		if ok := validateIntInRange(*v.MinDataRetentionTimeInDays, 0, 90); !ok {
-			return fmt.Errorf("MIN_DATA_RETENTION_TIME_IN_DAYS must be between 0 and 90")
+			errs = append(errs, fmt.Errorf("MIN_DATA_RETENTION_TIME_IN_DAYS must be between 0 and 90"))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 type AccountParametersUnset struct {
@@ -932,42 +933,43 @@ type SessionParameters struct {
 }
 
 func (v *SessionParameters) validate() error {
+	var errs []error
 	if valueSet(v.JSONIndent) {
 		if ok := validateIntInRange(*v.JSONIndent, 0, 16); !ok {
-			return fmt.Errorf("JSON_INDENT must be between 0 and 16")
+			errs = append(errs, fmt.Errorf("JSON_INDENT must be between 0 and 16"))
 		}
 	}
 	if valueSet(v.LockTimeout) {
 		if ok := validateIntGreaterThanOrEqual(*v.LockTimeout, 0); !ok {
-			return fmt.Errorf("LOCK_TIMEOUT must be greater than or equal to 0")
+			errs = append(errs, fmt.Errorf("LOCK_TIMEOUT must be greater than or equal to 0"))
 		}
 	}
 	if valueSet(v.QueryTag) {
 		if len(*v.QueryTag) > 2000 {
-			return fmt.Errorf("QUERY_TAG must be less than 2000 characters")
+			errs = append(errs, fmt.Errorf("QUERY_TAG must be less than 2000 characters"))
 		}
 	}
 	if valueSet(v.RowsPerResultset) {
 		if ok := validateIntGreaterThanOrEqual(*v.RowsPerResultset, 0); !ok {
-			return fmt.Errorf("ROWS_PER_RESULTSET must be greater than or equal to 0")
+			errs = append(errs, fmt.Errorf("ROWS_PER_RESULTSET must be greater than or equal to 0"))
 		}
 	}
 	if valueSet(v.TwoDigitCenturyStart) {
 		if ok := validateIntInRange(*v.TwoDigitCenturyStart, 1900, 2100); !ok {
-			return fmt.Errorf("TWO_DIGIT_CENTURY_START must be between 1900 and 2100")
+			errs = append(errs, fmt.Errorf("TWO_DIGIT_CENTURY_START must be between 1900 and 2100"))
 		}
 	}
 	if valueSet(v.WeekOfYearPolicy) {
 		if ok := validateIntInRange(*v.WeekOfYearPolicy, 0, 1); !ok {
-			return fmt.Errorf("WEEK_OF_YEAR_POLICY must be either 0 or 1")
+			errs = append(errs, fmt.Errorf("WEEK_OF_YEAR_POLICY must be either 0 or 1"))
 		}
 	}
 	if valueSet(v.WeekStart) {
 		if ok := validateIntInRange(*v.WeekStart, 0, 1); !ok {
-			return fmt.Errorf("WEEK_START must be either 0 or 1")
+			errs = append(errs, fmt.Errorf("WEEK_START must be either 0 or 1"))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 type SessionParametersUnset struct {
@@ -1011,8 +1013,8 @@ type SessionParametersUnset struct {
 }
 
 func (v *SessionParametersUnset) validate() error {
-	if ok := anyValueSet(v.AbortDetachedQuery, v.Autocommit, v.BinaryInputFormat, v.BinaryOutputFormat, v.DateInputFormat, v.DateOutputFormat, v.ErrorOnNondeterministicMerge, v.ErrorOnNondeterministicUpdate, v.GeographyOutputFormat, v.JSONIndent, v.LockTimeout, v.QueryTag, v.RowsPerResultset, v.SimulatedDataSharingConsumer, v.StatementTimeoutInSeconds, v.StrictJSONOutput, v.TimestampDayIsAlways24h, v.TimestampInputFormat, v.TimestampLTZOutputFormat, v.TimestampNTZOutputFormat, v.TimestampOutputFormat, v.TimestampTypeMapping, v.TimestampTZOutputFormat, v.Timezone, v.TimeInputFormat, v.TimeOutputFormat, v.TransactionDefaultIsolationLevel, v.TwoDigitCenturyStart, v.UnsupportedDDLAction, v.UseCachedResult, v.WeekOfYearPolicy, v.WeekStart); !ok {
-		return fmt.Errorf("at least one session parameter must be set")
+	if !anyValueSet(v.AbortDetachedQuery, v.Autocommit, v.BinaryInputFormat, v.BinaryOutputFormat, v.DateInputFormat, v.DateOutputFormat, v.ErrorOnNondeterministicMerge, v.ErrorOnNondeterministicUpdate, v.GeographyOutputFormat, v.JSONIndent, v.LockTimeout, v.QueryTag, v.RowsPerResultset, v.SimulatedDataSharingConsumer, v.StatementTimeoutInSeconds, v.StrictJSONOutput, v.TimestampDayIsAlways24h, v.TimestampInputFormat, v.TimestampLTZOutputFormat, v.TimestampNTZOutputFormat, v.TimestampOutputFormat, v.TimestampTypeMapping, v.TimestampTZOutputFormat, v.Timezone, v.TimeInputFormat, v.TimeOutputFormat, v.TransactionDefaultIsolationLevel, v.TwoDigitCenturyStart, v.UnsupportedDDLAction, v.UseCachedResult, v.WeekOfYearPolicy, v.WeekStart) {
+		return errors.Join(errAtLeastOneOf("SessionParametersUnset", "AbortDetachedQuery", "Autocommit", "BinaryInputFormat", "BinaryOutputFormat", "DateInputFormat", "DateOutputFormat", "ErrorOnNondeterministicMerge", "ErrorOnNondeterministicUpdate", "GeographyOutputFormat", "JSONIndent", "LockTimeout", "QueryTag", "RowsPerResultset", "SimulatedDataSharingConsumer", "StatementTimeoutInSeconds", "StrictJSONOutput", "TimestampDayIsAlways24h", "TimestampInputFormat", "TimestampLTZOutputFormat", "TimestampNTZOutputFormat", "TimestampOutputFormat", "TimestampTypeMapping", "TimestampTZOutputFormat", "Timezone", "TimeInputFormat", "TimeOutputFormat", "TransactionDefaultIsolationLevel", "TwoDigitCenturyStart", "UnsupportedDDLAction", "UseCachedResult", "WeekOfYearPolicy", "WeekStart"))
 	}
 	return nil
 }
@@ -1057,41 +1059,38 @@ type ObjectParameters struct {
 }
 
 func (v *ObjectParameters) validate() error {
+	var errs []error
 	if valueSet(v.DataRetentionTimeInDays) {
 		if ok := validateIntInRange(*v.DataRetentionTimeInDays, 0, 90); !ok {
-			return fmt.Errorf("DATA_RETENTION_TIME_IN_DAYS must be between 0 and 90")
+			errs = append(errs, errIntBetween("ObjectParameters", "DataRetentionTimeInDays", 0, 90))
 		}
 	}
 	if valueSet(v.MaxConcurrencyLevel) {
 		if ok := validateIntGreaterThanOrEqual(*v.MaxConcurrencyLevel, 1); !ok {
-			return fmt.Errorf("MAX_CONCURRENCY_LEVEL must be greater than or equal to 1")
+			errs = append(errs, errIntValue("ObjectParameters", "MaxConcurrencyLevel", IntErrGreaterOrEqual, 1))
 		}
 	}
-
 	if valueSet(v.MaxDataExtensionTimeInDays) {
 		if ok := validateIntInRange(*v.MaxDataExtensionTimeInDays, 0, 90); !ok {
-			return fmt.Errorf("MAX_DATA_EXTENSION_TIME_IN_DAYS must be between 0 and 90")
+			errs = append(errs, errIntBetween("ObjectParameters", "MaxDataExtensionTimeInDays", 0, 90))
 		}
 	}
-
 	if valueSet(v.StatementQueuedTimeoutInSeconds) {
 		if ok := validateIntGreaterThanOrEqual(*v.StatementQueuedTimeoutInSeconds, 0); !ok {
-			return fmt.Errorf("STATEMENT_QUEUED_TIMEOUT_IN_SECONDS must be greater than or equal to 0")
+			errs = append(errs, errIntValue("ObjectParameters", "StatementQueuedTimeoutInSeconds", IntErrGreaterOrEqual, 0))
 		}
 	}
-
 	if valueSet(v.SuspendTaskAfterNumFailures) {
 		if ok := validateIntGreaterThanOrEqual(*v.SuspendTaskAfterNumFailures, 0); !ok {
-			return fmt.Errorf("SUSPEND_TASK_AFTER_NUM_FAILURES must be greater than or equal to 0")
+			errs = append(errs, errIntValue("ObjectParameters", "SuspendTaskAfterNumFailures", IntErrGreaterOrEqual, 0))
 		}
 	}
-
 	if valueSet(v.UserTaskTimeoutMs) {
 		if ok := validateIntInRange(*v.UserTaskTimeoutMs, 0, 86400000); !ok {
-			return fmt.Errorf("USER_TASK_TIMEOUT_MS must be between 0 and 86400000")
+			errs = append(errs, errIntBetween("ObjectParameters", "UserTaskTimeoutMs", 0, 86400000))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 type ObjectParametersUnset struct {
@@ -1152,8 +1151,8 @@ type ParametersIn struct {
 }
 
 func (v *ParametersIn) validate() error {
-	if ok := anyValueSet(v.Session, v.Account, v.User, v.Warehouse, v.Database, v.Schema, v.Task, v.Table); !ok {
-		return fmt.Errorf("at least one IN parameter must be set")
+	if !anyValueSet(v.Session, v.Account, v.User, v.Warehouse, v.Database, v.Schema, v.Task, v.Table) {
+		return errors.Join(errAtLeastOneOf("Session", "Account", "User", "Warehouse", "Database", "Schema", "Task", "Table"))
 	}
 	return nil
 }

--- a/pkg/sdk/parameters.go
+++ b/pkg/sdk/parameters.go
@@ -829,8 +829,8 @@ func (v *AccountParameters) validate() error {
 		}
 	}
 	if valueSet(v.MinDataRetentionTimeInDays) {
-		if ok := validateIntInRange(*v.MinDataRetentionTimeInDays, 0, 90); !ok {
-			errs = append(errs, fmt.Errorf("MIN_DATA_RETENTION_TIME_IN_DAYS must be between 0 and 90"))
+		if !validateIntInRange(*v.MinDataRetentionTimeInDays, 0, 90) {
+			errs = append(errs, errIntBetween("AccountParameters", "MinDataRetentionTimeInDays", 0, 90))
 		}
 	}
 	return errors.Join(errs...)
@@ -935,37 +935,37 @@ type SessionParameters struct {
 func (v *SessionParameters) validate() error {
 	var errs []error
 	if valueSet(v.JSONIndent) {
-		if ok := validateIntInRange(*v.JSONIndent, 0, 16); !ok {
-			errs = append(errs, fmt.Errorf("JSON_INDENT must be between 0 and 16"))
+		if !validateIntInRange(*v.JSONIndent, 0, 16) {
+			errs = append(errs, errIntBetween("SessionParameters", "JSONIndent", 0, 16))
 		}
 	}
 	if valueSet(v.LockTimeout) {
-		if ok := validateIntGreaterThanOrEqual(*v.LockTimeout, 0); !ok {
-			errs = append(errs, fmt.Errorf("LOCK_TIMEOUT must be greater than or equal to 0"))
+		if !validateIntGreaterThanOrEqual(*v.LockTimeout, 0) {
+			errs = append(errs, errIntValue("SessionParameters", "LockTimeout", IntErrGreaterOrEqual, 0))
 		}
 	}
 	if valueSet(v.QueryTag) {
 		if len(*v.QueryTag) > 2000 {
-			errs = append(errs, fmt.Errorf("QUERY_TAG must be less than 2000 characters"))
+			errs = append(errs, errIntValue("SessionParameters", "QueryTag", IntErrLess, 2000))
 		}
 	}
 	if valueSet(v.RowsPerResultset) {
-		if ok := validateIntGreaterThanOrEqual(*v.RowsPerResultset, 0); !ok {
-			errs = append(errs, fmt.Errorf("ROWS_PER_RESULTSET must be greater than or equal to 0"))
+		if !validateIntGreaterThanOrEqual(*v.RowsPerResultset, 0) {
+			errs = append(errs, errIntValue("SessionParameters", "RowsPerResultset", IntErrGreaterOrEqual, 0))
 		}
 	}
 	if valueSet(v.TwoDigitCenturyStart) {
-		if ok := validateIntInRange(*v.TwoDigitCenturyStart, 1900, 2100); !ok {
-			errs = append(errs, fmt.Errorf("TWO_DIGIT_CENTURY_START must be between 1900 and 2100"))
+		if !validateIntInRange(*v.TwoDigitCenturyStart, 1900, 2100) {
+			errs = append(errs, errIntBetween("SessionParameters", "TwoDigitCenturyStart", 1900, 2100))
 		}
 	}
 	if valueSet(v.WeekOfYearPolicy) {
-		if ok := validateIntInRange(*v.WeekOfYearPolicy, 0, 1); !ok {
+		if !validateIntInRange(*v.WeekOfYearPolicy, 0, 1) {
 			errs = append(errs, fmt.Errorf("WEEK_OF_YEAR_POLICY must be either 0 or 1"))
 		}
 	}
 	if valueSet(v.WeekStart) {
-		if ok := validateIntInRange(*v.WeekStart, 0, 1); !ok {
+		if !validateIntInRange(*v.WeekStart, 0, 1) {
 			errs = append(errs, fmt.Errorf("WEEK_START must be either 0 or 1"))
 		}
 	}
@@ -1061,32 +1061,32 @@ type ObjectParameters struct {
 func (v *ObjectParameters) validate() error {
 	var errs []error
 	if valueSet(v.DataRetentionTimeInDays) {
-		if ok := validateIntInRange(*v.DataRetentionTimeInDays, 0, 90); !ok {
+		if !validateIntInRange(*v.DataRetentionTimeInDays, 0, 90) {
 			errs = append(errs, errIntBetween("ObjectParameters", "DataRetentionTimeInDays", 0, 90))
 		}
 	}
 	if valueSet(v.MaxConcurrencyLevel) {
-		if ok := validateIntGreaterThanOrEqual(*v.MaxConcurrencyLevel, 1); !ok {
+		if !validateIntGreaterThanOrEqual(*v.MaxConcurrencyLevel, 1) {
 			errs = append(errs, errIntValue("ObjectParameters", "MaxConcurrencyLevel", IntErrGreaterOrEqual, 1))
 		}
 	}
 	if valueSet(v.MaxDataExtensionTimeInDays) {
-		if ok := validateIntInRange(*v.MaxDataExtensionTimeInDays, 0, 90); !ok {
+		if !validateIntInRange(*v.MaxDataExtensionTimeInDays, 0, 90) {
 			errs = append(errs, errIntBetween("ObjectParameters", "MaxDataExtensionTimeInDays", 0, 90))
 		}
 	}
 	if valueSet(v.StatementQueuedTimeoutInSeconds) {
-		if ok := validateIntGreaterThanOrEqual(*v.StatementQueuedTimeoutInSeconds, 0); !ok {
+		if !validateIntGreaterThanOrEqual(*v.StatementQueuedTimeoutInSeconds, 0) {
 			errs = append(errs, errIntValue("ObjectParameters", "StatementQueuedTimeoutInSeconds", IntErrGreaterOrEqual, 0))
 		}
 	}
 	if valueSet(v.SuspendTaskAfterNumFailures) {
-		if ok := validateIntGreaterThanOrEqual(*v.SuspendTaskAfterNumFailures, 0); !ok {
+		if !validateIntGreaterThanOrEqual(*v.SuspendTaskAfterNumFailures, 0) {
 			errs = append(errs, errIntValue("ObjectParameters", "SuspendTaskAfterNumFailures", IntErrGreaterOrEqual, 0))
 		}
 	}
 	if valueSet(v.UserTaskTimeoutMs) {
-		if ok := validateIntInRange(*v.UserTaskTimeoutMs, 0, 86400000); !ok {
+		if !validateIntInRange(*v.UserTaskTimeoutMs, 0, 86400000) {
 			errs = append(errs, errIntBetween("ObjectParameters", "UserTaskTimeoutMs", 0, 86400000))
 		}
 	}

--- a/pkg/sdk/password_policy.go
+++ b/pkg/sdk/password_policy.go
@@ -53,10 +53,12 @@ type CreatePasswordPolicyOptions struct {
 }
 
 func (opts *CreatePasswordPolicyOptions) validate() error {
-	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
 	}
-
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
+	}
 	return nil
 }
 
@@ -88,27 +90,27 @@ type AlterPasswordPolicyOptions struct {
 }
 
 func (opts *AlterPasswordPolicyOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
+	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-
 	if !exactlyOneValueSet(opts.Set, opts.Unset, opts.NewName) {
-		return errExactlyOneOf("Set", "Unset", "NewName")
+		errs = append(errs, errExactlyOneOf("Set", "Unset", "NewName"))
 	}
-
 	if valueSet(opts.Set) {
 		if err := opts.Set.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-
 	if valueSet(opts.Unset) {
 		if err := opts.Unset.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-
-	return nil
+	return errors.Join(errs...)
 }
 
 type PasswordPolicySet struct {
@@ -209,8 +211,11 @@ type DropPasswordPolicyOptions struct {
 }
 
 func (opts *DropPasswordPolicyOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
 	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -240,7 +245,10 @@ type ShowPasswordPolicyOptions struct {
 	Limit            *int  `ddl:"parameter,no_equals" sql:"LIMIT"`
 }
 
-func (input *ShowPasswordPolicyOptions) validate() error {
+func (opts *ShowPasswordPolicyOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
 	return nil
 }
 
@@ -339,9 +347,12 @@ type describePasswordPolicyOptions struct {
 	name           SchemaObjectIdentifier `ddl:"identifier"`
 }
 
-func (v *describePasswordPolicyOptions) validate() error {
-	if !ValidObjectIdentifier(v.name) {
-		return ErrInvalidObjectIdentifier
+func (opts *describePasswordPolicyOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }

--- a/pkg/sdk/password_policy_test.go
+++ b/pkg/sdk/password_policy_test.go
@@ -11,7 +11,7 @@ func TestPasswordPolicyCreate(t *testing.T) {
 
 	t.Run("validation: empty options", func(t *testing.T) {
 		opts := &CreatePasswordPolicyOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("only name", func(t *testing.T) {
@@ -46,14 +46,14 @@ func TestPasswordPolicyAlter(t *testing.T) {
 
 	t.Run("empty options", func(t *testing.T) {
 		opts := &AlterPasswordPolicyOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("only name", func(t *testing.T) {
 		opts := &AlterPasswordPolicyOptions{
 			name: id,
 		}
-		assertOptsInvalid(t, opts, errExactlyOneOf("Set", "Unset", "NewName"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("Set", "Unset", "NewName"))
 	})
 
 	t.Run("with set", func(t *testing.T) {
@@ -93,7 +93,7 @@ func TestPasswordPolicyDrop(t *testing.T) {
 
 	t.Run("validation: empty options", func(t *testing.T) {
 		opts := &DropPasswordPolicyOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("only name", func(t *testing.T) {
@@ -180,7 +180,7 @@ func TestPasswordPolicyDescribe(t *testing.T) {
 
 	t.Run("validation: empty options", func(t *testing.T) {
 		opts := &describePasswordPolicyOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("only name", func(t *testing.T) {

--- a/pkg/sdk/pipes_test.go
+++ b/pkg/sdk/pipes_test.go
@@ -16,19 +16,19 @@ func TestPipesCreate(t *testing.T) {
 
 	t.Run("validation: nil options", func(t *testing.T) {
 		var opts *CreatePipeOptions = nil
-		assertOptsInvalid(t, opts, ErrNilOptions)
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
 	})
 
 	t.Run("validation: incorrect identifier", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.name = NewSchemaObjectIdentifier("", "", "")
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("validation: copy statement required", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.copyStatement = ""
-		assertOptsInvalid(t, opts, errNotSet("CreatePipeOptions", "copyStatement"))
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("CreatePipeOptions", "copyStatement"))
 	})
 
 	t.Run("basic", func(t *testing.T) {
@@ -65,12 +65,12 @@ func TestPipesAlter(t *testing.T) {
 	t.Run("validation: incorrect identifier", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.name = NewSchemaObjectIdentifier("", "", "")
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("validation: no alter action", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalid(t, opts, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTags", "UnsetTags", "Refresh"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTags", "UnsetTags", "Refresh"))
 	})
 
 	t.Run("validation: multiple alter actions", func(t *testing.T) {
@@ -81,13 +81,13 @@ func TestPipesAlter(t *testing.T) {
 		opts.Unset = &PipeUnset{
 			Comment: Bool(true),
 		}
-		assertOptsInvalid(t, opts, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTags", "UnsetTags", "Refresh"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTags", "UnsetTags", "Refresh"))
 	})
 
 	t.Run("validation: no property to set", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Set = &PipeSet{}
-		assertOptsInvalid(t, opts, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTags", "UnsetTags", "Refresh"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterPipeOptions.Set", "ErrorIntegration", "PipeExecutionPaused", "Comment"))
 	})
 
 	t.Run("validation: empty tags slice for set", func(t *testing.T) {
@@ -95,13 +95,13 @@ func TestPipesAlter(t *testing.T) {
 		opts.SetTags = &PipeSetTags{
 			Tag: []TagAssociation{},
 		}
-		assertOptsInvalid(t, opts, errNotSet("AlterPipeOptions.SetTags", "Tag"))
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("AlterPipeOptions.SetTags", "Tag"))
 	})
 
 	t.Run("validation: no property to unset", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Unset = &PipeUnset{}
-		assertOptsInvalid(t, opts, errAtLeastOneOf("AlterPipeOptions.Unset", "PipeExecutionPaused", "Comment"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterPipeOptions.Unset", "PipeExecutionPaused", "Comment"))
 	})
 
 	t.Run("validation: empty tags slice for unset", func(t *testing.T) {
@@ -109,7 +109,7 @@ func TestPipesAlter(t *testing.T) {
 		opts.UnsetTags = &PipeUnsetTags{
 			Tag: []ObjectIdentifier{},
 		}
-		assertOptsInvalid(t, opts, errNotSet("AlterPipeOptions.UnsetTags", "Tag"))
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("AlterPipeOptions.UnsetTags", "Tag"))
 	})
 
 	t.Run("set tag: single", func(t *testing.T) {
@@ -218,7 +218,7 @@ func TestPipesDrop(t *testing.T) {
 	t.Run("validation: incorrect identifier", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.name = NewSchemaObjectIdentifier("", "", "")
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("empty options", func(t *testing.T) {
@@ -250,13 +250,13 @@ func TestPipesShow(t *testing.T) {
 	t.Run("validation: empty like", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Like = &Like{}
-		assertOptsInvalid(t, opts, ErrPatternRequiredForLikeKeyword)
+		assertOptsInvalidJoinedErrors(t, opts, ErrPatternRequiredForLikeKeyword)
 	})
 
 	t.Run("validation: empty in", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.In = &In{}
-		assertOptsInvalid(t, opts, errExactlyOneOf("ShowPipeOptions", "In.Account", "In.Database", "In.Schema"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("ShowPipeOptions", "In.Account", "In.Database", "In.Schema"))
 	})
 
 	t.Run("validation: exactly one scope for in", func(t *testing.T) {
@@ -265,7 +265,7 @@ func TestPipesShow(t *testing.T) {
 			Account:  Bool(true),
 			Database: databaseIdentifier,
 		}
-		assertOptsInvalid(t, opts, errExactlyOneOf("ShowPipeOptions", "In.Account", "In.Database", "In.Schema"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("ShowPipeOptions", "In.Account", "In.Database", "In.Schema"))
 	})
 
 	t.Run("empty options", func(t *testing.T) {
@@ -356,7 +356,7 @@ func TestPipesDescribe(t *testing.T) {
 	t.Run("validation: incorrect identifier", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.name = NewSchemaObjectIdentifier("", "", "")
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("with name", func(t *testing.T) {

--- a/pkg/sdk/pipes_test.go
+++ b/pkg/sdk/pipes_test.go
@@ -28,7 +28,7 @@ func TestPipesCreate(t *testing.T) {
 	t.Run("validation: copy statement required", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.copyStatement = ""
-		assertOptsInvalid(t, opts, errCopyStatementRequired)
+		assertOptsInvalid(t, opts, errNotSet("CreatePipeOptions", "copyStatement"))
 	})
 
 	t.Run("basic", func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestPipesAlter(t *testing.T) {
 
 	t.Run("validation: no alter action", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalid(t, opts, errAlterNeedsExactlyOneAction)
+		assertOptsInvalid(t, opts, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTags", "UnsetTags", "Refresh"))
 	})
 
 	t.Run("validation: multiple alter actions", func(t *testing.T) {
@@ -81,13 +81,13 @@ func TestPipesAlter(t *testing.T) {
 		opts.Unset = &PipeUnset{
 			Comment: Bool(true),
 		}
-		assertOptsInvalid(t, opts, errAlterNeedsExactlyOneAction)
+		assertOptsInvalid(t, opts, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTags", "UnsetTags", "Refresh"))
 	})
 
 	t.Run("validation: no property to set", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Set = &PipeSet{}
-		assertOptsInvalid(t, opts, errAlterNeedsAtLeastOneProperty)
+		assertOptsInvalid(t, opts, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTags", "UnsetTags", "Refresh"))
 	})
 
 	t.Run("validation: empty tags slice for set", func(t *testing.T) {
@@ -95,13 +95,13 @@ func TestPipesAlter(t *testing.T) {
 		opts.SetTags = &PipeSetTags{
 			Tag: []TagAssociation{},
 		}
-		assertOptsInvalid(t, opts, errAlterNeedsAtLeastOneProperty)
+		assertOptsInvalid(t, opts, errNotSet("AlterPipeOptions.SetTags", "Tag"))
 	})
 
 	t.Run("validation: no property to unset", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Unset = &PipeUnset{}
-		assertOptsInvalid(t, opts, errAlterNeedsAtLeastOneProperty)
+		assertOptsInvalid(t, opts, errAtLeastOneOf("AlterPipeOptions.Unset", "PipeExecutionPaused", "Comment"))
 	})
 
 	t.Run("validation: empty tags slice for unset", func(t *testing.T) {
@@ -109,7 +109,7 @@ func TestPipesAlter(t *testing.T) {
 		opts.UnsetTags = &PipeUnsetTags{
 			Tag: []ObjectIdentifier{},
 		}
-		assertOptsInvalid(t, opts, errAlterNeedsAtLeastOneProperty)
+		assertOptsInvalid(t, opts, errNotSet("AlterPipeOptions.UnsetTags", "Tag"))
 	})
 
 	t.Run("set tag: single", func(t *testing.T) {
@@ -256,7 +256,7 @@ func TestPipesShow(t *testing.T) {
 	t.Run("validation: empty in", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.In = &In{}
-		assertOptsInvalid(t, opts, errScopeRequiredForInKeyword)
+		assertOptsInvalid(t, opts, errExactlyOneOf("ShowPipeOptions", "In.Account", "In.Database", "In.Schema"))
 	})
 
 	t.Run("validation: exactly one scope for in", func(t *testing.T) {
@@ -265,7 +265,7 @@ func TestPipesShow(t *testing.T) {
 			Account:  Bool(true),
 			Database: databaseIdentifier,
 		}
-		assertOptsInvalid(t, opts, errScopeRequiredForInKeyword)
+		assertOptsInvalid(t, opts, errExactlyOneOf("ShowPipeOptions", "In.Account", "In.Database", "In.Schema"))
 	})
 
 	t.Run("empty options", func(t *testing.T) {

--- a/pkg/sdk/pipes_test.go
+++ b/pkg/sdk/pipes_test.go
@@ -59,7 +59,7 @@ func TestPipesAlter(t *testing.T) {
 
 	t.Run("validation: nil options", func(t *testing.T) {
 		var opts *AlterPipeOptions = nil
-		assertOptsInvalid(t, opts, ErrNilOptions)
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
 	})
 
 	t.Run("validation: incorrect identifier", func(t *testing.T) {
@@ -212,7 +212,7 @@ func TestPipesDrop(t *testing.T) {
 
 	t.Run("validation: nil options", func(t *testing.T) {
 		var opts *DropPipeOptions = nil
-		assertOptsInvalid(t, opts, ErrNilOptions)
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
 	})
 
 	t.Run("validation: incorrect identifier", func(t *testing.T) {
@@ -244,7 +244,7 @@ func TestPipesShow(t *testing.T) {
 
 	t.Run("validation: nil options", func(t *testing.T) {
 		var opts *ShowPipeOptions = nil
-		assertOptsInvalid(t, opts, ErrNilOptions)
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
 	})
 
 	t.Run("validation: empty like", func(t *testing.T) {
@@ -256,7 +256,7 @@ func TestPipesShow(t *testing.T) {
 	t.Run("validation: empty in", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.In = &In{}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("ShowPipeOptions", "In.Account", "In.Database", "In.Schema"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("ShowPipeOptions.In", "Account", "Database", "Schema"))
 	})
 
 	t.Run("validation: exactly one scope for in", func(t *testing.T) {
@@ -265,7 +265,7 @@ func TestPipesShow(t *testing.T) {
 			Account:  Bool(true),
 			Database: databaseIdentifier,
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("ShowPipeOptions", "In.Account", "In.Database", "In.Schema"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("ShowPipeOptions.In", "Account", "Database", "Schema"))
 	})
 
 	t.Run("empty options", func(t *testing.T) {
@@ -350,7 +350,7 @@ func TestPipesDescribe(t *testing.T) {
 
 	t.Run("validation: nil options", func(t *testing.T) {
 		var opts *describePipeOptions = nil
-		assertOptsInvalid(t, opts, ErrNilOptions)
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
 	})
 
 	t.Run("validation: incorrect identifier", func(t *testing.T) {

--- a/pkg/sdk/pipes_validations.go
+++ b/pkg/sdk/pipes_validations.go
@@ -28,7 +28,7 @@ func (opts *CreatePipeOptions) validate() error {
 
 func (opts *AlterPipeOptions) validate() error {
 	if opts == nil {
-		return ErrNilOptions
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
@@ -62,7 +62,7 @@ func (opts *AlterPipeOptions) validate() error {
 
 func (opts *DropPipeOptions) validate() error {
 	if opts == nil {
-		return ErrNilOptions
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
@@ -73,21 +73,21 @@ func (opts *DropPipeOptions) validate() error {
 
 func (opts *ShowPipeOptions) validate() error {
 	if opts == nil {
-		return ErrNilOptions
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if valueSet(opts.Like) && !valueSet(opts.Like.Pattern) {
 		errs = append(errs, ErrPatternRequiredForLikeKeyword)
 	}
 	if valueSet(opts.In) && !exactlyOneValueSet(opts.In.Account, opts.In.Database, opts.In.Schema) {
-		errs = append(errs, errExactlyOneOf("ShowPipeOptions", "In.Account", "In.Database", "In.Schema"))
+		errs = append(errs, errExactlyOneOf("ShowPipeOptions.In", "Account", "Database", "Schema"))
 	}
 	return errors.Join(errs...)
 }
 
 func (opts *describePipeOptions) validate() error {
 	if opts == nil {
-		return ErrNilOptions
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {

--- a/pkg/sdk/pipes_validations.go
+++ b/pkg/sdk/pipes_validations.go
@@ -14,23 +14,25 @@ var (
 
 func (opts *CreatePipeOptions) validate() error {
 	if opts == nil {
-		return ErrNilOptions
+		return errors.Join(errNilOptions)
 	}
-	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if opts.copyStatement == "" {
-		return errCopyStatementRequired
+		errs = append(errs, errNotSet("CreatePipeOptions", "copyStatement"))
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (opts *AlterPipeOptions) validate() error {
 	if opts == nil {
 		return ErrNilOptions
 	}
-	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
 	if ok := exactlyOneValueSet(
 		opts.Set,
@@ -39,67 +41,63 @@ func (opts *AlterPipeOptions) validate() error {
 		opts.UnsetTags,
 		opts.Refresh,
 	); !ok {
-		return errAlterNeedsExactlyOneAction
+		errs = append(errs, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTags", "UnsetTags", "Refresh"))
 	}
 	if set := opts.Set; valueSet(set) {
 		if !anyValueSet(set.ErrorIntegration, set.PipeExecutionPaused, set.Comment) {
-			return errAlterNeedsAtLeastOneProperty
+			errs = append(errs, errAtLeastOneOf("AlterPipeOptions.Set", "ErrorIntegration", "PipeExecutionPaused", "Comment"))
 		}
 	}
 	if unset := opts.Unset; valueSet(unset) {
 		if !anyValueSet(unset.PipeExecutionPaused, unset.Comment) {
-			return errAlterNeedsAtLeastOneProperty
+			errs = append(errs, errAtLeastOneOf("AlterPipeOptions.Unset", "PipeExecutionPaused", "Comment"))
 		}
 	}
 	if setTags := opts.SetTags; valueSet(setTags) {
 		if !valueSet(setTags.Tag) {
-			return errAlterNeedsAtLeastOneProperty
+			errs = append(errs, errNotSet("AlterPipeOptions.SetTags", "Tag"))
 		}
 	}
 	if unsetTags := opts.UnsetTags; valueSet(unsetTags) {
 		if !valueSet(unsetTags.Tag) {
-			return errAlterNeedsAtLeastOneProperty
+			errs = append(errs, errNotSet("AlterPipeOptions.UnsetTags", "Tag"))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (opts *DropPipeOptions) validate() error {
 	if opts == nil {
 		return ErrNilOptions
 	}
-	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (opts *ShowPipeOptions) validate() error {
 	if opts == nil {
 		return ErrNilOptions
 	}
+	var errs []error
 	if valueSet(opts.Like) && !valueSet(opts.Like.Pattern) {
-		return ErrPatternRequiredForLikeKeyword
+		errs = append(errs, errPatternRequiredForLikeKeyword)
 	}
 	if valueSet(opts.In) && !exactlyOneValueSet(opts.In.Account, opts.In.Database, opts.In.Schema) {
-		return errScopeRequiredForInKeyword
+		errs = append(errs, errExactlyOneOf("ShowPipeOptions", "In.Account", "In.Database", "In.Schema"))
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (opts *describePipeOptions) validate() error {
 	if opts == nil {
 		return ErrNilOptions
 	}
-	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+	var errs []error
+	if !validObjectidentifier(opts.name) {
+		errs = append(errs, errInvalidObjectIdentifier)
 	}
-	return nil
+	return errors.Join(errs...)
 }
-
-var (
-	errCopyStatementRequired        = errors.New("copy statement required")
-	errScopeRequiredForInKeyword    = errors.New("exactly one scope must be specified for in keyword")
-	errAlterNeedsExactlyOneAction   = errors.New("alter statement needs exactly one action from: set, unset, refresh")
-	errAlterNeedsAtLeastOneProperty = errors.New("alter statement needs at least one property")
-)

--- a/pkg/sdk/pipes_validations.go
+++ b/pkg/sdk/pipes_validations.go
@@ -14,11 +14,11 @@ var (
 
 func (opts *CreatePipeOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if opts.copyStatement == "" {
 		errs = append(errs, errNotSet("CreatePipeOptions", "copyStatement"))
@@ -31,16 +31,10 @@ func (opts *AlterPipeOptions) validate() error {
 		return ErrNilOptions
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if ok := exactlyOneValueSet(
-		opts.Set,
-		opts.Unset,
-		opts.SetTags,
-		opts.UnsetTags,
-		opts.Refresh,
-	); !ok {
+	if ok := exactlyOneValueSet(opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags, opts.Refresh); !ok {
 		errs = append(errs, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTags", "UnsetTags", "Refresh"))
 	}
 	if set := opts.Set; valueSet(set) {
@@ -71,8 +65,8 @@ func (opts *DropPipeOptions) validate() error {
 		return ErrNilOptions
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	return errors.Join(errs...)
 }
@@ -83,7 +77,7 @@ func (opts *ShowPipeOptions) validate() error {
 	}
 	var errs []error
 	if valueSet(opts.Like) && !valueSet(opts.Like.Pattern) {
-		errs = append(errs, errPatternRequiredForLikeKeyword)
+		errs = append(errs, ErrPatternRequiredForLikeKeyword)
 	}
 	if valueSet(opts.In) && !exactlyOneValueSet(opts.In.Account, opts.In.Database, opts.In.Schema) {
 		errs = append(errs, errExactlyOneOf("ShowPipeOptions", "In.Account", "In.Database", "In.Schema"))
@@ -96,8 +90,8 @@ func (opts *describePipeOptions) validate() error {
 		return ErrNilOptions
 	}
 	var errs []error
-	if !validObjectidentifier(opts.name) {
-		errs = append(errs, errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/poc/generator/field.go
+++ b/pkg/sdk/poc/generator/field.go
@@ -133,6 +133,15 @@ func (f *Field) Path() string {
 	}
 }
 
+// PathWithRoot returns the way through the tree to the top, with dot separator and root included (e.g. Struct.SomeField.SomeChild)
+func (f *Field) PathWithRoot() string {
+	if f.IsRoot() {
+		return f.Name
+	} else {
+		return fmt.Sprintf("%s.%s", f.Parent.Path(), f.Name)
+	}
+}
+
 // DtoKind returns what should be fields kind in generated DTO, because it may differ from Kind
 func (f *Field) DtoKind() string {
 	switch {

--- a/pkg/sdk/poc/generator/validation.go
+++ b/pkg/sdk/poc/generator/validation.go
@@ -22,8 +22,6 @@ const (
 	ExactlyOneValueSet
 	AtLeastOneValueSet
 	ValidateValue
-	ValidateIntValue
-	ValidateIntRange
 )
 
 type Validation struct {

--- a/pkg/sdk/poc/generator/validation.go
+++ b/pkg/sdk/poc/generator/validation.go
@@ -22,6 +22,8 @@ const (
 	ExactlyOneValueSet
 	AtLeastOneValueSet
 	ValidateValue
+	ValidateIntValue
+	ValidateIntRange
 )
 
 type Validation struct {
@@ -57,13 +59,13 @@ func (v *Validation) Condition(field *Field) string {
 	case ValidIdentifier:
 		return fmt.Sprintf("!ValidObjectIdentifier(%s)", strings.Join(v.fieldsWithPath(field), ","))
 	case ValidIdentifierIfSet:
-		return fmt.Sprintf("valueSet(%s) && !ValidObjectIdentifier(%s)", strings.Join(v.fieldsWithPath(field), ","), strings.Join(v.fieldsWithPath(field), ","))
+		return fmt.Sprintf("%s != nil && !ValidObjectIdentifier(%s)", strings.Join(v.fieldsWithPath(field), ","), strings.Join(v.fieldsWithPath(field), ","))
 	case ConflictingFields:
 		return fmt.Sprintf("everyValueSet(%s)", strings.Join(v.fieldsWithPath(field), ","))
 	case ExactlyOneValueSet:
-		return fmt.Sprintf("ok := exactlyOneValueSet(%s); !ok", strings.Join(v.fieldsWithPath(field), ","))
+		return fmt.Sprintf("!exactlyOneValueSet(%s)", strings.Join(v.fieldsWithPath(field), ","))
 	case AtLeastOneValueSet:
-		return fmt.Sprintf("ok := anyValueSet(%s); !ok", strings.Join(v.fieldsWithPath(field), ","))
+		return fmt.Sprintf("!anyValueSet(%s)", strings.Join(v.fieldsWithPath(field), ","))
 	case ValidateValue:
 		return fmt.Sprintf("err := %s.validate(); err != nil", strings.Join(v.fieldsWithPath(field.Parent), ","))
 	}
@@ -77,11 +79,11 @@ func (v *Validation) ReturnedError(field *Field) string {
 	case ValidIdentifierIfSet:
 		return "ErrInvalidObjectIdentifier"
 	case ConflictingFields:
-		return fmt.Sprintf(`errOneOf("%s", %s)`, field.Name, strings.Join(v.paramsQuoted(), ","))
+		return fmt.Sprintf(`errOneOf("%s%s", %s)`, field.Name, field.Path(), strings.Join(v.paramsQuoted(), ","))
 	case ExactlyOneValueSet:
-		return fmt.Sprintf("errExactlyOneOf(%s)", strings.Join(v.paramsQuoted(), ","))
+		return fmt.Sprintf(`errExactlyOneOf("%s%s", %s)`, field.Name, field.Path(), strings.Join(v.paramsQuoted(), ","))
 	case AtLeastOneValueSet:
-		return fmt.Sprintf("errAtLeastOneOf(%s)", strings.Join(v.paramsQuoted(), ","))
+		return fmt.Sprintf(`errAtLeastOneOf("%s%s", %s)`, field.Name, field.Path(), strings.Join(v.paramsQuoted(), ","))
 	case ValidateValue:
 		return "err"
 	}

--- a/pkg/sdk/poc/generator/validation.go
+++ b/pkg/sdk/poc/generator/validation.go
@@ -77,11 +77,11 @@ func (v *Validation) ReturnedError(field *Field) string {
 	case ValidIdentifierIfSet:
 		return "ErrInvalidObjectIdentifier"
 	case ConflictingFields:
-		return fmt.Sprintf(`errOneOf("%s%s", %s)`, field.Name, field.Path(), strings.Join(v.paramsQuoted(), ","))
+		return fmt.Sprintf(`errOneOf("%s", %s)`, field.PathWithRoot(), strings.Join(v.paramsQuoted(), ","))
 	case ExactlyOneValueSet:
-		return fmt.Sprintf(`errExactlyOneOf("%s%s", %s)`, field.Name, field.Path(), strings.Join(v.paramsQuoted(), ","))
+		return fmt.Sprintf(`errExactlyOneOf("%s", %s)`, field.PathWithRoot(), strings.Join(v.paramsQuoted(), ","))
 	case AtLeastOneValueSet:
-		return fmt.Sprintf(`errAtLeastOneOf("%s%s", %s)`, field.Name, field.Path(), strings.Join(v.paramsQuoted(), ","))
+		return fmt.Sprintf(`errAtLeastOneOf("%s", %s)`, field.PathWithRoot(), strings.Join(v.paramsQuoted(), ","))
 	case ValidateValue:
 		return "err"
 	}

--- a/pkg/sdk/replication_functions.go
+++ b/pkg/sdk/replication_functions.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
@@ -94,6 +95,9 @@ type ShowRegionsOptions struct {
 }
 
 func (opts *ShowRegionsOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
 	return nil
 }
 

--- a/pkg/sdk/resource_monitors.go
+++ b/pkg/sdk/resource_monitors.go
@@ -296,6 +296,9 @@ func (opts *AlterResourceMonitorOptions) validate() error {
 			errs = append(errs, errors.New("must specify frequency and start time together"))
 		}
 	}
+	if !exactlyOneValueSet(opts.Set, opts.NotifyUsers) && opts.Triggers == nil {
+		errs = append(errs, errExactlyOneOf("AlterResourceMonitorOptions", "Set", "NotifyUsers", "Triggers"))
+	}
 	return errors.Join(errs...)
 }
 

--- a/pkg/sdk/resource_monitors.go
+++ b/pkg/sdk/resource_monitors.go
@@ -295,8 +295,6 @@ func (opts *AlterResourceMonitorOptions) validate() error {
 		if (opts.Set.Frequency != nil && opts.Set.StartTimestamp == nil) || (opts.Set.Frequency == nil && opts.Set.StartTimestamp != nil) {
 			errs = append(errs, errors.New("must specify frequency and start time together"))
 		}
-	} else {
-		errs = append(errs, errNotSet("AlterResourceMonitorOptions", "Set"))
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/resource_monitors.go
+++ b/pkg/sdk/resource_monitors.go
@@ -196,8 +196,11 @@ type ResourceMonitorWith struct {
 }
 
 func (opts *CreateResourceMonitorOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
 	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -281,17 +284,21 @@ type AlterResourceMonitorOptions struct {
 }
 
 func (opts *AlterResourceMonitorOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
+	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if opts.Set == nil {
-		return nil
+	if valueSet(opts.Set) {
+		if (opts.Set.Frequency != nil && opts.Set.StartTimestamp == nil) || (opts.Set.Frequency == nil && opts.Set.StartTimestamp != nil) {
+			errs = append(errs, errors.New("must specify frequency and start time together"))
+		}
+	} else {
+		errs = append(errs, errNotSet("AlterResourceMonitorOptions", "Set"))
 	}
-	if (opts.Set.Frequency != nil && opts.Set.StartTimestamp == nil) || (opts.Set.Frequency == nil && opts.Set.StartTimestamp != nil) {
-		return errors.New("must specify frequency and start time together")
-	}
-
-	return nil
+	return errors.Join(errs...)
 }
 
 func (v *resourceMonitors) Alter(ctx context.Context, id AccountObjectIdentifier, opts *AlterResourceMonitorOptions) error {
@@ -327,8 +334,11 @@ type dropResourceMonitorOptions struct {
 }
 
 func (opts *dropResourceMonitorOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
 	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -356,6 +366,9 @@ type ShowResourceMonitorOptions struct {
 }
 
 func (opts *ShowResourceMonitorOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
 	return nil
 }
 

--- a/pkg/sdk/resource_monitors_test.go
+++ b/pkg/sdk/resource_monitors_test.go
@@ -10,7 +10,7 @@ func TestResourceMonitorCreate(t *testing.T) {
 
 	t.Run("validation: empty options", func(t *testing.T) {
 		opts := &CreateResourceMonitorOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("with complete options", func(t *testing.T) {
@@ -55,14 +55,14 @@ func TestResourceMonitorAlter(t *testing.T) {
 
 	t.Run("validation: empty options", func(t *testing.T) {
 		opts := &AlterResourceMonitorOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("only name", func(t *testing.T) {
 		opts := &AlterResourceMonitorOptions{
 			name: id,
 		}
-		assertOptsValidAndSQLEquals(t, opts, "ALTER RESOURCE MONITOR %s", id.FullyQualifiedName())
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("AlterResourceMonitorOptions", "Set"))
 	})
 
 	t.Run("with a single set", func(t *testing.T) {
@@ -97,7 +97,7 @@ func TestResourceMonitorDrop(t *testing.T) {
 
 	t.Run("empty options", func(t *testing.T) {
 		opts := &dropResourceMonitorOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("only name", func(t *testing.T) {

--- a/pkg/sdk/resource_monitors_test.go
+++ b/pkg/sdk/resource_monitors_test.go
@@ -62,7 +62,7 @@ func TestResourceMonitorAlter(t *testing.T) {
 		opts := &AlterResourceMonitorOptions{
 			name: id,
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errNotSet("AlterResourceMonitorOptions", "Set"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterResourceMonitorOptions", "Set", "NotifyUsers", "Triggers"))
 	})
 
 	t.Run("with a single set", func(t *testing.T) {

--- a/pkg/sdk/roles_test.go
+++ b/pkg/sdk/roles_test.go
@@ -1,7 +1,6 @@
 package sdk
 
 import (
-	"errors"
 	"testing"
 )
 
@@ -42,7 +41,7 @@ func TestRolesCreate(t *testing.T) {
 			IfNotExists: Bool(true),
 			OrReplace:   Bool(true),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errOneOf("OrReplace", "IfNotExists"))
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("CreateRoleOptions", "OrReplace", "IfNotExists"))
 	})
 }
 
@@ -66,7 +65,7 @@ func TestRolesDrop(t *testing.T) {
 		opts := &DropRoleOptions{
 			name: NewAccountObjectIdentifier(""),
 		}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 }
 
@@ -136,7 +135,7 @@ func TestRolesAlter(t *testing.T) {
 		opts := &AlterRoleOptions{
 			name: RandomAccountObjectIdentifier(),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errors.New("no alter action specified"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterRoleOptions", "RenameTo", "SetComment", "UnsetComment", "SetTags", "UnsetTags"))
 	})
 
 	t.Run("validation: more than one alter action specified", func(t *testing.T) {
@@ -145,7 +144,7 @@ func TestRolesAlter(t *testing.T) {
 			SetComment:   String("comment"),
 			UnsetComment: Bool(true),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errOneOf("RenameTo", "SetComment", "UnsetComment", "SetTags", "UnsetTags"))
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("AlterRoleOptions", "RenameTo", "SetComment", "UnsetComment", "SetTags", "UnsetTags"))
 	})
 }
 
@@ -216,7 +215,7 @@ func TestRolesGrant(t *testing.T) {
 		opts := &GrantRoleOptions{
 			name: NewAccountObjectIdentifier(""),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier, errors.New("only one grant option can be set [TO ROLE or TO USER]"))
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier, errOneOf("GrantRoleOptions.Grant", "Role", "User"))
 	})
 
 	t.Run("validation: invalid object identifier for granted role", func(t *testing.T) {
@@ -227,7 +226,7 @@ func TestRolesGrant(t *testing.T) {
 				Role: &id,
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errors.New("invalid object identifier for granted role"))
+		assertOptsInvalidJoinedErrors(t, opts, errInvalidIdentifier("GrantRoleOptions.Grant", "Role"))
 	})
 
 	t.Run("validation: invalid object identifier for granted user", func(t *testing.T) {
@@ -238,7 +237,7 @@ func TestRolesGrant(t *testing.T) {
 				User: &id,
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errors.New("invalid object identifier for granted user"))
+		assertOptsInvalidJoinedErrors(t, opts, errInvalidIdentifier("GrantRoleOptions.Grant", "User"))
 	})
 }
 
@@ -267,6 +266,6 @@ func TestRolesRevoke(t *testing.T) {
 		opts := &RevokeRoleOptions{
 			name: NewAccountObjectIdentifier(""),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier, errors.New("only one revoke option can be set [FROM ROLE or FROM USER]"))
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier, errOneOf("RevokeRoleOptions.Revoke", "Role", "User"))
 	})
 }

--- a/pkg/sdk/roles_validations.go
+++ b/pkg/sdk/roles_validations.go
@@ -13,49 +13,49 @@ var (
 
 func (opts *CreateRoleOptions) validate() error {
 	if opts == nil {
-		return ErrNilOptions
+		return errors.Join(errNilOptions)
 	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
-		errs = append(errs, errOneOf("OrReplace", "IfNotExists"))
+		errs = append(errs, errOneOf("CreateRoleOptions", "OrReplace", "IfNotExists"))
 	}
 	return errors.Join(errs...)
 }
 
 func (opts *AlterRoleOptions) validate() error {
 	if opts == nil {
-		return ErrNilOptions
+		return errors.Join(errNilOptions)
 	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if everyValueNil(opts.RenameTo, opts.SetComment, opts.UnsetComment, opts.SetTags, opts.UnsetTags) {
-		errs = append(errs, errors.New("no alter action specified"))
+		errs = append(errs, errAtLeastOneOf("CreateRoleOptions", "RenameTo", "SetComment", "UnsetComment", "SetTags", "UnsetTags"))
 	}
 	if anyValueSet(opts.RenameTo, opts.SetComment, opts.UnsetComment, opts.SetTags, opts.UnsetTags) &&
 		!exactlyOneValueSet(opts.RenameTo, opts.SetComment, opts.UnsetComment, opts.SetTags, opts.UnsetTags) {
-		errs = append(errs, errOneOf("RenameTo", "SetComment", "UnsetComment", "SetTags", "UnsetTags"))
+		errs = append(errs, errOneOf("CreateRoleOptions", "RenameTo", "SetComment", "UnsetComment", "SetTags", "UnsetTags"))
 	}
 	return errors.Join(errs...)
 }
 
 func (opts *DropRoleOptions) validate() error {
 	if opts == nil {
-		return ErrNilOptions
+		return errors.Join(errNilOptions)
 	}
-	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+	if !validObjectidentifier(opts.name) {
+		return errors.Join(errInvalidObjectIdentifier)
 	}
 	return nil
 }
 
 func (opts *ShowRoleOptions) validate() error {
 	if opts == nil {
-		return ErrNilOptions
+		return errors.Join(errNilOptions)
 	}
 	var errs []error
 	if valueSet(opts.Like) && !valueSet(opts.Like.Pattern) {
@@ -69,34 +69,34 @@ func (opts *ShowRoleOptions) validate() error {
 
 func (opts *GrantRoleOptions) validate() error {
 	if opts == nil {
-		return ErrNilOptions
+		return errors.Join(errNilOptions)
 	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if (opts.Grant.Role != nil && opts.Grant.User != nil) || (opts.Grant.Role == nil && opts.Grant.User == nil) {
-		errs = append(errs, errors.New("only one grant option can be set [TO ROLE or TO USER]"))
+		errs = append(errs, errOneOf("GrantRoleOptions", "Grant.Role", "Grant.User"))
 	}
 	if opts.Grant.Role != nil && !ValidObjectIdentifier(opts.Grant.Role) {
-		errs = append(errs, errors.New("invalid object identifier for granted role"))
+		errs = append(errs, errInvalidIdentifier("Grant.Role"))
 	}
 	if opts.Grant.User != nil && !ValidObjectIdentifier(opts.Grant.User) {
-		errs = append(errs, errors.New("invalid object identifier for granted user"))
+		errs = append(errs, errInvalidIdentifier("Grant.User"))
 	}
 	return errors.Join(errs...)
 }
 
 func (opts *RevokeRoleOptions) validate() error {
 	if opts == nil {
-		return ErrNilOptions
+		return errors.Join(errNilOptions)
 	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if (opts.Revoke.Role != nil && opts.Revoke.User != nil) || (opts.Revoke.Role == nil && opts.Revoke.User == nil) {
-		errs = append(errs, errors.New("only one revoke option can be set [FROM ROLE or FROM USER]"))
+		errs = append(errs, errOneOf("RevokeRoleOptions", "Revoke.Role", "Revoke.User"))
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/roles_validations.go
+++ b/pkg/sdk/roles_validations.go
@@ -13,7 +13,7 @@ var (
 
 func (opts *CreateRoleOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
@@ -27,7 +27,7 @@ func (opts *CreateRoleOptions) validate() error {
 
 func (opts *AlterRoleOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
@@ -45,17 +45,17 @@ func (opts *AlterRoleOptions) validate() error {
 
 func (opts *DropRoleOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
-	if !validObjectidentifier(opts.name) {
-		return errors.Join(errInvalidObjectIdentifier)
+	if !ValidObjectIdentifier(opts.name) {
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
 
 func (opts *ShowRoleOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if valueSet(opts.Like) && !valueSet(opts.Like.Pattern) {
@@ -69,7 +69,7 @@ func (opts *ShowRoleOptions) validate() error {
 
 func (opts *GrantRoleOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
@@ -89,7 +89,7 @@ func (opts *GrantRoleOptions) validate() error {
 
 func (opts *RevokeRoleOptions) validate() error {
 	if opts == nil {
-		return errors.Join(errNilOptions)
+		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {

--- a/pkg/sdk/roles_validations.go
+++ b/pkg/sdk/roles_validations.go
@@ -34,11 +34,11 @@ func (opts *AlterRoleOptions) validate() error {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if everyValueNil(opts.RenameTo, opts.SetComment, opts.UnsetComment, opts.SetTags, opts.UnsetTags) {
-		errs = append(errs, errAtLeastOneOf("CreateRoleOptions", "RenameTo", "SetComment", "UnsetComment", "SetTags", "UnsetTags"))
+		errs = append(errs, errAtLeastOneOf("AlterRoleOptions", "RenameTo", "SetComment", "UnsetComment", "SetTags", "UnsetTags"))
 	}
 	if anyValueSet(opts.RenameTo, opts.SetComment, opts.UnsetComment, opts.SetTags, opts.UnsetTags) &&
 		!exactlyOneValueSet(opts.RenameTo, opts.SetComment, opts.UnsetComment, opts.SetTags, opts.UnsetTags) {
-		errs = append(errs, errOneOf("CreateRoleOptions", "RenameTo", "SetComment", "UnsetComment", "SetTags", "UnsetTags"))
+		errs = append(errs, errOneOf("AlterRoleOptions", "RenameTo", "SetComment", "UnsetComment", "SetTags", "UnsetTags"))
 	}
 	return errors.Join(errs...)
 }
@@ -76,13 +76,13 @@ func (opts *GrantRoleOptions) validate() error {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if (opts.Grant.Role != nil && opts.Grant.User != nil) || (opts.Grant.Role == nil && opts.Grant.User == nil) {
-		errs = append(errs, errOneOf("GrantRoleOptions", "Grant.Role", "Grant.User"))
+		errs = append(errs, errOneOf("GrantRoleOptions.Grant", "Role", "User"))
 	}
 	if opts.Grant.Role != nil && !ValidObjectIdentifier(opts.Grant.Role) {
-		errs = append(errs, errInvalidIdentifier("GrantRoleOptions", "Grant.Role"))
+		errs = append(errs, errInvalidIdentifier("GrantRoleOptions.Grant", "Role"))
 	}
 	if opts.Grant.User != nil && !ValidObjectIdentifier(opts.Grant.User) {
-		errs = append(errs, errInvalidIdentifier("GrantRoleOptions", "Grant.User"))
+		errs = append(errs, errInvalidIdentifier("GrantRoleOptions.Grant", "User"))
 	}
 	return errors.Join(errs...)
 }
@@ -96,7 +96,7 @@ func (opts *RevokeRoleOptions) validate() error {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if (opts.Revoke.Role != nil && opts.Revoke.User != nil) || (opts.Revoke.Role == nil && opts.Revoke.User == nil) {
-		errs = append(errs, errOneOf("RevokeRoleOptions", "Revoke.Role", "Revoke.User"))
+		errs = append(errs, errOneOf("RevokeRoleOptions.Revoke", "Role", "User"))
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/roles_validations.go
+++ b/pkg/sdk/roles_validations.go
@@ -79,10 +79,10 @@ func (opts *GrantRoleOptions) validate() error {
 		errs = append(errs, errOneOf("GrantRoleOptions", "Grant.Role", "Grant.User"))
 	}
 	if opts.Grant.Role != nil && !ValidObjectIdentifier(opts.Grant.Role) {
-		errs = append(errs, errInvalidIdentifier("Grant.Role"))
+		errs = append(errs, errInvalidIdentifier("GrantRoleOptions", "Grant.Role"))
 	}
 	if opts.Grant.User != nil && !ValidObjectIdentifier(opts.Grant.User) {
-		errs = append(errs, errInvalidIdentifier("Grant.User"))
+		errs = append(errs, errInvalidIdentifier("GrantRoleOptions", "Grant.User"))
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/schemas.go
+++ b/pkg/sdk/schemas.go
@@ -121,7 +121,7 @@ func (opts *CreateSchemaOptions) validate() error {
 		}
 	}
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
-		errs = append(errs, errOneOf("IfNotExists", "OrReplace"))
+		errs = append(errs, errOneOf("CreateSchemaOptions", "IfNotExists", "OrReplace"))
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/schemas.go
+++ b/pkg/sdk/schemas.go
@@ -108,6 +108,9 @@ type CreateSchemaOptions struct {
 }
 
 func (opts *CreateSchemaOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
@@ -155,6 +158,9 @@ type AlterSchemaOptions struct {
 }
 
 func (opts *AlterSchemaOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
@@ -233,12 +239,15 @@ type DropSchemaOptions struct {
 }
 
 func (opts *DropSchemaOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
 	var errs []error
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if everyValueSet(opts.Cascade, opts.Restrict) {
-		errs = append(errs, errors.New("only one of the fields [ Cascade | Restrict ] can be set at once"))
+		errs = append(errs, errOneOf("DropSchemaOptions", "Cascade", "Restrict"))
 	}
 	return errors.Join(errs...)
 }
@@ -267,8 +276,11 @@ type undropSchemaOptions struct {
 }
 
 func (opts *undropSchemaOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
 	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -296,8 +308,11 @@ type describeSchemaOptions struct {
 }
 
 func (opts *describeSchemaOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
 	if !ValidObjectIdentifier(opts.name) {
-		return ErrInvalidObjectIdentifier
+		return errors.Join(ErrInvalidObjectIdentifier)
 	}
 	return nil
 }
@@ -346,6 +361,9 @@ type ShowSchemaOptions struct {
 }
 
 func (opts *ShowSchemaOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
 	return nil
 }
 

--- a/pkg/sdk/session_policies_gen_test.go
+++ b/pkg/sdk/session_policies_gen_test.go
@@ -68,7 +68,7 @@ func TestSessionPolicies_Alter(t *testing.T) {
 
 	t.Run("validation: exactly one field from [opts.RenameTo opts.Set opts.SetTags opts.UnsetTags opts.Unset] should be present - none present", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("RenameTo", "Set", "SetTags", "UnsetTags", "Unset"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterSessionPolicyOptions", "RenameTo", "Set", "SetTags", "UnsetTags", "Unset"))
 	})
 
 	t.Run("validation: exactly one field from [opts.RenameTo opts.Set opts.SetTags opts.UnsetTags opts.Unset] should be present - more present", func(t *testing.T) {
@@ -79,19 +79,19 @@ func TestSessionPolicies_Alter(t *testing.T) {
 		opts.Unset = &SessionPolicyUnset{
 			Comment: Bool(true),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("RenameTo", "Set", "SetTags", "UnsetTags", "Unset"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterSessionPolicyOptions", "RenameTo", "Set", "SetTags", "UnsetTags", "Unset"))
 	})
 
 	t.Run("validation: at least one of the fields [opts.Set.SessionIdleTimeoutMins opts.Set.SessionUiIdleTimeoutMins opts.Set.Comment] should be set", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Set = &SessionPolicySet{}
-		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("SessionIdleTimeoutMins", "SessionUiIdleTimeoutMins", "Comment"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterSessionPolicyOptions.Set", "SessionIdleTimeoutMins", "SessionUiIdleTimeoutMins", "Comment"))
 	})
 
 	t.Run("validation: at least one of the fields [opts.Unset.SessionIdleTimeoutMins opts.Unset.SessionUiIdleTimeoutMins opts.Unset.Comment] should be set", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Unset = &SessionPolicyUnset{}
-		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("SessionIdleTimeoutMins", "SessionUiIdleTimeoutMins", "Comment"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterSessionPolicyOptions.Unset", "SessionIdleTimeoutMins", "SessionUiIdleTimeoutMins", "Comment"))
 	})
 
 	t.Run("alter set", func(t *testing.T) {

--- a/pkg/sdk/session_policies_validations_gen.go
+++ b/pkg/sdk/session_policies_validations_gen.go
@@ -33,16 +33,16 @@ func (opts *AlterSessionPolicyOptions) validate() error {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if ok := exactlyOneValueSet(opts.RenameTo, opts.Set, opts.SetTags, opts.UnsetTags, opts.Unset); !ok {
-		errs = append(errs, errExactlyOneOf("RenameTo", "Set", "SetTags", "UnsetTags", "Unset"))
+		errs = append(errs, errExactlyOneOf("AlterSessionPolicyOptions", "RenameTo", "Set", "SetTags", "UnsetTags", "Unset"))
 	}
 	if valueSet(opts.Set) {
 		if ok := anyValueSet(opts.Set.SessionIdleTimeoutMins, opts.Set.SessionUiIdleTimeoutMins, opts.Set.Comment); !ok {
-			errs = append(errs, errAtLeastOneOf("SessionIdleTimeoutMins", "SessionUiIdleTimeoutMins", "Comment"))
+			errs = append(errs, errAtLeastOneOf("AlterSessionPolicyOptions.Set", "SessionIdleTimeoutMins", "SessionUiIdleTimeoutMins", "Comment"))
 		}
 	}
 	if valueSet(opts.Unset) {
 		if ok := anyValueSet(opts.Unset.SessionIdleTimeoutMins, opts.Unset.SessionUiIdleTimeoutMins, opts.Unset.Comment); !ok {
-			errs = append(errs, errAtLeastOneOf("SessionIdleTimeoutMins", "SessionUiIdleTimeoutMins", "Comment"))
+			errs = append(errs, errAtLeastOneOf("AlterSessionPolicyOptions.Unset", "SessionIdleTimeoutMins", "SessionUiIdleTimeoutMins", "Comment"))
 		}
 	}
 	return errors.Join(errs...)

--- a/pkg/sdk/sessions.go
+++ b/pkg/sdk/sessions.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
@@ -37,20 +38,24 @@ type AlterSessionOptions struct {
 }
 
 func (opts *AlterSessionOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
+	var errs []error
 	if everyValueNil(opts.Set, opts.Unset) {
-		return fmt.Errorf("either SET or UNSET must be set")
+		errs = append(errs, errOneOf("AlterSessionOptions", "Set", "Unset"))
 	}
 	if valueSet(opts.Set) {
 		if err := opts.Set.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
 	if valueSet(opts.Unset) {
 		if err := opts.Unset.validate(); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 type SessionSet struct {

--- a/pkg/sdk/shares_test.go
+++ b/pkg/sdk/shares_test.go
@@ -30,7 +30,7 @@ func TestShareAlter(t *testing.T) {
 		opts := &AlterShareOptions{
 			name: NewAccountObjectIdentifier("myshare"),
 		}
-		assertOptsInvalid(t, opts, errExactlyOneOf("Add", "Remove", "Set", "Unset"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterShareOptions", "Add", "Remove", "Set", "Unset"))
 	})
 
 	t.Run("with add", func(t *testing.T) {

--- a/pkg/sdk/streams_gen_test.go
+++ b/pkg/sdk/streams_gen_test.go
@@ -48,14 +48,14 @@ func TestStreams_CreateOnTable(t *testing.T) {
 		opts := defaultOpts()
 		opts.On.At = Bool(true)
 		opts.On.Before = Bool(true)
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("At", "Before"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateOnTableStreamOptions.On", "At", "Before"))
 	})
 
 	t.Run("validation: exactly one field from [opts.On.Statement.Timestamp opts.On.Statement.Offset opts.On.Statement.Statement opts.On.Statement.Stream] should be present", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.On.At = Bool(true)
 		opts.On.Statement = OnStreamStatement{}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("Timestamp", "Offset", "Statement", "Stream"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateOnTableStreamOptions.On.Statement", "Timestamp", "Offset", "Statement", "Stream"))
 	})
 
 	t.Run("basic", func(t *testing.T) {
@@ -126,13 +126,13 @@ func TestStreams_CreateOnExternalTable(t *testing.T) {
 		opts := defaultOpts()
 		opts.On.At = Bool(true)
 		opts.On.Before = Bool(true)
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("At", "Before"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateOnExternalTableStreamOptions.On", "At", "Before"))
 	})
 
 	t.Run("validation: exactly one field from [opts.On.Statement.Timestamp opts.On.Statement.Offset opts.On.Statement.Statement opts.On.Statement.Stream] should be present", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.On.Statement = OnStreamStatement{}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("Timestamp", "Offset", "Statement", "Stream"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateOnExternalTableStreamOptions.On.Statement", "Timestamp", "Offset", "Statement", "Stream"))
 	})
 
 	t.Run("basic", func(t *testing.T) {
@@ -253,13 +253,13 @@ func TestStreams_CreateOnView(t *testing.T) {
 		opts := defaultOpts()
 		opts.On.At = Bool(true)
 		opts.On.Before = Bool(true)
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("At", "Before"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateOnViewStreamOptions.On", "At", "Before"))
 	})
 
 	t.Run("validation: exactly one field from [opts.On.Statement.Timestamp opts.On.Statement.Offset opts.On.Statement.Statement opts.On.Statement.Stream] should be present", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.On.Statement = OnStreamStatement{}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("Timestamp", "Offset", "Statement", "Stream"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateOnViewStreamOptions.On.Statement", "Timestamp", "Offset", "Statement", "Stream"))
 	})
 
 	t.Run("basic", func(t *testing.T) {
@@ -351,7 +351,7 @@ func TestStreams_Alter(t *testing.T) {
 
 	t.Run("validation: exactly one field from [opts.SetComment opts.UnsetComment opts.SetTags opts.UnsetTags] should be present", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("SetComment", "UnsetComment", "SetTags", "UnsetTags"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterStreamOptions", "SetComment", "UnsetComment", "SetTags", "UnsetTags"))
 	})
 
 	t.Run("set comment", func(t *testing.T) {

--- a/pkg/sdk/streams_validations_gen.go
+++ b/pkg/sdk/streams_validations_gen.go
@@ -30,11 +30,11 @@ func (opts *CreateOnTableStreamOptions) validate() error {
 	}
 	if valueSet(opts.On) {
 		if ok := exactlyOneValueSet(opts.On.At, opts.On.Before); !ok {
-			errs = append(errs, errExactlyOneOf("At", "Before"))
+			errs = append(errs, errExactlyOneOf("CreateOnTableStreamOptions.On", "At", "Before"))
 		}
 		if valueSet(opts.On.Statement) {
 			if ok := exactlyOneValueSet(opts.On.Statement.Timestamp, opts.On.Statement.Offset, opts.On.Statement.Statement, opts.On.Statement.Stream); !ok {
-				errs = append(errs, errExactlyOneOf("Timestamp", "Offset", "Statement", "Stream"))
+				errs = append(errs, errExactlyOneOf("CreateOnTableStreamOptions.On.Statement", "Timestamp", "Offset", "Statement", "Stream"))
 			}
 		}
 	}
@@ -57,11 +57,11 @@ func (opts *CreateOnExternalTableStreamOptions) validate() error {
 	}
 	if valueSet(opts.On) {
 		if ok := exactlyOneValueSet(opts.On.At, opts.On.Before); !ok {
-			errs = append(errs, errExactlyOneOf("At", "Before"))
+			errs = append(errs, errExactlyOneOf("CreateOnExternalTableStreamOptions.On", "At", "Before"))
 		}
 		if valueSet(opts.On.Statement) {
 			if ok := exactlyOneValueSet(opts.On.Statement.Timestamp, opts.On.Statement.Offset, opts.On.Statement.Statement, opts.On.Statement.Stream); !ok {
-				errs = append(errs, errExactlyOneOf("Timestamp", "Offset", "Statement", "Stream"))
+				errs = append(errs, errExactlyOneOf("CreateOnExternalTableStreamOptions.On.Statement", "Timestamp", "Offset", "Statement", "Stream"))
 			}
 		}
 	}
@@ -101,11 +101,11 @@ func (opts *CreateOnViewStreamOptions) validate() error {
 	}
 	if valueSet(opts.On) {
 		if ok := exactlyOneValueSet(opts.On.At, opts.On.Before); !ok {
-			errs = append(errs, errExactlyOneOf("At", "Before"))
+			errs = append(errs, errExactlyOneOf("CreateOnViewStreamOptions.On", "At", "Before"))
 		}
 		if valueSet(opts.On.Statement) {
 			if ok := exactlyOneValueSet(opts.On.Statement.Timestamp, opts.On.Statement.Offset, opts.On.Statement.Statement, opts.On.Statement.Stream); !ok {
-				errs = append(errs, errExactlyOneOf("Timestamp", "Offset", "Statement", "Stream"))
+				errs = append(errs, errExactlyOneOf("CreateOnViewStreamOptions.On.Statement", "Timestamp", "Offset", "Statement", "Stream"))
 			}
 		}
 	}
@@ -135,7 +135,7 @@ func (opts *AlterStreamOptions) validate() error {
 		errs = append(errs, errOneOf("AlterStreamOptions", "IfExists", "UnsetTags"))
 	}
 	if ok := exactlyOneValueSet(opts.SetComment, opts.UnsetComment, opts.SetTags, opts.UnsetTags); !ok {
-		errs = append(errs, errExactlyOneOf("SetComment", "UnsetComment", "SetTags", "UnsetTags"))
+		errs = append(errs, errExactlyOneOf("AlterStreamOptions", "SetComment", "UnsetComment", "SetTags", "UnsetTags"))
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/tags_test.go
+++ b/pkg/sdk/tags_test.go
@@ -159,7 +159,7 @@ func TestTagShow(t *testing.T) {
 	t.Run("validation: empty in", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.In = &In{}
-		assertOptsInvalidJoinedErrors(t, opts, errScopeRequiredForInKeyword)
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("showTagOptions.In", "Account", "Database", "Schema"))
 	})
 
 	t.Run("show with empty options", func(t *testing.T) {
@@ -284,7 +284,7 @@ func TestTagAlter(t *testing.T) {
 
 	t.Run("validation: no alter action", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errAlterNeedsExactlyOneAction)
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("alterTagOptions", "Add", "Drop", "Set", "Unset", "Rename"))
 	})
 
 	t.Run("validation: multiple alter actions", func(t *testing.T) {
@@ -295,7 +295,7 @@ func TestTagAlter(t *testing.T) {
 		opts.Unset = &TagUnset{
 			AllowedValues: Bool(true),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errAlterNeedsExactlyOneAction)
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("alterTagOptions", "Add", "Drop", "Set", "Unset", "Rename"))
 	})
 
 	t.Run("validation: invalid new name", func(t *testing.T) {
@@ -319,6 +319,6 @@ func TestTagAlter(t *testing.T) {
 	t.Run("validation: no property to unset", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Unset = &TagUnset{}
-		assertOptsInvalidJoinedErrors(t, opts, errAlterNeedsAtLeastOneProperty)
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("alterTagOptions", "Add", "Drop", "Set", "Unset", "Rename"))
 	})
 }

--- a/pkg/sdk/tags_test.go
+++ b/pkg/sdk/tags_test.go
@@ -66,14 +66,14 @@ func TestTagCreate(t *testing.T) {
 			},
 		}
 		opts.Comment = String("comment")
-		assertOptsInvalidJoinedErrors(t, opts, errOneOf("Comment", "AllowedValues"))
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("createTagOptions", "Comment", "AllowedValues"))
 	})
 
 	t.Run("validation: both ifNotExists and orReplace present", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.IfNotExists = Bool(true)
 		opts.OrReplace = Bool(true)
-		assertOptsInvalidJoinedErrors(t, opts, errOneOf("OrReplace", "IfNotExists"))
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("createTagOptions", "OrReplace", "IfNotExists"))
 	})
 
 	t.Run("validation: multiple errors", func(t *testing.T) {
@@ -81,7 +81,7 @@ func TestTagCreate(t *testing.T) {
 		opts.name = NewSchemaObjectIdentifier("", "", "")
 		opts.IfNotExists = Bool(true)
 		opts.OrReplace = Bool(true)
-		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier, errOneOf("OrReplace", "IfNotExists"))
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier, errOneOf("createTagOptions", "OrReplace", "IfNotExists"))
 	})
 }
 
@@ -319,6 +319,6 @@ func TestTagAlter(t *testing.T) {
 	t.Run("validation: no property to unset", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Unset = &TagUnset{}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("alterTagOptions", "Add", "Drop", "Set", "Unset", "Rename"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("TagUnset", "MaskingPolicies", "AllowedValues", "Comment"))
 	})
 }

--- a/pkg/sdk/tags_validations.go
+++ b/pkg/sdk/tags_validations.go
@@ -38,7 +38,7 @@ func (opts *createTagOptions) validate() error {
 }
 
 func (v *AllowedValues) validate() error {
-	if ok := validateIntInRange(len(v.Values), 1, 50); !ok {
+	if !validateIntInRange(len(v.Values), 1, 50) {
 		return errIntBetween("AllowedValues", "Values", 1, 50)
 	}
 	return nil
@@ -50,7 +50,7 @@ func (v *TagSet) validate() error {
 		errs = append(errs, errOneOf("TagSet", "MaskingPolicies", "Comment"))
 	}
 	if valueSet(v.MaskingPolicies) {
-		if ok := validateIntGreaterThanOrEqual(len(v.MaskingPolicies.MaskingPolicies), 1); !ok {
+		if !validateIntGreaterThanOrEqual(len(v.MaskingPolicies.MaskingPolicies), 1) {
 			errs = append(errs, errIntValue("TagSet.MaskingPolicies", "MaskingPolicies", IntErrGreater, 0))
 		}
 	}
@@ -78,7 +78,7 @@ func (opts *alterTagOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if ok := exactlyOneValueSet(opts.Add, opts.Drop, opts.Set, opts.Unset, opts.Rename); !ok {
+	if !exactlyOneValueSet(opts.Add, opts.Drop, opts.Set, opts.Unset, opts.Rename) {
 		errs = append(errs, errExactlyOneOf("alterTagOptions", "Add", "Drop", "Set", "Unset", "Rename"))
 	}
 	if valueSet(opts.Add) && valueSet(opts.Add.AllowedValues) {

--- a/pkg/sdk/tags_validations.go
+++ b/pkg/sdk/tags_validations.go
@@ -50,7 +50,7 @@ func (v *TagSet) validate() error {
 		errs = append(errs, errOneOf("TagSet", "MaskingPolicies", "Comment"))
 	}
 	if valueSet(v.MaskingPolicies) {
-		if !validateIntGreaterThanOrEqual(len(v.MaskingPolicies.MaskingPolicies), 1) {
+		if !validateIntGreaterThan(len(v.MaskingPolicies.MaskingPolicies), 0) {
 			errs = append(errs, errIntValue("TagSet.MaskingPolicies", "MaskingPolicies", IntErrGreater, 0))
 		}
 	}
@@ -63,7 +63,7 @@ func (v *TagUnset) validate() error {
 		errs = append(errs, errExactlyOneOf("TagUnset", "MaskingPolicies", "AllowedValues", "Comment"))
 	}
 	if valueSet(v.MaskingPolicies) {
-		if !validateIntGreaterThanOrEqual(len(v.MaskingPolicies.MaskingPolicies), 1) {
+		if !validateIntGreaterThan(len(v.MaskingPolicies.MaskingPolicies), 0) {
 			errs = append(errs, errIntValue("TagUnset.MaskingPolicies", "MaskingPolicies", IntErrGreater, 0))
 		}
 	}

--- a/pkg/sdk/tags_validations.go
+++ b/pkg/sdk/tags_validations.go
@@ -2,7 +2,6 @@ package sdk
 
 import (
 	"errors"
-	"fmt"
 )
 
 var (
@@ -25,10 +24,10 @@ func (opts *createTagOptions) validate() error {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) && *opts.OrReplace && *opts.IfNotExists {
-		errs = append(errs, errOneOf("OrReplace", "IfNotExists"))
+		errs = append(errs, errOneOf("createTagOptions", "OrReplace", "IfNotExists"))
 	}
 	if valueSet(opts.Comment) && valueSet(opts.AllowedValues) {
-		errs = append(errs, errOneOf("Comment", "AllowedValues"))
+		errs = append(errs, errOneOf("createTagOptions", "Comment", "AllowedValues"))
 	}
 	if valueSet(opts.AllowedValues) {
 		if err := opts.AllowedValues.validate(); err != nil {
@@ -40,7 +39,7 @@ func (opts *createTagOptions) validate() error {
 
 func (v *AllowedValues) validate() error {
 	if ok := validateIntInRange(len(v.Values), 1, 50); !ok {
-		return fmt.Errorf("number of the AllowedValues must be between 1 and 50")
+		return errIntBetween("AllowedValues", "Values", 1, 50)
 	}
 	return nil
 }
@@ -48,11 +47,11 @@ func (v *AllowedValues) validate() error {
 func (v *TagSet) validate() error {
 	var errs []error
 	if !exactlyOneValueSet(v.MaskingPolicies, v.Comment) {
-		errs = append(errs, errOneOf("MaskingPolicies", "Comment"))
+		errs = append(errs, errOneOf("TagSet", "MaskingPolicies", "Comment"))
 	}
 	if valueSet(v.MaskingPolicies) {
 		if ok := validateIntGreaterThanOrEqual(len(v.MaskingPolicies.MaskingPolicies), 1); !ok {
-			errs = append(errs, fmt.Errorf("number of the MaskingPolicies must be greater than zero"))
+			errs = append(errs, errIntValue("TagSet.MaskingPolicies", "MaskingPolicies", IntErrGreater, 0))
 		}
 	}
 	return errors.Join(errs...)
@@ -61,11 +60,11 @@ func (v *TagSet) validate() error {
 func (v *TagUnset) validate() error {
 	var errs []error
 	if !exactlyOneValueSet(v.MaskingPolicies, v.AllowedValues, v.Comment) {
-		errs = append(errs, errOneOf("MaskingPolicies", "AllowedValues", "Comment"))
+		errs = append(errs, errOneOf("TagUnset", "MaskingPolicies", "AllowedValues", "Comment"))
 	}
 	if valueSet(v.MaskingPolicies) {
 		if ok := validateIntGreaterThanOrEqual(len(v.MaskingPolicies.MaskingPolicies), 1); !ok {
-			errs = append(errs, fmt.Errorf("number of the MaskingPolicies must be greater than zero"))
+			errs = append(errs, errIntValue("TagUnset.MaskingPolicies", "MaskingPolicies", IntErrGreater, 0))
 		}
 	}
 	return errors.Join(errs...)

--- a/pkg/sdk/tags_validations.go
+++ b/pkg/sdk/tags_validations.go
@@ -60,10 +60,10 @@ func (v *TagSet) validate() error {
 func (v *TagUnset) validate() error {
 	var errs []error
 	if !exactlyOneValueSet(v.MaskingPolicies, v.AllowedValues, v.Comment) {
-		errs = append(errs, errOneOf("TagUnset", "MaskingPolicies", "AllowedValues", "Comment"))
+		errs = append(errs, errExactlyOneOf("TagUnset", "MaskingPolicies", "AllowedValues", "Comment"))
 	}
 	if valueSet(v.MaskingPolicies) {
-		if ok := validateIntGreaterThanOrEqual(len(v.MaskingPolicies.MaskingPolicies), 1); !ok {
+		if !validateIntGreaterThanOrEqual(len(v.MaskingPolicies.MaskingPolicies), 1) {
 			errs = append(errs, errIntValue("TagUnset.MaskingPolicies", "MaskingPolicies", IntErrGreater, 0))
 		}
 	}
@@ -99,9 +99,6 @@ func (opts *alterTagOptions) validate() error {
 	if valueSet(opts.Unset) {
 		if err := opts.Unset.validate(); err != nil {
 			errs = append(errs, err)
-		}
-		if !anyValueSet(opts.Unset.MaskingPolicies, opts.Unset.AllowedValues, opts.Unset.Comment) {
-			errs = append(errs, errAtLeastOneOf("alterTagOptions.Unset", "MaskingPolicies", "AllowedValues", "Comment"))
 		}
 	}
 	if valueSet(opts.Rename) {

--- a/pkg/sdk/tags_validations.go
+++ b/pkg/sdk/tags_validations.go
@@ -79,14 +79,8 @@ func (opts *alterTagOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if ok := exactlyOneValueSet(
-		opts.Add,
-		opts.Drop,
-		opts.Set,
-		opts.Unset,
-		opts.Rename,
-	); !ok {
-		errs = append(errs, errAlterNeedsExactlyOneAction)
+	if ok := exactlyOneValueSet(opts.Add, opts.Drop, opts.Set, opts.Unset, opts.Rename); !ok {
+		errs = append(errs, errExactlyOneOf("alterTagOptions", "Add", "Drop", "Set", "Unset", "Rename"))
 	}
 	if valueSet(opts.Add) && valueSet(opts.Add.AllowedValues) {
 		if err := opts.Add.AllowedValues.validate(); err != nil {
@@ -108,7 +102,7 @@ func (opts *alterTagOptions) validate() error {
 			errs = append(errs, err)
 		}
 		if !anyValueSet(opts.Unset.MaskingPolicies, opts.Unset.AllowedValues, opts.Unset.Comment) {
-			errs = append(errs, errAlterNeedsAtLeastOneProperty)
+			errs = append(errs, errAtLeastOneOf("alterTagOptions.Unset", "MaskingPolicies", "AllowedValues", "Comment"))
 		}
 	}
 	if valueSet(opts.Rename) {
@@ -128,7 +122,7 @@ func (opts *showTagOptions) validate() error {
 		errs = append(errs, ErrPatternRequiredForLikeKeyword)
 	}
 	if valueSet(opts.In) && !exactlyOneValueSet(opts.In.Account, opts.In.Database, opts.In.Schema) {
-		errs = append(errs, errScopeRequiredForInKeyword)
+		errs = append(errs, errExactlyOneOf("showTagOptions.In", "Account", "Database", "Schema"))
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/sdk/tasks_gen_test.go
+++ b/pkg/sdk/tasks_gen_test.go
@@ -38,7 +38,7 @@ func TestTasks_Create(t *testing.T) {
 	t.Run("validation: exactly one field from [opts.Warehouse.Warehouse opts.Warehouse.UserTaskManagedInitialWarehouseSize] should be present", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Warehouse = &CreateTaskWarehouse{}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("Warehouse", "UserTaskManagedInitialWarehouseSize"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateTaskOptions.Warehouse", "Warehouse", "UserTaskManagedInitialWarehouseSize"))
 	})
 
 	t.Run("validation: opts.SessionParameters.SessionParameters should be valid", func(t *testing.T) {
@@ -156,20 +156,20 @@ func TestTasks_Alter(t *testing.T) {
 
 	t.Run("validation: exactly one field from [opts.Resume opts.Suspend opts.RemoveAfter opts.AddAfter opts.Set opts.Unset opts.SetTags opts.UnsetTags opts.ModifyAs opts.ModifyWhen] should be present", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("Resume", "Suspend", "RemoveAfter", "AddAfter", "Set", "Unset", "SetTags", "UnsetTags", "ModifyAs", "ModifyWhen"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterTaskOptions", "Resume", "Suspend", "RemoveAfter", "AddAfter", "Set", "Unset", "SetTags", "UnsetTags", "ModifyAs", "ModifyWhen"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Resume opts.Suspend opts.RemoveAfter opts.AddAfter opts.Set opts.Unset opts.SetTags opts.UnsetTags opts.ModifyAs opts.ModifyWhen] should be present - more present", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Resume = Bool(true)
 		opts.Suspend = Bool(true)
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("Resume", "Suspend", "RemoveAfter", "AddAfter", "Set", "Unset", "SetTags", "UnsetTags", "ModifyAs", "ModifyWhen"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterTaskOptions", "Resume", "Suspend", "RemoveAfter", "AddAfter", "Set", "Unset", "SetTags", "UnsetTags", "ModifyAs", "ModifyWhen"))
 	})
 
 	t.Run("validation: at least one of the fields [opts.Set.Warehouse opts.Set.UserTaskManagedInitialWarehouseSize opts.Set.Schedule opts.Set.Config opts.Set.AllowOverlappingExecution opts.Set.UserTaskTimeoutMs opts.Set.SuspendTaskAfterNumFailures opts.Set.ErrorIntegration opts.Set.Comment opts.Set.SessionParameters] should be set", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Set = &TaskSet{}
-		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("Warehouse", "UserTaskManagedInitialWarehouseSize", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParameters"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterTaskOptions.Set", "Warehouse", "UserTaskManagedInitialWarehouseSize", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParameters"))
 	})
 
 	t.Run("validation: conflicting fields for [opts.Set.Warehouse opts.Set.UserTaskManagedInitialWarehouseSize]", func(t *testing.T) {
@@ -178,7 +178,7 @@ func TestTasks_Alter(t *testing.T) {
 		opts.Set = &TaskSet{}
 		opts.Set.Warehouse = &warehouseId
 		opts.Set.UserTaskManagedInitialWarehouseSize = &WarehouseSizeXSmall
-		assertOptsInvalidJoinedErrors(t, opts, errOneOf("Set", "Warehouse", "UserTaskManagedInitialWarehouseSize"))
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("AlterTaskOptions.Set", "Warehouse", "UserTaskManagedInitialWarehouseSize"))
 	})
 
 	t.Run("validation: opts.Set.SessionParameters.SessionParameters should be valid", func(t *testing.T) {
@@ -193,7 +193,7 @@ func TestTasks_Alter(t *testing.T) {
 	t.Run("validation: at least one of the fields [opts.Unset.Warehouse opts.Unset.Schedule opts.Unset.Config opts.Unset.AllowOverlappingExecution opts.Unset.UserTaskTimeoutMs opts.Unset.SuspendTaskAfterNumFailures opts.Unset.ErrorIntegration opts.Unset.Comment opts.Unset.SessionParametersUnset] should be set", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Unset = &TaskUnset{}
-		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("Warehouse", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParametersUnset"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterTaskOptions.Unset", "Warehouse", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParametersUnset"))
 	})
 
 	t.Run("validation: opts.Unset.SessionParametersUnset.SessionParametersUnset should be valid", func(t *testing.T) {

--- a/pkg/sdk/tasks_gen_test.go
+++ b/pkg/sdk/tasks_gen_test.go
@@ -200,7 +200,7 @@ func TestTasks_Alter(t *testing.T) {
 		opts := defaultOpts()
 		opts.Unset = &TaskUnset{}
 		opts.Unset.SessionParametersUnset = &SessionParametersUnset{}
-		assertOptsInvalidJoinedErrors(t, opts, fmt.Errorf("at least one session parameter must be set"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("SessionParametersUnset", "AbortDetachedQuery", "Autocommit", "BinaryInputFormat", "BinaryOutputFormat", "DateInputFormat", "DateOutputFormat", "ErrorOnNondeterministicMerge", "ErrorOnNondeterministicUpdate", "GeographyOutputFormat", "JSONIndent", "LockTimeout", "QueryTag", "RowsPerResultset", "SimulatedDataSharingConsumer", "StatementTimeoutInSeconds", "StrictJSONOutput", "TimestampDayIsAlways24h", "TimestampInputFormat", "TimestampLTZOutputFormat", "TimestampNTZOutputFormat", "TimestampOutputFormat", "TimestampTypeMapping", "TimestampTZOutputFormat", "Timezone", "TimeInputFormat", "TimeOutputFormat", "TransactionDefaultIsolationLevel", "TwoDigitCenturyStart", "UnsupportedDDLAction", "UseCachedResult", "WeekOfYearPolicy", "WeekStart"))
 	})
 
 	t.Run("alter resume", func(t *testing.T) {

--- a/pkg/sdk/tasks_gen_test.go
+++ b/pkg/sdk/tasks_gen_test.go
@@ -1,7 +1,6 @@
 package sdk
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -46,7 +45,7 @@ func TestTasks_Create(t *testing.T) {
 		opts.SessionParameters = &SessionParameters{
 			JSONIndent: Int(25),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, fmt.Errorf("JSON_INDENT must be between 0 and 16"))
+		assertOptsInvalidJoinedErrors(t, opts, errIntBetween("SessionParameters", "JSONIndent", 0, 16))
 	})
 
 	t.Run("basic", func(t *testing.T) {
@@ -187,7 +186,7 @@ func TestTasks_Alter(t *testing.T) {
 		opts.Set.SessionParameters = &SessionParameters{
 			JSONIndent: Int(25),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, fmt.Errorf("JSON_INDENT must be between 0 and 16"))
+		assertOptsInvalidJoinedErrors(t, opts, errIntBetween("SessionParameters", "JSONIndent", 0, 16))
 	})
 
 	t.Run("validation: at least one of the fields [opts.Unset.Warehouse opts.Unset.Schedule opts.Unset.Config opts.Unset.AllowOverlappingExecution opts.Unset.UserTaskTimeoutMs opts.Unset.SuspendTaskAfterNumFailures opts.Unset.ErrorIntegration opts.Unset.Comment opts.Unset.SessionParametersUnset] should be set", func(t *testing.T) {

--- a/pkg/sdk/tasks_validations_gen.go
+++ b/pkg/sdk/tasks_validations_gen.go
@@ -25,7 +25,7 @@ func (opts *CreateTaskOptions) validate() error {
 	}
 	if valueSet(opts.Warehouse) {
 		if ok := exactlyOneValueSet(opts.Warehouse.Warehouse, opts.Warehouse.UserTaskManagedInitialWarehouseSize); !ok {
-			errs = append(errs, errExactlyOneOf("Warehouse", "UserTaskManagedInitialWarehouseSize"))
+			errs = append(errs, errExactlyOneOf("CreateTaskOptions.Warehouse", "Warehouse", "UserTaskManagedInitialWarehouseSize"))
 		}
 	}
 	if valueSet(opts.SessionParameters) {
@@ -59,14 +59,14 @@ func (opts *AlterTaskOptions) validate() error {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if ok := exactlyOneValueSet(opts.Resume, opts.Suspend, opts.RemoveAfter, opts.AddAfter, opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags, opts.ModifyAs, opts.ModifyWhen); !ok {
-		errs = append(errs, errExactlyOneOf("Resume", "Suspend", "RemoveAfter", "AddAfter", "Set", "Unset", "SetTags", "UnsetTags", "ModifyAs", "ModifyWhen"))
+		errs = append(errs, errExactlyOneOf("AlterTaskOptions", "Resume", "Suspend", "RemoveAfter", "AddAfter", "Set", "Unset", "SetTags", "UnsetTags", "ModifyAs", "ModifyWhen"))
 	}
 	if valueSet(opts.Set) {
 		if ok := anyValueSet(opts.Set.Warehouse, opts.Set.UserTaskManagedInitialWarehouseSize, opts.Set.Schedule, opts.Set.Config, opts.Set.AllowOverlappingExecution, opts.Set.UserTaskTimeoutMs, opts.Set.SuspendTaskAfterNumFailures, opts.Set.ErrorIntegration, opts.Set.Comment, opts.Set.SessionParameters); !ok {
-			errs = append(errs, errAtLeastOneOf("Warehouse", "UserTaskManagedInitialWarehouseSize", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParameters"))
+			errs = append(errs, errAtLeastOneOf("AlterTaskOptions.Set", "Warehouse", "UserTaskManagedInitialWarehouseSize", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParameters"))
 		}
 		if everyValueSet(opts.Set.Warehouse, opts.Set.UserTaskManagedInitialWarehouseSize) {
-			errs = append(errs, errOneOf("Set", "Warehouse", "UserTaskManagedInitialWarehouseSize"))
+			errs = append(errs, errOneOf("AlterTaskOptions.Set", "Warehouse", "UserTaskManagedInitialWarehouseSize"))
 		}
 		if valueSet(opts.Set.SessionParameters) {
 			if err := opts.Set.SessionParameters.validate(); err != nil {
@@ -76,7 +76,7 @@ func (opts *AlterTaskOptions) validate() error {
 	}
 	if valueSet(opts.Unset) {
 		if ok := anyValueSet(opts.Unset.Warehouse, opts.Unset.Schedule, opts.Unset.Config, opts.Unset.AllowOverlappingExecution, opts.Unset.UserTaskTimeoutMs, opts.Unset.SuspendTaskAfterNumFailures, opts.Unset.ErrorIntegration, opts.Unset.Comment, opts.Unset.SessionParametersUnset); !ok {
-			errs = append(errs, errAtLeastOneOf("Warehouse", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParametersUnset"))
+			errs = append(errs, errAtLeastOneOf("AlterTaskOptions.Unset", "Warehouse", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParametersUnset"))
 		}
 		if valueSet(opts.Unset.SessionParametersUnset) {
 			if err := opts.Unset.SessionParametersUnset.validate(); err != nil {

--- a/pkg/sdk/testint/dynamic_table_integration_test.go
+++ b/pkg/sdk/testint/dynamic_table_integration_test.go
@@ -2,6 +2,7 @@ package testint
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -131,7 +132,7 @@ func TestInt_DynamicTableAlter(t *testing.T) {
 
 		err := client.DynamicTables.Alter(ctx, sdk.NewAlterDynamicTableRequest(dynamicTable.ID()).WithSuspend(sdk.Bool(true)).WithResume(sdk.Bool(true)))
 		require.Error(t, err)
-		expected := "alter statement needs exactly one action from: set, unset, refresh"
+		expected := fmt.Sprintf("exactly one of %s fileds %v must be set", "alterDynamicTableOptions", []string{"Suspend", "Resume", "Refresh", "Set"})
 		require.Equal(t, expected, err.Error())
 	})
 

--- a/pkg/sdk/testint/dynamic_table_integration_test.go
+++ b/pkg/sdk/testint/dynamic_table_integration_test.go
@@ -2,7 +2,6 @@ package testint
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -132,8 +131,7 @@ func TestInt_DynamicTableAlter(t *testing.T) {
 
 		err := client.DynamicTables.Alter(ctx, sdk.NewAlterDynamicTableRequest(dynamicTable.ID()).WithSuspend(sdk.Bool(true)).WithResume(sdk.Bool(true)))
 		require.Error(t, err)
-		expected := fmt.Sprintf("exactly one of %s fileds %v must be set", "alterDynamicTableOptions", []string{"Suspend", "Resume", "Refresh", "Set"})
-		require.Equal(t, expected, err.Error())
+		require.Equal(t, sdk.ErrExactlyOneOf("alterDynamicTableOptions", "Suspend", "Resume", "Refresh", "Set").Error(), err.Error())
 	})
 
 	t.Run("alter with set", func(t *testing.T) {

--- a/pkg/sdk/testint/tags_integration_test.go
+++ b/pkg/sdk/testint/tags_integration_test.go
@@ -88,8 +88,7 @@ func TestInt_Tags(t *testing.T) {
 		comment := random.Comment()
 		values := []string{"value1", "value2"}
 		err := client.Tags.Create(ctx, sdk.NewCreateTagRequest(id).WithOrReplace(true).WithComment(&comment).WithAllowedValues(values))
-		expected := "Comment fields: [AllowedValues] are incompatible and cannot be set at the same time"
-		require.Equal(t, expected, err.Error())
+		require.Equal(t, sdk.ErrOneOf("createTagOptions", "Comment", "AllowedValues").Error(), err.Error())
 	})
 
 	t.Run("create tag: no optionals", func(t *testing.T) {

--- a/pkg/sdk/users.go
+++ b/pkg/sdk/users.go
@@ -283,16 +283,8 @@ func (opts *AlterUserOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(
-		opts.NewName,
-		opts.ResetPassword,
-		opts.AbortAllQueries,
-		opts.AddDelegatedAuthorization,
-		opts.RemoveDelegatedAuthorization,
-		opts.Set,
-		opts.Unset,
-	) {
-		errs = append(errs, errExactlyOneOf("NewName", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset"))
+	if !exactlyOneValueSet(opts.NewName, opts.ResetPassword, opts.AbortAllQueries, opts.AddDelegatedAuthorization, opts.RemoveDelegatedAuthorization, opts.Set, opts.Unset) {
+		errs = append(errs, errExactlyOneOf("AlterUserOptions", "NewName", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset"))
 	}
 	if valueSet(opts.RemoveDelegatedAuthorization) {
 		if err := opts.RemoveDelegatedAuthorization.validate(); err != nil {
@@ -363,8 +355,11 @@ type UserSet struct {
 
 func (opts *UserSet) validate() error {
 	var errs []error
-	if !exactlyOneValueSet(opts.SessionPolicy, opts.PasswordPolicy, opts.Tags) {
-		errs = append(errs, errExactlyOneOf("UserSet", "SessionPolicy", "PasswordPolicy", "Tags"))
+	if !anyValueSet(opts.PasswordPolicy, opts.SessionPolicy, opts.Tags, opts.ObjectProperties, opts.ObjectParameters, opts.SessionParameters) {
+		errs = append(errs, fmt.Errorf("at least one of password policy, tag, object properties, object parameters, or session parameters must be set"))
+	}
+	if moreThanOneValueSet(opts.SessionPolicy, opts.PasswordPolicy, opts.Tags) {
+		errs = append(errs, fmt.Errorf("setting session policy, password policy and tags must be done separately"))
 	}
 	if anyValueSet(opts.ObjectParameters, opts.SessionParameters, opts.ObjectProperties) {
 		if anyValueSet(opts.PasswordPolicy, opts.SessionPolicy, opts.Tags) {

--- a/pkg/sdk/users.go
+++ b/pkg/sdk/users.go
@@ -336,7 +336,7 @@ type RemoveDelegatedAuthorization struct {
 func (opts *RemoveDelegatedAuthorization) validate() error {
 	var errs []error
 	if !exactlyOneValueSet(opts.Role, opts.Authorizations) {
-		errs = append(errs, errOneOf("RemoveDelegatedAuthorization", "Role", "Authorization"))
+		errs = append(errs, errExactlyOneOf("RemoveDelegatedAuthorization", "Role", "Authorization"))
 	}
 	if !valueSet(opts.Integration) {
 		errs = append(errs, errNotSet("RemoveDelegatedAuthorization", "Integration"))
@@ -354,19 +354,10 @@ type UserSet struct {
 }
 
 func (opts *UserSet) validate() error {
-	var errs []error
-	if !anyValueSet(opts.PasswordPolicy, opts.SessionPolicy, opts.Tags, opts.ObjectProperties, opts.ObjectParameters, opts.SessionParameters) {
-		errs = append(errs, fmt.Errorf("at least one of password policy, tag, object properties, object parameters, or session parameters must be set"))
+	if !exactlyOneValueSet(opts.PasswordPolicy, opts.SessionPolicy, opts.Tags, opts.ObjectProperties, opts.ObjectParameters, opts.SessionParameters) {
+		return errExactlyOneOf("UserSet", "PasswordPolicy", "SessionPolicy", "Tags", "ObjectProperties", "ObjectParameters", "SessionParameters")
 	}
-	if moreThanOneValueSet(opts.SessionPolicy, opts.PasswordPolicy, opts.Tags) {
-		errs = append(errs, fmt.Errorf("setting session policy, password policy and tags must be done separately"))
-	}
-	if anyValueSet(opts.ObjectParameters, opts.SessionParameters, opts.ObjectProperties) {
-		if anyValueSet(opts.PasswordPolicy, opts.SessionPolicy, opts.Tags) {
-			errs = append(errs, fmt.Errorf("cannot set both {object parameters, session parameters,object properties} and password policy, session policy, or tag"))
-		}
-	}
-	return errors.Join(errs...)
+	return nil
 }
 
 type UserUnset struct {

--- a/pkg/sdk/users_test.go
+++ b/pkg/sdk/users_test.go
@@ -11,7 +11,7 @@ func TestUserCreate(t *testing.T) {
 
 	t.Run("validation: empty options", func(t *testing.T) {
 		opts := &CreateUserOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("with complete options", func(t *testing.T) {
@@ -51,14 +51,14 @@ func TestUserAlter(t *testing.T) {
 
 	t.Run("empty options", func(t *testing.T) {
 		opts := &AlterUserOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("only name", func(t *testing.T) {
 		opts := &AlterUserOptions{
 			name: id,
 		}
-		assertOptsInvalid(t, opts, errExactlyOneOf("NewName", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterUserOptions", "NewName", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset"))
 	})
 
 	t.Run("with setting a policy", func(t *testing.T) {
@@ -225,7 +225,7 @@ func TestUserDrop(t *testing.T) {
 
 	t.Run("validation: empty options", func(t *testing.T) {
 		opts := &DropUserOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("only name", func(t *testing.T) {
@@ -292,7 +292,7 @@ func TestUserDescribe(t *testing.T) {
 
 	t.Run("validation: empty options", func(t *testing.T) {
 		opts := &describeUserOptions{}
-		assertOptsInvalid(t, opts, ErrInvalidObjectIdentifier)
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
 	t.Run("only name", func(t *testing.T) {

--- a/pkg/sdk/validations.go
+++ b/pkg/sdk/validations.go
@@ -99,6 +99,10 @@ func validateIntInRange(value int, min int, max int) bool {
 	return true
 }
 
+func validateIntGreaterThan(value int, min int) bool {
+	return value > min
+}
+
 func validateIntGreaterThanOrEqual(value int, min int) bool {
 	return value >= min
 }

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -186,9 +186,6 @@ func (opts *AlterWarehouseOptions) validate() error {
 	if (valueSet(opts.IfSuspended) && *opts.IfSuspended) && (!valueSet(opts.Resume) || !*opts.Resume) {
 		errs = append(errs, fmt.Errorf(`"Resume" has to be set when using "IfSuspended"`))
 	}
-	if everyValueSet(opts.Set, opts.Unset) {
-		errs = append(errs, errOneOf("AlterWarehouseOptions", "Set", "Unset"))
-	}
 	if valueSet(opts.Set) {
 		if err := opts.Set.validate(); err != nil {
 			errs = append(errs, err)

--- a/pkg/sdk/warehouses_test.go
+++ b/pkg/sdk/warehouses_test.go
@@ -61,7 +61,7 @@ func TestWarehouseSizing(t *testing.T) {
 			MaxClusterCount: Int(1),
 			MinClusterCount: Int(2),
 		}
-		assertOptsInvalid(t, opts, fmt.Errorf("MinClusterCount must be less than or equal to MaxClusterCount"))
+		assertOptsInvalidJoinedErrors(t, opts, fmt.Errorf("MinClusterCount must be less than or equal to MaxClusterCount"))
 	})
 
 	t.Run("Max equal Min", func(t *testing.T) {


### PR DESCRIPTION
Some of the other stuff done in this pr
- Returned always joined errors for Query structs (didn't applied that to nested structures, because It didn't matter that much - because if there's an error It'll be wrapped anyways by Query struct validation)
- Added common number error messages in errors.go
- Merged some of the validations, making them shorter (e.g. instead of check every combination and returning unique message for that OneOf combination. I've used `exactlyOneValueSet`)
- Replaced plain errors.New() errors with our predefined ones from errors.go (I've left some that had unique or not that much repeating error message that would be worth to make into a separate function in errors.go)
- Adjusted generator's validation files generation

Notes
To be consistent with new validation I've adjusted Query struct (...Options structs) validation functions to include at the top.
```go
if opts == nil {
	return errors.Join(ErrNilOptions)
}
```
and, If there was only one validation after opts nil check I've inlined the join, so instead
```go
var errs []error
if !ValidObjectIdentifier(opts.name) {
	errs = append(errs, ErrInvalidObjectIdentifier)
}
return errors.Join(errs...)
```
I've returned
```go
if !ValidObjectIdentifier(opts.name) {
	return errors.Join(ErrInvalidObjectIdentifier)
}
return nil
```

The advantage of always using joined errors is that we can have one assert function in the unit tests `assertOptsInvalidJoinedErrors` (I can remove the other one now (`assertOptsInvalid`). I didn't, but lmk if we can do it or should we return single errors e.g. like in the above case).
