### PR TITLE
feat: stages migration follow-up

### DIFF
--- a/pkg/sdk/file_format.go
+++ b/pkg/sdk/file_format.go
@@ -375,9 +375,8 @@ type AlterFileFormatOptions struct {
 	IfExists   *bool                  `ddl:"keyword" sql:"IF EXISTS"`
 	name       SchemaObjectIdentifier `ddl:"identifier"`
 
-	Rename     *AlterFileFormatRenameOptions
-	Set        *FileFormatTypeOptions `ddl:"list,no_comma" sql:"SET"`
-	SetComment *string                `ddl:"parameter,single_quotes" sql:"SET COMMENT"`
+	Rename *AlterFileFormatRenameOptions
+	Set    *FileFormatTypeOptions `ddl:"list,no_comma" sql:"SET"`
 }
 
 func (opts *AlterFileFormatOptions) validate() error {
@@ -398,6 +397,8 @@ type AlterFileFormatRenameOptions struct {
 }
 
 type FileFormatTypeOptions struct {
+	Comment *string `ddl:"parameter,single_quotes" sql:"COMMENT"`
+
 	// CSV type options
 	CSVCompression                *CSVCompression `ddl:"parameter" sql:"COMPRESSION"`
 	CSVRecordDelimiter            *string         `ddl:"parameter,single_quotes" sql:"RECORD_DELIMITER"`

--- a/pkg/sdk/file_format_test.go
+++ b/pkg/sdk/file_format_test.go
@@ -200,6 +200,21 @@ func TestFileFormatsAlter(t *testing.T) {
 		}
 		assertOptsValidAndSQLEquals(t, opts, `ALTER FILE FORMAT IF EXISTS "db"."schema"."fileformat" SET COMPRESSION = BROTLI TRIM_SPACE = true REPLACE_INVALID_CHARACTERS = true NULL_IF = ('nil')`)
 	})
