### PR TITLE
update goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,11 @@
 builds:
 - env:
-  - CGO_ENABLED=0
+  - >-
+    {{- if eq .Os "darwin" or eq .Os "windows" }}
+      CGO_ENABLED=1
+    {{- else }}
+      CGO_ENABLED=0
+    {{- end }}
   goos:
     - windows
     - linux


### PR DESCRIPTION
mfa token caching does not work for windows / darwin OS when CGO is disabled. Its recommended to turn of CGO for performance reasons, so adding an env variable to gorelaser to only turn on CGO for windows and darwin