### PR TITLE
chore: Export QueryStruct

### DIFF
--- a/pkg/sdk/network_policies_def.go
+++ b/pkg/sdk/network_policies_def.go
@@ -5,7 +5,7 @@ import g "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/poc/gen
 //go:generate go run ./poc/main.go
 
 var (
-	ip = g.QueryStruct("IP").
+	ip = g.NewQueryStruct("IP").
 		Text("IP", g.KeywordOptions().SingleQuotes().Required())
 
 	NetworkPoliciesDef = g.NewInterface(
@@ -15,7 +15,7 @@ var (
 	).
 		CreateOperation(
 			"https://docs.snowflake.com/en/sql-reference/sql/create-network-policy",
-			g.QueryStruct("CreateNetworkPolicies").
+			g.NewQueryStruct("CreateNetworkPolicies").
 				Create().
 				OrReplace().
 				SQL("NETWORK POLICY").
@@ -27,14 +27,14 @@ var (
 		).
 		AlterOperation(
 			"https://docs.snowflake.com/en/sql-reference/sql/alter-network-policy",
-			g.QueryStruct("AlterNetworkPolicy").
+			g.NewQueryStruct("AlterNetworkPolicy").
 				Alter().
 				SQL("NETWORK POLICY").
 				IfExists().
 				Name().
 				OptionalQueryStructField(
 					"Set",
-					g.QueryStruct("NetworkPolicySet").
+					g.NewQueryStruct("NetworkPolicySet").
 						ListQueryStructField("AllowedIpList", ip, g.ParameterOptions().SQL("ALLOWED_IP_LIST").Parentheses()).
 						ListQueryStructField("BlockedIpList", ip, g.ParameterOptions().SQL("BLOCKED_IP_LIST").Parentheses()).
 						OptionalTextAssignment("COMMENT", g.ParameterOptions().SingleQuotes()).
@@ -49,7 +49,7 @@ var (
 		).
 		DropOperation(
 			"https://docs.snowflake.com/en/sql-reference/sql/drop-network-policy",
-			g.QueryStruct("DropNetworkPolicy").
+			g.NewQueryStruct("DropNetworkPolicy").
 				Drop().
 				SQL("NETWORK POLICY").
 				IfExists().
@@ -70,7 +70,7 @@ var (
 				Field("Comment", "string").
 				Field("EntriesInAllowedIpList", "int").
 				Field("EntriesInBlockedIpList", "int"),
-			g.QueryStruct("ShowNetworkPolicies").
+			g.NewQueryStruct("ShowNetworkPolicies").
 				Show().
 				SQL("NETWORK POLICIES"),
 		).
@@ -83,7 +83,7 @@ var (
 			g.PlainStruct("NetworkPolicyDescription").
 				Field("Name", "string").
 				Field("Value", "string"),
-			g.QueryStruct("DescribeNetworkPolicy").
+			g.NewQueryStruct("DescribeNetworkPolicy").
 				Describe().
 				SQL("NETWORK POLICY").
 				Name().

--- a/pkg/sdk/poc/example/database_role_def.go
+++ b/pkg/sdk/poc/example/database_role_def.go
@@ -7,24 +7,24 @@ import (
 //go:generate go run ../main.go
 
 var (
-	dbRoleRename = g.QueryStruct("DatabaseRoleRename").
+	dbRoleRename = g.NewQueryStruct("DatabaseRoleRename").
 		// Fields
 		Identifier("Name", g.KindOfT[DatabaseObjectIdentifier](), g.IdentifierOptions().Required()).
 		// Validations
 		WithValidation(g.ValidIdentifier, "Name")
 
-	nestedThirdLevel = g.QueryStruct("NestedThirdLevel").
+	nestedThirdLevel = g.NewQueryStruct("NestedThirdLevel").
 		// Fields
 		Identifier("Field", g.KindOfT[DatabaseObjectIdentifier](), g.IdentifierOptions().Required()).
 		// Validations
 		WithValidation(g.AtLeastOneValueSet, "Field")
 
-	dbRoleSet = g.QueryStruct("DatabaseRoleSet").
+	dbRoleSet = g.NewQueryStruct("DatabaseRoleSet").
 		// Fields
 		TextAssignment("COMMENT", g.ParameterOptions().SingleQuotes().Required()).
 		OptionalQueryStructField("NestedThirdLevel", nestedThirdLevel, g.ListOptions().NoParentheses().SQL("NESTED"))
 
-	dbRoleUnset = g.QueryStruct("DatabaseRoleUnset").
+	dbRoleUnset = g.NewQueryStruct("DatabaseRoleUnset").
 		// Fields
 		OptionalSQL("COMMENT").
 		// Validations
@@ -37,7 +37,7 @@ var (
 	).
 		CreateOperation(
 			"https://docs.snowflake.com/en/sql-reference/sql/create-database-role",
-			g.QueryStruct("CreateDatabaseRole").
+			g.NewQueryStruct("CreateDatabaseRole").
 				// Fields
 				Create().
 				OrReplace().
@@ -51,7 +51,7 @@ var (
 		).
 		AlterOperation(
 			"https://docs.snowflake.com/en/sql-reference/sql/alter-database-role",
-			g.QueryStruct("AlterDatabaseRole").
+			g.NewQueryStruct("AlterDatabaseRole").
 				// Fields
 				Alter().
 				SQL("DATABASE ROLE").

--- a/pkg/sdk/poc/generator/identifier_builders.go
+++ b/pkg/sdk/poc/generator/identifier_builders.go
@@ -1,19 +1,19 @@
 package generator
 
 // Name adds identifier with field name "name" and type will be inferred from interface definition
-func (v *queryStruct) Name() *queryStruct {
+func (v *QueryStruct) Name() *QueryStruct {
 	identifier := NewField("name", "<will be replaced>", Tags().Identifier(), IdentifierOptions().Required())
 	v.identifierField = identifier
 	v.fields = append(v.fields, identifier)
 	return v
 }
 
-func (v *queryStruct) Identifier(fieldName string, kind string, transformer *IdentifierTransformer) *queryStruct {
+func (v *QueryStruct) Identifier(fieldName string, kind string, transformer *IdentifierTransformer) *QueryStruct {
 	v.fields = append(v.fields, NewField(fieldName, kind, Tags().Identifier(), transformer))
 	return v
 }
 
-func (v *queryStruct) OptionalIdentifier(name string, kind string, transformer *IdentifierTransformer) *queryStruct {
+func (v *QueryStruct) OptionalIdentifier(name string, kind string, transformer *IdentifierTransformer) *QueryStruct {
 	if len(kind) > 0 && kind[0] != '*' {
 		kind = KindOfPointer(kind)
 	}

--- a/pkg/sdk/poc/generator/keyword_builders.go
+++ b/pkg/sdk/poc/generator/keyword_builders.go
@@ -1,87 +1,87 @@
 package generator
 
-func (v *queryStruct) OptionalSQL(sql string) *queryStruct {
+func (v *QueryStruct) OptionalSQL(sql string) *QueryStruct {
 	v.fields = append(v.fields, NewField(sqlToFieldName(sql, true), "*bool", Tags().Keyword().SQL(sql), nil))
 	return v
 }
 
-func (v *queryStruct) OrReplace() *queryStruct {
+func (v *QueryStruct) OrReplace() *QueryStruct {
 	return v.OptionalSQL("OR REPLACE")
 }
 
-func (v *queryStruct) IfNotExists() *queryStruct {
+func (v *QueryStruct) IfNotExists() *QueryStruct {
 	return v.OptionalSQL("IF NOT EXISTS")
 }
 
-func (v *queryStruct) IfExists() *queryStruct {
+func (v *QueryStruct) IfExists() *QueryStruct {
 	return v.OptionalSQL("IF EXISTS")
 }
 
-func (v *queryStruct) Terse() *queryStruct {
+func (v *QueryStruct) Terse() *QueryStruct {
 	return v.OptionalSQL("TERSE")
 }
 
-func (v *queryStruct) Text(name string, transformer *KeywordTransformer) *queryStruct {
+func (v *QueryStruct) Text(name string, transformer *KeywordTransformer) *QueryStruct {
 	v.fields = append(v.fields, NewField(name, "string", Tags().Keyword(), transformer))
 	return v
 }
 
-func (v *queryStruct) OptionalText(name string, transformer *KeywordTransformer) *queryStruct {
+func (v *QueryStruct) OptionalText(name string, transformer *KeywordTransformer) *QueryStruct {
 	v.fields = append(v.fields, NewField(name, "*string", Tags().Keyword(), transformer))
 	return v
 }
 
 // SessionParameters *SessionParameters `ddl:"list,no_parentheses"`
-func (v *queryStruct) SessionParameters() *queryStruct {
+func (v *QueryStruct) SessionParameters() *QueryStruct {
 	v.fields = append(v.fields, NewField("SessionParameters", "*SessionParameters", Tags().List().NoParentheses(), nil).withValidations(NewValidation(ValidateValue, "SessionParameters")))
 	return v
 }
 
-func (v *queryStruct) OptionalSessionParameters() *queryStruct {
+func (v *QueryStruct) OptionalSessionParameters() *QueryStruct {
 	v.fields = append(v.fields, NewField("SessionParameters", "*SessionParameters", Tags().List().NoParentheses(), nil).withValidations(NewValidation(ValidateValue, "SessionParameters")))
 	return v
 }
 
-func (v *queryStruct) OptionalSessionParametersUnset() *queryStruct {
+func (v *QueryStruct) OptionalSessionParametersUnset() *QueryStruct {
 	v.fields = append(v.fields, NewField("SessionParametersUnset", "*SessionParametersUnset", Tags().List().NoParentheses(), nil).withValidations(NewValidation(ValidateValue, "SessionParametersUnset")))
 	return v
 }
 
-func (v *queryStruct) WithTags() *queryStruct {
+func (v *QueryStruct) WithTags() *QueryStruct {
 	v.fields = append(v.fields, NewField("Tag", "[]TagAssociation", Tags().Keyword().Parentheses().SQL("TAG"), nil))
 	return v
 }
 
-func (v *queryStruct) SetTags() *queryStruct {
+func (v *QueryStruct) SetTags() *QueryStruct {
 	v.fields = append(v.fields, NewField("SetTags", "[]TagAssociation", Tags().Keyword().SQL("SET TAG"), nil))
 	return v
 }
 
-func (v *queryStruct) UnsetTags() *queryStruct {
+func (v *QueryStruct) UnsetTags() *QueryStruct {
 	v.fields = append(v.fields, NewField("UnsetTags", "[]ObjectIdentifier", Tags().Keyword().SQL("UNSET TAG"), nil))
 	return v
 }
 
-func (v *queryStruct) OptionalLike() *queryStruct {
+func (v *QueryStruct) OptionalLike() *QueryStruct {
 	v.fields = append(v.fields, NewField("Like", "*Like", Tags().Keyword().SQL("LIKE"), nil))
 	return v
 }
 
-func (v *queryStruct) OptionalIn() *queryStruct {
+func (v *QueryStruct) OptionalIn() *QueryStruct {
 	v.fields = append(v.fields, NewField("In", "*In", Tags().Keyword().SQL("IN"), nil))
 	return v
 }
 
-func (v *queryStruct) OptionalStartsWith() *queryStruct {
+func (v *QueryStruct) OptionalStartsWith() *QueryStruct {
 	v.fields = append(v.fields, NewField("StartsWith", "*string", Tags().Parameter().NoEquals().SingleQuotes().SQL("STARTS WITH"), nil))
 	return v
 }
 
-func (v *queryStruct) OptionalLimit() *queryStruct {
+func (v *QueryStruct) OptionalLimit() *QueryStruct {
 	v.fields = append(v.fields, NewField("Limit", "*LimitFrom", Tags().Keyword().SQL("LIMIT"), nil))
 	return v
 }
 
-func (v *queryStruct) OptionalCopyGrants() *queryStruct {
+func (v *QueryStruct) OptionalCopyGrants() *QueryStruct {
 	return v.OptionalSQL("COPY GRANTS")
 }

--- a/pkg/sdk/poc/generator/operation.go
+++ b/pkg/sdk/poc/generator/operation.go
@@ -90,7 +90,7 @@ func (i *Interface) newNoSqlOperation(kind string) *Interface {
 	return i
 }
 
-func (i *Interface) newSimpleOperation(kind string, doc string, queryStruct *queryStruct, helperStructs ...IntoField) *Interface {
+func (i *Interface) newSimpleOperation(kind string, doc string, queryStruct *QueryStruct, helperStructs ...IntoField) *Interface {
 	if queryStruct.identifierField != nil {
 		queryStruct.identifierField.Kind = i.IdentifierKind
 	}
@@ -112,7 +112,7 @@ func (i *Interface) newOperationWithDBMapping(
 	doc string,
 	dbRepresentation *dbStruct,
 	resourceRepresentation *plainStruct,
-	queryStruct *queryStruct,
+	queryStruct *QueryStruct,
 	addMappingFunc func(op *Operation, from, to *Field),
 ) *Operation {
 	db := dbRepresentation.IntoField()
@@ -133,19 +133,19 @@ type IntoField interface {
 	IntoField() *Field
 }
 
-func (i *Interface) CreateOperation(doc string, queryStruct *queryStruct, helperStructs ...IntoField) *Interface {
+func (i *Interface) CreateOperation(doc string, queryStruct *QueryStruct, helperStructs ...IntoField) *Interface {
 	return i.newSimpleOperation(string(OperationKindCreate), doc, queryStruct, helperStructs...)
 }
 
-func (i *Interface) AlterOperation(doc string, queryStruct *queryStruct) *Interface {
+func (i *Interface) AlterOperation(doc string, queryStruct *QueryStruct) *Interface {
 	return i.newSimpleOperation(string(OperationKindAlter), doc, queryStruct)
 }
 
-func (i *Interface) DropOperation(doc string, queryStruct *queryStruct) *Interface {
+func (i *Interface) DropOperation(doc string, queryStruct *QueryStruct) *Interface {
 	return i.newSimpleOperation(string(OperationKindDrop), doc, queryStruct)
 }
 
-func (i *Interface) ShowOperation(doc string, dbRepresentation *dbStruct, resourceRepresentation *plainStruct, queryStruct *queryStruct) *Interface {
+func (i *Interface) ShowOperation(doc string, dbRepresentation *dbStruct, resourceRepresentation *plainStruct, queryStruct *QueryStruct) *Interface {
 	i.newOperationWithDBMapping(string(OperationKindShow), doc, dbRepresentation, resourceRepresentation, queryStruct, addShowMapping)
 	return i
 }
@@ -154,12 +154,12 @@ func (i *Interface) ShowByIdOperation() *Interface {
 	return i.newNoSqlOperation(string(OperationKindShowByID))
 }
 
-func (i *Interface) DescribeOperation(describeKind DescriptionMappingKind, doc string, dbRepresentation *dbStruct, resourceRepresentation *plainStruct, queryStruct *queryStruct) *Interface {
+func (i *Interface) DescribeOperation(describeKind DescriptionMappingKind, doc string, dbRepresentation *dbStruct, resourceRepresentation *plainStruct, queryStruct *QueryStruct) *Interface {
 	op := i.newOperationWithDBMapping(string(OperationKindDescribe), doc, dbRepresentation, resourceRepresentation, queryStruct, addDescriptionMapping)
 	op.DescribeKind = &describeKind
 	return i
 }
 
-func (i *Interface) CustomOperation(kind string, doc string, queryStruct *queryStruct) *Interface {
+func (i *Interface) CustomOperation(kind string, doc string, queryStruct *QueryStruct) *Interface {
 	return i.newSimpleOperation(kind, doc, queryStruct)
 }

--- a/pkg/sdk/poc/generator/parameter_builders.go
+++ b/pkg/sdk/poc/generator/parameter_builders.go
@@ -1,11 +1,11 @@
 package generator
 
-func (v *queryStruct) assignment(name string, kind string, transformer *ParameterTransformer) *queryStruct {
+func (v *QueryStruct) assignment(name string, kind string, transformer *ParameterTransformer) *QueryStruct {
 	v.fields = append(v.fields, NewField(name, kind, Tags().Parameter(), transformer))
 	return v
 }
 
-func (v *queryStruct) Assignment(sqlPrefix string, kind string, transformer *ParameterTransformer) *queryStruct {
+func (v *QueryStruct) Assignment(sqlPrefix string, kind string, transformer *ParameterTransformer) *QueryStruct {
 	if transformer != nil {
 		transformer = transformer.SQL(sqlPrefix)
 	} else {
@@ -14,49 +14,49 @@ func (v *queryStruct) Assignment(sqlPrefix string, kind string, transformer *Par
 	return v.assignment(sqlToFieldName(sqlPrefix, true), kind, transformer)
 }
 
-func (v *queryStruct) OptionalAssignment(sqlPrefix string, kind string, transformer *ParameterTransformer) *queryStruct {
+func (v *QueryStruct) OptionalAssignment(sqlPrefix string, kind string, transformer *ParameterTransformer) *QueryStruct {
 	if len(kind) > 0 && kind[0] != '*' {
 		kind = KindOfPointer(kind)
 	}
 	return v.Assignment(sqlPrefix, kind, transformer)
 }
 
-func (v *queryStruct) ListAssignment(sqlPrefix string, listItemKind string, transformer *ParameterTransformer) *queryStruct {
+func (v *QueryStruct) ListAssignment(sqlPrefix string, listItemKind string, transformer *ParameterTransformer) *QueryStruct {
 	return v.Assignment(sqlPrefix, KindOfSlice(listItemKind), transformer)
 }
 
-func (v *queryStruct) NumberAssignment(sqlPrefix string, transformer *ParameterTransformer) *queryStruct {
+func (v *QueryStruct) NumberAssignment(sqlPrefix string, transformer *ParameterTransformer) *QueryStruct {
 	return v.Assignment(sqlPrefix, "int", transformer)
 }
 
-func (v *queryStruct) OptionalNumberAssignment(sqlPrefix string, transformer *ParameterTransformer) *queryStruct {
+func (v *QueryStruct) OptionalNumberAssignment(sqlPrefix string, transformer *ParameterTransformer) *QueryStruct {
 	return v.Assignment(sqlPrefix, "*int", transformer)
 }
 
-func (v *queryStruct) TextAssignment(sqlPrefix string, transformer *ParameterTransformer) *queryStruct {
+func (v *QueryStruct) TextAssignment(sqlPrefix string, transformer *ParameterTransformer) *QueryStruct {
 	return v.Assignment(sqlPrefix, "string", transformer)
 }
 
-func (v *queryStruct) OptionalTextAssignment(sqlPrefix string, transformer *ParameterTransformer) *queryStruct {
+func (v *QueryStruct) OptionalTextAssignment(sqlPrefix string, transformer *ParameterTransformer) *QueryStruct {
 	return v.Assignment(sqlPrefix, "*string", transformer)
 }
 
-func (v *queryStruct) BooleanAssignment(sqlPrefix string, transformer *ParameterTransformer) *queryStruct {
+func (v *QueryStruct) BooleanAssignment(sqlPrefix string, transformer *ParameterTransformer) *QueryStruct {
 	return v.Assignment(sqlPrefix, "bool", transformer)
 }
 
-func (v *queryStruct) OptionalBooleanAssignment(sqlPrefix string, transformer *ParameterTransformer) *queryStruct {
+func (v *QueryStruct) OptionalBooleanAssignment(sqlPrefix string, transformer *ParameterTransformer) *QueryStruct {
 	return v.Assignment(sqlPrefix, "*bool", transformer)
 }
 
-func (v *queryStruct) OptionalIdentifierAssignment(sqlPrefix string, identifierKind string, transformer *ParameterTransformer) *queryStruct {
+func (v *QueryStruct) OptionalIdentifierAssignment(sqlPrefix string, identifierKind string, transformer *ParameterTransformer) *QueryStruct {
 	return v.OptionalAssignment(sqlPrefix, identifierKind, transformer)
 }
 
-func (v *queryStruct) OptionalComment() *queryStruct {
+func (v *QueryStruct) OptionalComment() *QueryStruct {
 	return v.OptionalTextAssignment("COMMENT", ParameterOptions().SingleQuotes())
 }
 
-func (v *queryStruct) SetComment() *queryStruct {
+func (v *QueryStruct) SetComment() *QueryStruct {
 	return v.OptionalTextAssignment("SET COMMENT", ParameterOptions().SingleQuotes())
 }

--- a/pkg/sdk/poc/generator/query_struct.go
+++ b/pkg/sdk/poc/generator/query_struct.go
@@ -2,49 +2,49 @@ package generator
 
 // TODO For Field abstractions use internal Field representation instead of copying only needed fields, e.g.
 //
-//	type queryStruct struct {
+//	type QueryStruct struct {
 //		internalRepresentation *Field
 //		...additional fields that are not present in the Field
 //	}
-type queryStruct struct {
+type QueryStruct struct {
 	name            string
 	fields          []*Field
 	identifierField *Field
 	validations     []*Validation
 }
 
-func QueryStruct(name string) *queryStruct {
-	return &queryStruct{
+func NewQueryStruct(name string) *QueryStruct {
+	return &QueryStruct{
 		name:        name,
 		fields:      make([]*Field, 0),
 		validations: make([]*Validation, 0),
 	}
 }
 
-func (v *queryStruct) IntoField() *Field {
+func (v *QueryStruct) IntoField() *Field {
 	return NewField(v.name, v.name, nil, nil).
 		withFields(v.fields...).
 		withValidations(v.validations...)
 }
 
-func (v *queryStruct) WithValidation(validationType ValidationType, fieldNames ...string) *queryStruct {
+func (v *QueryStruct) WithValidation(validationType ValidationType, fieldNames ...string) *QueryStruct {
 	v.validations = append(v.validations, NewValidation(validationType, fieldNames...))
 	return v
 }
 
-func (v *queryStruct) QueryStructField(name string, queryStruct *queryStruct, transformer FieldTransformer) *queryStruct {
+func (v *QueryStruct) QueryStructField(name string, queryStruct *QueryStruct, transformer FieldTransformer) *QueryStruct {
 	return v.queryStructField(name, queryStruct, "", transformer)
 }
 
-func (v *queryStruct) ListQueryStructField(name string, queryStruct *queryStruct, transformer FieldTransformer) *queryStruct {
+func (v *QueryStruct) ListQueryStructField(name string, queryStruct *QueryStruct, transformer FieldTransformer) *QueryStruct {
 	return v.queryStructField(name, queryStruct, "[]", transformer)
 }
 
-func (v *queryStruct) OptionalQueryStructField(name string, queryStruct *queryStruct, transformer FieldTransformer) *queryStruct {
+func (v *QueryStruct) OptionalQueryStructField(name string, queryStruct *QueryStruct, transformer FieldTransformer) *QueryStruct {
 	return v.queryStructField(name, queryStruct, "*", transformer)
 }
 
-func (v *queryStruct) queryStructField(name string, queryStruct *queryStruct, kindPrefix string, transformer FieldTransformer) *queryStruct {
+func (v *QueryStruct) queryStructField(name string, queryStruct *QueryStruct, kindPrefix string, transformer FieldTransformer) *QueryStruct {
 	qs := queryStruct.IntoField()
 	qs.Name = name
 	qs.Kind = kindPrefix + qs.Kind

--- a/pkg/sdk/poc/generator/static_builders.go
+++ b/pkg/sdk/poc/generator/static_builders.go
@@ -1,26 +1,26 @@
 package generator
 
-func (v *queryStruct) SQL(sql string) *queryStruct {
+func (v *QueryStruct) SQL(sql string) *QueryStruct {
 	v.fields = append(v.fields, NewField(sqlToFieldName(sql, false), "bool", Tags().Static().SQL(sql), nil))
 	return v
 }
 
-func (v *queryStruct) Create() *queryStruct {
+func (v *QueryStruct) Create() *QueryStruct {
 	return v.SQL("CREATE")
 }
 
-func (v *queryStruct) Alter() *queryStruct {
+func (v *QueryStruct) Alter() *QueryStruct {
 	return v.SQL("ALTER")
 }
 
-func (v *queryStruct) Drop() *queryStruct {
+func (v *QueryStruct) Drop() *QueryStruct {
 	return v.SQL("DROP")
 }
 
-func (v *queryStruct) Show() *queryStruct {
+func (v *QueryStruct) Show() *QueryStruct {
 	return v.SQL("SHOW")
 }
 
-func (v *queryStruct) Describe() *queryStruct {
+func (v *QueryStruct) Describe() *QueryStruct {
 	return v.SQL("DESCRIBE")
 }

--- a/pkg/sdk/session_policies_def.go
+++ b/pkg/sdk/session_policies_def.go
@@ -11,7 +11,7 @@ var SessionPoliciesDef = g.NewInterface(
 ).
 	CreateOperation(
 		"https://docs.snowflake.com/en/sql-reference/sql/create-session-policy",
-		g.QueryStruct("CreateSessionPolicy").
+		g.NewQueryStruct("CreateSessionPolicy").
 			Create().
 			OrReplace().
 			SQL("SESSION POLICY").
@@ -25,7 +25,7 @@ var SessionPoliciesDef = g.NewInterface(
 	).
 	AlterOperation(
 		"https://docs.snowflake.com/en/sql-reference/sql/alter-session-policy",
-		g.QueryStruct("AlterSessionPolicy").
+		g.NewQueryStruct("AlterSessionPolicy").
 			Alter().
 			SQL("SESSION POLICY").
 			IfExists().
@@ -33,7 +33,7 @@ var SessionPoliciesDef = g.NewInterface(
 			OptionalIdentifier("RenameTo", g.KindOfT[SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
 			OptionalQueryStructField(
 				"Set",
-				g.QueryStruct("SessionPolicySet").
+				g.NewQueryStruct("SessionPolicySet").
 					OptionalNumberAssignment("SESSION_IDLE_TIMEOUT_MINS", g.ParameterOptions().NoQuotes()).
 					OptionalNumberAssignment("SESSION_UI_IDLE_TIMEOUT_MINS", g.ParameterOptions().NoQuotes()).
 					OptionalTextAssignment("COMMENT", g.ParameterOptions().SingleQuotes()).
@@ -44,7 +44,7 @@ var SessionPoliciesDef = g.NewInterface(
 			UnsetTags().
 			OptionalQueryStructField(
 				"Unset",
-				g.QueryStruct("SessionPolicyUnset").
+				g.NewQueryStruct("SessionPolicyUnset").
 					OptionalSQL("SESSION_IDLE_TIMEOUT_MINS").
 					OptionalSQL("SESSION_UI_IDLE_TIMEOUT_MINS").
 					OptionalSQL("COMMENT").
@@ -56,7 +56,7 @@ var SessionPoliciesDef = g.NewInterface(
 	).
 	DropOperation(
 		"https://docs.snowflake.com/en/sql-reference/sql/drop-session-policy",
-		g.QueryStruct("DropSessionPolicy").
+		g.NewQueryStruct("DropSessionPolicy").
 			Drop().
 			SQL("SESSION POLICY").
 			IfExists().
@@ -83,7 +83,7 @@ var SessionPoliciesDef = g.NewInterface(
 			Field("Owner", "string").
 			Field("Comment", "string").
 			Field("Options", "string"),
-		g.QueryStruct("ShowSessionPolicies").
+		g.NewQueryStruct("ShowSessionPolicies").
 			Show().
 			SQL("SESSION POLICIES"),
 	).
@@ -102,7 +102,7 @@ var SessionPoliciesDef = g.NewInterface(
 			Field("SessionIdleTimeoutMins", "int").
 			Field("SessionUIIdleTimeoutMins", "int").
 			Field("Comment", "string"),
-		g.QueryStruct("DescribeSessionPolicy").
+		g.NewQueryStruct("DescribeSessionPolicy").
 			Describe().
 			SQL("SESSION POLICY").
 			Name().

--- a/pkg/sdk/streams_def.go
+++ b/pkg/sdk/streams_def.go
@@ -5,12 +5,12 @@ import g "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/poc/gen
 //go:generate go run ./poc/main.go
 
 var (
-	onStreamDef = g.QueryStruct("OnStream").
+	onStreamDef = g.NewQueryStruct("OnStream").
 			OptionalSQL("AT").
 			OptionalSQL("BEFORE").
 			QueryStructField(
 			"Statement",
-			g.QueryStruct("OnStreamStatement").
+			g.NewQueryStruct("OnStreamStatement").
 				OptionalTextAssignment("TIMESTAMP", g.ParameterOptions().ArrowEquals()).
 				OptionalTextAssignment("OFFSET", g.ParameterOptions().ArrowEquals()).
 				OptionalTextAssignment("STATEMENT", g.ParameterOptions().ArrowEquals()).
@@ -64,7 +64,7 @@ var (
 		CustomOperation(
 			"CreateOnTable",
 			"https://docs.snowflake.com/en/sql-reference/sql/create-stream",
-			g.QueryStruct("CreateStreamOnTable").
+			g.NewQueryStruct("CreateStreamOnTable").
 				Create().
 				OrReplace().
 				SQL("STREAM").
@@ -84,7 +84,7 @@ var (
 		CustomOperation(
 			"CreateOnExternalTable",
 			"https://docs.snowflake.com/en/sql-reference/sql/create-stream",
-			g.QueryStruct("CreateStreamOnExternalTable").
+			g.NewQueryStruct("CreateStreamOnExternalTable").
 				Create().
 				OrReplace().
 				SQL("STREAM").
@@ -103,7 +103,7 @@ var (
 		CustomOperation(
 			"CreateOnDirectoryTable",
 			"https://docs.snowflake.com/en/sql-reference/sql/create-stream",
-			g.QueryStruct("CreateStreamOnDirectoryTable").
+			g.NewQueryStruct("CreateStreamOnDirectoryTable").
 				Create().
 				OrReplace().
 				SQL("STREAM").
@@ -120,7 +120,7 @@ var (
 		CustomOperation(
 			"CreateOnView",
 			"https://docs.snowflake.com/en/sql-reference/sql/create-stream",
-			g.QueryStruct("CreateStreamOnView").
+			g.NewQueryStruct("CreateStreamOnView").
 				Create().
 				OrReplace().
 				SQL("STREAM").
@@ -140,7 +140,7 @@ var (
 		CustomOperation(
 			"Clone",
 			"https://docs.snowflake.com/en/sql-reference/sql/create-stream#variant-syntax",
-			g.QueryStruct("CloneStream").
+			g.NewQueryStruct("CloneStream").
 				Create().
 				OrReplace().
 				SQL("STREAM").
@@ -151,7 +151,7 @@ var (
 		).
 		AlterOperation(
 			"https://docs.snowflake.com/en/sql-reference/sql/alter-stream",
-			g.QueryStruct("AlterStream").
+			g.NewQueryStruct("AlterStream").
 				Alter().
 				SQL("STREAM").
 				IfExists().
@@ -166,7 +166,7 @@ var (
 		).
 		DropOperation(
 			"https://docs.snowflake.com/en/sql-reference/sql/drop-stream",
-			g.QueryStruct("DropStream").
+			g.NewQueryStruct("DropStream").
 				Drop().
 				SQL("STREAM").
 				IfExists().
@@ -177,7 +177,7 @@ var (
 			"https://docs.snowflake.com/en/sql-reference/sql/show-streams",
 			showStreamDbRowDef,
 			streamPlainStructDef,
-			g.QueryStruct("ShowStreams").
+			g.NewQueryStruct("ShowStreams").
 				Show().
 				Terse().
 				SQL("STREAMS").
@@ -192,7 +192,7 @@ var (
 			"https://docs.snowflake.com/en/sql-reference/sql/desc-stream",
 			showStreamDbRowDef,
 			streamPlainStructDef,
-			g.QueryStruct("DescribeStream").
+			g.NewQueryStruct("DescribeStream").
 				Describe().
 				SQL("STREAM").
 				Name().

--- a/pkg/sdk/tasks_def.go
+++ b/pkg/sdk/tasks_def.go
@@ -55,7 +55,7 @@ var TasksDef = g.NewInterface(
 ).
 	CreateOperation(
 		"https://docs.snowflake.com/en/sql-reference/sql/create-task",
-		g.QueryStruct("CreateTask").
+		g.NewQueryStruct("CreateTask").
 			Create().
 			OrReplace().
 			SQL("TASK").
@@ -63,7 +63,7 @@ var TasksDef = g.NewInterface(
 			Name().
 			OptionalQueryStructField(
 				"Warehouse",
-				g.QueryStruct("CreateTaskWarehouse").
+				g.NewQueryStruct("CreateTaskWarehouse").
 					OptionalIdentifier("Warehouse", g.KindOfT[AccountObjectIdentifier](), g.IdentifierOptions().Equals().SQL("WAREHOUSE")).
 					OptionalAssignment("USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE", "WarehouseSize", g.ParameterOptions().SingleQuotes()).
 					WithValidation(g.ExactlyOneValueSet, "Warehouse", "UserTaskManagedInitialWarehouseSize"),
@@ -89,7 +89,7 @@ var TasksDef = g.NewInterface(
 	CustomOperation(
 		"Clone",
 		"https://docs.snowflake.com/en/sql-reference/sql/create-task#variant-syntax",
-		g.QueryStruct("CloneTask").
+		g.NewQueryStruct("CloneTask").
 			Create().
 			OrReplace().
 			SQL("TASK").
@@ -102,7 +102,7 @@ var TasksDef = g.NewInterface(
 	).
 	AlterOperation(
 		"https://docs.snowflake.com/en/sql-reference/sql/alter-task",
-		g.QueryStruct("AlterTask").
+		g.NewQueryStruct("AlterTask").
 			Alter().
 			SQL("TASK").
 			IfExists().
@@ -113,7 +113,7 @@ var TasksDef = g.NewInterface(
 			ListAssignment("ADD AFTER", "SchemaObjectIdentifier", g.ParameterOptions().NoEquals()).
 			OptionalQueryStructField(
 				"Set",
-				g.QueryStruct("TaskSet").
+				g.NewQueryStruct("TaskSet").
 					OptionalIdentifier("Warehouse", g.KindOfT[AccountObjectIdentifier](), g.IdentifierOptions().Equals().SQL("WAREHOUSE")).
 					OptionalAssignment("USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE", "WarehouseSize", g.ParameterOptions().SingleQuotes()).
 					OptionalTextAssignment("SCHEDULE", g.ParameterOptions().SingleQuotes()).
@@ -130,7 +130,7 @@ var TasksDef = g.NewInterface(
 			).
 			OptionalQueryStructField(
 				"Unset",
-				g.QueryStruct("TaskUnset").
+				g.NewQueryStruct("TaskUnset").
 					OptionalSQL("WAREHOUSE").
 					OptionalSQL("SCHEDULE").
 					OptionalSQL("CONFIG").
@@ -152,7 +152,7 @@ var TasksDef = g.NewInterface(
 	).
 	DropOperation(
 		"https://docs.snowflake.com/en/sql-reference/sql/drop-task",
-		g.QueryStruct("DropTask").
+		g.NewQueryStruct("DropTask").
 			Drop().
 			SQL("TASK").
 			IfExists().
@@ -163,7 +163,7 @@ var TasksDef = g.NewInterface(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-tasks",
 		taskDbRow,
 		task,
-		g.QueryStruct("ShowTasks").
+		g.NewQueryStruct("ShowTasks").
 			Show().
 			Terse().
 			SQL("TASKS").
@@ -179,7 +179,7 @@ var TasksDef = g.NewInterface(
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-task",
 		taskDbRow,
 		task,
-		g.QueryStruct("DescribeTask").
+		g.NewQueryStruct("DescribeTask").
 			Describe().
 			SQL("TASK").
 			Name().
@@ -188,7 +188,7 @@ var TasksDef = g.NewInterface(
 	CustomOperation(
 		"Execute",
 		"https://docs.snowflake.com/en/sql-reference/sql/execute-task",
-		g.QueryStruct("ExecuteTask").
+		g.NewQueryStruct("ExecuteTask").
 			SQL("EXECUTE").
 			SQL("TASK").
 			Name().


### PR DESCRIPTION
This change contains 
- export of QueryStruct
- rename of its constructor to NewQueryStruct.
Other name proposal could be to name the type QueryStructBuilder (and other struct builders too) and leave QueryStruct constructor name. 

The change enables to create helper functions in definitions file, that are specific to given definition and shouldn't be put into generator common package.