### PR TITLE
fix: schemas show by id

### DIFF
--- a/pkg/resources/schema_acceptance_test.go
+++ b/pkg/resources/schema_acceptance_test.go
@@ -97,6 +97,7 @@ func TestAcc_Schema_Rename(t *testing.T) {
 // TestAcc_Schema_TwoSchemasWithTheSameNameOnDifferentDatabases proves https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2209 issue.
 func TestAcc_Schema_TwoSchemasWithTheSameNameOnDifferentDatabases(t *testing.T) {
 	name := "test_schema"
+	// It seems like Snowflake orders the output of SHOW command based on names, so they do matter
 	newDatabaseName := "SELDQBXEKC"
 
 	resource.Test(t, resource.TestCase{

--- a/pkg/resources/testdata/TestAcc_Schema/test.tf
+++ b/pkg/resources/testdata/TestAcc_Schema/test.tf
@@ -1,0 +1,5 @@
+resource "snowflake_schema" "test" {
+  name = var.name
+  database = var.database
+  comment = var.comment
+}

--- a/pkg/resources/testdata/TestAcc_Schema/variables.tf
+++ b/pkg/resources/testdata/TestAcc_Schema/variables.tf
@@ -1,0 +1,11 @@
+variable "name" {
+  type = string
+}
+
+variable "database" {
+  type = string
+}
+
+variable "comment" {
+  type = string
+}

--- a/pkg/resources/testdata/TestAcc_Schema_Rename/test.tf
+++ b/pkg/resources/testdata/TestAcc_Schema_Rename/test.tf
@@ -1,0 +1,5 @@
+resource "snowflake_schema" "test" {
+  name = var.name
+  database = var.database
+  comment = var.comment
+}

--- a/pkg/resources/testdata/TestAcc_Schema_Rename/variables.tf
+++ b/pkg/resources/testdata/TestAcc_Schema_Rename/variables.tf
@@ -1,0 +1,11 @@
+variable "name" {
+  type = string
+}
+
+variable "database" {
+  type = string
+}
+
+variable "comment" {
+  type = string
+}

--- a/pkg/resources/testdata/TestAcc_Schema_TwoSchemasWithTheSameNameOnDifferentDatabases/1/test.tf
+++ b/pkg/resources/testdata/TestAcc_Schema_TwoSchemasWithTheSameNameOnDifferentDatabases/1/test.tf
@@ -1,0 +1,4 @@
+resource "snowflake_schema" "test" {
+  name = var.name
+  database = var.database
+}

--- a/pkg/resources/testdata/TestAcc_Schema_TwoSchemasWithTheSameNameOnDifferentDatabases/1/variables.tf
+++ b/pkg/resources/testdata/TestAcc_Schema_TwoSchemasWithTheSameNameOnDifferentDatabases/1/variables.tf
@@ -1,0 +1,7 @@
+variable "name" {
+  type = string
+}
+
+variable "database" {
+  type = string
+}

--- a/pkg/resources/testdata/TestAcc_Schema_TwoSchemasWithTheSameNameOnDifferentDatabases/2/test.tf
+++ b/pkg/resources/testdata/TestAcc_Schema_TwoSchemasWithTheSameNameOnDifferentDatabases/2/test.tf
@@ -1,0 +1,13 @@
+resource "snowflake_schema" "test" {
+  name = var.name
+  database = var.database
+}
+
+resource "snowflake_database" "test" {
+  name = var.new_database
+}
+
+resource "snowflake_schema" "test_2" {
+  name = var.name
+  database = snowflake_database.test.name
+}

--- a/pkg/resources/testdata/TestAcc_Schema_TwoSchemasWithTheSameNameOnDifferentDatabases/2/variables.tf
+++ b/pkg/resources/testdata/TestAcc_Schema_TwoSchemasWithTheSameNameOnDifferentDatabases/2/variables.tf
@@ -1,0 +1,11 @@
+variable "name" {
+  type = string
+}
+
+variable "database" {
+  type = string
+}
+
+variable "new_database" {
+  type = string
+}

--- a/pkg/sdk/schemas.go
+++ b/pkg/sdk/schemas.go
@@ -389,6 +389,10 @@ func (v *schemas) Show(ctx context.Context, opts *ShowSchemaOptions) ([]Schema, 
 
 func (v *schemas) ShowByID(ctx context.Context, id DatabaseObjectIdentifier) (*Schema, error) {
 	schemas, err := v.client.Schemas.Show(ctx, &ShowSchemaOptions{
+		//In: &SchemaIn{
+		//	Database: Bool(true),
+		//	Name:     NewAccountObjectIdentifier(id.DatabaseName()),
+		//},
 		Like: &Like{
 			Pattern: String(id.Name()),
 		},

--- a/pkg/sdk/schemas.go
+++ b/pkg/sdk/schemas.go
@@ -389,10 +389,10 @@ func (v *schemas) Show(ctx context.Context, opts *ShowSchemaOptions) ([]Schema, 
 
 func (v *schemas) ShowByID(ctx context.Context, id DatabaseObjectIdentifier) (*Schema, error) {
 	schemas, err := v.client.Schemas.Show(ctx, &ShowSchemaOptions{
-		//In: &SchemaIn{
-		//	Database: Bool(true),
-		//	Name:     NewAccountObjectIdentifier(id.DatabaseName()),
-		//},
+		In: &SchemaIn{
+			Database: Bool(true),
+			Name:     NewAccountObjectIdentifier(id.DatabaseName()),
+		},
 		Like: &Like{
 			Pattern: String(id.Name()),
 		},


### PR DESCRIPTION
A fix for #2209

## Test Plan
- [x] Tests re-written to use plugin framework
- [x] added a test case where we create two schemas with the same name on different databases