### PR TITLE
fix: Fix old masking policy implementation

### DIFF
--- a/pkg/snowflake/masking_policy_application.go
+++ b/pkg/snowflake/masking_policy_application.go
@@ -38,10 +38,10 @@ func (m *TableColumnMaskingPolicyApplicationManager) Read(x *TableColumnMaskingP
 }
 
 func (m *TableColumnMaskingPolicyApplicationManager) Parse(rows *sql.Rows, column string) (string, error) {
-	var name, sqlType, kind, null, defaultValue, primaryKey, uniqueKey, check, expression, comment, policyName sql.NullString
+	var name, sqlType, kind, null, defaultValue, primaryKey, uniqueKey, check, expression, comment, policyName, privacyDomain sql.NullString
 
 	for rows.Next() {
-		if err := rows.Scan(&name, &sqlType, &kind, &null, &defaultValue, &primaryKey, &uniqueKey, &check, &expression, &comment, &policyName); err != nil {
+		if err := rows.Scan(&name, &sqlType, &kind, &null, &defaultValue, &primaryKey, &uniqueKey, &check, &expression, &comment, &policyName, &privacyDomain); err != nil {
 			return "", err
 		}
 


### PR DESCRIPTION
Fix old masking policy implementation

Test `TestAcc_TableColumnMaskingPolicyApplication` started to fail after bundle 2023_08.

Fix #2362