### PR TITLE
fix: view statement update

### DIFF
--- a/pkg/resources/helpers_test.go
+++ b/pkg/resources/helpers_test.go
@@ -2,7 +2,7 @@ package resources_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"strconv"
 	"testing"
 
@@ -474,34 +474,32 @@ func tagGrant(t *testing.T, id string, params map[string]interface{}) *schema.Re
 	return d
 }
 
-type attrLenComparison int
+type attrIntComparison int
 
 const (
-	AttrLenIsGreaterThan attrLenComparison = iota
-	AttrLenIsLessThan
-	AttrLenIsEqualTo
+	AttrIsGreaterThan attrIntComparison = iota
+	AttrIsLessThan
+	AttrIsEqualTo
 )
 
-func checkIntComparison(path, attr string, comp attrLenComparison, value int) func(*terraform.State) error {
-	return func(state *terraform.State) error {
-		is := state.RootModule().Resources[path].Primary
-		d := is.Attributes[attr]
-		attribute, err := strconv.ParseInt(d, 10, 8)
+var checkIntComparison = func(comp attrIntComparison, expected int) resource.CheckResourceAttrWithFunc {
+	return func(value string) error {
+		actual, err := strconv.ParseInt(value, 10, 8)
 		if err != nil {
 			return err
 		}
 		switch comp {
-		case AttrLenIsGreaterThan:
-			if int(attribute) <= value {
-				return fmt.Errorf("attribute %s at path %s is not greater than %d", attr, path, value)
+		case AttrIsGreaterThan:
+			if int(actual) <= expected {
+				return fmt.Errorf("expected attribute to be greater than %d, but got %d", expected, actual)
 			}
-		case AttrLenIsLessThan:
-			if int(attribute) >= value {
-				return fmt.Errorf("attribute %s at path %s is not less than %d", attr, path, value)
+		case AttrIsLessThan:
+			if int(actual) >= expected {
+				return fmt.Errorf("expected attribute to be less than %d, but got %d", expected, actual)
 			}
-		case AttrLenIsEqualTo:
-			if int(attribute) != value {
-				return fmt.Errorf("attribute %s at path %s is not equal to %d", attr, path, value)
+		case AttrIsEqualTo:
+			if int(actual) != expected {
+				return fmt.Errorf("expected attribute to be equal to %d, but got %d", expected, actual)
 			}
 		default:
 			return fmt.Errorf("invalid comparison: %v", comp)

--- a/pkg/resources/helpers_test.go
+++ b/pkg/resources/helpers_test.go
@@ -1,9 +1,6 @@
 package resources_test
 
 import (
-	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -472,38 +469,4 @@ func tagGrant(t *testing.T, id string, params map[string]interface{}) *schema.Re
 	r.NotNil(d)
 	d.SetId(id)
 	return d
-}
-
-type attrIntComparison int
-
-const (
-	AttrIsGreaterThan attrIntComparison = iota
-	AttrIsLessThan
-	AttrIsEqualTo
-)
-
-var checkIntComparison = func(comp attrIntComparison, expected int) resource.CheckResourceAttrWithFunc {
-	return func(value string) error {
-		actual, err := strconv.ParseInt(value, 10, 8)
-		if err != nil {
-			return err
-		}
-		switch comp {
-		case AttrIsGreaterThan:
-			if int(actual) <= expected {
-				return fmt.Errorf("expected attribute to be greater than %d, but got %d", expected, actual)
-			}
-		case AttrIsLessThan:
-			if int(actual) >= expected {
-				return fmt.Errorf("expected attribute to be less than %d, but got %d", expected, actual)
-			}
-		case AttrIsEqualTo:
-			if int(actual) != expected {
-				return fmt.Errorf("expected attribute to be equal to %d, but got %d", expected, actual)
-			}
-		default:
-			return fmt.Errorf("invalid comparison: %v", comp)
-		}
-		return nil
-	}
 }

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -64,7 +64,6 @@ var viewSchema = map[string]*schema.Schema{
 		Type:             schema.TypeString,
 		Required:         true,
 		Description:      "Specifies the query used to create the view.",
-		ForceNew:         true,
 		DiffSuppressFunc: DiffSuppressStatement,
 	},
 	"created_on": {
@@ -81,7 +80,7 @@ func normalizeQuery(str string) string {
 
 // DiffSuppressStatement will suppress diffs between statements if they differ in only case or in
 // runs of whitespace (\s+ = \s). This is needed because the snowflake api does not faithfully
-// round-trip queries so we cannot do a simple character-wise comparison to detect changes.
+// round-trip queries, so we cannot do a simple character-wise comparison to detect changes.
 //
 // Warnings: We will have false positives in cases where a change in case or run of whitespace is
 // semantically significant.
@@ -279,11 +278,41 @@ func UpdateView(d *schema.ResourceData, meta interface{}) error {
 	schema := viewID.SchemaName
 	view := viewID.ViewName
 	builder := snowflake.NewViewBuilder(view).WithDB(dbName).WithSchema(schema)
-
 	db := meta.(*sql.DB)
+
+	// in order to update the statement field in a view is to perform create or replace
+	// what we could do is to apply all the changes in create or replace, because that would be less sql queries,
+	// but for now I've implemented it that create or replace will be performed with all the old parameters, except statement
+	// and copy grants (which will be set to true, so that it would copy all the grants after create or replace,
+	// since create or replace works like atomic drop and create, which could break some things that require certain set of permissions
+	// which could be lost after drop)
+	if d.HasChange("statement") {
+		isSecureOld, _ := d.GetChange("is_secure")
+		commentOld, _ := d.GetChange("comment")
+		tagsOld, _ := d.GetChange("tag")
+
+		if isSecureOld.(bool) {
+			builder.WithSecure()
+		}
+
+		query, err := builder.
+			WithReplace().
+			WithStatement(d.Get("statement").(string)).
+			WithCopyGrants().
+			WithComment(commentOld.(string)).
+			WithTags(getTags(tagsOld).toSnowflakeTagValues()).
+			Create()
+		if err != nil {
+			return fmt.Errorf("error when building sql query on %v, err = %w", d.Id(), err)
+		}
+
+		if err := snowflake.Exec(db, query); err != nil {
+			return fmt.Errorf("error when changing property on %v and performing create or replace to update view statements, err = %w", d.Id(), err)
+		}
+	}
+
 	if d.HasChange("name") {
 		name := d.Get("name")
-
 		q, err := builder.Rename(name.(string))
 		if err != nil {
 			return err
@@ -291,7 +320,6 @@ func UpdateView(d *schema.ResourceData, meta interface{}) error {
 		if err = snowflake.Exec(db, q); err != nil {
 			return fmt.Errorf("error renaming view %v", d.Id())
 		}
-
 		viewID := &ViewID{
 			DatabaseName: dbName,
 			SchemaName:   schema,
@@ -305,9 +333,7 @@ func UpdateView(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("comment") {
-		comment := d.Get("comment")
-
-		if c := comment.(string); c == "" {
+		if comment := d.Get("comment").(string); comment == "" {
 			q, err := builder.RemoveComment()
 			if err != nil {
 				return err
@@ -316,7 +342,7 @@ func UpdateView(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("error unsetting comment for view %v", d.Id())
 			}
 		} else {
-			q, err := builder.ChangeComment(c)
+			q, err := builder.ChangeComment(comment)
 			if err != nil {
 				return err
 			}
@@ -325,10 +351,9 @@ func UpdateView(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 	}
-	if d.HasChange("is_secure") {
-		secure := d.Get("is_secure")
 
-		if secure.(bool) {
+	if d.HasChange("is_secure") {
+		if d.Get("is_secure").(bool) {
 			q, err := builder.Secure()
 			if err != nil {
 				return err
@@ -346,6 +371,7 @@ func UpdateView(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 	}
+
 	tagChangeErr := handleTagChanges(db, d, builder)
 	if tagChangeErr != nil {
 		return tagChangeErr

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -280,12 +280,9 @@ func UpdateView(d *schema.ResourceData, meta interface{}) error {
 	builder := snowflake.NewViewBuilder(view).WithDB(dbName).WithSchema(schema)
 	db := meta.(*sql.DB)
 
-	// in order to update the statement field in a view is to perform create or replace
-	// what we could do is to apply all the changes in create or replace, because that would be less sql queries,
-	// but for now I've implemented it that create or replace will be performed with all the old parameters, except statement
-	// and copy grants (which will be set to true, so that it would copy all the grants after create or replace,
-	// since create or replace works like atomic drop and create, which could break some things that require certain set of permissions
-	// which could be lost after drop)
+	// The only way to update the statement field in a view is to perform create or replace with the new statement.
+	// In case of any statement change, create or replace will be performed with all the old parameters, except statement
+	// and copy grants (which is always set to true to keep the permissions from the previous state).
 	if d.HasChange("statement") {
 		isSecureOld, _ := d.GetChange("is_secure")
 		commentOld, _ := d.GetChange("comment")

--- a/pkg/resources/view_acceptance_test.go
+++ b/pkg/resources/view_acceptance_test.go
@@ -161,13 +161,15 @@ func TestAcc_ViewStatementUpdate(t *testing.T) {
 				Config: viewConfigWithGrants(acc.TestDatabaseName, acc.TestSchemaName, `\"name\"`),
 				Check: resource.ComposeTestCheckFunc(
 					// there should be more than one privilege, because we applied grant all privileges and initially there's always one which is ownership
-					checkIntComparison("data.snowflake_grants.grants", "grants.#", AttrLenIsGreaterThan, 1),
+					resource.TestCheckResourceAttr("data.snowflake_grants.grants", "grants.#", "2"),
+					resource.TestCheckResourceAttr("data.snowflake_grants.grants", "grants.1.privilege", "SELECT"),
 				),
 			},
 			{
 				Config: viewConfigWithGrants(acc.TestDatabaseName, acc.TestSchemaName, "*"),
 				Check: resource.ComposeTestCheckFunc(
-					checkIntComparison("data.snowflake_grants.grants", "grants.#", AttrLenIsGreaterThan, 1),
+					resource.TestCheckResourceAttr("data.snowflake_grants.grants", "grants.#", "2"),
+					resource.TestCheckResourceAttr("data.snowflake_grants.grants", "grants.1.privilege", "SELECT"),
 				),
 			},
 		},
@@ -222,7 +224,7 @@ resource "snowflake_view_grant" "grant" {
   database_name = "%s"
   schema_name = "%s"
   view_name = snowflake_view.test.name
-  privilege = "ALL PRIVILEGES"
+  privilege = "SELECT"
   roles = [snowflake_role.test.name]
 }
 
@@ -233,5 +235,10 @@ data "snowflake_grants" "grants" {
     object_type = "VIEW"
   }
 }
-	`, databaseName, schemaName, databaseName, schemaName, selectStatement, databaseName, schemaName, databaseName, schemaName, databaseName, schemaName)
+	`, databaseName, schemaName,
+		databaseName, schemaName,
+		selectStatement,
+		databaseName, schemaName,
+		databaseName, schemaName,
+		databaseName, schemaName)
 }

--- a/pkg/resources/view_acceptance_test.go
+++ b/pkg/resources/view_acceptance_test.go
@@ -151,6 +151,29 @@ func TestAcc_ViewChangeCopyGrantsReversed(t *testing.T) {
 	})
 }
 
+func TestAcc_ViewStatementUpdate(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    acc.TestAccProviders(),
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: viewConfigWithGrants(acc.TestDatabaseName, acc.TestSchemaName, `\"name\"`),
+				Check: resource.ComposeTestCheckFunc(
+					// there should be more than one privilege, because we applied grant all privileges and initially there's always one which is ownership
+					checkIntComparison("data.snowflake_grants.grants", "grants.#", AttrLenIsGreaterThan, 1),
+				),
+			},
+			{
+				Config: viewConfigWithGrants(acc.TestDatabaseName, acc.TestSchemaName, "*"),
+				Check: resource.ComposeTestCheckFunc(
+					checkIntComparison("data.snowflake_grants.grants", "grants.#", AttrLenIsGreaterThan, 1),
+				),
+			},
+		},
+	})
+}
+
 func viewConfig(n string, copyGrants bool, q string, databaseName string, schemaName string) string {
 	return fmt.Sprintf(`
 resource "snowflake_view" "test" {
@@ -164,4 +187,51 @@ resource "snowflake_view" "test" {
 	statement   = "%s"
 }
 `, n, databaseName, schemaName, copyGrants, copyGrants, q)
+}
+
+func viewConfigWithGrants(databaseName string, schemaName string, selectStatement string) string {
+	return fmt.Sprintf(`
+resource "snowflake_table" "table" {
+  database = "%s"
+  schema = "%s"
+  name     = "view_test_table"
+
+  column {
+    name = "name"
+    type = "text"
+  }
+}
+
+resource "snowflake_view" "test" {
+  depends_on = [snowflake_table.table]
+  name = "test"
+  comment = "created by terraform"
+  database = "%s"
+  schema = "%s"
+  statement = "select %s from \"%s\".\"%s\".\"${snowflake_table.table.name}\""
+  or_replace = true
+  copy_grants = true
+  is_secure = true
+}
+
+resource "snowflake_role" "test" {
+  name = "test"
+}
+
+resource "snowflake_view_grant" "grant" {
+  database_name = "%s"
+  schema_name = "%s"
+  view_name = snowflake_view.test.name
+  privilege = "ALL PRIVILEGES"
+  roles = [snowflake_role.test.name]
+}
+
+data "snowflake_grants" "grants" {
+  depends_on = [snowflake_view_grant.grant, snowflake_view.test]
+  grants_on {
+    object_name = "\"%s\".\"%s\".\"${snowflake_view.test.name}\""
+    object_type = "VIEW"
+  }
+}
+	`, databaseName, schemaName, databaseName, schemaName, selectStatement, databaseName, schemaName, databaseName, schemaName, databaseName, schemaName)
 }


### PR DESCRIPTION
It's a fix that customer issued. It was failing, because statement attribute on view had a force new which issued terraform delete and then create actions which are not atomic and because of that view was missing grants. To fix it I've removed force new from statement attribute and then I modified terraform update method for view, so that when there's a change in the statement we'll perform create or replace (which is the only way of changing statement in views) with old settings and copy grants regardless of the copy grants attribute, because we would like to keep the grants as they were before, without them users might get the same error if copy grants wouldn't be specified. 

The only thing I'm not sure about is implicit copy grants, but I felt like copy grants attribute is only for or_replace which is only needed during the initial creation in a case of replacing the old existing view.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance test that shows it should work now (I've ran it for main version and it failed as expected)

## Update
After discussions
- or_replace and copy_grants are attributes that are needed only during the initial creation of the TF resource
- copy_grants will be always set during "statement" create or replace query
