### PR TITLE
chore: Allow setting gosnowflake logging level from environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ test-architecture: ## check architecture constraints between packages
 	go test ./pkg/architests/... -v
 
 test-client: ## runs test that checks sdk.Client without instrumentedsql
-	SF_TF_NO_INSTRUMENTED_SQL=1 go test ./pkg/sdk/internal/client/... -v
+	SF_TF_NO_INSTRUMENTED_SQL=1 SF_TF_GOSNOWFLAKE_LOG_LEVEL=debug go test ./pkg/sdk/internal/client/... -v
 
 build-local: ## build the binary locally
 	go build -o $(BASE_BINARY_NAME) .

--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ Set environment variable `SF_TF_ADDITIONAL_DEBUG_LOGGING` to a non-empty value. 
 ## Additional SQL Client configuration
 Currently underlying sql [gosnowflake](https://github.com/snowflakedb/gosnowflake) driver is wrapped with [instrumentedsql](https://github.com/luna-duclos/instrumentedsql). In order to use raw [gosnowflake](https://github.com/snowflakedb/gosnowflake) driver, set environment variable `SF_TF_NO_INSTRUMENTED_SQL` to a non-empty value.
 
+By default, the underlying driver is set to error level logging. It can be changed by setting `SF_TF_GOSNOWFLAKE_LOG_LEVEL` to one of:
+- `panic`
+- `fatal`
+- `error`
+- `warn`
+- `warning`
+- `info`
+- `debug`
+- `trace`
+
+*note*: It's possible it will be one of the provider config parameters in the future provider versions.
+
 ## Contributing
 
 Cf. [Contributing](./CONTRIBUTING.md).

--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -13,10 +13,14 @@ import (
 	"github.com/snowflakedb/gosnowflake"
 )
 
-var instrumentedSQL bool
+var (
+	instrumentedSQL         bool
+	gosnowflakeLoggingLevel string
+)
 
 func init() {
 	instrumentedSQL = os.Getenv("SF_TF_NO_INSTRUMENTED_SQL") == ""
+	gosnowflakeLoggingLevel = os.Getenv("SF_TF_GOSNOWFLAKE_LOG_LEVEL")
 }
 
 type Client struct {
@@ -118,6 +122,10 @@ func NewClient(cfg *gosnowflake.Config) (*Client, error) {
 			sql.Register("snowflake-instrumented", instrumentedsql.WrapDriver(new(gosnowflake.SnowflakeDriver), instrumentedsql.WithLogger(logger)))
 		}
 		driverName = "snowflake-instrumented"
+	}
+
+	if gosnowflakeLoggingLevel != "" {
+		cfg.Tracing = gosnowflakeLoggingLevel
 	}
 
 	dsn, err := gosnowflake.DSN(cfg)

--- a/pkg/sdk/client_integration_test.go
+++ b/pkg/sdk/client_integration_test.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/snowflakedb/gosnowflake"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -75,4 +75,23 @@ func TestClient_queryOne(t *testing.T) {
 	err := client.queryOne(ctx, &row, "SELECT 1 AS ONE")
 	require.NoError(t, err)
 	require.Equal(t, 1, row.One)
+}
+
+func TestClient_NewClientDriverLoggingLevel(t *testing.T) {
+	t.Run("get default gosnowflake driver logging level", func(t *testing.T) {
+		config := DefaultConfig()
+		_, err := NewClient(config)
+		require.NoError(t, err)
+
+		assert.Equal(t, "error", gosnowflake.GetLogger().GetLogLevel())
+	})
+
+	t.Run("set gosnowflake driver logging level with config", func(t *testing.T) {
+		config := DefaultConfig()
+		config.Tracing = "trace"
+		_, err := NewClient(config)
+		require.NoError(t, err)
+
+		assert.Equal(t, "trace", gosnowflake.GetLogger().GetLogLevel())
+	})
 }

--- a/pkg/sdk/client_integration_test.go
+++ b/pkg/sdk/client_integration_test.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"database/sql"
+	"os"
 	"testing"
 
 	"github.com/snowflakedb/gosnowflake"
@@ -83,7 +84,13 @@ func TestClient_NewClientDriverLoggingLevel(t *testing.T) {
 		_, err := NewClient(config)
 		require.NoError(t, err)
 
-		assert.Equal(t, "error", gosnowflake.GetLogger().GetLogLevel())
+		var expected string
+		if os.Getenv("GITHUB_ACTIONS") != "" {
+			expected = "fatal"
+		} else {
+			expected = "error"
+		}
+		assert.Equal(t, expected, gosnowflake.GetLogger().GetLogLevel())
 	})
 
 	t.Run("set gosnowflake driver logging level with config", func(t *testing.T) {

--- a/pkg/sdk/internal/client/client_test.go
+++ b/pkg/sdk/internal/client/client_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/snowflakedb/gosnowflake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,5 +26,19 @@ func TestNewClientWithoutInstrumentedSQL(t *testing.T) {
 
 		assert.NotContains(t, sql.Drivers(), "snowflake-instrumented")
 		assert.Contains(t, sql.Drivers(), "snowflake")
+	})
+}
+
+func TestNewClientWithDebugLoggingSetFromEnv(t *testing.T) {
+	t.Run("set gosnowflake driver logging to debug", func(t *testing.T) {
+		if os.Getenv("SF_TF_GOSNOWFLAKE_LOG_LEVEL") == "" {
+			t.Skip("Skipping TestNewClientWithDebugLoggingSet, because SF_TF_GOSNOWFLAKE_LOG_LEVEL is not set")
+		}
+
+		config := sdk.DefaultConfig()
+		_, err := sdk.NewClient(config)
+		require.NoError(t, err)
+
+		assert.Equal(t, "debug", gosnowflake.GetLogger().GetLogLevel())
 	})
 }


### PR DESCRIPTION
Allow setting gosnowflake logging level from `SF_TF_GOSNOWFLAKE_LOG_LEVEL` environment variable.