### PR TITLE
fix: Fix email notification integration

### DIFF
--- a/docs/resources/email_notification_integration.md
+++ b/docs/resources/email_notification_integration.md
@@ -27,12 +27,12 @@ resource "snowflake_email_notification_integration" "email_int" {
 
 ### Required
 
-- `allowed_recipients` (Set of String) List of email addresses that should receive notifications.
 - `enabled` (Boolean)
 - `name` (String)
 
 ### Optional
 
+- `allowed_recipients` (Set of String) List of email addresses that should receive notifications.
 - `comment` (String) A comment for the email integration.
 
 ### Read-Only

--- a/pkg/resources/email_notification_integration.go
+++ b/pkg/resources/email_notification_integration.go
@@ -119,6 +119,8 @@ func ReadEmailNotificationIntegration(d *schema.ResourceData, meta interface{}) 
 		}
 		switch k {
 		case "ALLOWED_RECIPIENTS":
+			// Empty list returns strange string (it's empty on worksheet level).
+			// This is a quick workaround, should be fixed with moving the email integration to SDK.
 			r := regexp.MustCompile(`[[:print:]]`)
 			if r.MatchString(v.(string)) {
 				if err := d.Set("allowed_recipients", strings.Split(v.(string), ",")); err != nil {

--- a/pkg/resources/email_notification_integration_acceptance_test.go
+++ b/pkg/resources/email_notification_integration_acceptance_test.go
@@ -18,15 +18,18 @@ func TestAcc_EmailNotificationIntegration(t *testing.T) {
 	}
 
 	emailIntegrationName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	verifiedEmail := "artur.sawicki@snowflake.com"
+
 	resource.Test(t, resource.TestCase{
 		Providers:    acc.TestAccProviders(),
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: emailNotificationIntegrationConfig(emailIntegrationName),
+				Config: emailNotificationIntegrationConfig(emailIntegrationName, verifiedEmail),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_email_notification_integration.test", "name", emailIntegrationName),
+					resource.TestCheckResourceAttr("snowflake_email_notification_integration.test", "allowed_recipients.0", verifiedEmail),
 				),
 			},
 			{
@@ -38,12 +41,12 @@ func TestAcc_EmailNotificationIntegration(t *testing.T) {
 	})
 }
 
-func emailNotificationIntegrationConfig(name string) string {
+func emailNotificationIntegrationConfig(name string, email string) string {
 	s := `
 resource "snowflake_email_notification_integration" "test" {
   name               = "%s"
   enabled            = true
-  allowed_recipients = ["joe@domain.com"] # Verified Email Addresses is required
+  allowed_recipients = ["%s"] # Verified Email Addresses is required
   comment            = "test"
   /*
 Error: error creating notification integration: 394209 (22023):
@@ -52,5 +55,34 @@ Either these email addresses are not yet validated or do not belong to any user 
   */
 }
 `
+	return fmt.Sprintf(s, name, email)
+}
+
+// TestAcc_EmailNotificationIntegration_issue2223 proves https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2223 issue.
+// Snowflake allowed empty allowed recipients in https://docs.snowflake.com/en/release-notes/2023/7_40#email-notification-integrations-allowed-recipients-no-longer-required.
+func TestAcc_EmailNotificationIntegration_issue2223(t *testing.T) {
+	emailIntegrationName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	resource.Test(t, resource.TestCase{
+		Providers:    acc.TestAccProviders(),
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: emailNotificationIntegrationWithoutRecipientsConfig(emailIntegrationName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_email_notification_integration.test", "name", emailIntegrationName),
+					resource.TestCheckNoResourceAttr("snowflake_email_notification_integration.test", "allowed_recipients"),
+				),
+			},
+		},
+	})
+}
+
+func emailNotificationIntegrationWithoutRecipientsConfig(name string) string {
+	s := `
+resource "snowflake_email_notification_integration" "test" {
+  name               = "%s"
+  enabled            = true
+}`
 	return fmt.Sprintf(s, name)
 }


### PR DESCRIPTION
Fix email notification integration due to https://docs.snowflake.com/en/release-notes/2023/7_40#email-notification-integrations-allowed-recipients-no-longer-required.

Fix #2223 