### PR TITLE
fix: Add secondary account and fix tests

### DIFF
--- a/pkg/sdk/testint/databases_integration_test.go
+++ b/pkg/sdk/testint/databases_integration_test.go
@@ -141,6 +141,7 @@ func TestInt_CreateShared(t *testing.T) {
 			Accounts: accountsToSet,
 		},
 	})
+	require.NoError(t, err)
 
 	databaseID := sdk.RandomAccountObjectIdentifier()
 	err = client.Databases.CreateShared(ctx, databaseID, shareTest.ExternalID(), nil)

--- a/pkg/sdk/testint/databases_integration_test.go
+++ b/pkg/sdk/testint/databases_integration_test.go
@@ -109,29 +109,33 @@ func TestInt_DatabasesCreate(t *testing.T) {
 }
 
 func TestInt_CreateShared(t *testing.T) {
-	t.Skipf("Snowflake secondary account is not configured. Must be set in ~./snowflake/config.yml with profile name: %s", secondaryAccountProfile)
 	client := testClient(t)
+	secondaryClient := testSecondaryClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
+
+	databaseTest, databaseCleanup := createDatabase(t, secondaryClient)
 	t.Cleanup(databaseCleanup)
-	shareTest, _ := createShare(t, client)
-	// t.Cleanup(shareCleanup)
-	err := client.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
+
+	shareTest, shareCleanup := createShare(t, secondaryClient)
+	t.Cleanup(shareCleanup)
+
+	err := secondaryClient.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
 		Database: databaseTest.ID(),
 	}, shareTest.ID())
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		err = client.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
+		err := secondaryClient.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
 			Database: databaseTest.ID(),
 		}, shareTest.ID())
+		require.NoError(t, err)
 	})
-	require.NoError(t, err)
-	secondaryClient := testSecondaryClient(t)
+
 	accountsToSet := []sdk.AccountIdentifier{
-		getAccountIdentifier(t, secondaryClient),
+		getAccountIdentifier(t, client),
 	}
+
 	// first add the account.
