### PR TITLE
feat: create a workaround for granting privileges on all pipes

### DIFF
--- a/pkg/resources/grant_privileges_to_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_role_acceptance_test.go
@@ -3,7 +3,6 @@ package resources_test
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/config"
 	"regexp"
 	"strings"
 	"testing"

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/OnAllPipes/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/OnAllPipes/test.tf
@@ -1,0 +1,12 @@
+resource "snowflake_grant_privileges_to_account_role" "test" {
+  account_role_name = var.name
+  privileges        = var.privileges
+  with_grant_option = var.with_grant_option
+
+  on_schema_object {
+    all {
+      object_type_plural = "PIPES"
+      in_database        = var.database
+    }
+  }
+}

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/OnAllPipes/variables.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/OnAllPipes/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  type = string
+}
+
+variable "privileges" {
+  type = list(string)
+}
+
+variable "database" {
+  type = string
+}
+
+variable "with_grant_option" {
+  type = bool
+}

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToDatabaseRole/OnAllPipes/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToDatabaseRole/OnAllPipes/test.tf
@@ -1,0 +1,12 @@
+resource "snowflake_grant_privileges_to_database_role" "test" {
+  database_role_name = "\"${var.database}\".\"${var.name}\""
+  privileges        = var.privileges
+  with_grant_option = var.with_grant_option
+
+  on_schema_object {
+    all {
+      object_type_plural = "PIPES"
+      in_database        = "\"${var.database}\""
+    }
+  }
+}

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToDatabaseRole/OnAllPipes/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToDatabaseRole/OnAllPipes/test.tf
@@ -1,7 +1,7 @@
 resource "snowflake_grant_privileges_to_database_role" "test" {
   database_role_name = "\"${var.database}\".\"${var.name}\""
-  privileges        = var.privileges
-  with_grant_option = var.with_grant_option
+  privileges         = var.privileges
+  with_grant_option  = var.with_grant_option
 
   on_schema_object {
     all {

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToDatabaseRole/OnAllPipes/variables.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToDatabaseRole/OnAllPipes/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  type = string
+}
+
+variable "privileges" {
+  type = list(string)
+}
+
+variable "database" {
+  type = string
+}
+
+variable "with_grant_option" {
+  type = bool
+}

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToRole/OnAllPipes/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToRole/OnAllPipes/test.tf
@@ -1,5 +1,5 @@
 resource "snowflake_grant_privileges_to_role" "test" {
-  role_name = var.name
+  role_name         = var.name
   privileges        = var.privileges
   with_grant_option = var.with_grant_option
 

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToRole/OnAllPipes/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToRole/OnAllPipes/test.tf
@@ -1,0 +1,12 @@
+resource "snowflake_grant_privileges_to_role" "test" {
+  role_name = var.name
+  privileges        = var.privileges
+  with_grant_option = var.with_grant_option
+
+  on_schema_object {
+    all {
+      object_type_plural = "PIPES"
+      in_database        = var.database
+    }
+  }
+}

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToRole/OnAllPipes/variables.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToRole/OnAllPipes/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  type = string
+}
+
+variable "privileges" {
+  type = list(string)
+}
+
+variable "database" {
+  type = string
+}
+
+variable "with_grant_option" {
+  type = bool
+}

--- a/pkg/sdk/grants_impl.go
+++ b/pkg/sdk/grants_impl.go
@@ -23,7 +23,9 @@ func (v *grants) GrantPrivilegesToAccountRole(ctx context.Context, privileges *A
 	opts.accountRole = role
 	logging.DebugLogger.Printf("[DEBUG] Grant privileges to account role: opts %+v", opts)
 
-	// TODO: Describe why it's here
+	// Snowflake doesn't allow bulk operations on Pipes. Because of that, when SDK user
+	// issues "grant x on all pipes" operation, we'll go and grant specified privileges
+	// to every Pipe one by one.
 	if on != nil &&
 		on.SchemaObject != nil &&
 		on.SchemaObject.All != nil &&
@@ -64,7 +66,9 @@ func (v *grants) RevokePrivilegesFromAccountRole(ctx context.Context, privileges
 	opts.accountRole = role
 	logging.DebugLogger.Printf("[DEBUG] Revoke privileges from account role: opts %+v", opts)
 
-	// TODO: Describe why it's here
+	// Snowflake doesn't allow bulk operations on Pipes. Because of that, when SDK user
+	// issues "revoke x on all pipes" operation, we'll go and revoke specified privileges
+	// from every Pipe one by one.
 	if on != nil &&
 		on.SchemaObject != nil &&
 		on.SchemaObject.All != nil &&
@@ -103,7 +107,9 @@ func (v *grants) GrantPrivilegesToDatabaseRole(ctx context.Context, privileges *
 	opts.on = on
 	opts.databaseRole = role
 
-	// TODO: Describe why it's here
+	// Snowflake doesn't allow bulk operations on Pipes. Because of that, when SDK user
+	// issues "grant x on all pipes" operation, we'll go and grant specified privileges
+	// to every Pipe one by one.
 	if on != nil &&
 		on.SchemaObject != nil &&
 		on.SchemaObject.All != nil &&
@@ -142,7 +148,9 @@ func (v *grants) RevokePrivilegesFromDatabaseRole(ctx context.Context, privilege
 	opts.on = on
 	opts.databaseRole = role
 
-	// TODO: Describe why it's here
+	// Snowflake doesn't allow bulk operations on Pipes. Because of that, when SDK user
+	// issues "revoke x on all pipes" operation, we'll go and revoke specified privileges
+	// from every Pipe one by one.
 	if on != nil &&
 		on.SchemaObject != nil &&
 		on.SchemaObject.All != nil &&

--- a/pkg/sdk/testint/grants_integration_test.go
+++ b/pkg/sdk/testint/grants_integration_test.go
@@ -1,12 +1,13 @@
 package testint
 
 import (
+	"testing"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestInt_GrantAndRevokePrivilegesToAccountRole(t *testing.T) {


### PR DESCRIPTION
`granting privileges on all pipes to role/database role` is not allowed in Snowflake. As it was just one case, we decided to create an internal workaround that would make `on_all pipes` work as it was supported by Snowflake. The workaround works as follows:
- check if on_all pipes are called
- fetch pipes (in database or in schema; depending on what was in the original request)
- loop through the pipes and grant/revoke privileges on them
- created integration tests for the SDK and acceptance tests for `snowflake_grant_privileges_to_role`, `snowflake_grant_privileges_to_account_role`, and `snowflake_grant_privileges_to_database_role`

> Note: grant on_future pipes works as intended

[Reference](https://docs.snowflake.com/en/sql-reference/sql/grant-privilege#required-parameters) (check the text at the bottom of <object_type>)