### PR TITLE
feat: add parse_header option to file format resource

### DIFF
--- a/docs/resources/file_format.md
+++ b/docs/resources/file_format.md
@@ -52,6 +52,7 @@ resource "snowflake_file_format" "example_file_format" {
 - `file_extension` (String) Specifies the extension for files unloaded to a stage.
 - `ignore_utf8_errors` (Boolean) Boolean that specifies whether UTF-8 encoding errors produce error conditions.
 - `null_if` (List of String) String used to convert to and from SQL NULL.
+- `parse_header` (Boolean) Boolean that specifies whether to use the first row headers in the data files to determine column names.
 - `preserve_space` (Boolean) Boolean that specifies whether the XML parser preserves leading and trailing spaces in element content.
 - `record_delimiter` (String) Specifies one or more singlebyte or multibyte characters that separate records in an input file (data loading) or unloaded file (data unloading).
 - `replace_invalid_characters` (Boolean) Boolean that specifies whether to replace invalid UTF-8 characters with the Unicode replacement character (�).

--- a/pkg/resources/file_format.go
+++ b/pkg/resources/file_format.go
@@ -26,6 +26,7 @@ var formatTypeOptions = map[string][]string{
 		"record_delimiter",
 		"field_delimiter",
 		"file_extension",
+		"parse_header",
 		"skip_header",
 		"skip_blank_lines",
 		"date_format",
@@ -134,6 +135,11 @@ var fileFormatSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "Specifies the extension for files unloaded to a stage.",
+	},
+	"parse_header": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Boolean that specifies whether to use the first row headers in the data files to determine column names.",
 	},
 	"skip_header": {
 		Type:        schema.TypeInt,
@@ -345,6 +351,7 @@ func CreateFileFormat(d *schema.ResourceData, meta interface{}) error {
 		if v, ok := d.GetOk("file_extension"); ok {
 			opts.CSVFileExtension = sdk.String(v.(string))
 		}
+		opts.CSVParseHeader = sdk.Bool(d.Get("parse_header").(bool))
 		opts.CSVSkipHeader = sdk.Int(d.Get("skip_header").(int))
 		opts.CSVSkipBlankLines = sdk.Bool(d.Get("skip_blank_lines").(bool))
 		if v, ok := d.GetOk("date_format"); ok {
@@ -563,6 +570,9 @@ func ReadFileFormat(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		if err := d.Set("file_extension", fileFormat.Options.CSVFileExtension); err != nil {
+			return err
+		}
+		if err := d.Set("parse_header", fileFormat.Options.CSVParseHeader); err != nil {
 			return err
 		}
 		if err := d.Set("skip_header", fileFormat.Options.CSVSkipHeader); err != nil {
@@ -787,6 +797,10 @@ func UpdateFileFormat(d *schema.ResourceData, meta interface{}) error {
 		if d.HasChange("file_extension") {
 			v := d.Get("file_extension").(string)
 			opts.Set.CSVFileExtension = &v
+		}
+		if d.HasChange("parse_header") {
+			v := d.Get("parse_header").(bool)
+			opts.Set.CSVParseHeader = &v
 		}
 		if d.HasChange("skip_header") {
 			v := d.Get("skip_header").(int)

--- a/pkg/sdk/file_format.go
+++ b/pkg/sdk/file_format.go
@@ -737,7 +737,7 @@ func (v *fileFormats) Describe(ctx context.Context, id SchemaObjectIdentifier) (
 			case "PARSE_HEADER":
 				b, err := strconv.ParseBool(v)
 				if err != nil {
-					return nil, fmt.Errorf(`cannot cast SKIP_HEADER value "%s" to bool: %w`, v, err)
+					return nil, fmt.Errorf(`cannot cast PARSE_HEADER value "%s" to bool: %w`, v, err)
 				}
 				details.Options.CSVParseHeader = &b
 			case "DATE_FORMAT":


### PR DESCRIPTION
Modified `pkg/resources/file_format.go` to include the `parse_header` option for File Formats.

This option was already included in `pkg/sdk/file_format.go`, but it was never mapped to a Terraform configuration option.

## References

* #2050 