### PR TITLE
fix: Fix encode Snowflake ID for object identifiers

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -65,15 +65,26 @@ func EncodeSnowflakeID(attributes ...interface{}) string {
 	// is attribute already an object identifier?
 	if len(attributes) == 1 {
 		if id, ok := attributes[0].(sdk.ObjectIdentifier); ok {
+			if val := reflect.ValueOf(id); val.Kind() == reflect.Ptr && val.IsNil() {
+				log.Panicf("Nil object identifier received")
+			}
 			parts := make([]string, 0)
 			switch v := id.(type) {
 			case sdk.AccountObjectIdentifier:
 				parts = append(parts, v.Name())
+			case *sdk.AccountObjectIdentifier:
+				parts = append(parts, v.Name())
 			case sdk.DatabaseObjectIdentifier:
+				parts = append(parts, v.DatabaseName(), v.Name())
+			case *sdk.DatabaseObjectIdentifier:
 				parts = append(parts, v.DatabaseName(), v.Name())
 			case sdk.SchemaObjectIdentifier:
 				parts = append(parts, v.DatabaseName(), v.SchemaName(), v.Name())
+			case *sdk.SchemaObjectIdentifier:
+				parts = append(parts, v.DatabaseName(), v.SchemaName(), v.Name())
 			case sdk.TableColumnIdentifier:
+				parts = append(parts, v.DatabaseName(), v.SchemaName(), v.TableName(), v.Name())
+			case *sdk.TableColumnIdentifier:
 				parts = append(parts, v.DatabaseName(), v.SchemaName(), v.TableName(), v.Name())
 			default:
 				log.Panicf("Unsupported object identifier: %v", id)

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -66,15 +66,15 @@ func EncodeSnowflakeID(attributes ...interface{}) string {
 	if len(attributes) == 1 {
 		if id, ok := attributes[0].(sdk.ObjectIdentifier); ok {
 			parts := make([]string, 0)
-			switch id.(type) {
+			switch v := id.(type) {
 			case sdk.AccountObjectIdentifier:
-				parts = append(parts, id.(sdk.AccountObjectIdentifier).Name())
+				parts = append(parts, v.Name())
 			case sdk.DatabaseObjectIdentifier:
-				parts = append(parts, id.(sdk.DatabaseObjectIdentifier).DatabaseName(), id.(sdk.DatabaseObjectIdentifier).Name())
+				parts = append(parts, v.DatabaseName(), v.Name())
 			case sdk.SchemaObjectIdentifier:
-				parts = append(parts, id.(sdk.SchemaObjectIdentifier).DatabaseName(), id.(sdk.SchemaObjectIdentifier).SchemaName(), id.(sdk.SchemaObjectIdentifier).Name())
+				parts = append(parts, v.DatabaseName(), v.SchemaName(), v.Name())
 			case sdk.TableColumnIdentifier:
-				parts = append(parts, id.(sdk.TableColumnIdentifier).DatabaseName(), id.(sdk.TableColumnIdentifier).SchemaName(), id.(sdk.TableColumnIdentifier).TableName(), id.(sdk.TableColumnIdentifier).Name())
+				parts = append(parts, v.DatabaseName(), v.SchemaName(), v.TableName(), v.Name())
 			default:
 				log.Panicf("Unsupported object identifier: %v", id)
 			}

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -65,10 +65,18 @@ func EncodeSnowflakeID(attributes ...interface{}) string {
 	// is attribute already an object identifier?
 	if len(attributes) == 1 {
 		if id, ok := attributes[0].(sdk.ObjectIdentifier); ok {
-			// remove quotes and replace dots with pipes
-			parts := strings.Split(id.FullyQualifiedName(), ".")
-			for i, part := range parts {
-				parts[i] = strings.Trim(part, `"`)
+			parts := make([]string, 0)
+			switch id.(type) {
+			case sdk.AccountObjectIdentifier:
+				parts = append(parts, id.(sdk.AccountObjectIdentifier).Name())
+			case sdk.DatabaseObjectIdentifier:
+				parts = append(parts, id.(sdk.DatabaseObjectIdentifier).DatabaseName(), id.(sdk.DatabaseObjectIdentifier).Name())
+			case sdk.SchemaObjectIdentifier:
+				parts = append(parts, id.(sdk.SchemaObjectIdentifier).DatabaseName(), id.(sdk.SchemaObjectIdentifier).SchemaName(), id.(sdk.SchemaObjectIdentifier).Name())
+			case sdk.TableColumnIdentifier:
+				parts = append(parts, id.(sdk.TableColumnIdentifier).DatabaseName(), id.(sdk.TableColumnIdentifier).SchemaName(), id.(sdk.TableColumnIdentifier).TableName(), id.(sdk.TableColumnIdentifier).Name())
+			default:
+				log.Panicf("Unsupported object identifier: %v", id)
 			}
 			return strings.Join(parts, IDDelimiter)
 		}

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -77,7 +77,7 @@ func TestDecodeSnowflakeParameterID(t *testing.T) {
 // TODO: add tests for non object identifiers
 func TestEncodeSnowflakeID(t *testing.T) {
 	testCases := map[string]struct {
-		identifier        any
+		identifier        sdk.ObjectIdentifier
 		expectedEncodedID string
 	}{
 		"encodes account object identifier": {

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -80,40 +80,40 @@ func TestEncodeSnowflakeID(t *testing.T) {
 		expectedEncodedID string
 	}{
 		"encodes account object identifier": {
-			identifier:        sdk.NewAccountObjectIdentifier("account"),
-			expectedEncodedID: `account`,
+			identifier:        sdk.NewAccountObjectIdentifier("database"),
+			expectedEncodedID: `database`,
 		},
 		"encodes quoted account object identifier": {
-			identifier:        sdk.NewAccountObjectIdentifier("\"account\""),
-			expectedEncodedID: `account`,
+			identifier:        sdk.NewAccountObjectIdentifier("\"database\""),
+			expectedEncodedID: `database`,
 		},
 		"encodes account object identifier with a dot": {
-			identifier:        sdk.NewAccountObjectIdentifier("acc.ount"),
-			expectedEncodedID: `acc.ount`,
+			identifier:        sdk.NewAccountObjectIdentifier("data.base"),
+			expectedEncodedID: `data.base`,
 		},
 		"encodes database object identifier": {
-			identifier:        sdk.NewDatabaseObjectIdentifier("account", "database"),
-			expectedEncodedID: `account|database`,
+			identifier:        sdk.NewDatabaseObjectIdentifier("database", "schema"),
+			expectedEncodedID: `database|schema`,
 		},
 		"encodes quoted database object identifier": {
-			identifier:        sdk.NewDatabaseObjectIdentifier("\"account\"", "\"database\""),
-			expectedEncodedID: `account|database`,
+			identifier:        sdk.NewDatabaseObjectIdentifier("\"database\"", "\"schema\""),
+			expectedEncodedID: `database|schema`,
 		},
 		"encodes database object identifier with dots": {
-			identifier:        sdk.NewDatabaseObjectIdentifier("acc.ount", "data.base"),
-			expectedEncodedID: `acc.ount|data.base`,
+			identifier:        sdk.NewDatabaseObjectIdentifier("data.base", "sche.ma"),
+			expectedEncodedID: `data.base|sche.ma`,
 		},
 		"encodes schema object identifier": {
-			identifier:        sdk.NewSchemaObjectIdentifier("account", "database", "schema"),
-			expectedEncodedID: `account|database|schema`,
+			identifier:        sdk.NewSchemaObjectIdentifier("database", "schema", "table"),
+			expectedEncodedID: `database|schema|table`,
 		},
 		"encodes quoted schema object identifier": {
-			identifier:        sdk.NewSchemaObjectIdentifier("\"account\"", "\"database\"", "\"schema\""),
-			expectedEncodedID: `account|database|schema`,
+			identifier:        sdk.NewSchemaObjectIdentifier("\"database\"", "\"schema\"", "\"table\""),
+			expectedEncodedID: `database|schema|table`,
 		},
 		"encodes schema object identifier with dots": {
-			identifier:        sdk.NewSchemaObjectIdentifier("acc.ount", "data.base", "sche.ma"),
-			expectedEncodedID: `acc.ount|data.base|sche.ma`,
+			identifier:        sdk.NewSchemaObjectIdentifier("data.base", "sche.ma", "tab.le"),
+			expectedEncodedID: `data.base|sche.ma|tab.le`,
 		},
 		"encodes table column identifier": {
 			identifier:        sdk.NewTableColumnIdentifier("database", "schema", "table", "column"),
@@ -135,4 +135,20 @@ func TestEncodeSnowflakeID(t *testing.T) {
 			require.Equal(t, tc.expectedEncodedID, encodedID)
 		})
 	}
+
+	t.Run("panics for unsupported object identifier", func(t *testing.T) {
+		require.Panics(t, func() {
+			EncodeSnowflakeID(unsupportedObjectIdentifier{})
+		})
+	})
+}
+
+type unsupportedObjectIdentifier struct{}
+
+func (i unsupportedObjectIdentifier) Name() string {
+	return "name"
+}
+
+func (i unsupportedObjectIdentifier) FullyQualifiedName() string {
+	return "fully qualified name"
 }

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"testing"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,4 +71,68 @@ func TestDecodeSnowflakeParameterID(t *testing.T) {
 		_, err := DecodeSnowflakeParameterID(id)
 		require.Errorf(t, err, "incompatible identifier: %s", id)
 	})
+}
+
+// TODO: add tests for non object identifiers
+func TestEncodeSnowflakeID(t *testing.T) {
+	testCases := map[string]struct {
+		identifier        sdk.ObjectIdentifier
+		expectedEncodedID string
+	}{
+		"encodes account object identifier": {
+			identifier:        sdk.NewAccountObjectIdentifier("account"),
+			expectedEncodedID: `account`,
+		},
+		"encodes quoted account object identifier": {
+			identifier:        sdk.NewAccountObjectIdentifier("\"account\""),
+			expectedEncodedID: `account`,
+		},
+		"encodes account object identifier with a dot": {
+			identifier:        sdk.NewAccountObjectIdentifier("acc.ount"),
+			expectedEncodedID: `acc.ount`,
+		},
+		"encodes database object identifier": {
+			identifier:        sdk.NewDatabaseObjectIdentifier("account", "database"),
+			expectedEncodedID: `account|database`,
+		},
+		"encodes quoted database object identifier": {
+			identifier:        sdk.NewDatabaseObjectIdentifier("\"account\"", "\"database\""),
+			expectedEncodedID: `account|database`,
+		},
+		"encodes database object identifier with dots": {
+			identifier:        sdk.NewDatabaseObjectIdentifier("acc.ount", "data.base"),
+			expectedEncodedID: `acc.ount|data.base`,
+		},
+		"encodes schema object identifier": {
+			identifier:        sdk.NewSchemaObjectIdentifier("account", "database", "schema"),
+			expectedEncodedID: `account|database|schema`,
+		},
+		"encodes quoted schema object identifier": {
+			identifier:        sdk.NewSchemaObjectIdentifier("\"account\"", "\"database\"", "\"schema\""),
+			expectedEncodedID: `account|database|schema`,
+		},
+		"encodes schema object identifier with dots": {
+			identifier:        sdk.NewSchemaObjectIdentifier("acc.ount", "data.base", "sche.ma"),
+			expectedEncodedID: `acc.ount|data.base|sche.ma`,
+		},
+		"encodes table column identifier": {
+			identifier:        sdk.NewTableColumnIdentifier("database", "schema", "table", "column"),
+			expectedEncodedID: `database|schema|table|column`,
+		},
+		"encodes quoted table column identifier": {
+			identifier:        sdk.NewTableColumnIdentifier("\"database\"", "\"schema\"", "\"table\"", "\"column\""),
+			expectedEncodedID: `database|schema|table|column`,
+		},
+		"encodes table column identifier with dots": {
+			identifier:        sdk.NewTableColumnIdentifier("data.base", "sche.ma", "tab.le", "col.umn"),
+			expectedEncodedID: `data.base|sche.ma|tab.le|col.umn`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			encodedID := EncodeSnowflakeID(tc.identifier)
+			require.Equal(t, tc.expectedEncodedID, encodedID)
+		})
+	}
 }

--- a/pkg/resources/testdata/TestAcc_ExternalTable_basic/test.tf
+++ b/pkg/resources/testdata/TestAcc_ExternalTable_basic/test.tf
@@ -1,22 +1,22 @@
 resource "snowflake_storage_integration" "i" {
-  name = var.name
+  name                      = var.name
   storage_allowed_locations = [var.location]
-  storage_provider = "S3"
-  storage_aws_role_arn = var.aws_arn
+  storage_provider          = "S3"
+  storage_aws_role_arn      = var.aws_arn
 }
 
 resource "snowflake_stage" "test" {
-  name = var.name
-  url = var.location
-  database = var.database
-  schema = var.schema
+  name                = var.name
+  url                 = var.location
+  database            = var.database
+  schema              = var.schema
   storage_integration = snowflake_storage_integration.i.name
 }
 
 resource "snowflake_external_table" "test_table" {
-  name = var.name
+  name     = var.name
   database = var.database
-  schema = var.schema
+  schema   = var.schema
   comment  = "Terraform acceptance test"
   column {
     name = "column1"
@@ -29,5 +29,5 @@ resource "snowflake_external_table" "test_table" {
     as   = "($1:\"CreatedDate\"::timestamp)"
   }
   file_format = "TYPE = CSV"
-  location = "@\"${var.database}\".\"${var.schema}\".\"${snowflake_stage.test.name}\""
+  location    = "@\"${var.database}\".\"${var.schema}\".\"${snowflake_stage.test.name}\""
 }

--- a/pkg/resources/user_acceptance_test.go
+++ b/pkg/resources/user_acceptance_test.go
@@ -162,3 +162,26 @@ resource "snowflake_user" "w" {
 	log.Printf("[DEBUG] s2 %s", s)
 	return fmt.Sprintf(s, prefix, prefix)
 }
+
+func TestAcc_User_withDotInID(t *testing.T) {
+	r := require.New(t)
+	prefix := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)) + "user.123"
+	sshkey1, err := testhelpers.Fixture("userkey1")
+	r.NoError(err)
+	sshkey2, err := testhelpers.Fixture("userkey2")
+	r.NoError(err)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    acc.TestAccProviders(),
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: uConfig(prefix, sshkey1, sshkey2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_user.w", "name", prefix),
+				),
+			},
+		},
+	})
+}

--- a/pkg/resources/user_acceptance_test.go
+++ b/pkg/resources/user_acceptance_test.go
@@ -163,7 +163,10 @@ resource "snowflake_user" "w" {
 	return fmt.Sprintf(s, prefix, prefix)
 }
 
-func TestAcc_User_withDotInID(t *testing.T) {
+// TestAcc_User_issue2058 proves https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2058 issue.
+// The problem was with a dot in user identifier.
+// Before the fix it results in panic: interface conversion: sdk.ObjectIdentifier is sdk.DatabaseObjectIdentifier, not sdk.AccountObjectIdentifier error.
+func TestAcc_User_issue2058(t *testing.T) {
 	r := require.New(t)
 	prefix := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)) + "user.123"
 	sshkey1, err := testhelpers.Fixture("userkey1")

--- a/pkg/sdk/identifier_helpers.go
+++ b/pkg/sdk/identifier_helpers.go
@@ -121,7 +121,9 @@ type AccountObjectIdentifier struct {
 }
 
 func NewAccountObjectIdentifier(name string) AccountObjectIdentifier {
-	return AccountObjectIdentifier{name: name}
+	return AccountObjectIdentifier{
+		name: strings.Trim(name, `"`),
+	}
 }
 
 func NewAccountObjectIdentifierFromFullyQualifiedName(fullyQualifiedName string) AccountObjectIdentifier {
@@ -268,7 +270,12 @@ type TableColumnIdentifier struct {
 }
 
 func NewTableColumnIdentifier(databaseName, schemaName, tableName, columnName string) TableColumnIdentifier {
-	return TableColumnIdentifier{databaseName: databaseName, schemaName: schemaName, tableName: tableName, columnName: columnName}
+	return TableColumnIdentifier{
+		databaseName: strings.Trim(databaseName, `"`),
+		schemaName:   strings.Trim(schemaName, `"`),
+		tableName:    strings.Trim(tableName, `"`),
+		columnName:   strings.Trim(columnName, `"`),
+	}
 }
 
 func NewTableColumnIdentifierFromFullyQualifiedName(fullyQualifiedName string) TableColumnIdentifier {

--- a/pkg/sdk/privileges.go
+++ b/pkg/sdk/privileges.go
@@ -186,12 +186,12 @@ const (
 
 	// -- For ICEBERG TABLE
 	SchemaObjectPrivilegeApplyBudget SchemaObjectPrivilege = "APPLYBUDGET"
-	//SchemaObjectPrivilegeDelete      SchemaObjectPrivilege = "DELETE" (duplicate)
-	//SchemaObjectPrivilegeInsert      SchemaObjectPrivilege = "INSERT" (duplicate)
-	//SchemaObjectPrivilegeReferences  SchemaObjectPrivilege = "REFERENCES" (duplicate)
-	//SchemaObjectPrivilegeSelect      SchemaObjectPrivilege = "SELECT" (duplicate)
-	//SchemaObjectPrivilegeTruncate      SchemaObjectPrivilege = "Truncate" (duplicate)
-	//SchemaObjectPrivilegeUpdate      SchemaObjectPrivilege = "Update" (duplicate)
+	// SchemaObjectPrivilegeDelete      SchemaObjectPrivilege = "DELETE" (duplicate)
+	// SchemaObjectPrivilegeInsert      SchemaObjectPrivilege = "INSERT" (duplicate)
+	// SchemaObjectPrivilegeReferences  SchemaObjectPrivilege = "REFERENCES" (duplicate)
+	// SchemaObjectPrivilegeSelect      SchemaObjectPrivilege = "SELECT" (duplicate)
+	// SchemaObjectPrivilegeTruncate      SchemaObjectPrivilege = "Truncate" (duplicate)
+	// SchemaObjectPrivilegeUpdate      SchemaObjectPrivilege = "Update" (duplicate)
 
 	// -- For PIPE
 	// { MONITOR | OPERATE } [ , ... ]


### PR DESCRIPTION
Fix encoding SnowflakeIDs for SDK object identifiers.

It still needs work for other types; we will revisit this with identifiers rework.

Fix #2058 