### PR TITLE
chore: Split existing alter operations

### DIFF
--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -237,9 +237,7 @@ func UpdateSchema(d *schema.ResourceData, meta interface{}) error {
 			unsetTags[i] = sdk.NewDatabaseObjectIdentifier(t.database, t.name)
 		}
 		err := client.Schemas.Alter(ctx, id, &sdk.AlterSchemaOptions{
-			Unset: &sdk.SchemaUnset{
-				Tag: unsetTags,
-			},
+			UnsetTag: unsetTags,
 		})
 		if err != nil {
 			return fmt.Errorf("error dropping tags on %v", d.Id())
@@ -259,9 +257,7 @@ func UpdateSchema(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 		err = client.Schemas.Alter(ctx, id, &sdk.AlterSchemaOptions{
-			Set: &sdk.SchemaSet{
-				Tag: setTags,
-			},
+			SetTag: setTags,
 		})
 		if err != nil {
 			return fmt.Errorf("error setting tags on %v", d.Id())

--- a/pkg/sdk/accounts.go
+++ b/pkg/sdk/accounts.go
@@ -90,10 +90,12 @@ type AlterAccountOptions struct {
 	alter   bool `ddl:"static" sql:"ALTER"`
 	account bool `ddl:"static" sql:"ACCOUNT"`
 
-	Set    *AccountSet    `ddl:"keyword" sql:"SET"`
-	Unset  *AccountUnset  `ddl:"list,no_parentheses" sql:"UNSET"`
-	Rename *AccountRename `ddl:"-"`
-	Drop   *AccountDrop   `ddl:"-"`
+	Set      *AccountSet        `ddl:"keyword" sql:"SET"`
+	Unset    *AccountUnset      `ddl:"list,no_parentheses" sql:"UNSET"`
+	SetTag   []TagAssociation   `ddl:"keyword" sql:"SET TAG"`
+	UnsetTag []ObjectIdentifier `ddl:"keyword" sql:"UNSET TAG"`
+	Rename   *AccountRename     `ddl:"-"`
+	Drop     *AccountDrop       `ddl:"-"`
 }
 
 func (opts *AlterAccountOptions) validate() error {
@@ -101,8 +103,8 @@ func (opts *AlterAccountOptions) validate() error {
 		return errors.Join(ErrNilOptions)
 	}
 	var errs []error
-	if !exactlyOneValueSet(opts.Set, opts.Unset, opts.Drop, opts.Rename) {
-		errs = append(errs, errExactlyOneOf("CreateAccountOptions", "Set", "Unset", "Drop", "Rename"))
+	if !exactlyOneValueSet(opts.Set, opts.Unset, opts.SetTag, opts.UnsetTag, opts.Drop, opts.Rename) {
+		errs = append(errs, errExactlyOneOf("CreateAccountOptions", "Set", "Unset", "SetTag", "UnsetTag", "Drop", "Rename"))
 	}
 	if valueSet(opts.Set) {
 		if err := opts.Set.validate(); err != nil {
@@ -164,13 +166,12 @@ type AccountSet struct {
 	ResourceMonitor AccountObjectIdentifier `ddl:"identifier,equals" sql:"RESOURCE_MONITOR"`
 	PasswordPolicy  SchemaObjectIdentifier  `ddl:"identifier" sql:"PASSWORD POLICY"`
 	SessionPolicy   SchemaObjectIdentifier  `ddl:"identifier" sql:"SESSION POLICY"`
-	Tag             []TagAssociation        `ddl:"keyword" sql:"TAG"`
 }
 
 func (opts *AccountSet) validate() error {
 	var errs []error
-	if !exactlyOneValueSet(opts.Parameters, opts.ResourceMonitor, opts.PasswordPolicy, opts.SessionPolicy, opts.Tag) {
-		errs = append(errs, errExactlyOneOf("AccountSet", "Parameters", "ResourceMonitor", "PasswordPolicy", "SessionPolicy", "Tag"))
+	if !exactlyOneValueSet(opts.Parameters, opts.ResourceMonitor, opts.PasswordPolicy, opts.SessionPolicy) {
+		errs = append(errs, errExactlyOneOf("AccountSet", "Parameters", "ResourceMonitor", "PasswordPolicy", "SessionPolicy"))
 	}
 	if valueSet(opts.Parameters) {
 		if err := opts.Parameters.validate(); err != nil {
@@ -198,13 +199,12 @@ type AccountUnset struct {
 	Parameters     *AccountLevelParametersUnset `ddl:"list,no_parentheses"`
 	PasswordPolicy *bool                        `ddl:"keyword" sql:"PASSWORD POLICY"`
 	SessionPolicy  *bool                        `ddl:"keyword" sql:"SESSION POLICY"`
-	Tag            []ObjectIdentifier           `ddl:"keyword" sql:"TAG"`
 }
 
 func (opts *AccountUnset) validate() error {
 	var errs []error
-	if !exactlyOneValueSet(opts.Parameters, opts.PasswordPolicy, opts.SessionPolicy, opts.Tag) {
-		errs = append(errs, errExactlyOneOf("AccountUnset", "Parameters", "PasswordPolicy", "SessionPolicy", "Tag"))
+	if !exactlyOneValueSet(opts.Parameters, opts.PasswordPolicy, opts.SessionPolicy) {
+		errs = append(errs, errExactlyOneOf("AccountUnset", "Parameters", "PasswordPolicy", "SessionPolicy"))
 	}
 	if valueSet(opts.Parameters) {
 		if err := opts.Parameters.validate(); err != nil {

--- a/pkg/sdk/accounts_test.go
+++ b/pkg/sdk/accounts_test.go
@@ -140,16 +140,14 @@ func TestAccountAlter(t *testing.T) {
 
 	t.Run("with set tag", func(t *testing.T) {
 		opts := &AlterAccountOptions{
-			Set: &AccountSet{
-				Tag: []TagAssociation{
-					{
-						Name:  NewSchemaObjectIdentifier("db", "schema", "tag1"),
-						Value: "v1",
-					},
-					{
-						Name:  NewSchemaObjectIdentifier("db", "schema", "tag2"),
-						Value: "v2",
-					},
+			SetTag: []TagAssociation{
+				{
+					Name:  NewSchemaObjectIdentifier("db", "schema", "tag1"),
+					Value: "v1",
+				},
+				{
+					Name:  NewSchemaObjectIdentifier("db", "schema", "tag2"),
+					Value: "v2",
 				},
 			},
 		}
@@ -158,10 +156,8 @@ func TestAccountAlter(t *testing.T) {
 
 	t.Run("with unset tag", func(t *testing.T) {
 		opts := &AlterAccountOptions{
-			Unset: &AccountUnset{
-				Tag: []ObjectIdentifier{
-					NewSchemaObjectIdentifier("db", "schema", "tag1"),
-				},
+			UnsetTag: []ObjectIdentifier{
+				NewSchemaObjectIdentifier("db", "schema", "tag1"),
 			},
 		}
 		assertOptsValidAndSQLEquals(t, opts, `ALTER ACCOUNT UNSET TAG "db"."schema"."tag1"`)

--- a/pkg/sdk/errors.go
+++ b/pkg/sdk/errors.go
@@ -53,7 +53,7 @@ func errNotSet(structName string, fieldNames ...string) error {
 }
 
 func errExactlyOneOf(structName string, fieldNames ...string) error {
-	return newError(fmt.Sprintf("exactly one of %s fileds %v must be set", structName, fieldNames), 2)
+	return newError(fmt.Sprintf("exactly one of %s fields %v must be set", structName, fieldNames), 2)
 }
 
 func errAtLeastOneOf(structName string, fieldNames ...string) error {

--- a/pkg/sdk/masking_policy.go
+++ b/pkg/sdk/masking_policy.go
@@ -99,6 +99,8 @@ type AlterMaskingPolicyOptions struct {
 	NewName       *SchemaObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
 	Set           *MaskingPolicySet       `ddl:"keyword" sql:"SET"`
 	Unset         *MaskingPolicyUnset     `ddl:"keyword" sql:"UNSET"`
+	SetTag        []TagAssociation        `ddl:"keyword" sql:"SET TAG"`
+	UnsetTag      []ObjectIdentifier      `ddl:"keyword" sql:"UNSET TAG"`
 }
 
 func (opts *AlterMaskingPolicyOptions) validate() error {
@@ -112,8 +114,8 @@ func (opts *AlterMaskingPolicyOptions) validate() error {
 	if opts.NewName != nil && !ValidObjectIdentifier(opts.NewName) {
 		errs = append(errs, errInvalidIdentifier("AlterMaskingPolicyOptions", "NewName"))
 	}
-	if !exactlyOneValueSet(opts.NewName, opts.Set, opts.Unset) {
-		errs = append(errs, errExactlyOneOf("AlterMaskingPolicyOptions", "NewName", "Set", "Unset"))
+	if !exactlyOneValueSet(opts.Set, opts.Unset, opts.SetTag, opts.UnsetTag, opts.NewName) {
+		errs = append(errs, errExactlyOneOf("AlterMaskingPolicyOptions", "Set", "Unset", "SetTag", "UnsetTag", "NewName"))
 	}
 	if valueSet(opts.Set) {
 		if err := opts.Set.validate(); err != nil {
@@ -129,26 +131,24 @@ func (opts *AlterMaskingPolicyOptions) validate() error {
 }
 
 type MaskingPolicySet struct {
-	Body    *string          `ddl:"parameter,no_equals" sql:"BODY ->"`
-	Tag     []TagAssociation `ddl:"keyword" sql:"TAG"`
-	Comment *string          `ddl:"parameter,single_quotes" sql:"COMMENT"`
+	Body    *string `ddl:"parameter,no_equals" sql:"BODY ->"`
+	Comment *string `ddl:"parameter,single_quotes" sql:"COMMENT"`
 }
 
 func (v *MaskingPolicySet) validate() error {
-	if !exactlyOneValueSet(v.Body, v.Tag, v.Comment) {
-		return errExactlyOneOf("MaskingPolicySet", "Body", "Tag", "Comment")
+	if !exactlyOneValueSet(v.Body, v.Comment) {
+		return errExactlyOneOf("MaskingPolicySet", "Body", "Comment")
 	}
 	return nil
 }
 
 type MaskingPolicyUnset struct {
-	Tag     []ObjectIdentifier `ddl:"keyword" sql:"TAG"`
-	Comment *bool              `ddl:"keyword" sql:"COMMENT"`
+	Comment *bool `ddl:"keyword" sql:"COMMENT"`
 }
 
 func (v *MaskingPolicyUnset) validate() error {
-	if !exactlyOneValueSet(v.Tag, v.Comment) {
-		return errExactlyOneOf("MaskingPolicyUnset", "Tag", "Comment")
+	if !exactlyOneValueSet(v.Comment) {
+		return errExactlyOneOf("MaskingPolicyUnset", "Comment")
 	}
 	return nil
 }

--- a/pkg/sdk/masking_policy_test.go
+++ b/pkg/sdk/masking_policy_test.go
@@ -88,7 +88,7 @@ func TestMaskingPolicyAlter(t *testing.T) {
 		opts := &AlterMaskingPolicyOptions{
 			name: id,
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterMaskingPolicyOptions", "NewName", "Set", "Unset"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterMaskingPolicyOptions", "Set", "Unset", "SetTag", "UnsetTag", "NewName"))
 	})
 
 	t.Run("with set", func(t *testing.T) {

--- a/pkg/sdk/pipes.go
+++ b/pkg/sdk/pipes.go
@@ -42,11 +42,11 @@ type AlterPipeOptions struct {
 	name     SchemaObjectIdentifier `ddl:"identifier"`
 
 	// One of
-	Set       *PipeSet       `ddl:"list,no_parentheses" sql:"SET"`
-	Unset     *PipeUnset     `ddl:"list,no_parentheses" sql:"UNSET"`
-	SetTags   *PipeSetTags   `ddl:"list,no_parentheses" sql:"SET TAG"`
-	UnsetTags *PipeUnsetTags `ddl:"list,no_parentheses" sql:"UNSET TAG"`
-	Refresh   *PipeRefresh   `ddl:"keyword" sql:"REFRESH"`
+	Set      *PipeSet           `ddl:"list,no_parentheses" sql:"SET"`
+	Unset    *PipeUnset         `ddl:"list,no_parentheses" sql:"UNSET"`
+	SetTag   []TagAssociation   `ddl:"keyword" sql:"SET TAG"`
+	UnsetTag []ObjectIdentifier `ddl:"keyword" sql:"UNSET TAG"`
+	Refresh  *PipeRefresh       `ddl:"keyword" sql:"REFRESH"`
 }
 
 type PipeSet struct {
@@ -58,14 +58,6 @@ type PipeSet struct {
 type PipeUnset struct {
 	PipeExecutionPaused *bool `ddl:"keyword" sql:"PIPE_EXECUTION_PAUSED"`
 	Comment             *bool `ddl:"keyword" sql:"COMMENT"`
-}
-
-type PipeSetTags struct {
-	Tag []TagAssociation `ddl:"keyword"`
-}
-
-type PipeUnsetTags struct {
-	Tag []ObjectIdentifier `ddl:"keyword"`
 }
 
 type PipeRefresh struct {

--- a/pkg/sdk/pipes_test.go
+++ b/pkg/sdk/pipes_test.go
@@ -70,7 +70,7 @@ func TestPipesAlter(t *testing.T) {
 
 	t.Run("validation: no alter action", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTags", "UnsetTags", "Refresh"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTag", "UnsetTag", "Refresh"))
 	})
 
 	t.Run("validation: multiple alter actions", func(t *testing.T) {
@@ -81,7 +81,7 @@ func TestPipesAlter(t *testing.T) {
 		opts.Unset = &PipeUnset{
 			Comment: Bool(true),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTags", "UnsetTags", "Refresh"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTag", "UnsetTag", "Refresh"))
 	})
 
 	t.Run("validation: no property to set", func(t *testing.T) {
@@ -90,36 +90,18 @@ func TestPipesAlter(t *testing.T) {
 		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterPipeOptions.Set", "ErrorIntegration", "PipeExecutionPaused", "Comment"))
 	})
 
-	t.Run("validation: empty tags slice for set", func(t *testing.T) {
-		opts := defaultOpts()
-		opts.SetTags = &PipeSetTags{
-			Tag: []TagAssociation{},
-		}
-		assertOptsInvalidJoinedErrors(t, opts, errNotSet("AlterPipeOptions.SetTags", "Tag"))
-	})
-
 	t.Run("validation: no property to unset", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Unset = &PipeUnset{}
 		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterPipeOptions.Unset", "PipeExecutionPaused", "Comment"))
 	})
 
-	t.Run("validation: empty tags slice for unset", func(t *testing.T) {
-		opts := defaultOpts()
-		opts.UnsetTags = &PipeUnsetTags{
-			Tag: []ObjectIdentifier{},
-		}
-		assertOptsInvalidJoinedErrors(t, opts, errNotSet("AlterPipeOptions.UnsetTags", "Tag"))
-	})
-
 	t.Run("set tag: single", func(t *testing.T) {
 		opts := defaultOpts()
-		opts.SetTags = &PipeSetTags{
-			Tag: []TagAssociation{
-				{
-					Name:  NewAccountObjectIdentifier("tag_name1"),
-					Value: "v1",
-				},
+		opts.SetTag = []TagAssociation{
+			{
+				Name:  NewAccountObjectIdentifier("tag_name1"),
+				Value: "v1",
 			},
 		}
 		assertOptsValidAndSQLEquals(t, opts, `ALTER PIPE %s SET TAG "tag_name1" = 'v1'`, id.FullyQualifiedName())
@@ -127,16 +109,14 @@ func TestPipesAlter(t *testing.T) {
 
 	t.Run("set tag: multiple", func(t *testing.T) {
 		opts := defaultOpts()
-		opts.SetTags = &PipeSetTags{
-			Tag: []TagAssociation{
-				{
-					Name:  NewAccountObjectIdentifier("tag_name1"),
-					Value: "v1",
-				},
-				{
-					Name:  NewAccountObjectIdentifier("tag_name2"),
-					Value: "v2",
-				},
+		opts.SetTag = []TagAssociation{
+			{
+				Name:  NewAccountObjectIdentifier("tag_name1"),
+				Value: "v1",
+			},
+			{
+				Name:  NewAccountObjectIdentifier("tag_name2"),
+				Value: "v2",
 			},
 		}
 		assertOptsValidAndSQLEquals(t, opts, `ALTER PIPE %s SET TAG "tag_name1" = 'v1', "tag_name2" = 'v2'`, id.FullyQualifiedName())
@@ -155,21 +135,17 @@ func TestPipesAlter(t *testing.T) {
 
 	t.Run("unset tag: single", func(t *testing.T) {
 		opts := defaultOpts()
-		opts.UnsetTags = &PipeUnsetTags{
-			Tag: []ObjectIdentifier{
-				NewAccountObjectIdentifier("tag_name1"),
-			},
+		opts.UnsetTag = []ObjectIdentifier{
+			NewAccountObjectIdentifier("tag_name1"),
 		}
 		assertOptsValidAndSQLEquals(t, opts, `ALTER PIPE %s UNSET TAG "tag_name1"`, id.FullyQualifiedName())
 	})
 
 	t.Run("unset tag: multi", func(t *testing.T) {
 		opts := defaultOpts()
-		opts.UnsetTags = &PipeUnsetTags{
-			Tag: []ObjectIdentifier{
-				NewAccountObjectIdentifier("tag_name1"),
-				NewAccountObjectIdentifier("tag_name2"),
-			},
+		opts.UnsetTag = []ObjectIdentifier{
+			NewAccountObjectIdentifier("tag_name1"),
+			NewAccountObjectIdentifier("tag_name2"),
 		}
 		assertOptsValidAndSQLEquals(t, opts, `ALTER PIPE %s UNSET TAG "tag_name1", "tag_name2"`, id.FullyQualifiedName())
 	})

--- a/pkg/sdk/pipes_validations.go
+++ b/pkg/sdk/pipes_validations.go
@@ -34,8 +34,14 @@ func (opts *AlterPipeOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if ok := exactlyOneValueSet(opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags, opts.Refresh); !ok {
-		errs = append(errs, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTags", "UnsetTags", "Refresh"))
+	if ok := exactlyOneValueSet(
+		opts.Set,
+		opts.Unset,
+		opts.SetTag,
+		opts.UnsetTag,
+		opts.Refresh,
+	); !ok {
+		errs = append(errs, errExactlyOneOf("AlterPipeOptions", "Set", "Unset", "SetTag", "UnsetTag", "Refresh"))
 	}
 	if set := opts.Set; valueSet(set) {
 		if !anyValueSet(set.ErrorIntegration, set.PipeExecutionPaused, set.Comment) {
@@ -45,16 +51,6 @@ func (opts *AlterPipeOptions) validate() error {
 	if unset := opts.Unset; valueSet(unset) {
 		if !anyValueSet(unset.PipeExecutionPaused, unset.Comment) {
 			errs = append(errs, errAtLeastOneOf("AlterPipeOptions.Unset", "PipeExecutionPaused", "Comment"))
-		}
-	}
-	if setTags := opts.SetTags; valueSet(setTags) {
-		if !valueSet(setTags.Tag) {
-			errs = append(errs, errNotSet("AlterPipeOptions.SetTags", "Tag"))
-		}
-	}
-	if unsetTags := opts.UnsetTags; valueSet(unsetTags) {
-		if !valueSet(unsetTags.Tag) {
-			errs = append(errs, errNotSet("AlterPipeOptions.UnsetTags", "Tag"))
 		}
 	}
 	return errors.Join(errs...)

--- a/pkg/sdk/schemas.go
+++ b/pkg/sdk/schemas.go
@@ -152,6 +152,8 @@ type AlterSchemaOptions struct {
 	SwapWith DatabaseObjectIdentifier `ddl:"identifier" sql:"SWAP WITH"`
 	Set      *SchemaSet               `ddl:"list,no_parentheses" sql:"SET"`
 	Unset    *SchemaUnset             `ddl:"list,no_parentheses" sql:"UNSET"`
+	SetTag   []TagAssociation         `ddl:"keyword" sql:"SET TAG"`
+	UnsetTag []ObjectIdentifier       `ddl:"keyword" sql:"UNSET TAG"`
 	// One of
 	EnableManagedAccess  *bool `ddl:"keyword" sql:"ENABLE MANAGED ACCESS"`
 	DisableManagedAccess *bool `ddl:"keyword" sql:"DISABLE MANAGED ACCESS"`
@@ -165,8 +167,8 @@ func (opts *AlterSchemaOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.NewName, opts.SwapWith, opts.Set, opts.Unset, opts.EnableManagedAccess, opts.DisableManagedAccess) {
-		errs = append(errs, errOneOf("NewName", "SwapWith", "Set", "Unset", "EnableManagedAccess", "DisableManagedAccess"))
+	if !exactlyOneValueSet(opts.NewName, opts.SwapWith, opts.Set, opts.Unset, opts.SetTag, opts.UnsetTag, opts.EnableManagedAccess, opts.DisableManagedAccess) {
+		errs = append(errs, errOneOf("NewName", "SwapWith", "Set", "Unset", "SetTag", "UnsetTag", "EnableManagedAccess", "DisableManagedAccess"))
 	}
 	if valueSet(opts.Set) {
 		if err := opts.Set.validate(); err != nil {
@@ -182,31 +184,29 @@ func (opts *AlterSchemaOptions) validate() error {
 }
 
 type SchemaSet struct {
-	DataRetentionTimeInDays    *int             `ddl:"parameter" sql:"DATA_RETENTION_TIME_IN_DAYS"`
-	MaxDataExtensionTimeInDays *int             `ddl:"parameter" sql:"MAX_DATA_EXTENSION_TIME_IN_DAYS"`
-	DefaultDDLCollation        *string          `ddl:"parameter,single_quotes" sql:"DEFAULT_DDL_COLLATION"`
-	Comment                    *string          `ddl:"parameter,single_quotes" sql:"COMMENT"`
-	Tag                        []TagAssociation `ddl:"keyword" sql:"TAG"`
+	DataRetentionTimeInDays    *int    `ddl:"parameter" sql:"DATA_RETENTION_TIME_IN_DAYS"`
+	MaxDataExtensionTimeInDays *int    `ddl:"parameter" sql:"MAX_DATA_EXTENSION_TIME_IN_DAYS"`
+	DefaultDDLCollation        *string `ddl:"parameter,single_quotes" sql:"DEFAULT_DDL_COLLATION"`
+	Comment                    *string `ddl:"parameter,single_quotes" sql:"COMMENT"`
 }
 
 func (v *SchemaSet) validate() error {
-	if valueSet(v.Tag) && anyValueSet(v.DataRetentionTimeInDays, v.MaxDataExtensionTimeInDays, v.DefaultDDLCollation, v.Comment) {
-		return errors.New("tag field cannot be set with other options")
+	if !anyValueSet(v.DataRetentionTimeInDays, v.MaxDataExtensionTimeInDays, v.DefaultDDLCollation, v.Comment) {
+		return errAtLeastOneOf("DataRetentionTimeInDays", "MaxDataExtensionTimeInDays", "DefaultDDLCollation", "Comment")
 	}
 	return nil
 }
 
 type SchemaUnset struct {
-	DataRetentionTimeInDays    *bool              `ddl:"keyword" sql:"DATA_RETENTION_TIME_IN_DAYS"`
-	MaxDataExtensionTimeInDays *bool              `ddl:"keyword" sql:"MAX_DATA_EXTENSION_TIME_IN_DAYS"`
-	DefaultDDLCollation        *bool              `ddl:"keyword" sql:"DEFAULT_DDL_COLLATION"`
-	Comment                    *bool              `ddl:"keyword" sql:"COMMENT"`
-	Tag                        []ObjectIdentifier `ddl:"keyword" sql:"TAG"`
+	DataRetentionTimeInDays    *bool `ddl:"keyword" sql:"DATA_RETENTION_TIME_IN_DAYS"`
+	MaxDataExtensionTimeInDays *bool `ddl:"keyword" sql:"MAX_DATA_EXTENSION_TIME_IN_DAYS"`
+	DefaultDDLCollation        *bool `ddl:"keyword" sql:"DEFAULT_DDL_COLLATION"`
+	Comment                    *bool `ddl:"keyword" sql:"COMMENT"`
 }
 
 func (v *SchemaUnset) validate() error {
-	if valueSet(v.Tag) && anyValueSet(v.DataRetentionTimeInDays, v.MaxDataExtensionTimeInDays, v.DefaultDDLCollation, v.Comment) {
-		return errors.New("tag field cannot be set with other options")
+	if !anyValueSet(v.DataRetentionTimeInDays, v.MaxDataExtensionTimeInDays, v.DefaultDDLCollation, v.Comment) {
+		return errAtLeastOneOf("DataRetentionTimeInDays", "MaxDataExtensionTimeInDays", "DefaultDDLCollation", "Comment")
 	}
 	return nil
 }

--- a/pkg/sdk/schemas.go
+++ b/pkg/sdk/schemas.go
@@ -192,7 +192,7 @@ type SchemaSet struct {
 
 func (v *SchemaSet) validate() error {
 	if !anyValueSet(v.DataRetentionTimeInDays, v.MaxDataExtensionTimeInDays, v.DefaultDDLCollation, v.Comment) {
-		return errAtLeastOneOf("DataRetentionTimeInDays", "MaxDataExtensionTimeInDays", "DefaultDDLCollation", "Comment")
+		return errAtLeastOneOf("SchemaSet", "DataRetentionTimeInDays", "MaxDataExtensionTimeInDays", "DefaultDDLCollation", "Comment")
 	}
 	return nil
 }
@@ -206,7 +206,7 @@ type SchemaUnset struct {
 
 func (v *SchemaUnset) validate() error {
 	if !anyValueSet(v.DataRetentionTimeInDays, v.MaxDataExtensionTimeInDays, v.DefaultDDLCollation, v.Comment) {
-		return errAtLeastOneOf("DataRetentionTimeInDays", "MaxDataExtensionTimeInDays", "DefaultDDLCollation", "Comment")
+		return errAtLeastOneOf("SchemaUnset", "DataRetentionTimeInDays", "MaxDataExtensionTimeInDays", "DefaultDDLCollation", "Comment")
 	}
 	return nil
 }

--- a/pkg/sdk/schemas_test.go
+++ b/pkg/sdk/schemas_test.go
@@ -78,16 +78,14 @@ func TestSchemasAlter(t *testing.T) {
 	t.Run("set tags", func(t *testing.T) {
 		opts := &AlterSchemaOptions{
 			name: NewDatabaseObjectIdentifier("database_name", "schema_name"),
-			Set: &SchemaSet{
-				Tag: []TagAssociation{
-					{
-						Name:  NewAccountObjectIdentifier("tag1"),
-						Value: "value1",
-					},
-					{
-						Name:  NewAccountObjectIdentifier("tag2"),
-						Value: "value2",
-					},
+			SetTag: []TagAssociation{
+				{
+					Name:  NewAccountObjectIdentifier("tag1"),
+					Value: "value1",
+				},
+				{
+					Name:  NewAccountObjectIdentifier("tag2"),
+					Value: "value2",
 				},
 			},
 		}
@@ -97,11 +95,9 @@ func TestSchemasAlter(t *testing.T) {
 	t.Run("unset tags", func(t *testing.T) {
 		opts := &AlterSchemaOptions{
 			name: NewDatabaseObjectIdentifier("database_name", "schema_name"),
-			Unset: &SchemaUnset{
-				Tag: []ObjectIdentifier{
-					NewAccountObjectIdentifier("tag1"),
-					NewAccountObjectIdentifier("tag2"),
-				},
+			UnsetTag: []ObjectIdentifier{
+				NewAccountObjectIdentifier("tag1"),
+				NewAccountObjectIdentifier("tag2"),
 			},
 		}
 		assertOptsValidAndSQLEquals(t, opts, `ALTER SCHEMA "database_name"."schema_name" UNSET TAG "tag1", "tag2"`)

--- a/pkg/sdk/shares.go
+++ b/pkg/sdk/shares.go
@@ -179,6 +179,8 @@ type AlterShareOptions struct {
 	Remove   *ShareRemove            `ddl:"keyword" sql:"REMOVE"`
 	Set      *ShareSet               `ddl:"keyword" sql:"SET"`
 	Unset    *ShareUnset             `ddl:"keyword" sql:"UNSET"`
+	SetTag   []TagAssociation        `ddl:"keyword" sql:"SET TAG"`
+	UnsetTag []ObjectIdentifier      `ddl:"keyword" sql:"UNSET TAG"`
 }
 
 func (opts *AlterShareOptions) validate() error {
@@ -189,8 +191,8 @@ func (opts *AlterShareOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.Add, opts.Remove, opts.Set, opts.Unset) {
-		errs = append(errs, errExactlyOneOf("AlterShareOptions", "Add", "Remove", "Set", "Unset"))
+	if !exactlyOneValueSet(opts.Add, opts.Remove, opts.Set, opts.Unset, opts.SetTag, opts.UnsetTag) {
+		errs = append(errs, errExactlyOneOf("AlterShareOptions", "Add", "Remove", "Set", "Unset", "SetTag", "UnsetTag"))
 	}
 	if valueSet(opts.Add) {
 		if err := opts.Add.validate(); err != nil {
@@ -241,24 +243,22 @@ func (v *ShareRemove) validate() error {
 type ShareSet struct {
 	Accounts []AccountIdentifier `ddl:"parameter" sql:"ACCOUNTS"`
 	Comment  *string             `ddl:"parameter,single_quotes" sql:"COMMENT"`
-	Tag      []TagAssociation    `ddl:"keyword" sql:"TAG"`
 }
 
 func (v *ShareSet) validate() error {
-	if valueSet(v.Tag) && anyValueSet(v.Accounts, v.Comment) {
-		return fmt.Errorf("accounts and comment cannot be set when tag is set")
+	if !anyValueSet(v.Accounts, v.Comment) {
+		return errAtLeastOneOf("Accounts", "Comment")
 	}
 	return nil
 }
 
 type ShareUnset struct {
-	Tag     []ObjectIdentifier `ddl:"keyword" sql:"TAG"`
-	Comment *bool              `ddl:"keyword" sql:"COMMENT"`
+	Comment *bool `ddl:"keyword" sql:"COMMENT"`
 }
 
 func (v *ShareUnset) validate() error {
-	if !exactlyOneValueSet(v.Comment, v.Tag) {
-		return errExactlyOneOf("ShareUnset", "Comment", "Tag")
+	if !exactlyOneValueSet(v.Comment) {
+		return errExactlyOneOf("ShareUnset", "Comment")
 	}
 	return nil
 }

--- a/pkg/sdk/shares.go
+++ b/pkg/sdk/shares.go
@@ -247,7 +247,7 @@ type ShareSet struct {
 
 func (v *ShareSet) validate() error {
 	if !anyValueSet(v.Accounts, v.Comment) {
-		return errAtLeastOneOf("Accounts", "Comment")
+		return errAtLeastOneOf("ShareSet", "Accounts", "Comment")
 	}
 	return nil
 }

--- a/pkg/sdk/shares_test.go
+++ b/pkg/sdk/shares_test.go
@@ -30,7 +30,7 @@ func TestShareAlter(t *testing.T) {
 		opts := &AlterShareOptions{
 			name: NewAccountObjectIdentifier("myshare"),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterShareOptions", "Add", "Remove", "Set", "Unset"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterShareOptions", "Add", "Remove", "Set", "Unset", "SetTag", "UnsetTag"))
 	})
 
 	t.Run("with add", func(t *testing.T) {
@@ -76,12 +76,10 @@ func TestShareAlter(t *testing.T) {
 		opts := &AlterShareOptions{
 			IfExists: Bool(true),
 			name:     NewAccountObjectIdentifier("myshare"),
-			Set: &ShareSet{
-				Tag: []TagAssociation{
-					{
-						Name:  NewSchemaObjectIdentifier("db", "schema", "tag"),
-						Value: "v1",
-					},
+			SetTag: []TagAssociation{
+				{
+					Name:  NewSchemaObjectIdentifier("db", "schema", "tag"),
+					Value: "v1",
 				},
 			},
 		}
@@ -103,10 +101,8 @@ func TestShareAlter(t *testing.T) {
 		opts := &AlterShareOptions{
 			IfExists: Bool(true),
 			name:     NewAccountObjectIdentifier("myshare"),
-			Unset: &ShareUnset{
-				Tag: []ObjectIdentifier{
-					NewSchemaObjectIdentifier("db", "schema", "tag"),
-				},
+			UnsetTag: []ObjectIdentifier{
+				NewSchemaObjectIdentifier("db", "schema", "tag"),
 			},
 		}
 		assertOptsValidAndSQLEquals(t, opts, `ALTER SHARE IF EXISTS "myshare" UNSET TAG "db"."schema"."tag"`)

--- a/pkg/sdk/testint/accounts_integration_test.go
+++ b/pkg/sdk/testint/accounts_integration_test.go
@@ -282,16 +282,14 @@ func TestInt_AccountAlter(t *testing.T) {
 		t.Cleanup(tagCleanup2)
 
 		opts := &sdk.AlterAccountOptions{
-			Set: &sdk.AccountSet{
-				Tag: []sdk.TagAssociation{
-					{
-						Name:  tagTest1.ID(),
-						Value: "abc",
-					},
-					{
-						Name:  tagTest2.ID(),
-						Value: "123",
-					},
+			SetTag: []sdk.TagAssociation{
+				{
+					Name:  tagTest1.ID(),
+					Value: "abc",
+				},
+				{
+					Name:  tagTest2.ID(),
+					Value: "123",
 				},
 			},
 		}

--- a/pkg/sdk/testint/masking_policy_integration_test.go
+++ b/pkg/sdk/testint/masking_policy_integration_test.go
@@ -342,9 +342,7 @@ func TestInt_MaskingPolicyAlter(t *testing.T) {
 
 		tagAssociations := []sdk.TagAssociation{{Name: tag.ID(), Value: "value1"}, {Name: tag2.ID(), Value: "value2"}}
 		alterOptions := &sdk.AlterMaskingPolicyOptions{
-			Set: &sdk.MaskingPolicySet{
-				Tag: tagAssociations,
-			},
+			SetTag: tagAssociations,
 		}
 		err := client.MaskingPolicies.Alter(ctx, id, alterOptions)
 		require.NoError(t, err)
@@ -357,9 +355,7 @@ func TestInt_MaskingPolicyAlter(t *testing.T) {
 
 		// unset tag
 		alterOptions = &sdk.AlterMaskingPolicyOptions{
-			Unset: &sdk.MaskingPolicyUnset{
-				Tag: []sdk.ObjectIdentifier{tag.ID()},
-			},
+			UnsetTag: []sdk.ObjectIdentifier{tag.ID()},
 		}
 		err = client.MaskingPolicies.Alter(ctx, id, alterOptions)
 		require.NoError(t, err)

--- a/pkg/sdk/testint/pipes_integration_test.go
+++ b/pkg/sdk/testint/pipes_integration_test.go
@@ -304,12 +304,10 @@ func TestInt_PipeAlter(t *testing.T) {
 
 		tagValue := "abc"
 		alterOptions := &sdk.AlterPipeOptions{
-			SetTags: &sdk.PipeSetTags{
-				Tag: []sdk.TagAssociation{
-					{
-						Name:  tag.ID(),
-						Value: tagValue,
-					},
+			SetTag: []sdk.TagAssociation{
+				{
+					Name:  tag.ID(),
+					Value: tagValue,
 				},
 			},
 		}
@@ -323,10 +321,8 @@ func TestInt_PipeAlter(t *testing.T) {
 		assert.Equal(t, tagValue, returnedTagValue)
 
 		alterOptions = &sdk.AlterPipeOptions{
-			UnsetTags: &sdk.PipeUnsetTags{
-				Tag: []sdk.ObjectIdentifier{
-					tag.ID(),
-				},
+			UnsetTag: []sdk.ObjectIdentifier{
+				tag.ID(),
 			},
 		}
 

--- a/pkg/sdk/testint/schemas_integration_test.go
+++ b/pkg/sdk/testint/schemas_integration_test.go
@@ -225,12 +225,10 @@ func TestInt_SchemasAlter(t *testing.T) {
 
 		tagValue := "tag-value"
 		err = client.Schemas.Alter(ctx, schemaID, &sdk.AlterSchemaOptions{
-			Set: &sdk.SchemaSet{
-				Tag: []sdk.TagAssociation{
-					{
-						Name:  tag.ID(),
-						Value: tagValue,
-					},
+			SetTag: []sdk.TagAssociation{
+				{
+					Name:  tag.ID(),
+					Value: tagValue,
 				},
 			},
 		})
@@ -268,10 +266,8 @@ func TestInt_SchemasAlter(t *testing.T) {
 		})
 
 		err = client.Schemas.Alter(ctx, schemaID, &sdk.AlterSchemaOptions{
-			Unset: &sdk.SchemaUnset{
-				Tag: []sdk.ObjectIdentifier{
-					tagID,
-				},
+			UnsetTag: []sdk.ObjectIdentifier{
+				tagID,
 			},
 		})
 		require.NoError(t, err)

--- a/pkg/sdk/testint/shares_integration_test.go
+++ b/pkg/sdk/testint/shares_integration_test.go
@@ -299,9 +299,7 @@ func TestInt_SharesAlter(t *testing.T) {
 		}
 		err = client.Shares.Alter(ctx, shareTest.ID(), &sdk.AlterShareOptions{
 			IfExists: sdk.Bool(true),
-			Set: &sdk.ShareSet{
-				Tag: tagAssociations,
-			},
+			SetTag:   tagAssociations,
 		})
 		require.NoError(t, err)
 		tagValue, err := client.SystemFunctions.GetTag(ctx, tagTest.ID(), shareTest.ID(), sdk.ObjectTypeShare)
@@ -314,10 +312,8 @@ func TestInt_SharesAlter(t *testing.T) {
 		// unset tags
 		err = client.Shares.Alter(ctx, shareTest.ID(), &sdk.AlterShareOptions{
 			IfExists: sdk.Bool(true),
-			Unset: &sdk.ShareUnset{
-				Tag: []sdk.ObjectIdentifier{
-					tagTest.ID(),
-				},
+			UnsetTag: []sdk.ObjectIdentifier{
+				tagTest.ID(),
 			},
 		})
 		require.NoError(t, err)

--- a/pkg/sdk/testint/system_functions_integration_test.go
+++ b/pkg/sdk/testint/system_functions_integration_test.go
@@ -22,12 +22,10 @@ func TestInt_GetTag(t *testing.T) {
 
 		tagValue := random.String()
 		err := client.MaskingPolicies.Alter(ctx, maskingPolicyTest.ID(), &sdk.AlterMaskingPolicyOptions{
-			Set: &sdk.MaskingPolicySet{
-				Tag: []sdk.TagAssociation{
-					{
-						Name:  tagTest.ID(),
-						Value: tagValue,
-					},
+			SetTag: []sdk.TagAssociation{
+				{
+					Name:  tagTest.ID(),
+					Value: tagValue,
 				},
 			},
 		})

--- a/pkg/sdk/testint/warehouses_integration_test.go
+++ b/pkg/sdk/testint/warehouses_integration_test.go
@@ -440,16 +440,14 @@ func TestInt_WarehouseAlter(t *testing.T) {
 		t.Cleanup(warehouseCleanup)
 
 		alterOptions := &sdk.AlterWarehouseOptions{
-			Set: &sdk.WarehouseSet{
-				Tag: []sdk.TagAssociation{
-					{
-						Name:  tag.ID(),
-						Value: "val",
-					},
-					{
-						Name:  tag2.ID(),
-						Value: "val2",
-					},
+			SetTag: []sdk.TagAssociation{
+				{
+					Name:  tag.ID(),
+					Value: "val",
+				},
+				{
+					Name:  tag2.ID(),
+					Value: "val2",
 				},
 			},
 		}
@@ -470,16 +468,14 @@ func TestInt_WarehouseAlter(t *testing.T) {
 		t.Cleanup(warehouseCleanup)
 
 		alterOptions := &sdk.AlterWarehouseOptions{
-			Set: &sdk.WarehouseSet{
-				Tag: []sdk.TagAssociation{
-					{
-						Name:  tag.ID(),
-						Value: "val1",
-					},
-					{
-						Name:  tag2.ID(),
-						Value: "val2",
-					},
+			SetTag: []sdk.TagAssociation{
+				{
+					Name:  tag.ID(),
+					Value: "val1",
+				},
+				{
+					Name:  tag2.ID(),
+					Value: "val2",
 				},
 			},
 		}
@@ -493,11 +489,9 @@ func TestInt_WarehouseAlter(t *testing.T) {
 		require.Equal(t, "val2", val2)
 
 		alterOptions = &sdk.AlterWarehouseOptions{
-			Unset: &sdk.WarehouseUnset{
-				Tag: []sdk.ObjectIdentifier{
-					tag.ID(),
-					tag2.ID(),
-				},
+			UnsetTag: []sdk.ObjectIdentifier{
+				tag.ID(),
+				tag2.ID(),
 			},
 		}
 		err = client.Warehouses.Alter(ctx, warehouse.ID(), alterOptions)

--- a/pkg/sdk/users.go
+++ b/pkg/sdk/users.go
@@ -273,6 +273,8 @@ type AlterUserOptions struct {
 	RemoveDelegatedAuthorization *RemoveDelegatedAuthorization `ddl:"keyword"`
 	Set                          *UserSet                      `ddl:"keyword" sql:"SET"`
 	Unset                        *UserUnset                    `ddl:"keyword" sql:"UNSET"`
+	SetTag                       []TagAssociation              `ddl:"keyword" sql:"SET TAG"`
+	UnsetTag                     []ObjectIdentifier            `ddl:"keyword" sql:"UNSET TAG"`
 }
 
 func (opts *AlterUserOptions) validate() error {
@@ -283,8 +285,8 @@ func (opts *AlterUserOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.NewName, opts.ResetPassword, opts.AbortAllQueries, opts.AddDelegatedAuthorization, opts.RemoveDelegatedAuthorization, opts.Set, opts.Unset) {
-		errs = append(errs, errExactlyOneOf("AlterUserOptions", "NewName", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset"))
+	if !exactlyOneValueSet(opts.NewName, opts.ResetPassword, opts.AbortAllQueries, opts.AddDelegatedAuthorization, opts.RemoveDelegatedAuthorization, opts.Set, opts.Unset, opts.SetTag, opts.UnsetTag) {
+		errs = append(errs, errExactlyOneOf("AlterUserOptions", "NewName", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset", "SetTag", "UnsetTag"))
 	}
 	if valueSet(opts.RemoveDelegatedAuthorization) {
 		if err := opts.RemoveDelegatedAuthorization.validate(); err != nil {
@@ -347,15 +349,14 @@ func (opts *RemoveDelegatedAuthorization) validate() error {
 type UserSet struct {
 	PasswordPolicy    *string               `ddl:"parameter" sql:"PASSWORD POLICY"`
 	SessionPolicy     *string               `ddl:"parameter" sql:"SESSION POLICY"`
-	Tags              []TagAssociation      `ddl:"keyword,parentheses" sql:"TAG"`
 	ObjectProperties  *UserObjectProperties `ddl:"keyword"`
 	ObjectParameters  *UserObjectParameters `ddl:"keyword"`
 	SessionParameters *SessionParameters    `ddl:"keyword"`
 }
 
 func (opts *UserSet) validate() error {
-	if !exactlyOneValueSet(opts.PasswordPolicy, opts.SessionPolicy, opts.Tags, opts.ObjectProperties, opts.ObjectParameters, opts.SessionParameters) {
-		return errExactlyOneOf("UserSet", "PasswordPolicy", "SessionPolicy", "Tags", "ObjectProperties", "ObjectParameters", "SessionParameters")
+	if !exactlyOneValueSet(opts.PasswordPolicy, opts.SessionPolicy, opts.ObjectProperties, opts.ObjectParameters, opts.SessionParameters) {
+		return errExactlyOneOf("UserSet", "PasswordPolicy", "SessionPolicy", "ObjectProperties", "ObjectParameters", "SessionParameters")
 	}
 	return nil
 }
@@ -363,15 +364,14 @@ func (opts *UserSet) validate() error {
 type UserUnset struct {
 	PasswordPolicy    *bool                      `ddl:"keyword" sql:"PASSWORD POLICY"`
 	SessionPolicy     *bool                      `ddl:"keyword" sql:"SESSION POLICY"`
-	Tags              *[]string                  `ddl:"keyword" sql:"TAG"`
 	ObjectProperties  *UserObjectPropertiesUnset `ddl:"list"`
 	ObjectParameters  *UserObjectParametersUnset `ddl:"list"`
 	SessionParameters *SessionParametersUnset    `ddl:"list"`
 }
 
 func (opts *UserUnset) validate() error {
-	if !exactlyOneValueSet(opts.Tags, opts.PasswordPolicy, opts.SessionPolicy, opts.ObjectProperties, opts.ObjectParameters, opts.SessionParameters) {
-		return errExactlyOneOf("UserUnset", "Tags", "PasswordPolicy", "SessionPolicy", "ObjectProperties", "ObjectParameters", "SessionParameters")
+	if !exactlyOneValueSet(opts.PasswordPolicy, opts.SessionPolicy, opts.ObjectProperties, opts.ObjectParameters, opts.SessionParameters) {
+		return errExactlyOneOf("UserUnset", "PasswordPolicy", "SessionPolicy", "ObjectProperties", "ObjectParameters", "SessionParameters")
 	}
 	return nil
 }

--- a/pkg/sdk/users_test.go
+++ b/pkg/sdk/users_test.go
@@ -58,7 +58,7 @@ func TestUserAlter(t *testing.T) {
 		opts := &AlterUserOptions{
 			name: id,
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterUserOptions", "NewName", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterUserOptions", "NewName", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset", "SetTag", "UnsetTag"))
 	})
 
 	t.Run("with setting a policy", func(t *testing.T) {
@@ -84,12 +84,10 @@ func TestUserAlter(t *testing.T) {
 			},
 		}
 		opts := &AlterUserOptions{
-			name: id,
-			Set: &UserSet{
-				Tags: tags,
-			},
+			name:   id,
+			SetTag: tags,
 		}
-		assertOptsValidAndSQLEquals(t, opts, `ALTER USER %s SET TAG ("db"."schema"."tag1" = 'v1', "db"."schema"."tag2" = 'v2')`, id.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, `ALTER USER %s SET TAG "db"."schema"."tag1" = 'v1', "db"."schema"."tag2" = 'v2'`, id.FullyQualifiedName())
 	})
 
 	t.Run("with setting properties and parameters", func(t *testing.T) {
@@ -171,15 +169,13 @@ func TestUserAlter(t *testing.T) {
 	})
 
 	t.Run("with unsetting tags", func(t *testing.T) {
-		tag1 := "USER_TAG1"
-		tag2 := "USER_TAG2"
+		tag1 := NewSchemaObjectIdentifier("db", "schema", "USER_TAG1")
+		tag2 := NewSchemaObjectIdentifier("db", "schema", "USER_TAG2")
 		opts := &AlterUserOptions{
-			name: id,
-			Unset: &UserUnset{
-				Tags: &[]string{tag1, tag2},
-			},
+			name:     id,
+			UnsetTag: []ObjectIdentifier{tag1, tag2},
 		}
-		assertOptsValidAndSQLEquals(t, opts, "ALTER USER %s UNSET TAG %s, %s", id.FullyQualifiedName(), tag1, tag2)
+		assertOptsValidAndSQLEquals(t, opts, "ALTER USER %s UNSET TAG %s, %s", id.FullyQualifiedName(), tag1.FullyQualifiedName(), tag2.FullyQualifiedName())
 	})
 
 	t.Run("with unsetting properties", func(t *testing.T) {

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -165,8 +165,10 @@ type AlterWarehouseOptions struct {
 	AbortAllQueries *bool                    `ddl:"keyword" sql:"ABORT ALL QUERIES"`
 	NewName         *AccountObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
 
-	Set   *WarehouseSet   `ddl:"keyword" sql:"SET"`
-	Unset *WarehouseUnset `ddl:"list,no_parentheses" sql:"UNSET"`
+	Set      *WarehouseSet      `ddl:"keyword" sql:"SET"`
+	Unset    *WarehouseUnset    `ddl:"list,no_parentheses" sql:"UNSET"`
+	SetTag   []TagAssociation   `ddl:"keyword" sql:"SET TAG"`
+	UnsetTag []ObjectIdentifier `ddl:"keyword" sql:"UNSET TAG"`
 }
 
 func (opts *AlterWarehouseOptions) validate() error {
@@ -177,8 +179,8 @@ func (opts *AlterWarehouseOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.Suspend, opts.Resume, opts.AbortAllQueries, opts.NewName, opts.Set, opts.Unset) {
-		errs = append(errs, errExactlyOneOf("AlterWarehouseOptions", "Suspend", "Resume", "AbortAllQueries", "NewName", "Set", "Unset"))
+	if !exactlyOneValueSet(opts.Suspend, opts.Resume, opts.AbortAllQueries, opts.NewName, opts.Set, opts.Unset, opts.SetTag, opts.UnsetTag) {
+		errs = append(errs, errExactlyOneOf("AlterWarehouseOptions", "Suspend", "Resume", "AbortAllQueries", "NewName", "Set", "Unset", "SetTag", "UnsetTag"))
 	}
 	if everyValueSet(opts.Suspend, opts.Resume) && (*opts.Suspend && *opts.Resume) {
 		errs = append(errs, errOneOf("AlterWarehouseOptions", "Suspend", "Resume"))
@@ -218,8 +220,6 @@ type WarehouseSet struct {
 	MaxConcurrencyLevel             *int `ddl:"parameter" sql:"MAX_CONCURRENCY_LEVEL"`
 	StatementQueuedTimeoutInSeconds *int `ddl:"parameter" sql:"STATEMENT_QUEUED_TIMEOUT_IN_SECONDS"`
 	StatementTimeoutInSeconds       *int `ddl:"parameter" sql:"STATEMENT_TIMEOUT_IN_SECONDS"`
-
-	Tag []TagAssociation `ddl:"keyword" sql:"TAG"`
 }
 
 func (v *WarehouseSet) validate() error {
@@ -244,8 +244,8 @@ func (v *WarehouseSet) validate() error {
 			return fmt.Errorf("QueryAccelerationMaxScaleFactor must be between 0 and 100")
 		}
 	}
-	if valueSet(v.Tag) && !everyValueNil(v.AutoResume, v.EnableQueryAcceleration, v.MaxClusterCount, v.MinClusterCount, v.AutoSuspend, v.QueryAccelerationMaxScaleFactor) {
-		return fmt.Errorf("Tag cannot be set with any other Set parameter")
+	if everyValueNil(v.AutoResume, v.EnableQueryAcceleration, v.MaxClusterCount, v.MinClusterCount, v.AutoSuspend, v.QueryAccelerationMaxScaleFactor) {
+		return errAtLeastOneOf("AutoResume", "EnableQueryAcceleration", "MaxClusterCount", "MinClusterCount", "AutoSuspend", "QueryAccelerationMaxScaleFactor")
 	}
 	return nil
 }
@@ -266,15 +266,14 @@ type WarehouseUnset struct {
 	QueryAccelerationMaxScaleFactor *bool `ddl:"keyword" sql:"QUERY_ACCELERATION_MAX_SCALE_FACTOR"`
 
 	// Object params
-	MaxConcurrencyLevel             *bool              `ddl:"keyword" sql:"MAX_CONCURRENCY_LEVEL"`
-	StatementQueuedTimeoutInSeconds *bool              `ddl:"keyword" sql:"STATEMENT_QUEUED_TIMEOUT_IN_SECONDS"`
-	StatementTimeoutInSeconds       *bool              `ddl:"keyword" sql:"STATEMENT_TIMEOUT_IN_SECONDS"`
-	Tag                             []ObjectIdentifier `ddl:"keyword" sql:"TAG"`
+	MaxConcurrencyLevel             *bool `ddl:"keyword" sql:"MAX_CONCURRENCY_LEVEL"`
+	StatementQueuedTimeoutInSeconds *bool `ddl:"keyword" sql:"STATEMENT_QUEUED_TIMEOUT_IN_SECONDS"`
+	StatementTimeoutInSeconds       *bool `ddl:"keyword" sql:"STATEMENT_TIMEOUT_IN_SECONDS"`
 }
 
 func (v *WarehouseUnset) validate() error {
-	if valueSet(v.Tag) && !everyValueNil(v.AutoResume, v.EnableQueryAcceleration, v.MaxClusterCount, v.MinClusterCount, v.AutoSuspend, v.QueryAccelerationMaxScaleFactor) {
-		return fmt.Errorf("Tag cannot be unset with any other Unset parameter")
+	if everyValueNil(v.AutoResume, v.EnableQueryAcceleration, v.MaxClusterCount, v.MinClusterCount, v.AutoSuspend, v.QueryAccelerationMaxScaleFactor) {
+		return errAtLeastOneOf("AutoResume", "EnableQueryAcceleration", "MaxClusterCount", "MinClusterCount", "AutoSuspend", "QueryAccelerationMaxScaleFactor")
 	}
 	return nil
 }

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -245,7 +245,7 @@ func (v *WarehouseSet) validate() error {
 		}
 	}
 	if everyValueNil(v.WarehouseType, v.WarehouseSize, v.WaitForCompletion, v.MaxClusterCount, v.MinClusterCount, v.ScalingPolicy, v.AutoSuspend, v.AutoResume, v.ResourceMonitor, v.Comment, v.EnableQueryAcceleration, v.QueryAccelerationMaxScaleFactor, v.MaxConcurrencyLevel, v.StatementQueuedTimeoutInSeconds, v.StatementTimeoutInSeconds) {
-		return errAtLeastOneOf("WarehouseType", "WarehouseSize", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds")
+		return errAtLeastOneOf("WarehouseSet", "WarehouseType", "WarehouseSize", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds")
 	}
 	return nil
 }
@@ -272,7 +272,7 @@ type WarehouseUnset struct {
 
 func (v *WarehouseUnset) validate() error {
 	if everyValueNil(v.WarehouseType, v.WaitForCompletion, v.MaxClusterCount, v.MinClusterCount, v.ScalingPolicy, v.AutoSuspend, v.AutoResume, v.ResourceMonitor, v.Comment, v.EnableQueryAcceleration, v.QueryAccelerationMaxScaleFactor, v.MaxConcurrencyLevel, v.StatementQueuedTimeoutInSeconds, v.StatementTimeoutInSeconds) {
-		return errAtLeastOneOf("WarehouseType", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds")
+		return errAtLeastOneOf("WarehouseUnset", "WarehouseType", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds")
 	}
 	return nil
 }

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -244,8 +244,8 @@ func (v *WarehouseSet) validate() error {
 			return fmt.Errorf("QueryAccelerationMaxScaleFactor must be between 0 and 100")
 		}
 	}
-	if everyValueNil(v.AutoResume, v.EnableQueryAcceleration, v.MaxClusterCount, v.MinClusterCount, v.AutoSuspend, v.QueryAccelerationMaxScaleFactor) {
-		return errAtLeastOneOf("AutoResume", "EnableQueryAcceleration", "MaxClusterCount", "MinClusterCount", "AutoSuspend", "QueryAccelerationMaxScaleFactor")
+	if everyValueNil(v.WarehouseType, v.WarehouseSize, v.WaitForCompletion, v.MaxClusterCount, v.MinClusterCount, v.ScalingPolicy, v.AutoSuspend, v.AutoResume, v.ResourceMonitor, v.Comment, v.EnableQueryAcceleration, v.QueryAccelerationMaxScaleFactor, v.MaxConcurrencyLevel, v.StatementQueuedTimeoutInSeconds, v.StatementTimeoutInSeconds) {
+		return errAtLeastOneOf("WarehouseType", "WarehouseSize", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds")
 	}
 	return nil
 }
@@ -253,7 +253,6 @@ func (v *WarehouseSet) validate() error {
 type WarehouseUnset struct {
 	// Object properties
 	WarehouseType                   *bool `ddl:"keyword" sql:"WAREHOUSE_TYPE"`
-	WarehouseSize                   *bool `ddl:"keyword" sql:"WAREHOUSE_SIZE"`
 	WaitForCompletion               *bool `ddl:"keyword" sql:"WAIT_FOR_COMPLETION"`
 	MaxClusterCount                 *bool `ddl:"keyword" sql:"MAX_CLUSTER_COUNT"`
 	MinClusterCount                 *bool `ddl:"keyword" sql:"MIN_CLUSTER_COUNT"`
@@ -272,8 +271,8 @@ type WarehouseUnset struct {
 }
 
 func (v *WarehouseUnset) validate() error {
-	if everyValueNil(v.AutoResume, v.EnableQueryAcceleration, v.MaxClusterCount, v.MinClusterCount, v.AutoSuspend, v.QueryAccelerationMaxScaleFactor) {
-		return errAtLeastOneOf("AutoResume", "EnableQueryAcceleration", "MaxClusterCount", "MinClusterCount", "AutoSuspend", "QueryAccelerationMaxScaleFactor")
+	if everyValueNil(v.WarehouseType, v.WaitForCompletion, v.MaxClusterCount, v.MinClusterCount, v.ScalingPolicy, v.AutoSuspend, v.AutoResume, v.ResourceMonitor, v.Comment, v.EnableQueryAcceleration, v.QueryAccelerationMaxScaleFactor, v.MaxConcurrencyLevel, v.StatementQueuedTimeoutInSeconds, v.StatementTimeoutInSeconds) {
+		return errAtLeastOneOf("WarehouseType", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds")
 	}
 	return nil
 }

--- a/pkg/sdk/warehouses_test.go
+++ b/pkg/sdk/warehouses_test.go
@@ -114,16 +114,14 @@ func TestWarehouseAlter(t *testing.T) {
 	t.Run("with set tag", func(t *testing.T) {
 		opts := &AlterWarehouseOptions{
 			name: NewAccountObjectIdentifier("mywarehouse"),
-			Set: &WarehouseSet{
-				Tag: []TagAssociation{
-					{
-						Name:  NewSchemaObjectIdentifier("db", "schema", "tag1"),
-						Value: "v1",
-					},
-					{
-						Name:  NewSchemaObjectIdentifier("db", "schema", "tag2"),
-						Value: "v2",
-					},
+			SetTag: []TagAssociation{
+				{
+					Name:  NewSchemaObjectIdentifier("db", "schema", "tag1"),
+					Value: "v1",
+				},
+				{
+					Name:  NewSchemaObjectIdentifier("db", "schema", "tag2"),
+					Value: "v2",
 				},
 			},
 		}
@@ -133,10 +131,8 @@ func TestWarehouseAlter(t *testing.T) {
 	t.Run("with unset tag", func(t *testing.T) {
 		opts := &AlterWarehouseOptions{
 			name: NewAccountObjectIdentifier("mywarehouse"),
-			Unset: &WarehouseUnset{
-				Tag: []ObjectIdentifier{
-					NewSchemaObjectIdentifier("db", "schema", "tag1"),
-				},
+			UnsetTag: []ObjectIdentifier{
+				NewSchemaObjectIdentifier("db", "schema", "tag1"),
 			},
 		}
 		assertOptsValidAndSQLEquals(t, opts, `ALTER WAREHOUSE "mywarehouse" UNSET TAG "db"."schema"."tag1"`)
@@ -191,16 +187,14 @@ func TestWarehouseAlter(t *testing.T) {
 	t.Run("with set tag", func(t *testing.T) {
 		opts := &AlterWarehouseOptions{
 			name: NewAccountObjectIdentifier("mywarehouse"),
-			Set: &WarehouseSet{
-				Tag: []TagAssociation{
-					{
-						Name:  NewSchemaObjectIdentifier("db1", "schema1", "tag1"),
-						Value: "v1",
-					},
-					{
-						Name:  NewSchemaObjectIdentifier("db2", "schema2", "tag2"),
-						Value: "v2",
-					},
+			SetTag: []TagAssociation{
+				{
+					Name:  NewSchemaObjectIdentifier("db1", "schema1", "tag1"),
+					Value: "v1",
+				},
+				{
+					Name:  NewSchemaObjectIdentifier("db2", "schema2", "tag2"),
+					Value: "v2",
 				},
 			},
 		}
@@ -210,11 +204,9 @@ func TestWarehouseAlter(t *testing.T) {
 	t.Run("with unset tag", func(t *testing.T) {
 		opts := &AlterWarehouseOptions{
 			name: NewAccountObjectIdentifier("mywarehouse"),
-			Unset: &WarehouseUnset{
-				Tag: []ObjectIdentifier{
-					NewSchemaObjectIdentifier("db1", "schema1", "tag1"),
-					NewSchemaObjectIdentifier("db2", "schema2", "tag2"),
-				},
+			UnsetTag: []ObjectIdentifier{
+				NewSchemaObjectIdentifier("db1", "schema1", "tag1"),
+				NewSchemaObjectIdentifier("db2", "schema2", "tag2"),
 			},
 		}
 		assertOptsValidAndSQLEquals(t, opts, `ALTER WAREHOUSE "mywarehouse" UNSET TAG "db1"."schema1"."tag1", "db2"."schema2"."tag2"`)

--- a/pkg/sdk/warehouses_test.go
+++ b/pkg/sdk/warehouses_test.go
@@ -142,12 +142,11 @@ func TestWarehouseAlter(t *testing.T) {
 		opts := &AlterWarehouseOptions{
 			name: NewAccountObjectIdentifier("mywarehouse"),
 			Unset: &WarehouseUnset{
-				WarehouseSize:   Bool(true),
 				MaxClusterCount: Bool(true),
 				AutoResume:      Bool(true),
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `ALTER WAREHOUSE "mywarehouse" UNSET WAREHOUSE_SIZE, MAX_CLUSTER_COUNT, AUTO_RESUME`)
+		assertOptsValidAndSQLEquals(t, opts, `ALTER WAREHOUSE "mywarehouse" UNSET MAX_CLUSTER_COUNT, AUTO_RESUME`)
 	})
 
 	t.Run("rename", func(t *testing.T) {


### PR DESCRIPTION
Split existing alter operations to be more consistent with the docs.

## Changes
* Extracted `SetTag` and `UnsetTag` from Set/Unset structs
* Adjusted validations and tests
* Fixed warehouse validation to check each possible param
* Removed unsetting a warehouse size; based on [docs](https://docs.snowflake.com/en/sql-reference/sql/alter-warehouse) - also our current resource implementation has been using set for warehouse size correctly already