### PR TITLE
fix: Updates dynamic tables query parsing to correctly handle tables that include "as" in their name (#2329)

### DIFF
--- a/pkg/resources/dynamic_table.go
+++ b/pkg/resources/dynamic_table.go
@@ -201,7 +201,7 @@ func ReadDynamicTable(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	// trim up to " ..AS" and remove whitespace
-	query := strings.TrimSpace(text[strings.Index(text, "AS")+3:])
+	query := strings.TrimSpace(text[strings.Index(text, " AS ")+3:])
 	if err := d.Set("query", query); err != nil {
 		return err
 	}


### PR DESCRIPTION
The Index in the query parsing is too greedy and grabs any string with the letter "as" in them. If a table has "as" then the query is never a match and the dynamic is recreated in every terraform plan.

## Test Plan
I have not tested locally since I'm not comfortable running acceptance tests against our live snowflake account. Creating a draft PR in hopes that CI will run tests and you all can review and verify the change.

## References
Attempts to fix #2329 
