### PR TITLE
fix: Update .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,6 @@
 builds:
 - env:
-  - >-
-    {{- if or (eq .Os "darwin") (eq .Os "windows") -}}
-      CGO_ENABLED=1
-    {{- else -}}
-      CGO_ENABLED=0
-    {{- end -}}
+    - CGO_ENABLED=0
   goos:
     - windows
     - linux


### PR DESCRIPTION
Getting error when performing the release:

`clang: error: argument unused during compilation: '-arch x86_64' [-Werror,-Wunused-command-line-argument]
`
It seems like CGO [isn't supported with goreleaser](https://goreleaser.com/cookbooks/cgo-and-crosscompiling/) and instead it recommends using [goreleaser-cross](https://github.com/goreleaser/goreleaser-cross) instead.  example goreleaser file is shown here: https://github.com/goreleaser/goreleaser-cross-example/blob/master/.goreleaser.yaml. This may be tricky to do, as we would be having to different goreleasers running, one for cross compliatied binaries and the other for native binaries. In the meantime, rolling back change.