### PR TITLE
fix: Fix whitespace in goreleaser envs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist --verbose
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,11 @@
 builds:
 - env:
   - >-
-    {{- if or (eq .Os "darwin") (eq .Os "windows") }}
+    {{- if or (eq .Os "darwin") (eq .Os "windows") -}}
       CGO_ENABLED=1
-    {{- else }}
+    {{- else -}}
       CGO_ENABLED=0
-    {{- end }}
+    {{- end -}}
   goos:
     - windows
     - linux


### PR DESCRIPTION
Result of #2384.
The formatting in goreleaser env template was bad, therefore `CGO_ENABLED=1` was used as a default (because invalid envs are being ignored, check: https://goreleaser.com/customization/builds/#builds) for every build distro.