-	err = client.Shares.Alter(ctx, shareTest.ID(), &sdk.AlterShareOptions{
+	err = secondaryClient.Shares.Alter(ctx, shareTest.ID(), &sdk.AlterShareOptions{
 		IfExists: sdk.Bool(true),
 		Set: &sdk.ShareSet{
 			Accounts: accountsToSet,
@@ -139,15 +143,17 @@ func TestInt_CreateShared(t *testing.T) {
 	})
 
 	databaseID := sdk.RandomAccountObjectIdentifier()
-	err = secondaryClient.Databases.CreateShared(ctx, databaseID, shareTest.ExternalID(), nil)
+	err = client.Databases.CreateShared(ctx, databaseID, shareTest.ExternalID(), nil)
 	require.NoError(t, err)
-	database, err := secondaryClient.Databases.ShowByID(ctx, databaseID)
-	require.NoError(t, err)
-	assert.Equal(t, databaseID.Name(), database.Name)
 	t.Cleanup(func() {
-		err = secondaryClient.Databases.Drop(ctx, databaseID, nil)
+		err = client.Databases.Drop(ctx, databaseID, nil)
 		require.NoError(t, err)
 	})
+
+	database, err := client.Databases.ShowByID(ctx, databaseID)
+	require.NoError(t, err)
+
+	assert.Equal(t, databaseID.Name(), database.Name)
 }
 
 func TestInt_DatabasesCreateSecondary(t *testing.T) {
@@ -269,36 +275,38 @@ func TestInt_AlterReplication(t *testing.T) {
 
 func TestInt_AlterFailover(t *testing.T) {
 	client := testClient(t)
-	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
-	t.Cleanup(databaseCleanup)
 	secondaryClient := testSecondaryClient(t)
+	ctx := testContext(t)
+
+	databaseTest, databaseCleanup := createDatabase(t, secondaryClient)
+	t.Cleanup(databaseCleanup)
 
 	toAccounts := []sdk.AccountIdentifier{
-		getAccountIdentifier(t, secondaryClient),
+		getAccountIdentifier(t, client),
 	}
+
 	t.Run("enable and disable failover", func(t *testing.T) {
-		opts := &sdk.AlterDatabaseFailoverOptions{
+		err := secondaryClient.Databases.AlterFailover(ctx, databaseTest.ID(), &sdk.AlterDatabaseFailoverOptions{
 			EnableFailover: &sdk.EnableFailover{
 				ToAccounts: toAccounts,
 			},
-		}
-		err := client.Databases.AlterFailover(ctx, databaseTest.ID(), opts)
+		})
+		// TODO: has to be enabled by ORGADMIN (SNOW-1002025)
 		if strings.Contains(err.Error(), "Accounts enabled for failover must also be enabled for replication. Enable replication to account") {
 			t.Skip("Skipping test because secondary account not enabled for replication")
 		}
 		require.NoError(t, err)
-		opts = &sdk.AlterDatabaseFailoverOptions{
+
+		err = secondaryClient.Databases.AlterFailover(ctx, databaseTest.ID(), &sdk.AlterDatabaseFailoverOptions{
 			DisableFailover: &sdk.DisableFailover{
 				ToAccounts: toAccounts,
 			},
-		}
-		err = client.Databases.AlterFailover(ctx, databaseTest.ID(), opts)
+		})
 		require.NoError(t, err)
-		opts = &sdk.AlterDatabaseFailoverOptions{
+
+		err = secondaryClient.Databases.AlterFailover(ctx, databaseTest.ID(), &sdk.AlterDatabaseFailoverOptions{
 			Primary: sdk.Bool(true),
-		}
-		err = client.Databases.AlterFailover(ctx, databaseTest.ID(), opts)
+		})
 		require.NoError(t, err)
 	})
 }

--- a/pkg/sdk/testint/failover_groups_integration_test.go
+++ b/pkg/sdk/testint/failover_groups_integration_test.go
@@ -29,7 +29,7 @@ func TestInt_FailoverGroupsCreate(t *testing.T) {
 			sdk.PluralObjectTypeDatabases,
 		}
 		allowedAccounts := []sdk.AccountIdentifier{
-			getSecondaryAccountIdentifier(t),
+			getAccountIdentifier(t, testSecondaryClient(t)),
 		}
 		replicationSchedule := "10 MINUTE"
 		err := client.FailoverGroups.Create(ctx, id, objectTypes, allowedAccounts, &sdk.CreateFailoverGroupOptions{
@@ -80,7 +80,7 @@ func TestInt_FailoverGroupsCreate(t *testing.T) {
 			sdk.PluralObjectTypeIntegrations,
 		}
 		allowedAccounts := []sdk.AccountIdentifier{
-			getSecondaryAccountIdentifier(t),
+			getAccountIdentifier(t, testSecondaryClient(t)),
 		}
 		allowedIntegrationTypes := []sdk.IntegrationType{
 			sdk.IntegrationTypeAPIIntegrations,
@@ -105,6 +105,7 @@ func TestInt_FailoverGroupsCreate(t *testing.T) {
 }
 
 func TestInt_CreateSecondaryReplicationGroup(t *testing.T) {
+	// TODO: Business Critical Snowflake Edition (SNOW-1002023)
 	if os.Getenv("SNOWFLAKE_TEST_BUSINESS_CRITICAL_FEATURES") != "1" {
 		t.Skip("Skipping TestInt_FailoverGroupsCreate")
 	}
@@ -386,7 +387,7 @@ func TestInt_FailoverGroupsAlterSource(t *testing.T) {
 		failoverGroup, cleanupFailoverGroup := createFailoverGroup(t, client)
 		t.Cleanup(cleanupFailoverGroup)
 
-		secondaryAccountID := getSecondaryAccountIdentifier(t)
+		secondaryAccountID := getAccountIdentifier(t, testSecondaryClient(t))
 		// first add target account
 		opts := &sdk.AlterSourceFailoverGroupOptions{
 			Add: &sdk.FailoverGroupAdd{
@@ -538,6 +539,7 @@ func TestInt_FailoverGroupsAlterSource(t *testing.T) {
 }
 
 func TestInt_FailoverGroupsAlterTarget(t *testing.T) {
+	// TODO: Business Critical Snowflake Edition (SNOW-1002023)
 	if os.Getenv("SNOWFLAKE_TEST_BUSINESS_CRITICAL_FEATURES") != "1" {
 		t.Skip("Skipping TestInt_FailoverGroupsCreate")
 	}

--- a/pkg/sdk/testint/helpers_test.go
+++ b/pkg/sdk/testint/helpers_test.go
@@ -91,7 +91,7 @@ func createDatabaseWithOptions(t *testing.T, client *sdk.Client, id sdk.AccountO
 	return database, func() {
 		err := client.Databases.Drop(ctx, id, nil)
 		require.NoError(t, err)
-		err = client.Sessions.UseSchema(ctx, testSchema(t).ID())
+		err = testClient(t).Sessions.UseSchema(ctx, testSchema(t).ID())
 		require.NoError(t, err)
 	}
 }

--- a/pkg/sdk/testint/helpers_test.go
+++ b/pkg/sdk/testint/helpers_test.go
@@ -47,10 +47,10 @@ func useWarehouse(t *testing.T, client *sdk.Client, warehouseID sdk.AccountObjec
 
 func createDatabase(t *testing.T, client *sdk.Client) (*sdk.Database, func()) {
 	t.Helper()
-	return createDatabaseWithOptions(t, client, sdk.RandomAccountObjectIdentifier(), testSchema(t).ID(), &sdk.CreateDatabaseOptions{})
+	return createDatabaseWithOptions(t, client, sdk.RandomAccountObjectIdentifier(), &sdk.CreateDatabaseOptions{})
 }
 
-func createDatabaseWithOptions(t *testing.T, client *sdk.Client, id sdk.AccountObjectIdentifier, useSchemaAfterDatabaseDrop sdk.DatabaseObjectIdentifier, opts *sdk.CreateDatabaseOptions) (*sdk.Database, func()) {
+func createDatabaseWithOptions(t *testing.T, client *sdk.Client, id sdk.AccountObjectIdentifier, opts *sdk.CreateDatabaseOptions) (*sdk.Database, func()) {
 	t.Helper()
 	ctx := context.Background()
 	err := client.Databases.Create(ctx, id, opts)
@@ -60,7 +60,7 @@ func createDatabaseWithOptions(t *testing.T, client *sdk.Client, id sdk.AccountO
 	return database, func() {
 		err := client.Databases.Drop(ctx, id, nil)
 		require.NoError(t, err)
-		err = client.Sessions.UseSchema(ctx, useSchemaAfterDatabaseDrop)
+		err = client.Sessions.UseSchema(ctx, sdk.NewDatabaseObjectIdentifier(TestDatabaseName, TestSchemaName))
 		require.NoError(t, err)
 	}
 }

--- a/pkg/sdk/testint/setup_test.go
+++ b/pkg/sdk/testint/setup_test.go
@@ -15,6 +15,12 @@ const (
 	secondaryAccountProfile = "secondary_test_account"
 )
 
+var (
+	TestWarehouseName = "int_test_wh_" + random.UUID()
+	TestDatabaseName  = "int_test_db_" + random.UUID()
+	TestSchemaName    = "int_test_sc_" + random.UUID()
+)
+
 var itc integrationTestContext
 
 func TestMain(m *testing.M) {
@@ -146,8 +152,7 @@ func (itc *integrationTestContext) initialize() error {
 }
 
 func createDb(client *sdk.Client, ctx context.Context) (*sdk.Database, func(), error) {
-	name := "int_test_db_" + random.UUID()
-	id := sdk.NewAccountObjectIdentifier(name)
+	id := sdk.NewAccountObjectIdentifier(TestDatabaseName)
 	err := client.Databases.Create(ctx, id, nil)
 	if err != nil {
 		return nil, nil, err
@@ -159,21 +164,19 @@ func createDb(client *sdk.Client, ctx context.Context) (*sdk.Database, func(), e
 }
 
 func createSc(client *sdk.Client, ctx context.Context, db *sdk.Database) (*sdk.Schema, func(), error) {
-	name := "int_test_sc_" + random.UUID()
-	id := sdk.NewDatabaseObjectIdentifier(db.Name, name)
+	id := sdk.NewDatabaseObjectIdentifier(db.Name, TestSchemaName)
 	err := client.Schemas.Create(ctx, id, nil)
 	if err != nil {
 		return nil, nil, err
 	}
-	schema, err := client.Schemas.ShowByID(ctx, sdk.NewDatabaseObjectIdentifier(db.Name, name))
+	schema, err := client.Schemas.ShowByID(ctx, sdk.NewDatabaseObjectIdentifier(db.Name, TestSchemaName))
 	return schema, func() {
 		_ = client.Schemas.Drop(ctx, id, nil)
 	}, err
 }
 
 func createWh(client *sdk.Client, ctx context.Context) (*sdk.Warehouse, func(), error) {
-	name := "int_test_wh_" + random.UUID()
-	id := sdk.NewAccountObjectIdentifier(name)
+	id := sdk.NewAccountObjectIdentifier(TestWarehouseName)
 	err := client.Warehouses.Create(ctx, id, nil)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/sdk/testint/shares_integration_test.go
+++ b/pkg/sdk/testint/shares_integration_test.go
@@ -125,10 +125,11 @@ func TestInt_SharesDrop(t *testing.T) {
 
 func TestInt_SharesAlter(t *testing.T) {
 	client := testClient(t)
+	secondaryClient, err := testClientFromProfile(t, secondaryAccountProfile)
+	require.NoError(t, err)
 	ctx := testContext(t)
 
 	t.Run("add and remove accounts", func(t *testing.T) {
-		t.Skipf("Snowflake secondary account is not configured. Must be set in ~./snowflake/config.yml with profile name: %s", secondaryAccountProfile)
 		shareTest, shareCleanup := createShare(t, client)
 		t.Cleanup(shareCleanup)
 		err := client.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
@@ -141,7 +142,6 @@ func TestInt_SharesAlter(t *testing.T) {
 			}, shareTest.ID())
 		})
 		require.NoError(t, err)
-		secondaryClient := testSecondaryClient(t)
 		accountsToAdd := []sdk.AccountIdentifier{
 			getAccountIdentifier(t, secondaryClient),
 		}
@@ -184,32 +184,32 @@ func TestInt_SharesAlter(t *testing.T) {
 	})
 
 	t.Run("set accounts", func(t *testing.T) {
-		t.Skipf("Snowflake secondary account is not configured. Must be set in ~./snowflake/config.yml with profile name: %s", secondaryAccountProfile)
-		shareTest, shareCleanup := createShare(t, client)
+		db, dbCleanup := createDatabase(t, secondaryClient)
+		t.Cleanup(dbCleanup)
+		shareTest, shareCleanup := createShare(t, secondaryClient)
 		t.Cleanup(shareCleanup)
-		err := client.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
-			Database: testDb(t).ID(),
+		err := secondaryClient.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
+			Database: db.ID(),
 		}, shareTest.ID())
 		require.NoError(t, err)
 		t.Cleanup(func() {
-			err = client.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
-				Database: testDb(t).ID(),
+			err = secondaryClient.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
+				Database: db.ID(),
 			}, shareTest.ID())
 		})
 		require.NoError(t, err)
-		secondaryClient := testSecondaryClient(t)
 		accountsToSet := []sdk.AccountIdentifier{
-			getAccountIdentifier(t, secondaryClient),
+			getAccountIdentifier(t, client),
 		}
 		// first add the account.
-		err = client.Shares.Alter(ctx, shareTest.ID(), &sdk.AlterShareOptions{
+		err = secondaryClient.Shares.Alter(ctx, shareTest.ID(), &sdk.AlterShareOptions{
 			IfExists: sdk.Bool(true),
 			Set: &sdk.ShareSet{
 				Accounts: accountsToSet,
 			},
 		})
 		require.NoError(t, err)
-		shares, err := client.Shares.Show(ctx, &sdk.ShowShareOptions{
+		shares, err := secondaryClient.Shares.Show(ctx, &sdk.ShowShareOptions{
 			Like: &sdk.Like{
 				Pattern: sdk.String(shareTest.Name.Name()),
 			},
@@ -346,39 +346,40 @@ func TestInt_ShareDescribeProvider(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		t.Run("describe share by name", func(t *testing.T) {
-			shareDetails, err := client.Shares.DescribeProvider(ctx, shareTest.ID())
-			require.NoError(t, err)
-			assert.Equal(t, 1, len(shareDetails.SharedObjects))
-			sharedObject := shareDetails.SharedObjects[0]
-			assert.Equal(t, sdk.ObjectTypeDatabase, sharedObject.Kind)
-			assert.Equal(t, testDb(t).ID(), sharedObject.Name)
-		})
+		shareDetails, err := client.Shares.DescribeProvider(ctx, shareTest.ID())
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, len(shareDetails.SharedObjects))
+		sharedObject := shareDetails.SharedObjects[0]
+		assert.Equal(t, sdk.ObjectTypeDatabase, sharedObject.Kind)
+		assert.Equal(t, testDb(t).ID(), sharedObject.Name)
 	})
 }
 
 func TestInt_ShareDescribeConsumer(t *testing.T) {
-	consumerClient := testSecondaryClient(t)
 	ctx := testContext(t)
-	providerClient := testClient(t)
+	providerClient := testSecondaryClient(t)
+	consumerClient := testClient(t)
 
 	t.Run("describe share", func(t *testing.T) {
-		t.Skipf("Snowflake secondary account is not configured. Must be set in ~./snowflake/config.yml with profile name: %s", secondaryAccountProfile)
+		db, dbCleanup := createDatabase(t, providerClient)
+		t.Cleanup(dbCleanup)
+
 		shareTest, shareCleanup := createShare(t, providerClient)
 		t.Cleanup(shareCleanup)
 
 		err := providerClient.Grants.GrantPrivilegeToShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.GrantPrivilegeToShareOn{
-			Database: testDb(t).ID(),
+			Database: db.ID(),
 		}, shareTest.ID())
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = providerClient.Grants.RevokePrivilegeFromShare(ctx, sdk.ObjectPrivilegeUsage, &sdk.RevokePrivilegeFromShareOn{
-				Database: testDb(t).ID(),
+				Database: db.ID(),
 			}, shareTest.ID())
 			require.NoError(t, err)
 		})
 
-		// add consumer account to share.
+		// add a consumer account to share.
 		err = providerClient.Shares.Alter(ctx, shareTest.ID(), &sdk.AlterShareOptions{
 			Add: &sdk.ShareAdd{
 				Accounts: []sdk.AccountIdentifier{
@@ -387,13 +388,13 @@ func TestInt_ShareDescribeConsumer(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		t.Run("describe consume share", func(t *testing.T) {
-			shareDetails, err := consumerClient.Shares.DescribeConsumer(ctx, shareTest.ExternalID())
-			require.NoError(t, err)
-			assert.Equal(t, 1, len(shareDetails.SharedObjects))
-			sharedObject := shareDetails.SharedObjects[0]
-			assert.Equal(t, sdk.ObjectTypeDatabase, sharedObject.Kind)
-			assert.Equal(t, sdk.NewAccountObjectIdentifier("<DB>"), sharedObject.Name)
-		})
+
+		shareDetails, err := consumerClient.Shares.DescribeConsumer(ctx, shareTest.ExternalID())
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, len(shareDetails.SharedObjects))
+		sharedObject := shareDetails.SharedObjects[0]
+		assert.Equal(t, sdk.ObjectTypeDatabase, sharedObject.Kind)
+		assert.Equal(t, sdk.NewAccountObjectIdentifier("<DB>"), sharedObject.Name)
 	})
 }

--- a/pkg/sdk/testint/shares_integration_test.go
+++ b/pkg/sdk/testint/shares_integration_test.go
@@ -183,7 +183,7 @@ func TestInt_SharesAlter(t *testing.T) {
 	})
 
 	t.Run("set accounts", func(t *testing.T) {
-		db, dbCleanup := createDatabaseWithOptions(t, secondaryClient, sdk.RandomAccountObjectIdentifier(), testSchema(t).ID(), nil)
+		db, dbCleanup := createDatabase(t, secondaryClient)
 		t.Cleanup(dbCleanup)
 
 		shareTest, shareCleanup := createShare(t, secondaryClient)
@@ -372,7 +372,7 @@ func TestInt_ShareDescribeConsumer(t *testing.T) {
 	consumerClient := testClient(t)
 
 	t.Run("describe share", func(t *testing.T) {
-		db, dbCleanup := createDatabaseWithOptions(t, providerClient, sdk.RandomAccountObjectIdentifier(), testSchema(t).ID(), nil)
+		db, dbCleanup := createDatabase(t, providerClient)
 		t.Cleanup(dbCleanup)
 
 		shareTest, shareCleanup := createShare(t, providerClient)


### PR DESCRIPTION
The secondary account was added + tests with shares were fixed.
It turned out that the secondary has different business criticality (they probably should have the same business criticality). But for now, it only means I had to swap accounts in some places because you cannot share something from lower to higher business critically account (or vice-verse didn't remember). 