### PR TITLE
fix: Fix warehouse read and resource monitor empty set

### DIFF
--- a/pkg/resources/resource_monitor.go
+++ b/pkg/resources/resource_monitor.go
@@ -317,7 +317,7 @@ func UpdateResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 	ctx := context.Background()
 	var runSetStatement bool
 
-	opts := sdk.AlterResourceMonitorOptions{Set: &sdk.ResourceMonitorSet{}}
+	opts := sdk.AlterResourceMonitorOptions{}
 
 	if d.HasChange("notify_users") {
 		runSetStatement = true
@@ -332,9 +332,10 @@ func UpdateResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	set := sdk.ResourceMonitorSet{}
 	if d.HasChange("credit_quota") {
 		runSetStatement = true
-		opts.Set.CreditQuota = sdk.Pointer(d.Get("credit_quota").(int))
+		set.CreditQuota = sdk.Pointer(d.Get("credit_quota").(int))
 	}
 
 	if d.HasChange("frequency") || d.HasChange("start_timestamp") {
@@ -343,13 +344,17 @@ func UpdateResourceMonitor(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return err
 		}
-		opts.Set.Frequency = frequency
-		opts.Set.StartTimestamp = sdk.Pointer(d.Get("start_timestamp").(string))
+		set.Frequency = frequency
+		set.StartTimestamp = sdk.Pointer(d.Get("start_timestamp").(string))
 	}
 
 	if d.HasChange("end_timestamp") {
 		runSetStatement = true
-		opts.Set.EndTimestamp = sdk.Pointer(d.Get("end_timestamp").(string))
+		set.EndTimestamp = sdk.Pointer(d.Get("end_timestamp").(string))
+	}
+
+	if set != (sdk.ResourceMonitorSet{}) {
+		opts.Set = &set
 	}
 
 	// If ANY of the triggers changed, we collect all triggers and set them

--- a/pkg/resources/resource_monitor_acceptance_test.go
+++ b/pkg/resources/resource_monitor_acceptance_test.go
@@ -36,13 +36,25 @@ func TestAcc_ResourceMonitor(t *testing.T) {
 			},
 			// CHANGE PROPERTIES
 			{
-				Config: resourceMonitorConfig2(name),
+				Config: resourceMonitorConfig2(name, 75),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "name", name),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "credit_quota", "150"),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "set_for_account", "true"),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "notify_triggers.0", "50"),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "suspend_trigger", "75"),
+					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "suspend_immediate_trigger", "95"),
+				),
+			},
+			// CHANGE JUST suspend_trigger; proves https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2316
+			{
+				Config: resourceMonitorConfig2(name, 60),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "name", name),
+					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "credit_quota", "150"),
+					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "set_for_account", "true"),
+					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "notify_triggers.0", "50"),
+					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "suspend_trigger", "60"),
 					resource.TestCheckResourceAttr("snowflake_resource_monitor.test", "suspend_immediate_trigger", "95"),
 				),
 			},
@@ -198,7 +210,7 @@ resource "snowflake_resource_monitor" "test" {
 `, accName)
 }
 
-func resourceMonitorConfig2(accName string) string {
+func resourceMonitorConfig2(accName string, suspendTrigger int) string {
 	return fmt.Sprintf(`
 resource "snowflake_warehouse" "warehouse" {
   name           = "test"
@@ -212,10 +224,10 @@ resource "snowflake_resource_monitor" "test" {
 	set_for_account = true
 	notify_triggers = [50]
 	warehouses      = []
-	suspend_trigger = 75
+	suspend_trigger = %d
 	suspend_immediate_trigger = 95
 }
-`, accName)
+`, accName, suspendTrigger)
 }
 
 // TestAcc_ResourceMonitor_issue2167 proves https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2167 issue.

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -3,8 +3,8 @@ package resources
 import (
 	"context"
 	"database/sql"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/logging"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	snowflakevalidation "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -264,10 +264,47 @@ func ReadWarehouse(d *schema.ResourceData, meta interface{}) error {
 	if err = d.Set("enable_query_acceleration", w.EnableQueryAcceleration); err != nil {
 		return err
 	}
+
+	err = readWarehouseObjectProperties(d, id, client, ctx)
+	if err != nil {
+		return err
+	}
+
 	if w.EnableQueryAcceleration {
 		if err = d.Set("query_acceleration_max_scale_factor", w.QueryAccelerationMaxScaleFactor); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func readWarehouseObjectProperties(d *schema.ResourceData, warehouseId sdk.AccountObjectIdentifier, client *sdk.Client, ctx context.Context) error {
+	statementTimeoutInSecondsParameter, err := client.Parameters.ShowObjectParameter(ctx, "STATEMENT_TIMEOUT_IN_SECONDS", sdk.Object{ObjectType: sdk.ObjectTypeWarehouse, Name: warehouseId})
+	if err != nil {
+		return err
+	}
+	logging.DebugLogger.Printf("[DEBUG] STATEMENT_TIMEOUT_IN_SECONDS parameter was fetched: %v", statementTimeoutInSecondsParameter)
+	if err = d.Set("statement_timeout_in_seconds", sdk.ToInt(statementTimeoutInSecondsParameter.Value)); err != nil {
+		return err
+	}
+
+	statementQueuedTimeoutInSecondsParameter, err := client.Parameters.ShowObjectParameter(ctx, "STATEMENT_QUEUED_TIMEOUT_IN_SECONDS", sdk.Object{ObjectType: sdk.ObjectTypeWarehouse, Name: warehouseId})
+	if err != nil {
+		return err
+	}
+	logging.DebugLogger.Printf("[DEBUG] STATEMENT_QUEUED_TIMEOUT_IN_SECONDS parameter was fetched: %v", statementQueuedTimeoutInSecondsParameter)
+	if err = d.Set("statement_queued_timeout_in_seconds", sdk.ToInt(statementQueuedTimeoutInSecondsParameter.Value)); err != nil {
+		return err
+	}
+
+	maxConcurrencyLevelParameter, err := client.Parameters.ShowObjectParameter(ctx, "MAX_CONCURRENCY_LEVEL", sdk.Object{ObjectType: sdk.ObjectTypeWarehouse, Name: warehouseId})
+	if err != nil {
+		return err
+	}
+	logging.DebugLogger.Printf("[DEBUG] MAX_CONCURRENCY_LEVEL parameter was fetched: %v", maxConcurrencyLevelParameter)
+	if err = d.Set("max_concurrency_level", sdk.ToInt(maxConcurrencyLevelParameter.Value)); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"database/sql"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/logging"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"

--- a/pkg/resources/warehouse_acceptance_test.go
+++ b/pkg/resources/warehouse_acceptance_test.go
@@ -3,7 +3,6 @@ package resources_test
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"os"
 	"strings"
 	"testing"
@@ -12,6 +11,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Fix warehouse read and resource monitor empty set:
- Warehouse object parameters were not read, so external changes to them were not recognized by the resource.
- The resource monitor was always setting Set for alter (even when no properties were altered), which led to syntax errors on SQL generation.

Fix #2318
Fix #2316