### PR TITLE
chore: Disable static check temporarily

### DIFF
--- a/.github/workflows/reviewdog-staticcheck.yml
+++ b/.github/workflows/reviewdog-staticcheck.yml
@@ -2,6 +2,8 @@ name: staticcheck
 on: [pull_request]
 jobs:
   reviewdog:
+    # disable the job temporarily (until we configure linters appropriately)
+    if: false
     name: reviewdog
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Disable the `staticcheck` until we configure linters appropriately or fix the reported problems (PRs are messy because it was turned on without checking).