### PR TITLE
fix: Adjust tests after Snowflake behavior change

### DIFF
--- a/pkg/sdk/testint/streams_gen_integration_test.go
+++ b/pkg/sdk/testint/streams_gen_integration_test.go
@@ -55,7 +55,8 @@ func TestInt_Streams(t *testing.T) {
 	})
 
 	t.Run("CreateOnExternalTable", func(t *testing.T) {
-		stageID := sdk.NewSchemaObjectIdentifier(TestDatabaseName, TestSchemaName, "EXTERNAL_TABLE_STAGE")
+		stageName := random.AlphaN(10)
+		stageID := sdk.NewSchemaObjectIdentifier(TestDatabaseName, TestSchemaName, stageName)
 		stageLocation := fmt.Sprintf("@%s", stageID.FullyQualifiedName())
 		_, _ = createStageWithURL(t, client, stageID, nycWeatherDataURL)
 


### PR DESCRIPTION
Changes in tests:
- pipe test, that were intentionally documenting the incorrect behavior; they started to fail after Snowflake 8.3.1 release; they have been adjusted
- stream test was failing because of multiple objects named the same; random name added