### PR TITLE
fix: snowflake_grant_privileges_to_role read

### DIFF
--- a/pkg/resources/grant_privileges_to_role.go
+++ b/pkg/resources/grant_privileges_to_role.go
@@ -844,7 +844,7 @@ func readRoleGrantPrivileges(ctx context.Context, client *sdk.Client, grantedOn 
 		if !slices.Contains(id.Privileges, grant.Privilege) {
 			continue
 		}
-		if grant.GrantOption == withGrantOption && grant.GranteeName.Name() == roleName {
+		if grant.GrantOption == withGrantOption && grant.GranteeName.Name() == sdk.NewAccountObjectIdentifier(roleName).Name() {
 			// future grants do not have grantedBy, only current grants do. If grantedby
 			// is an empty string it means the grant could not have been created by terraform
 			if !id.Future && grant.GrantedBy.Name() == "" {

--- a/pkg/resources/grant_privileges_to_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_role_acceptance_test.go
@@ -59,7 +59,9 @@ func TestAcc_GrantPrivilegesToRole_onAccount(t *testing.T) {
 // contains escaped identifier, it won't match in the comparison grant.GranteeName == role_name. This results in
 // setting privileges to an empty array, which causes infinite plan.
 func TestAcc_GrantPrivilegesToRole_OnSchema_InfinitePlan(t *testing.T) {
-	name := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	name := []byte(strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)))
+	name[3] = '.'
+	name[7] = '-'
 	databaseName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	resource.Test(t, resource.TestCase{
@@ -88,7 +90,7 @@ func TestAcc_GrantPrivilegesToRole_OnSchema_InfinitePlan(t *testing.T) {
 						object_name = snowflake_database.db.name
 					  }
 				   }
-				 `, name, databaseName),
+				 `, string(name), databaseName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),


### PR DESCRIPTION
Fix read by trimming any quotes from the specified identifier