### PR TITLE
fix: Fix few smaller issues

### DIFF
--- a/docs/resources/table.md
+++ b/docs/resources/table.md
@@ -95,7 +95,7 @@ resource "snowflake_table" "table" {
 - `cluster_by` (List of String) A list of one or more table columns/expressions to be used as clustering key(s) for the table
 - `comment` (String) Specifies a comment for the table.
 - `data_retention_days` (Number, Deprecated) Specifies the retention period for the table so that Time Travel actions (SELECT, CLONE, UNDROP) can be performed on historical data in the table. Default value is 1, if you wish to inherit the parent schema setting then pass in the schema attribute to this argument.
-- `data_retention_time_in_days` (Number, Deprecated) Specifies the retention period for the table so that Time Travel actions (SELECT, CLONE, UNDROP) can be performed on historical data in the table. Default value is 1, if you wish to inherit the parent schema setting then pass in the schema attribute to this argument.
+- `data_retention_time_in_days` (Number) Specifies the retention period for the table so that Time Travel actions (SELECT, CLONE, UNDROP) can be performed on historical data in the table. Default value is 1, if you wish to inherit the parent schema setting then pass in the schema attribute to this argument.
 - `primary_key` (Block List, Max: 1, Deprecated) Definitions of primary key constraint to create on table (see [below for nested schema](#nestedblock--primary_key))
 - `tag` (Block List, Deprecated) Definitions of a tag to associate with the resource. (see [below for nested schema](#nestedblock--tag))
 

--- a/pkg/resources/external_function.go
+++ b/pkg/resources/external_function.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -180,6 +181,8 @@ var externalFunctionSchema = map[string]*schema.Schema{
 // ExternalFunction returns a pointer to the resource representing an external function.
 func ExternalFunction() *schema.Resource {
 	return &schema.Resource{
+		SchemaVersion: 1,
+
 		CreateContext: CreateContextExternalFunction,
 		ReadContext:   ReadContextExternalFunction,
 		UpdateContext: UpdateContextExternalFunction,
@@ -188,6 +191,15 @@ func ExternalFunction() *schema.Resource {
 		Schema: externalFunctionSchema,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				// setting type to cty.EmptyObject is a bit hacky here but following https://developer.hashicorp.com/terraform/plugin/framework/migrating/resources/state-upgrade#sdkv2-1 would require lots of repetitive code; this should work with cty.EmptyObject
+				Type:    cty.EmptyObject,
+				Upgrade: v085ExternalFunctionStateUpgrader,
+			},
 		},
 	}
 }

--- a/pkg/resources/external_function_acceptance_test.go
+++ b/pkg/resources/external_function_acceptance_test.go
@@ -8,6 +8,7 @@ import (
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -256,6 +257,7 @@ func TestAcc_ExternalFunction_migrateFromVersion085(t *testing.T) {
 				},
 				Config: externalFunctionConfig(acc.TestDatabaseName, acc.TestSchemaName, name),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s|%s|%s|VARCHAR-VARCHAR", acc.TestDatabaseName, acc.TestSchemaName, name)),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "database", "\""+acc.TestDatabaseName+"\""),
 					resource.TestCheckResourceAttr(resourceName, "schema", "\""+acc.TestSchemaName+"\""),
@@ -270,6 +272,7 @@ func TestAcc_ExternalFunction_migrateFromVersion085(t *testing.T) {
 					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 				},
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", sdk.NewSchemaObjectIdentifierWithArguments(acc.TestDatabaseName, acc.TestSchemaName, name, []sdk.DataType{sdk.DataTypeVARCHAR, sdk.DataTypeVARCHAR}).FullyQualifiedName()),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "database", acc.TestDatabaseName),
 					resource.TestCheckResourceAttr(resourceName, "schema", acc.TestSchemaName),

--- a/pkg/resources/external_function_state_upgraders.go
+++ b/pkg/resources/external_function_state_upgraders.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"encoding/csv"
-	"fmt"
 	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -21,14 +20,14 @@ func parseV085ExternalFunctionId(stringID string) (*v085ExternalFunctionId, erro
 	reader.Comma = '|'
 	lines, err := reader.ReadAll()
 	if err != nil {
-		return nil, fmt.Errorf("not CSV compatible")
+		return nil, sdk.NewError("not CSV compatible")
 	}
 
 	if len(lines) != 1 {
-		return nil, fmt.Errorf("1 line at a time")
+		return nil, sdk.NewError("1 line at a time")
 	}
 	if len(lines[0]) != 4 {
-		return nil, fmt.Errorf("4 fields allowed")
+		return nil, sdk.NewError("4 fields allowed")
 	}
 
 	return &v085ExternalFunctionId{

--- a/pkg/resources/external_function_state_upgraders.go
+++ b/pkg/resources/external_function_state_upgraders.go
@@ -1,0 +1,76 @@
+package resources
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"strings"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+)
+
+type v085ExternalFunctionId struct {
+	DatabaseName             string
+	SchemaName               string
+	ExternalFunctionName     string
+	ExternalFunctionArgTypes string
+}
+
+func parseV085ExternalFunctionId(stringID string) (*v085ExternalFunctionId, error) {
+	reader := csv.NewReader(strings.NewReader(stringID))
+	reader.Comma = '|'
+	lines, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("not CSV compatible")
+	}
+
+	if len(lines) != 1 {
+		return nil, fmt.Errorf("1 line at a time")
+	}
+	if len(lines[0]) != 4 {
+		return nil, fmt.Errorf("4 fields allowed")
+	}
+
+	return &v085ExternalFunctionId{
+		DatabaseName:             lines[0][0],
+		SchemaName:               lines[0][1],
+		ExternalFunctionName:     lines[0][2],
+		ExternalFunctionArgTypes: lines[0][3],
+	}, nil
+}
+
+func v085ExternalFunctionStateUpgrader(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	if rawState == nil {
+		return rawState, nil
+	}
+
+	oldId := rawState["id"].(string)
+	parsedV085ExternalFunctionId, err := parseV085ExternalFunctionId(oldId)
+	if err != nil {
+		return nil, err
+	}
+
+	argDataTypes := make([]sdk.DataType, len(parsedV085ExternalFunctionId.ExternalFunctionArgTypes))
+	for i, argType := range strings.Split(parsedV085ExternalFunctionId.ExternalFunctionArgTypes, "-") {
+		argDataType, err := sdk.ToDataType(argType)
+		if err != nil {
+			return nil, err
+		}
+		argDataTypes[i] = argDataType
+	}
+
+	schemaObjectIdentifierWithArguments := sdk.NewSchemaObjectIdentifierWithArguments(parsedV085ExternalFunctionId.DatabaseName, parsedV085ExternalFunctionId.SchemaName, parsedV085ExternalFunctionId.ExternalFunctionName, argDataTypes)
+	rawState["id"] = schemaObjectIdentifierWithArguments.FullyQualifiedName()
+
+	oldDatabase := rawState["database"].(string)
+	oldSchema := rawState["schema"].(string)
+
+	rawState["database"] = strings.Trim(oldDatabase, "\"")
+	rawState["schema"] = strings.Trim(oldSchema, "\"")
+
+	if old, isPresent := rawState["return_null_allowed"]; !isPresent || old == nil || old.(string) == "" {
+		rawState["return_null_allowed"] = "true"
+	}
+
+	return rawState, nil
+}

--- a/pkg/resources/external_function_state_upgraders.go
+++ b/pkg/resources/external_function_state_upgraders.go
@@ -50,13 +50,15 @@ func v085ExternalFunctionStateUpgrader(ctx context.Context, rawState map[string]
 		return nil, err
 	}
 
-	argDataTypes := make([]sdk.DataType, len(parsedV085ExternalFunctionId.ExternalFunctionArgTypes))
-	for i, argType := range strings.Split(parsedV085ExternalFunctionId.ExternalFunctionArgTypes, "-") {
-		argDataType, err := sdk.ToDataType(argType)
-		if err != nil {
-			return nil, err
+	argDataTypes := make([]sdk.DataType, 0)
+	if parsedV085ExternalFunctionId.ExternalFunctionArgTypes != "" {
+		for _, argType := range strings.Split(parsedV085ExternalFunctionId.ExternalFunctionArgTypes, "-") {
+			argDataType, err := sdk.ToDataType(argType)
+			if err != nil {
+				return nil, err
+			}
+			argDataTypes = append(argDataTypes, argDataType)
 		}
-		argDataTypes[i] = argDataType
 	}
 
 	schemaObjectIdentifierWithArguments := sdk.NewSchemaObjectIdentifierWithArguments(parsedV085ExternalFunctionId.DatabaseName, parsedV085ExternalFunctionId.SchemaName, parsedV085ExternalFunctionId.ExternalFunctionName, argDataTypes)

--- a/pkg/resources/function_acceptance_test.go
+++ b/pkg/resources/function_acceptance_test.go
@@ -209,6 +209,7 @@ func TestAcc_Function_migrateFromVersion085(t *testing.T) {
 				},
 				Config: functionConfig(acc.TestDatabaseName, acc.TestSchemaName, name),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s|%s|%s|VARCHAR", acc.TestDatabaseName, acc.TestSchemaName, name)),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "database", acc.TestDatabaseName),
 					resource.TestCheckResourceAttr(resourceName, "schema", acc.TestSchemaName),
@@ -218,6 +219,7 @@ func TestAcc_Function_migrateFromVersion085(t *testing.T) {
 				ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 				Config:                   functionConfig(acc.TestDatabaseName, acc.TestSchemaName, name),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", sdk.NewSchemaObjectIdentifierWithArguments(acc.TestDatabaseName, acc.TestSchemaName, name, []sdk.DataType{sdk.DataTypeVARCHAR}).FullyQualifiedName()),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "database", acc.TestDatabaseName),
 					resource.TestCheckResourceAttr(resourceName, "schema", acc.TestSchemaName),

--- a/pkg/resources/function_state_upgraders.go
+++ b/pkg/resources/function_state_upgraders.go
@@ -18,7 +18,7 @@ type v085FunctionId struct {
 func parseV085FunctionId(v string) (*v085FunctionId, error) {
 	arr := strings.Split(v, "|")
 	if len(arr) != 4 {
-		return nil, fmt.Errorf("ID %v is invalid", v)
+		return nil, sdk.NewError(fmt.Sprintf("ID %v is invalid", v))
 	}
 
 	// this is a bit different from V085 state, but it was buggy

--- a/pkg/resources/function_state_upgraders.go
+++ b/pkg/resources/function_state_upgraders.go
@@ -21,11 +21,17 @@ func parseV085FunctionId(v string) (*v085FunctionId, error) {
 		return nil, fmt.Errorf("ID %v is invalid", v)
 	}
 
+	// this is a bit different from V085 state, but it was buggy
+	var args []string
+	if arr[3] != "" {
+		args = strings.Split(arr[3], "-")
+	}
+
 	return &v085FunctionId{
 		DatabaseName: arr[0],
 		SchemaName:   arr[1],
 		FunctionName: arr[2],
-		ArgTypes:     strings.Split(arr[3], "-"),
+		ArgTypes:     args,
 	}, nil
 }
 

--- a/pkg/resources/notification_integration.go
+++ b/pkg/resources/notification_integration.go
@@ -42,8 +42,10 @@ var notificationIntegrationSchema = map[string]*schema.Schema{
 		Optional:     true,
 		ValidateFunc: validation.StringInSlice([]string{"INBOUND", "OUTBOUND"}, true),
 		Description:  "Direction of the cloud messaging with respect to Snowflake (required only for error notifications)",
-		ForceNew:     true,
 		Deprecated:   "Will be removed - it is added automatically on the SDK level.",
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return true
+		},
 	},
 	// This part of the schema is the cloudProviderParams in the Snowflake documentation and differs between vendors
 	"notification_provider": {

--- a/pkg/resources/procedure.go
+++ b/pkg/resources/procedure.go
@@ -88,9 +88,8 @@ var procedureSchema = map[string]*schema.Schema{
 			}
 			return false
 		},
-		ValidateFunc: IsDataType(),
-		Required:     true,
-		ForceNew:     true,
+		Required: true,
+		ForceNew: true,
 	},
 	"statement": {
 		Type:             schema.TypeString,

--- a/pkg/resources/procedure.go
+++ b/pkg/resources/procedure.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -173,6 +174,8 @@ var procedureSchema = map[string]*schema.Schema{
 // Procedure returns a pointer to the resource representing a stored procedure.
 func Procedure() *schema.Resource {
 	return &schema.Resource{
+		SchemaVersion: 1,
+
 		CreateContext: CreateContextProcedure,
 		ReadContext:   ReadContextProcedure,
 		UpdateContext: UpdateContextProcedure,
@@ -181,6 +184,15 @@ func Procedure() *schema.Resource {
 		Schema: procedureSchema,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				// setting type to cty.EmptyObject is a bit hacky here but following https://developer.hashicorp.com/terraform/plugin/framework/migrating/resources/state-upgrade#sdkv2-1 would require lots of repetitive code; this should work with cty.EmptyObject
+				Type:    cty.EmptyObject,
+				Upgrade: v085ProcedureStateUpgrader,
+			},
 		},
 	}
 }

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -7,6 +7,7 @@ import (
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -202,6 +203,7 @@ func TestAcc_Procedure_migrateFromVersion085(t *testing.T) {
 				},
 				Config: procedureConfig(acc.TestDatabaseName, acc.TestSchemaName, name),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf("%s|%s|%s|", acc.TestDatabaseName, acc.TestSchemaName, name)),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "database", acc.TestDatabaseName),
 					resource.TestCheckResourceAttr(resourceName, "schema", acc.TestSchemaName),
@@ -214,6 +216,7 @@ func TestAcc_Procedure_migrateFromVersion085(t *testing.T) {
 					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 				},
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", sdk.NewSchemaObjectIdentifier(acc.TestDatabaseName, acc.TestSchemaName, name).FullyQualifiedName()),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "database", acc.TestDatabaseName),
 					resource.TestCheckResourceAttr(resourceName, "schema", acc.TestSchemaName),

--- a/pkg/resources/procedure_state_upgraders.go
+++ b/pkg/resources/procedure_state_upgraders.go
@@ -1,0 +1,62 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+)
+
+type v085ProcedureId struct {
+	DatabaseName  string
+	SchemaName    string
+	ProcedureName string
+	ArgTypes      []string
+}
+
+func parseV085ProcedureId(v string) (*v085ProcedureId, error) {
+	arr := strings.Split(v, "|")
+	if len(arr) != 4 {
+		return nil, fmt.Errorf("ID %v is invalid", v)
+	}
+
+	// this is a bit different from V085 state, but it was buggy
+	var args []string
+	if arr[3] != "" {
+		args = strings.Split(arr[3], "-")
+	}
+
+	return &v085ProcedureId{
+		DatabaseName:  arr[0],
+		SchemaName:    arr[1],
+		ProcedureName: arr[2],
+		ArgTypes:      args,
+	}, nil
+}
+
+func v085ProcedureStateUpgrader(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	if rawState == nil {
+		return rawState, nil
+	}
+
+	oldId := rawState["id"].(string)
+	parsedV085ProcedureId, err := parseV085ProcedureId(oldId)
+	if err != nil {
+		return nil, err
+	}
+
+	argDataTypes := make([]sdk.DataType, len(parsedV085ProcedureId.ArgTypes))
+	for i, argType := range parsedV085ProcedureId.ArgTypes {
+		argDataType, err := sdk.ToDataType(argType)
+		if err != nil {
+			return nil, err
+		}
+		argDataTypes[i] = argDataType
+	}
+
+	schemaObjectIdentifierWithArguments := sdk.NewSchemaObjectIdentifierWithArguments(parsedV085ProcedureId.DatabaseName, parsedV085ProcedureId.SchemaName, parsedV085ProcedureId.ProcedureName, argDataTypes)
+	rawState["id"] = schemaObjectIdentifierWithArguments.FullyQualifiedName()
+
+	return rawState, nil
+}

--- a/pkg/resources/procedure_state_upgraders.go
+++ b/pkg/resources/procedure_state_upgraders.go
@@ -18,7 +18,7 @@ type v085ProcedureId struct {
 func parseV085ProcedureId(v string) (*v085ProcedureId, error) {
 	arr := strings.Split(v, "|")
 	if len(arr) != 4 {
-		return nil, fmt.Errorf("ID %v is invalid", v)
+		return nil, sdk.NewError(fmt.Sprintf("ID %v is invalid", v))
 	}
 
 	// this is a bit different from V085 state, but it was buggy

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -189,7 +189,6 @@ var tableSchema = map[string]*schema.Schema{
 		Optional:      true,
 		Description:   "Specifies the retention period for the table so that Time Travel actions (SELECT, CLONE, UNDROP) can be performed on historical data in the table. Default value is 1, if you wish to inherit the parent schema setting then pass in the schema attribute to this argument.",
 		ValidateFunc:  validation.IntBetween(0, 90),
-		Deprecated:    "Use snowflake_object_parameter instead",
 		ConflictsWith: []string{"data_retention_days"},
 	},
 	"change_tracking": {

--- a/pkg/sdk/views_impl_gen.go
+++ b/pkg/sdk/views_impl_gen.go
@@ -38,7 +38,7 @@ func (v *views) Show(ctx context.Context, request *ShowViewRequest) ([]View, err
 }
 
 func (v *views) ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*View, error) {
-	request := NewShowViewRequest().WithIn(&In{Database: NewAccountObjectIdentifier(id.DatabaseName())}).WithLike(&Like{String(id.Name())})
+	request := NewShowViewRequest().WithIn(&In{Schema: NewDatabaseObjectIdentifier(id.DatabaseName(), id.SchemaName())}).WithLike(&Like{String(id.Name())})
 	views, err := v.Show(ctx, request)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Removed incorrect validation on procedure resources that were causing failure of the following tests:
  - `TestAcc_Procedure_Java`
  - `TestAcc_Procedure_Scala`
- Removed incorrect deprecation from table resource (#2488)
- Fixed ShowByID for views (#2506)
- Fixed notification_integration resource warnings for deprecated parameters (#2501)
- Fixed external functions and procedure - state migrations similar to functions (#2490)

References: #2501 #2506 #2488 #2490