### PR TITLE
Parse External table partitions correctly

### DIFF
--- a/pkg/resources/external_table.go
+++ b/pkg/resources/external_table.go
@@ -178,7 +178,8 @@ func CreateExternalTable(d *schema.ResourceData, meta any) error {
 	req.WithCopyGrants(sdk.Bool(d.Get("copy_grants").(bool)))
 
 	if v, ok := d.GetOk("partition_by"); ok {
-		req.WithPartitionBy(v.([]string))
+		partitionBy := expandStringList(v.([]any))
+		req.WithPartitionBy(partitionBy)
 	}
 
 	if v, ok := d.GetOk("pattern"); ok {


### PR DESCRIPTION
Fix for #2283
Reason: The Terraform on a ListType field returns a list of []any, so the Go assertion to []string failed because the underlying type was not known. A helper `expandStringList` function should be used instead.