### PR TITLE
fix: user error handling

### DIFF
--- a/pkg/resources/user.go
+++ b/pkg/resources/user.go
@@ -245,10 +245,10 @@ func ReadUser(d *schema.ResourceData, meta interface{}) error {
 	objectIdentifier := helpers.DecodeSnowflakeID(d.Id()).(sdk.AccountObjectIdentifier)
 	ctx := context.Background()
 	user, err := client.Users.Describe(ctx, objectIdentifier)
+
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			// If not found, mark resource to be removed from state file during apply or refresh
-			log.Printf("[DEBUG] user (%s) not found or we are not authorized.Err:\n%s", d.Id(), err.Error())
+		if errors.Is(err, sdk.ErrObjectNotExistOrAuthorized) {
+			log.Printf("[DEBUG] user (%s) not found or we are not authorized. Err: %s", d.Id(), err)
 			d.SetId("")
 			return nil
 		}

--- a/pkg/resources/user.go
+++ b/pkg/resources/user.go
@@ -245,7 +245,6 @@ func ReadUser(d *schema.ResourceData, meta interface{}) error {
 	objectIdentifier := helpers.DecodeSnowflakeID(d.Id()).(sdk.AccountObjectIdentifier)
 	ctx := context.Background()
 	user, err := client.Users.Describe(ctx, objectIdentifier)
-
 	if err != nil {
 		if errors.Is(err, sdk.ErrObjectNotExistOrAuthorized) {
 			log.Printf("[DEBUG] user (%s) not found or we are not authorized. Err: %s", d.Id(), err)


### PR DESCRIPTION
Fix for https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2481
Adjusted error handling in the User's Read operation. Now when an error happens and we get the "object does not exist or not authorized" error then we're marking the resource as removed and return nil. Otherwise, we return the error. Also, added a test case that proves no error happens when the user is removed outside of the Terraform (it failed with the previous implementation).