### PR TITLE
fix: change comment in Account struct to NullString

### DIFF
--- a/pkg/sdk/accounts.go
+++ b/pkg/sdk/accounts.go
@@ -318,7 +318,7 @@ type accountDBRow struct {
 	Edition                              string         `db:"edition"`
 	AccountURL                           string         `db:"account_url"`
 	CreatedOn                            time.Time      `db:"created_on"`
-	Comment                              string         `db:"comment"`
+	Comment                              sql.NullString `db:"comment"`
 	AccountLocator                       string         `db:"account_locator"`
 	AccountLocatorURL                    string         `db:"account_locator_url"`
 	AccountOldURLSavedOn                 sql.NullString `db:"account_old_url_saved_on"`
@@ -339,7 +339,7 @@ func (row accountDBRow) convert() *Account {
 		Edition:                              AccountEdition(row.Edition),
 		AccountURL:                           row.AccountURL,
 		CreatedOn:                            row.CreatedOn,
-		Comment:                              row.Comment,
+		Comment:                              row.Comment.String,
 		AccountLocator:                       row.AccountLocator,
 		AccountLocatorURL:                    row.AccountLocatorURL,
 		ManagedAccounts:                      row.ManagedAccounts,


### PR DESCRIPTION
 SNOW-932299
 getting the following error where running the command: SHOW ORGANIZATION ACCOUNTS LIKE ‘XXXXX’ 

```
2023-09-28T08:38:17.676-0400 [INFO] provider.terraform-provider-snowflake_v0.71.0: 2023/09/28 08:38:17 [DEBUG] sql-conn-query [query SHOW ORGANIZATION ACCOUNTS LIKE ‘XXXXX’ err <nil> duration 341.364ms args {}]: timestamp=2023-09-28T08:38:17.676-0400
2023-09-28T08:38:17.676-0400 [INFO] provider.terraform-provider-snowflake_v0.71.0: 2023/09/28 08:38:17 [DEBUG] sql-rows-next [err <nil> duration 389.375µs]: timestamp=2023-09-28T08:38:17.676-0400
2023-09-28T08:38:17.677-0400 [INFO] provider.terraform-provider-snowflake_v0.71.0: 2023/09/28 08:38:17 [DEBUG] err: sql: Scan error on column index 6, name “comment”: converting NULL to string is unsupported
```