### PR TITLE
feat: Add create streamlit privilege to the SDK

### DIFF
--- a/pkg/sdk/privileges.go
+++ b/pkg/sdk/privileges.go
@@ -148,6 +148,7 @@ const (
 	SchemaPrivilegeCreateSequence         SchemaPrivilege = "CREATE SEQUENCE"
 	SchemaPrivilegeCreateStage            SchemaPrivilege = "CREATE STAGE"
 	SchemaPrivilegeCreateStream           SchemaPrivilege = "CREATE STREAM"
+	SchemaPrivilegeCreateStreamlit        SchemaPrivilege = "CREATE STREAMLIT"
 	SchemaPrivilegeCreateTag              SchemaPrivilege = "CREATE TAG"
 	SchemaPrivilegeCreateTable            SchemaPrivilege = "CREATE TABLE"
 	SchemaPrivilegeCreateTask             SchemaPrivilege = "CREATE TASK"


### PR DESCRIPTION
A fix for #2290 
It doesn't include any stack trace, but it seems like we were just missing a privilege in the Go enum in the SDK (resources/privileges.go already had create streamlit privilege).