### PR TITLE
fix: grant read opeartion

### DIFF
--- a/pkg/resources/grant_privileges_to_role.go
+++ b/pkg/resources/grant_privileges_to_role.go
@@ -834,7 +834,7 @@ func readAccountRoleGrantPrivileges(ctx context.Context, client *sdk.Client, gra
 
 	withGrantOption := d.Get("with_grant_option").(bool)
 	privileges := []string{}
-	roleName := d.Get("role_name").(string)
+	roleName := sdk.NewAccountObjectIdentifier(d.Get("role_name").(string)).Name()
 
 	logging.DebugLogger.Printf("[DEBUG] Filtering grants to be set on account: count = %d", len(grants))
 	for _, grant := range grants {

--- a/pkg/resources/grant_privileges_to_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_role_acceptance_test.go
@@ -2,10 +2,11 @@ package resources_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"


### PR DESCRIPTION
The grant read operation can cause infinite plan and grant privileges on every `terraform apply`. It can occur when role_name is defined with the quotes. The solution for it is to compare always without quotes as one of the sides already uses AccountObjectIdentifier which doesn't save information if the identifier was originally quoted or not.