### PR TITLE
fix: parameter issues

### DIFF
--- a/pkg/datasources/parameters_acceptance_test.go
+++ b/pkg/datasources/parameters_acceptance_test.go
@@ -2,10 +2,11 @@ package datasources_test
 
 import (
 	"fmt"
-	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"strings"
 	"testing"
+
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/pkg/datasources/parameters_acceptance_test.go
+++ b/pkg/datasources/parameters_acceptance_test.go
@@ -2,6 +2,8 @@ package datasources_test
 
 import (
 	"fmt"
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"strings"
 	"testing"
 
@@ -60,6 +62,44 @@ func TestAcc_ParametersOnObject(t *testing.T) {
 					resource.TestCheckResourceAttr("data.snowflake_parameters.p", "object_type", "DATABASE"),
 					resource.TestCheckResourceAttr("data.snowflake_parameters.p", "object_name", dbName),
 				),
+			},
+		},
+	})
+}
+
+// proves https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2353 is fixed
+func TestAcc_Parameters_TransactionAbortOnErrorCanBeSet(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { acc.TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "snowflake_account_parameter" "test" {
+				   key   = "TRANSACTION_ABORT_ON_ERROR"
+				   value = "true"
+				}`,
+			},
+		},
+	})
+}
+
+// proves https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2353 is fixed
+func TestAcc_Parameters_QuotedIdentifiersIgnoreCaseCanBeSet(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { acc.TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "snowflake_account_parameter" "test" {
+				  key   = "QUOTED_IDENTIFIERS_IGNORE_CASE"
+				  value = "true"
+				}`,
 			},
 		},
 	})

--- a/pkg/sdk/parameters.go
+++ b/pkg/sdk/parameters.go
@@ -362,6 +362,7 @@ const (
 	AccountParameterTimestampTypeMapping                  AccountParameter = "TIMESTAMP_TYPE_MAPPING"
 	AccountParameterTimestampTzOutputFormat               AccountParameter = "TIMESTAMP_TZ_OUTPUT_FORMAT"
 	AccountParameterTimezone                              AccountParameter = "TIMEZONE"
+	AccountParameterTransactionAbortOnError               AccountParameter = "TRANSACTION_ABORT_ON_ERROR"
 	AccountParameterTransactionDefaultIsolationLevel      AccountParameter = "TRANSACTION_DEFAULT_ISOLATION_LEVEL"
 	AccountParameterTwoDigitCenturyStart                  AccountParameter = "TWO_DIGIT_CENTURY_START"
 	AccountParameterUnsupportedDdlAction                  AccountParameter = "UNSUPPORTED_DDL_ACTION"
@@ -421,6 +422,7 @@ const (
 	SessionParameterTimestampTypeMapping                  SessionParameter = "TIMESTAMP_TYPE_MAPPING"
 	SessionParameterTimestampTZOutputFormat               SessionParameter = "TIMESTAMP_TZ_OUTPUT_FORMAT"
 	SessionParameterTimezone                              SessionParameter = "TIMEZONE"
+	SessionParameterTransactionAbortOnError               SessionParameter = "TRANSACTION_ABORT_ON_ERROR"
 	SessionParameterTransactionDefaultIsolationLevel      SessionParameter = "TRANSACTION_DEFAULT_ISOLATION_LEVEL"
 	SessionParameterTwoDigitCenturyStart                  SessionParameter = "TWO_DIGIT_CENTURY_START"
 	SessionParameterUnsupportedDDLAction                  SessionParameter = "UNSUPPORTED_DDL_ACTION"
@@ -614,7 +616,7 @@ type SessionParameters struct {
 	LockTimeout                           *int                              `ddl:"parameter" sql:"LOCK_TIMEOUT"`
 	MultiStatementCount                   *int                              `ddl:"parameter" sql:"MULTI_STATEMENT_COUNT"`
 	QueryTag                              *string                           `ddl:"parameter,single_quotes" sql:"QUERY_TAG"`
-	QuotedIdentifiersIgnoreCase           *bool                             `ddl:"parameter,single_quotes" sql:"QUOTED_IDENTIFIERS_IGNORE_CASE"`
+	QuotedIdentifiersIgnoreCase           *bool                             `ddl:"parameter" sql:"QUOTED_IDENTIFIERS_IGNORE_CASE"`
 	RowsPerResultset                      *int                              `ddl:"parameter" sql:"ROWS_PER_RESULTSET"`
 	SimulatedDataSharingConsumer          *string                           `ddl:"parameter,single_quotes" sql:"SIMULATED_DATA_SHARING_CONSUMER"`
 	StatementTimeoutInSeconds             *int                              `ddl:"parameter" sql:"STATEMENT_TIMEOUT_IN_SECONDS"`
@@ -629,6 +631,7 @@ type SessionParameters struct {
 	Timezone                              *string                           `ddl:"parameter,single_quotes" sql:"TIMEZONE"`
 	TimeInputFormat                       *string                           `ddl:"parameter,single_quotes" sql:"TIME_INPUT_FORMAT"`
 	TimeOutputFormat                      *string                           `ddl:"parameter,single_quotes" sql:"TIME_OUTPUT_FORMAT"`
+	TransactionAbortOnError               *bool                             `ddl:"parameter" sql:"TRANSACTION_ABORT_ON_ERROR"`
 	TransactionDefaultIsolationLevel      *TransactionDefaultIsolationLevel `ddl:"parameter,single_quotes" sql:"TRANSACTION_DEFAULT_ISOLATION_LEVEL"`
 	TwoDigitCenturyStart                  *int                              `ddl:"parameter" sql:"TWO_DIGIT_CENTURY_START"`
 	UnsupportedDDLAction                  *UnsupportedDDLAction             `ddl:"parameter,single_quotes" sql:"UNSUPPORTED_DDL_ACTION"`

--- a/pkg/sdk/parameters_impl.go
+++ b/pkg/sdk/parameters_impl.go
@@ -145,6 +145,12 @@ func (sessionParameters *SessionParameters) setParam(parameter SessionParameter,
 		sessionParameters.TimeInputFormat = &value
 	case SessionParameterTimeOutputFormat:
 		sessionParameters.TimeOutputFormat = &value
+	case SessionParameterTransactionAbortOnError:
+		b, err := parseBooleanParameter(string(parameter), value)
+		if err != nil {
+			return err
+		}
+		sessionParameters.TransactionAbortOnError = b
 	case SessionParameterTransactionDefaultIsolationLevel:
 		sessionParameters.TransactionDefaultIsolationLevel = Pointer(TransactionDefaultIsolationLevel(value))
 	case SessionParameterTwoDigitCenturyStart:


### PR DESCRIPTION
Fix for https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2353.

Issue 1 - TRANSACTION_ABORT_ON_ERROR couldn't be set
- I added TRANSACTION_ABORT_ON_ERROR to the available set of parameters and added a test that shows it can be set now

Issue 2 - QUOTED_IDENTIFIERS_IGNORE_CASE couldn't be set because of the invalid syntax produced by our SDK
- I removed the single_quotes that were causing the invalid syntax error and added a test to prove it works now