### PR TITLE
fix: Revert goreleaser mfa token caching

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,6 @@
 builds:
 - env:
-  - >-
-    {{- if eq .Os "darwin" or eq .Os "windows" }}
-      CGO_ENABLED=1
-    {{- else }}
-      CGO_ENABLED=0
-    {{- end }}
+  - CGO_ENABLED=0
   goos:
     - windows
     - linux


### PR DESCRIPTION
Fix for #2341
Goreleaser was unable to produce binaries for version 0.83.0.
We would like to release a bugfix version that will produce valid binaries which will be used in v0.83.0 and v0.83.1.