+
+	t.Run("set comment", func(t *testing.T) {
+		opts := &AlterFileFormatOptions{
+			IfExists: Bool(true),
+			name:     NewSchemaObjectIdentifier("db", "schema", "fileformat"),
+			Set: &FileFormatTypeOptions{
+				AvroCompression:              &AvroCompressionBrotli,
+				AvroTrimSpace:                Bool(true),
+				AvroReplaceInvalidCharacters: Bool(true),
+				AvroNullIf:                   &[]NullString{{"nil"}},
+				Comment:                      String("some comment"),
+			},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER FILE FORMAT IF EXISTS "db"."schema"."fileformat" SET COMMENT = 'some comment' COMPRESSION = BROTLI TRIM_SPACE = true REPLACE_INVALID_CHARACTERS = true NULL_IF = ('nil')`)
+	})
 }
 
 func TestFileFormatsDrop(t *testing.T) {

--- a/pkg/sdk/testint/application_roles_gen_integration_test.go
+++ b/pkg/sdk/testint/application_roles_gen_integration_test.go
@@ -22,7 +22,7 @@ func TestInt_ApplicationRoles(t *testing.T) {
 	client := testClient(t)
 
 	stageName := "stage_name"
-	stage, cleanupStage := createStage(t, client, testDb(t), testSchema(t), stageName)
+	stage, cleanupStage := createStage(t, client, sdk.NewSchemaObjectIdentifier(TestDatabaseName, TestSchemaName, stageName))
 	t.Cleanup(cleanupStage)
 
 	putOnStage(t, client, stage, "manifest.yml")

--- a/pkg/sdk/testint/external_tables_integration_test.go
+++ b/pkg/sdk/testint/external_tables_integration_test.go
@@ -15,8 +15,8 @@ func TestInt_ExternalTables(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	stageID := sdk.NewAccountObjectIdentifier("EXTERNAL_TABLE_STAGE")
-	stageLocation := "@external_table_stage"
+	stageID := sdk.NewSchemaObjectIdentifier(TestDatabaseName, TestSchemaName, "EXTERNAL_TABLE_STAGE")
+	stageLocation := fmt.Sprintf("@%s", stageID.FullyQualifiedName())
 	_, _ = createStageWithURL(t, client, stageID, nycWeatherDataURL)
 
 	tag, _ := createTag(t, client, testDb(t), testSchema(t))

--- a/pkg/sdk/testint/file_format_integration_test.go
+++ b/pkg/sdk/testint/file_format_integration_test.go
@@ -381,7 +381,7 @@ func TestInt_FileFormatsAlter(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("set", func(t *testing.T) {
+	t.Run("set + set comment", func(t *testing.T) {
 		fileFormat, fileFormatCleanup := createFileFormatWithOptions(t, client, testSchema(t).ID(), &sdk.CreateFileFormatOptions{
 			Type: sdk.FileFormatTypeCSV,
 			FileFormatTypeOptions: sdk.FileFormatTypeOptions{
@@ -393,6 +393,7 @@ func TestInt_FileFormatsAlter(t *testing.T) {
 
 		err := client.FileFormats.Alter(ctx, fileFormat.ID(), &sdk.AlterFileFormatOptions{
 			Set: &sdk.FileFormatTypeOptions{
+				Comment:        sdk.String("some comment"),
 				CSVCompression: &sdk.CSVCompressionBz2,
 				CSVParseHeader: sdk.Bool(true),
 			},
@@ -403,6 +404,7 @@ func TestInt_FileFormatsAlter(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, sdk.CSVCompressionBz2, *result.Options.CSVCompression)
 		assert.Equal(t, true, *result.Options.CSVParseHeader)
+		assert.Equal(t, "some comment", result.Comment)
 	})
 }
 

--- a/pkg/sdk/testint/helpers_test.go
+++ b/pkg/sdk/testint/helpers_test.go
@@ -19,16 +19,16 @@ const (
 )
 
 var (
-	awsBucketUrl, awsBucketUrlIsSet = os.LookupEnv("AWS_EXTERNAL_BUCKET_URL")
-	awsKeyId, awsKeyIdIsSet         = os.LookupEnv("AWS_EXTERNAL_KEY_ID")
-	awsSecretKey, awsSecretKeyIsSet = os.LookupEnv("AWS_EXTERNAL_SECRET_KEY")
-	awsRoleARN, awsRoleARNIsSet     = os.LookupEnv("AWS_EXTERNAL_ROLE_ARN")
+	awsBucketUrl, awsBucketUrlIsSet = os.LookupEnv("TEST_SF_TF_AWS_EXTERNAL_BUCKET_URL")
+	awsKeyId, awsKeyIdIsSet         = os.LookupEnv("TEST_SF_TF_AWS_EXTERNAL_KEY_ID")
+	awsSecretKey, awsSecretKeyIsSet = os.LookupEnv("TEST_SF_TF_AWS_EXTERNAL_SECRET_KEY")
+	awsRoleARN, awsRoleARNIsSet     = os.LookupEnv("TEST_SF_TF_AWS_EXTERNAL_ROLE_ARN")
 
-	gcsBucketUrl, gcsBucketUrlIsSet = os.LookupEnv("GCS_EXTERNAL_BUCKET_URL")
+	gcsBucketUrl, gcsBucketUrlIsSet = os.LookupEnv("TEST_SF_TF_GCS_EXTERNAL_BUCKET_URL")
 
-	azureBucketUrl, azureBucketUrlIsSet = os.LookupEnv("AZURE_EXTERNAL_BUCKET_URL")
-	azureTenantId, azureTenantIdIsSet   = os.LookupEnv("AZURE_EXTERNAL_TENANT_ID")
-	azureSasToken, azureSasTokenIsSet   = os.LookupEnv("AZURE_EXTERNAL_SAS_TOKEN")
+	azureBucketUrl, azureBucketUrlIsSet = os.LookupEnv("TEST_SF_TF_AZURE_EXTERNAL_BUCKET_URL")
+	azureTenantId, azureTenantIdIsSet   = os.LookupEnv("TEST_SF_TF_AZURE_EXTERNAL_TENANT_ID")
+	azureSasToken, azureSasTokenIsSet   = os.LookupEnv("TEST_SF_TF_AZURE_EXTERNAL_SAS_TOKEN")
 
 	hasExternalEnvironmentVariablesSet = awsBucketUrlIsSet &&
 		awsKeyIdIsSet &&

--- a/pkg/sdk/testint/helpers_test.go
+++ b/pkg/sdk/testint/helpers_test.go
@@ -278,7 +278,7 @@ func createStageWithURL(t *testing.T, client *sdk.Client, id sdk.SchemaObjectIde
 	require.NoError(t, err)
 
 	return stage, func() {
-		client.Stages.Drop(ctx, sdk.NewDropStageRequest(id))
+		err := client.Stages.Drop(ctx, sdk.NewDropStageRequest(id))
 		require.NoError(t, err)
 	}
 }
@@ -293,7 +293,7 @@ func createStageWithOptions(t *testing.T, client *sdk.Client, id sdk.SchemaObjec
 	require.NoError(t, err)
 
 	return stage, func() {
-		client.Stages.Drop(ctx, sdk.NewDropStageRequest(id))
+		err := client.Stages.Drop(ctx, sdk.NewDropStageRequest(id))
 		require.NoError(t, err)
 	}
 }

--- a/pkg/sdk/testint/helpers_test.go
+++ b/pkg/sdk/testint/helpers_test.go
@@ -28,6 +28,7 @@ var (
 
 	azureBucketUrl, azureBucketUrlIsSet = os.LookupEnv("AZURE_EXTERNAL_BUCKET_URL")
 	azureTenantId, azureTenantIdIsSet   = os.LookupEnv("AZURE_EXTERNAL_TENANT_ID")
+	azureSasToken, azureSasTokenIsSet   = os.LookupEnv("AZURE_EXTERNAL_SAS_TOKEN")
 
 	hasExternalEnvironmentVariablesSet = awsBucketUrlIsSet &&
 		awsKeyIdIsSet &&
@@ -35,7 +36,8 @@ var (
 		awsRoleARNIsSet &&
 		gcsBucketUrlIsSet &&
 		azureBucketUrlIsSet &&
-		azureTenantIdIsSet
+		azureTenantIdIsSet &&
+		azureSasTokenIsSet
 )
 
 // there is no direct way to get the account identifier from Snowflake API, but you can get it if you know

--- a/pkg/sdk/testint/pipes_integration_test.go
+++ b/pkg/sdk/testint/pipes_integration_test.go
@@ -28,7 +28,7 @@ func TestInt_IncorrectCreatePipeBehaviour(t *testing.T) {
 	t.Cleanup(tableCleanup)
 
 	stageName := random.AlphanumericN(20)
-	stage, stageCleanup := createStage(t, itc.client, testDb(t), schema, stageName)
+	stage, stageCleanup := createStage(t, itc.client, sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, stageName))
 	t.Cleanup(stageCleanup)
 
 	t.Run("if we have special characters in db or schema name, create pipe returns error in copy <> from <> section", func(t *testing.T) {
@@ -71,7 +71,7 @@ func TestInt_PipesShowAndDescribe(t *testing.T) {
 	t.Cleanup(table2Cleanup)
 
 	stageName := random.AlphanumericN(20)
-	stage, stageCleanup := createStage(t, itc.client, testDb(t), testSchema(t), stageName)
+	stage, stageCleanup := createStage(t, itc.client, sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, stageName))
 	t.Cleanup(stageCleanup)
 
 	pipe1Name := random.AlphanumericN(20)
@@ -152,7 +152,7 @@ func TestInt_PipeCreate(t *testing.T) {
 	t.Cleanup(tableCleanup)
 
 	stageName := random.AlphanumericN(20)
-	stage, stageCleanup := createStage(t, itc.client, testDb(t), testSchema(t), stageName)
+	stage, stageCleanup := createStage(t, itc.client, sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, stageName))
 	t.Cleanup(stageCleanup)
 
 	copyStatement := createPipeCopyStatement(t, table, stage)
@@ -224,7 +224,7 @@ func TestInt_PipeDrop(t *testing.T) {
 	t.Cleanup(tableCleanup)
 
 	stageName := random.AlphanumericN(20)
-	stage, stageCleanup := createStage(t, itc.client, testDb(t), testSchema(t), stageName)
+	stage, stageCleanup := createStage(t, itc.client, sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, stageName))
 	t.Cleanup(stageCleanup)
 
 	t.Run("pipe exists", func(t *testing.T) {
@@ -252,7 +252,7 @@ func TestInt_PipeAlter(t *testing.T) {
 	t.Cleanup(tableCleanup)
 
 	stageName := random.AlphanumericN(20)
-	stage, stageCleanup := createStage(t, itc.client, testDb(t), testSchema(t), stageName)
+	stage, stageCleanup := createStage(t, itc.client, sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, stageName))
 	t.Cleanup(stageCleanup)
 
 	pipeCopyStatement := createPipeCopyStatement(t, table, stage)

--- a/pkg/sdk/testint/stages_gen_integration_test.go
+++ b/pkg/sdk/testint/stages_gen_integration_test.go
@@ -2,11 +2,12 @@ package testint
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestInt_Stages(t *testing.T) {
@@ -56,6 +57,7 @@ func TestInt_Stages(t *testing.T) {
 	}
 
 	createBasicAzureStage := func(t *testing.T, stageId sdk.SchemaObjectIdentifier) {
+		t.Helper()
 		err := client.Stages.CreateOnAzure(ctx, sdk.NewCreateOnAzureStageRequest(stageId).
 			WithFileFormat(sdk.NewStageFileFormatRequest().WithType(&sdk.FileFormatTypeJSON)).
 			WithExternalStageParams(sdk.NewExternalAzureStageParamsRequest(azureBucketUrl).

--- a/pkg/sdk/testint/stages_gen_integration_test.go
+++ b/pkg/sdk/testint/stages_gen_integration_test.go
@@ -1,49 +1,203 @@
 package testint
 
 import (
-	"testing"
-
+	"fmt"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestInt_Stages(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	t.Run("CreateInternal", func(t *testing.T) {
-		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+	if !hasExternalEnvironmentVariablesSet {
+		t.Skip("Skipping TestInt_Stages (External env variables are not set)")
+	}
 
-		err := client.Stages.CreateInternal(ctx, sdk.NewCreateInternalStageRequest(id))
-		require.NoError(t, err)
+	s3StorageIntegration, err := client.StorageIntegrations.ShowByID(ctx, sdk.NewAccountObjectIdentifier("S3_STORAGE_INTEGRATION"))
+	require.NoError(t, err)
+	gcpStorageIntegration, err := client.StorageIntegrations.ShowByID(ctx, sdk.NewAccountObjectIdentifier("GCP_STORAGE_INTEGRATION"))
+	require.NoError(t, err)
+	azureStorageIntegration, err := client.StorageIntegrations.ShowByID(ctx, sdk.NewAccountObjectIdentifier("AZURE_STORAGE_INTEGRATION"))
+	require.NoError(t, err)
+
+	cleanupStage := func(t *testing.T, id sdk.SchemaObjectIdentifier) {
+		t.Helper()
 		t.Cleanup(func() {
 			err := client.Stages.Drop(ctx, sdk.NewDropStageRequest(id))
 			require.NoError(t, err)
 		})
+	}
 
-		stage, err := client.Stages.ShowByID(ctx, id)
+	createBasicS3Stage := func(t *testing.T, stageId sdk.SchemaObjectIdentifier) {
+		t.Helper()
+		s3Req := sdk.NewExternalS3StageParamsRequest(awsBucketUrl).
+			WithCredentials(sdk.NewExternalStageS3CredentialsRequest().
+				WithAwsKeyId(&awsKeyId).
+				WithAwsSecretKey(&awsSecretKey))
+		err := client.Stages.CreateOnS3(ctx, sdk.NewCreateOnS3StageRequest(stageId).
+			WithFileFormat(sdk.NewStageFileFormatRequest().WithType(&sdk.FileFormatTypeJSON)).
+			WithExternalStageParams(s3Req))
 		require.NoError(t, err)
+		cleanupStage(t, stageId)
+	}
+
+	createBasicGcsStage := func(t *testing.T, stageId sdk.SchemaObjectIdentifier) {
+		t.Helper()
+		err := client.Stages.CreateOnGCS(ctx, sdk.NewCreateOnGCSStageRequest(stageId).
+			WithFileFormat(sdk.NewStageFileFormatRequest().WithType(&sdk.FileFormatTypeJSON)).
+			WithExternalStageParams(sdk.NewExternalGCSStageParamsRequest(gcsBucketUrl).
+				WithStorageIntegration(sdk.Pointer(sdk.NewAccountObjectIdentifier(gcpStorageIntegration.Name)))))
+		require.NoError(t, err)
+		cleanupStage(t, stageId)
+	}
+
+	createBasicAzureStage := func(t *testing.T, stageId sdk.SchemaObjectIdentifier) {
+		err := client.Stages.CreateOnAzure(ctx, sdk.NewCreateOnAzureStageRequest(stageId).
+			WithFileFormat(sdk.NewStageFileFormatRequest().WithType(&sdk.FileFormatTypeJSON)).
+			WithExternalStageParams(sdk.NewExternalAzureStageParamsRequest(azureBucketUrl).
+				WithCredentials(sdk.NewExternalStageAzureCredentialsRequest(azureSasToken))))
+		require.NoError(t, err)
+		cleanupStage(t, stageId)
+	}
+
+	assertStage := func(t *testing.T, stage *sdk.Stage, id sdk.SchemaObjectIdentifier, stageType string, comment string, cloud string, url string, storageIntegration string) {
+		t.Helper()
 		assert.Equal(t, id.DatabaseName(), stage.DatabaseName)
 		assert.Equal(t, id.SchemaName(), stage.SchemaName)
 		assert.Equal(t, id.Name(), stage.Name)
+		assert.Equal(t, comment, stage.Comment)
+		if len(url) > 0 {
+			assert.Equal(t, url, stage.Url)
+		}
+		assert.Equal(t, stageType, stage.Type)
+		if len(cloud) > 0 {
+			assert.Equal(t, cloud, *stage.Cloud)
+		}
+		if len(storageIntegration) > 0 {
+			assert.Equal(t, storageIntegration, *stage.StorageIntegration)
+		}
+	}
+
+	t.Run("CreateInternal", func(t *testing.T) {
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+
+		err := client.Stages.CreateInternal(ctx, sdk.NewCreateInternalStageRequest(id).
+			WithFileFormat(sdk.NewStageFileFormatRequest().WithType(&sdk.FileFormatTypeJSON)).
+			WithComment(sdk.String("some comment")))
+		require.NoError(t, err)
+		cleanupStage(t, id)
+
+		stage, err := client.Stages.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assertStage(t, stage, id, "INTERNAL", "some comment", "", "", "")
 	})
 
-	t.Run("CreateOnS3", func(t *testing.T) {
-		// TODO: fill me
+	t.Run("CreateInternal - temporary", func(t *testing.T) {
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+
+		err := client.Stages.CreateInternal(ctx, sdk.NewCreateInternalStageRequest(id).
+			WithTemporary(sdk.Bool(true)).
+			WithFileFormat(sdk.NewStageFileFormatRequest().WithType(&sdk.FileFormatTypeJSON)).
+			WithComment(sdk.String("some comment")))
+		require.NoError(t, err)
+		cleanupStage(t, id)
+
+		stage, err := client.Stages.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assertStage(t, stage, id, "INTERNAL TEMPORARY", "some comment", "", "", "")
+	})
+
+	t.Run("CreateOnS3 - IAM User", func(t *testing.T) {
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+
+		s3Req := sdk.NewExternalS3StageParamsRequest(awsBucketUrl).
+			WithCredentials(sdk.NewExternalStageS3CredentialsRequest().
+				WithAwsKeyId(&awsKeyId).
+				WithAwsSecretKey(&awsSecretKey))
+		err := client.Stages.CreateOnS3(ctx, sdk.NewCreateOnS3StageRequest(id).
+			WithFileFormat(sdk.NewStageFileFormatRequest().WithType(&sdk.FileFormatTypeJSON)).
+			WithExternalStageParams(s3Req).
+			WithComment(sdk.String("some comment")))
+		require.NoError(t, err)
+		cleanupStage(t, id)
+
+		stage, err := client.Stages.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assertStage(t, stage, id, "EXTERNAL", "some comment", "AWS", awsBucketUrl, "")
+	})
+
+	t.Run("CreateOnS3 - temporary - Storage Integration", func(t *testing.T) {
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+
+		s3Req := sdk.NewExternalS3StageParamsRequest(awsBucketUrl).
+			WithStorageIntegration(sdk.Pointer(sdk.NewAccountObjectIdentifier(s3StorageIntegration.Name)))
+		err := client.Stages.CreateOnS3(ctx, sdk.NewCreateOnS3StageRequest(id).
+			WithTemporary(sdk.Bool(true)).
+			WithFileFormat(sdk.NewStageFileFormatRequest().WithType(&sdk.FileFormatTypeJSON)).
+			WithExternalStageParams(s3Req).
+			WithComment(sdk.String("some comment")))
+		require.NoError(t, err)
+		cleanupStage(t, id)
+
+		stage, err := client.Stages.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assertStage(t, stage, id, "EXTERNAL TEMPORARY", "some comment", "AWS", awsBucketUrl, s3StorageIntegration.Name)
 	})
 
 	t.Run("CreateOnGCS", func(t *testing.T) {
-		// TODO: fill me
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+
+		err := client.Stages.CreateOnGCS(ctx, sdk.NewCreateOnGCSStageRequest(id).
+			WithFileFormat(sdk.NewStageFileFormatRequest().WithType(&sdk.FileFormatTypeJSON)).
+			WithExternalStageParams(sdk.NewExternalGCSStageParamsRequest(gcsBucketUrl).
+				WithStorageIntegration(sdk.Pointer(sdk.NewAccountObjectIdentifier(gcpStorageIntegration.Name)))).
+			WithComment(sdk.String("some comment")))
+		require.NoError(t, err)
+		cleanupStage(t, id)
+
+		stage, err := client.Stages.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assertStage(t, stage, id, "EXTERNAL", "some comment", "GCP", gcsBucketUrl, gcpStorageIntegration.Name)
 	})
 
-	t.Run("CreateOnAzure", func(t *testing.T) {
-		// TODO: fill me
+	t.Run("CreateOnAzure - Storage Integration", func(t *testing.T) {
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+
+		err := client.Stages.CreateOnAzure(ctx, sdk.NewCreateOnAzureStageRequest(id).
+			WithFileFormat(sdk.NewStageFileFormatRequest().WithType(&sdk.FileFormatTypeJSON)).
+			WithExternalStageParams(sdk.NewExternalAzureStageParamsRequest(azureBucketUrl).
+				WithStorageIntegration(sdk.Pointer(sdk.NewAccountObjectIdentifier(azureStorageIntegration.Name)))).
+			WithComment(sdk.String("some comment")))
+		require.NoError(t, err)
+		cleanupStage(t, id)
+
+		stage, err := client.Stages.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assertStage(t, stage, id, "EXTERNAL", "some comment", "AZURE", azureBucketUrl, azureStorageIntegration.Name)
+	})
+
+	t.Run("CreateOnAzure - Shared Access Signature", func(t *testing.T) {
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+
+		err := client.Stages.CreateOnAzure(ctx, sdk.NewCreateOnAzureStageRequest(id).
+			WithFileFormat(sdk.NewStageFileFormatRequest().WithType(&sdk.FileFormatTypeJSON)).
+			WithExternalStageParams(sdk.NewExternalAzureStageParamsRequest(azureBucketUrl).
+				WithCredentials(sdk.NewExternalStageAzureCredentialsRequest(azureSasToken))).
+			WithComment(sdk.String("some comment")))
+		require.NoError(t, err)
+		cleanupStage(t, id)
+
+		stage, err := client.Stages.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assertStage(t, stage, id, "EXTERNAL", "some comment", "AZURE", azureBucketUrl, "")
 	})
 
 	t.Run("CreateOnS3Compatible", func(t *testing.T) {
-		// TODO: fill me
+		// TODO: (SNOW-1012064) create s3 compat service for tests
 	})
 
 	t.Run("Alter - rename", func(t *testing.T) {
@@ -174,19 +328,81 @@ func TestInt_Stages(t *testing.T) {
 	})
 
 	t.Run("AlterExternalS3Stage", func(t *testing.T) {
-		// TODO: fill me
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+		createBasicS3Stage(t, id)
+
+		err := client.Stages.AlterExternalS3Stage(ctx, sdk.NewAlterExternalS3StageStageRequest(id).
+			WithExternalStageParams(sdk.NewExternalS3StageParamsRequest(awsBucketUrl).
+				WithStorageIntegration(sdk.Pointer(sdk.NewAccountObjectIdentifier(s3StorageIntegration.Name)))).
+			WithComment(sdk.String("Updated comment")))
+		require.NoError(t, err)
+
+		stage, err := client.Stages.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assertStage(t, stage, id, "EXTERNAL", "Updated comment", "AWS", awsBucketUrl, s3StorageIntegration.Name)
 	})
 
 	t.Run("AlterExternalGCSStage", func(t *testing.T) {
-		// TODO: fill me
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+		createBasicGcsStage(t, id)
+
+		err := client.Stages.AlterExternalGCSStage(ctx, sdk.NewAlterExternalGCSStageStageRequest(id).
+			WithExternalStageParams(sdk.NewExternalGCSStageParamsRequest(gcsBucketUrl).
+				WithStorageIntegration(sdk.Pointer(sdk.NewAccountObjectIdentifier(gcpStorageIntegration.Name)))).
+			WithComment(sdk.String("Updated comment")))
+		require.NoError(t, err)
+
+		stage, err := client.Stages.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assertStage(t, stage, id, "EXTERNAL", "Updated comment", "GCP", gcsBucketUrl, gcpStorageIntegration.Name)
 	})
 
 	t.Run("AlterExternalAzureStage", func(t *testing.T) {
-		// TODO: fill me
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+		createBasicAzureStage(t, id)
+
+		err := client.Stages.AlterExternalAzureStage(ctx, sdk.NewAlterExternalAzureStageStageRequest(id).
+			WithExternalStageParams(sdk.NewExternalAzureStageParamsRequest(azureBucketUrl).
+				WithStorageIntegration(sdk.Pointer(sdk.NewAccountObjectIdentifier(azureStorageIntegration.Name)))).
+			WithComment(sdk.String("Updated comment")))
+		require.NoError(t, err)
+
+		stage, err := client.Stages.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assertStage(t, stage, id, "EXTERNAL", "Updated comment", "AZURE", azureBucketUrl, azureStorageIntegration.Name)
 	})
 
 	t.Run("AlterDirectoryTable", func(t *testing.T) {
-		// TODO: fill me
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+		createBasicS3Stage(t, id)
+
+		stageProperties, err := client.Stages.Describe(ctx, id)
+		require.NoError(t, err)
+		assert.Contains(t, stageProperties, sdk.StageProperty{
+			Parent:  "DIRECTORY",
+			Name:    "ENABLE",
+			Type:    "Boolean",
+			Value:   "false",
+			Default: "false",
+		})
+
+		err = client.Stages.AlterDirectoryTable(ctx, sdk.NewAlterDirectoryTableStageRequest(id).
+			WithSetDirectory(sdk.NewDirectoryTableSetRequest(true)))
+		require.NoError(t, err)
+
+		err = client.Stages.AlterDirectoryTable(ctx, sdk.NewAlterDirectoryTableStageRequest(id).
+			WithRefresh(sdk.NewDirectoryTableRefreshRequest().WithSubpath(sdk.String("/"))))
+		require.NoError(t, err)
+
+		stageProperties, err = client.Stages.Describe(ctx, id)
+		require.NoError(t, err)
+		assert.Contains(t, stageProperties, sdk.StageProperty{
+			Parent:  "DIRECTORY",
+			Name:    "ENABLE",
+			Type:    "Boolean",
+			Value:   "true",
+			Default: "false",
+		})
 	})
 
 	t.Run("Drop", func(t *testing.T) {
@@ -237,12 +453,65 @@ func TestInt_Stages(t *testing.T) {
 	})
 
 	t.Run("Describe external s3", func(t *testing.T) {
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+		createBasicS3Stage(t, id)
+
+		stageProperties, err := client.Stages.Describe(ctx, id)
+		require.NoError(t, err)
+		require.NotEmpty(t, stageProperties)
+		assert.Contains(t, stageProperties, sdk.StageProperty{
+			Parent:  "STAGE_CREDENTIALS",
+			Name:    "AWS_KEY_ID",
+			Type:    "String",
+			Value:   awsKeyId,
+			Default: "",
+		})
+		assert.Contains(t, stageProperties, sdk.StageProperty{
+			Parent:  "STAGE_LOCATION",
+			Name:    "URL",
+			Type:    "String",
+			Value:   fmt.Sprintf("[\"%s\"]", awsBucketUrl),
+			Default: "",
+		})
 	})
 
 	t.Run("Describe external gcs", func(t *testing.T) {
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+		createBasicGcsStage(t, id)
+
+		stageProperties, err := client.Stages.Describe(ctx, id)
+		require.NoError(t, err)
+		require.NotEmpty(t, stageProperties)
+		assert.Contains(t, stageProperties, sdk.StageProperty{
+			Parent:  "STAGE_LOCATION",
+			Name:    "URL",
+			Type:    "String",
+			Value:   fmt.Sprintf("[\"%s\"]", gcsBucketUrl),
+			Default: "",
+		})
 	})
 
 	t.Run("Describe external azure", func(t *testing.T) {
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.AlphanumericN(32))
+		createBasicAzureStage(t, id)
+
+		stageProperties, err := client.Stages.Describe(ctx, id)
+		require.NoError(t, err)
+		require.NotEmpty(t, stageProperties)
+		assert.Contains(t, stageProperties, sdk.StageProperty{
+			Parent:  "DIRECTORY",
+			Name:    "ENABLE",
+			Type:    "Boolean",
+			Value:   "false",
+			Default: "false",
+		})
+		assert.Contains(t, stageProperties, sdk.StageProperty{
+			Parent:  "STAGE_LOCATION",
+			Name:    "URL",
+			Type:    "String",
+			Value:   fmt.Sprintf("[\"%s\"]", azureBucketUrl),
+			Default: "",
+		})
 	})
 
 	t.Run("Show internal", func(t *testing.T) {
@@ -272,14 +541,5 @@ func TestInt_Stages(t *testing.T) {
 		assert.Nil(t, stage.StorageIntegration)
 		assert.Nil(t, stage.Endpoint)
 		assert.True(t, stage.DirectoryEnabled)
-	})
-
-	t.Run("Show external s3", func(t *testing.T) {
-	})
-
-	t.Run("Show external gcs", func(t *testing.T) {
-	})
-
-	t.Run("Show external azure", func(t *testing.T) {
 	})
 }

--- a/pkg/sdk/testint/streams_gen_integration_test.go
+++ b/pkg/sdk/testint/streams_gen_integration_test.go
@@ -55,8 +55,8 @@ func TestInt_Streams(t *testing.T) {
 	})
 
 	t.Run("CreateOnExternalTable", func(t *testing.T) {
-		stageID := sdk.NewAccountObjectIdentifier("EXTERNAL_TABLE_STAGE")
-		stageLocation := "@external_table_stage"
+		stageID := sdk.NewSchemaObjectIdentifier(TestDatabaseName, TestSchemaName, "EXTERNAL_TABLE_STAGE")
+		stageLocation := fmt.Sprintf("@%s", stageID.FullyQualifiedName())
 		_, _ = createStageWithURL(t, client, stageID, nycWeatherDataURL)
 
 		externalTableId := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, random.AlphanumericN(32))


### PR DESCRIPTION
Follow-up for https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/2163

- Added missing tests for external resources (only s3compat was left, but created a separate ticket for later)
- Fixed set comment on the file format + tests for it
- File functions like GET, LS, COPY INTO, etc. are left for later
- Cleanup helper functions for creating stages