### PR TITLE
fix: snowpipe error integration

### DIFF
--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -200,8 +200,9 @@ func ReadPipe(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if strings.Contains(pipe.NotificationChannel, "arn:aws:sns:") {
-		err = d.Set("aws_sns_topic_arn", pipe.NotificationChannel)
-		return err
+		if err := d.Set("aws_sns_topic_arn", pipe.NotificationChannel); err != nil {
+			return err
+		}
 	}
 
 	if err := d.Set("error_integration", pipe.ErrorIntegration); err != nil {
@@ -236,10 +237,10 @@ func UpdatePipe(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("error_integration") {
 		if errorIntegration, ok := d.GetOk("error_integration"); ok {
 			runSetStatement = true
-			pipeSet.Comment = sdk.String(errorIntegration.(string))
+			pipeSet.ErrorIntegration = sdk.String(errorIntegration.(string))
 		} else {
 			runUnsetStatement = true
-			pipeUnset.Comment = sdk.Bool(true)
+			pipeUnset.ErrorIntegration = sdk.Bool(true)
 		}
 	}
 

--- a/pkg/sdk/pipes.go
+++ b/pkg/sdk/pipes.go
@@ -56,6 +56,7 @@ type PipeSet struct {
 }
 
 type PipeUnset struct {
+	ErrorIntegration    *bool `ddl:"keyword" sql:"ERROR_INTEGRATION"`
 	PipeExecutionPaused *bool `ddl:"keyword" sql:"PIPE_EXECUTION_PAUSED"`
 	Comment             *bool `ddl:"keyword" sql:"COMMENT"`
 }

--- a/pkg/sdk/pipes_test.go
+++ b/pkg/sdk/pipes_test.go
@@ -93,7 +93,7 @@ func TestPipesAlter(t *testing.T) {
 	t.Run("validation: no property to unset", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Unset = &PipeUnset{}
-		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterPipeOptions.Unset", "PipeExecutionPaused", "Comment"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterPipeOptions.Unset", "ErrorIntegration", "PipeExecutionPaused", "Comment"))
 	})
 
 	t.Run("set tag: single", func(t *testing.T) {
@@ -154,10 +154,11 @@ func TestPipesAlter(t *testing.T) {
 		opts := defaultOpts()
 		opts.IfExists = Bool(true)
 		opts.Unset = &PipeUnset{
+			ErrorIntegration:    Bool(true),
 			PipeExecutionPaused: Bool(true),
 			Comment:             Bool(true),
 		}
-		assertOptsValidAndSQLEquals(t, opts, `ALTER PIPE IF EXISTS %s UNSET PIPE_EXECUTION_PAUSED, COMMENT`, id.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, `ALTER PIPE IF EXISTS %s UNSET ERROR_INTEGRATION, PIPE_EXECUTION_PAUSED, COMMENT`, id.FullyQualifiedName())
 	})
 
 	t.Run("refresh", func(t *testing.T) {

--- a/pkg/sdk/pipes_validations.go
+++ b/pkg/sdk/pipes_validations.go
@@ -49,8 +49,8 @@ func (opts *AlterPipeOptions) validate() error {
 		}
 	}
 	if unset := opts.Unset; valueSet(unset) {
-		if !anyValueSet(unset.PipeExecutionPaused, unset.Comment) {
-			errs = append(errs, errAtLeastOneOf("AlterPipeOptions.Unset", "PipeExecutionPaused", "Comment"))
+		if !anyValueSet(unset.ErrorIntegration, unset.PipeExecutionPaused, unset.Comment) {
+			errs = append(errs, errAtLeastOneOf("AlterPipeOptions.Unset", "ErrorIntegration", "PipeExecutionPaused", "Comment"))
 		}
 	}
 	return errors.Join(errs...)


### PR DESCRIPTION
This PR fixes a bug where setting `error_integration` on a `snowflake_pipe` resource would cause the name of the integration to be written to the comment field on the pipe instead of the error integration. A separate bug prevented the `error_integration` diffs from being detected if an SNS topic was set.

## Test Plan

I tested this using an existing stack where I have many pipes. I made an earnest attempt to update `pipes_integration_test.go`, but I reached the point where I needed a real SNS topic and decided that was beyond the timebox I set for this.

Using version 0.76.0:
1. Started with already deployed pipes that had a `comment` but no `error_integration`
2. Added `error_integration` to the terraform config.
3. terraform apply
4. Ran `describe pipe` on the updated pipes in Snowflake. The comments now contained the name of the notification integration, whereas `error_integration` was null.
5. terraform apply again with no changes
6. Ran `describe pipe` on the updated pipes in Snowflake. The comments were back to their previous value, but `error_integration` was still null.
7. Removed `error_integration` from the terraform config.
8. terraform apply
9. Ran `describe pipe` on the updated pipes in Snowflake. The comments were now blank.

Using the modified provider
1. Started with pipes that had a `comment` but no `error_integration`
2. Added `error_integration` to the terraform config.
3. terraform apply
4. Ran `describe pipe` on the updated pipes in Snowflake. The comments were unchanged and error integrations were set to the expected value.
5. Removed `error_integration` from the terraform config
6. terraform apply
7. Ran `describe pipe` on the updated pipes in Snowflake. The comments were unchanged, and error integrations were null.

## References

I initially started to file a bug report, but during investigation I figured out how to fix it so I'm opening a PR instead. Let me know if this isn't the right process