### PR TITLE
fix: Fix tests that base on default data retention

### DIFF
--- a/pkg/sdk/testint/application_packages_integration_test.go
+++ b/pkg/sdk/testint/application_packages_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -57,6 +58,12 @@ func TestInt_ApplicationPackages(t *testing.T) {
 	assertApplicationPackage := func(t *testing.T, id sdk.AccountObjectIdentifier) {
 		t.Helper()
 
+		param, err := client.Parameters.ShowAccountParameter(ctx, sdk.AccountParameterDataRetentionTimeInDays)
+		require.NoError(t, err)
+
+		defaultDataRetentionTimeInDays, err := strconv.Atoi(param.Value)
+		require.NoError(t, err)
+
 		e, err := client.ApplicationPackages.ShowByID(ctx, id)
 		require.NoError(t, err)
 
@@ -67,7 +74,7 @@ func TestInt_ApplicationPackages(t *testing.T) {
 		assert.Equal(t, sdk.DistributionInternal, sdk.Distribution(e.Distribution))
 		assert.Equal(t, "ACCOUNTADMIN", e.Owner)
 		assert.Empty(t, e.Comment)
-		assert.Equal(t, 1, e.RetentionTime)
+		assert.Equal(t, defaultDataRetentionTimeInDays, e.RetentionTime)
 		assert.Empty(t, e.Options)
 		assert.Empty(t, e.DroppedOn)
 		assert.Empty(t, e.ApplicationClass)
@@ -95,7 +102,14 @@ func TestInt_ApplicationPackages(t *testing.T) {
 		require.Equal(t, sdk.DistributionExternal, sdk.Distribution(e.Distribution))
 		require.Equal(t, "ACCOUNTADMIN", e.Owner)
 		require.Equal(t, comment, e.Comment)
-		require.Equal(t, 1, e.RetentionTime)
+
+		param, err := client.Parameters.ShowAccountParameter(ctx, sdk.AccountParameterDataRetentionTimeInDays)
+		require.NoError(t, err)
+
+		defaultDataRetentionTimeInDays, err := strconv.Atoi(param.Value)
+		require.NoError(t, err)
+
+		require.Equal(t, defaultDataRetentionTimeInDays, e.RetentionTime)
 	})
 
 	t.Run("alter application package: set", func(t *testing.T) {

--- a/pkg/sdk/testint/applications_integration_test.go
+++ b/pkg/sdk/testint/applications_integration_test.go
@@ -83,6 +83,12 @@ func TestInt_Applications(t *testing.T) {
 	assertApplication := func(t *testing.T, id sdk.AccountObjectIdentifier, applicationPackageName, version string, patch int, comment string) {
 		t.Helper()
 
+		param, err := client.Parameters.ShowAccountParameter(ctx, sdk.AccountParameterDataRetentionTimeInDays)
+		require.NoError(t, err)
+
+		defaultDataRetentionTimeInDays, err := strconv.Atoi(param.Value)
+		require.NoError(t, err)
+
 		e, err := client.Applications.ShowByID(ctx, id)
 		require.NoError(t, err)
 
@@ -96,7 +102,7 @@ func TestInt_Applications(t *testing.T) {
 		assert.Equal(t, patch, e.Patch)
 		assert.Equal(t, "ACCOUNTADMIN", e.Owner)
 		assert.Equal(t, comment, e.Comment)
-		assert.Equal(t, 1, e.RetentionTime)
+		assert.Equal(t, defaultDataRetentionTimeInDays, e.RetentionTime)
 		assert.Empty(t, e.Options)
 	}
 

--- a/pkg/sdk/testint/helpers_test.go
+++ b/pkg/sdk/testint/helpers_test.go
@@ -850,3 +850,20 @@ type informationSchemaColumns struct {
 	IdentityOrdered        sql.NullString `db:"IDENTITY_ORDERED"`
 	Comment                sql.NullString `db:"COMMENT"`
 }
+
+func updateAccountParameterTemporarily(t *testing.T, client *sdk.Client, parameter sdk.AccountParameter, newValue string) func() {
+	t.Helper()
+	ctx := context.Background()
+
+	param, err := client.Parameters.ShowAccountParameter(ctx, parameter)
+	require.NoError(t, err)
+	oldValue := param.Value
+
+	err = client.Parameters.SetAccountParameter(ctx, parameter, newValue)
+	require.NoError(t, err)
+
+	return func() {
+		err = client.Parameters.SetAccountParameter(ctx, parameter, oldValue)
+		require.NoError(t, err)
+	}
+}

--- a/pkg/sdk/testint/tables_integration_test.go
+++ b/pkg/sdk/testint/tables_integration_test.go
@@ -301,7 +301,7 @@ func TestInt_Table(t *testing.T) {
 
 		// ensure that time travel is allowed (and revert if needed after the test)
 		revertParameter := updateAccountParameterTemporarily(t, client, sdk.AccountParameterDataRetentionTimeInDays, "1")
-		defer revertParameter()
+		t.Cleanup(revertParameter)
 
 		err := client.Tables.CreateClone(ctx, request)
 		require.NoError(t, err)

--- a/pkg/sdk/testint/tables_integration_test.go
+++ b/pkg/sdk/testint/tables_integration_test.go
@@ -299,6 +299,10 @@ func TestInt_Table(t *testing.T) {
 			WithAt(*sdk.NewTimeTravelRequest().WithOffset(sdk.Pointer(0))).
 			WithMoment(sdk.CloneMomentAt))
 
+		// ensure that time travel is allowed (and revert if needed after the test)
+		revertParameter := updateAccountParameterTemporarily(t, client, sdk.AccountParameterDataRetentionTimeInDays, "1")
+		defer revertParameter()
+
 		err := client.Tables.CreateClone(ctx, request)
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))


### PR DESCRIPTION
There were some tests failing on the CI since Thursday/Friday (2 in application packages, multiple in application and one for table cloning). The same tests were passing "locally". The reason for all of them was the assumption that the account level parameter `DATA_RETENTION_TIME_IN_DAYS` is set to `1` (default). For some reason, on our CI account, it was changed to `0` (either by some test in which cleanup failed or manually by someone). I did two things so that our tests pass again:
- reverted the param to `1` default
- prepared a fix for the tests, as to not make assumptions about this param (or for table cloning setting it temporarily to `1` and reverting to the previous value after the test)