### PR TITLE
FileFormat Update() bugs

### DIFF
--- a/pkg/resources/file_format.go
+++ b/pkg/resources/file_format.go
@@ -1092,6 +1092,12 @@ func UpdateFileFormat(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if d.HasChange("comment") {
+		v := d.Get("comment").(string)
+		opts.Set.Comment = &v
+		runSet = true
+	}
+
 	if runSet {
 		err = client.FileFormats.Alter(ctx, id, &opts)
 		if err != nil {

--- a/pkg/resources/file_format.go
+++ b/pkg/resources/file_format.go
@@ -781,9 +781,9 @@ func UpdateFileFormat(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	runSet := false
-	opts := sdk.AlterFileFormatOptions{}
+	opts := sdk.AlterFileFormatOptions{Set: &sdk.FileFormatTypeOptions{}}
 
-	switch d.Get("format_type") {
+	switch sdk.FileFormatType(d.Get("format_type").(string)) {
 	case sdk.FileFormatTypeCSV:
 		if d.HasChange("compression") {
 			v := sdk.CSVCompression(d.Get("compression").(string))

--- a/pkg/resources/file_format_acceptance_test.go
+++ b/pkg/resources/file_format_acceptance_test.go
@@ -19,7 +19,7 @@ func TestAcc_FileFormatCSV(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: fileFormatConfigCSV(accName, acc.TestDatabaseName, acc.TestSchemaName),
+				Config: fileFormatConfigCSV(accName, acc.TestDatabaseName, acc.TestSchemaName, ";"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_file_format.test", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_file_format.test", "database", acc.TestDatabaseName),
@@ -49,6 +49,11 @@ func TestAcc_FileFormatCSV(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_file_format.test", "encoding", "UTF-16"),
 					resource.TestCheckResourceAttr("snowflake_file_format.test", "comment", "Terraform acceptance test"),
 				),
+			},
+			// UPDATE
+			{
+				Config: fileFormatConfigCSV(accName, acc.TestDatabaseName, acc.TestSchemaName, ","),
+				Check:  resource.TestCheckResourceAttr("snowflake_file_format.test", "field_delimiter", ","),
 			},
 			// IMPORT
 			{
@@ -398,7 +403,7 @@ func TestAcc_FileFormat_issue1947(t *testing.T) {
 	})
 }
 
-func fileFormatConfigCSV(n string, databaseName string, schemaName string) string {
+func fileFormatConfigCSV(n string, databaseName string, schemaName string, fieldDelimiter string) string {
 	return fmt.Sprintf(`
 resource "snowflake_file_format" "test" {
 	name = "%v"
@@ -407,7 +412,7 @@ resource "snowflake_file_format" "test" {
 	format_type = "CSV"
 	compression = "GZIP"
 	record_delimiter = "\r"
-	field_delimiter = ";"
+	field_delimiter = "%s"
 	file_extension = ".ssv"
 	parse_header = true
 	skip_blank_lines = true
@@ -427,7 +432,7 @@ resource "snowflake_file_format" "test" {
 	encoding = "UTF-16"
 	comment = "Terraform acceptance test"
 }
-`, n, databaseName, schemaName)
+`, n, databaseName, schemaName, fieldDelimiter)
 }
 
 func fileFormatConfigJSON(n string, databaseName string, schemaName string) string {

--- a/pkg/resources/file_format_acceptance_test.go
+++ b/pkg/resources/file_format_acceptance_test.go
@@ -19,7 +19,7 @@ func TestAcc_FileFormatCSV(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: fileFormatConfigCSV(accName, acc.TestDatabaseName, acc.TestSchemaName, ";"),
+				Config: fileFormatConfigCSV(accName, acc.TestDatabaseName, acc.TestSchemaName, ";", "Terraform acceptance test"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_file_format.test", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_file_format.test", "database", acc.TestDatabaseName),
@@ -52,7 +52,7 @@ func TestAcc_FileFormatCSV(t *testing.T) {
 			},
 			// UPDATE
 			{
-				Config: fileFormatConfigCSV(accName, acc.TestDatabaseName, acc.TestSchemaName, ","),
+				Config: fileFormatConfigCSV(accName, acc.TestDatabaseName, acc.TestSchemaName, ",", "Terraform acceptance test"),
 				Check:  resource.TestCheckResourceAttr("snowflake_file_format.test", "field_delimiter", ","),
 			},
 			// IMPORT
@@ -403,7 +403,7 @@ func TestAcc_FileFormat_issue1947(t *testing.T) {
 	})
 }
 
-func fileFormatConfigCSV(n string, databaseName string, schemaName string, fieldDelimiter string) string {
+func fileFormatConfigCSV(n string, databaseName string, schemaName string, fieldDelimiter string, comment string) string {
 	return fmt.Sprintf(`
 resource "snowflake_file_format" "test" {
 	name = "%v"
@@ -430,9 +430,9 @@ resource "snowflake_file_format" "test" {
 	empty_field_as_null = false
 	skip_byte_order_mark = false
 	encoding = "UTF-16"
-	comment = "Terraform acceptance test"
+	comment = "%s"
 }
-`, n, databaseName, schemaName, fieldDelimiter)
+`, n, databaseName, schemaName, fieldDelimiter, comment)
 }
 
 func fileFormatConfigJSON(n string, databaseName string, schemaName string) string {


### PR DESCRIPTION
ref https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2385

2 bugs:

1. `d.Get("format_type")` has to be casted first to type `sdk.FileFormatType` in order to be compared with another FileFormatType, if not, the comparitson is always `False`. 

2. The attribute `comment` was not part of the Update() function