### PR TITLE
fix: SHOW GRANTS mapping for share data type

### DIFF
--- a/pkg/resources/grant_database_role_acceptance_test.go
+++ b/pkg/resources/grant_database_role_acceptance_test.go
@@ -97,15 +97,17 @@ func TestAcc_GrantDatabaseRole_accountRole(t *testing.T) {
 	})
 }
 
-/*
-todo: once snowflake_grant_privileges_to_share is implemented. Cannot test this without having  'GRANT USAGE ON DATABASE <NAME> TO SHARE <share_name>',
+// proves https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2410 is fixed
 func TestAcc_GrantDatabaseRole_share(t *testing.T) {
+	databaseName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	databaseRoleName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	databaseRoleId := sdk.NewDatabaseObjectIdentifier(databaseName, databaseRoleName).FullyQualifiedName()
 	shareName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
-	resourceName := "snowflake_grant_database_role.g"
-	m := func() map[string]config.Variable {
-		return map[string]config.Variable{
-			"database":           config.StringVariable(acc.TestDatabaseName),
+	shareId := sdk.NewAccountObjectIdentifier(shareName).FullyQualifiedName()
+	resourceName := "snowflake_grant_database_role.test"
+	configVariables := func() config.Variables {
+		return config.Variables{
+			"database":           config.StringVariable(databaseName),
 			"database_role_name": config.StringVariable(databaseRoleName),
 			"share_name":         config.StringVariable(shareName),
 		}
@@ -120,17 +122,17 @@ func TestAcc_GrantDatabaseRole_share(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/TestAcc_GrantDatabaseRole/share"),
-				ConfigVariables: m(),
+				ConfigVariables: configVariables(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "database_role_name", databaseRoleName),
+					resource.TestCheckResourceAttr(resourceName, "database_role_name", databaseRoleId),
 					resource.TestCheckResourceAttr(resourceName, "share_name", shareName),
-					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf(`%v|%v|%v`, databaseRoleName, "SHARE", shareName)),
+					resource.TestCheckResourceAttr(resourceName, "id", fmt.Sprintf(`%v|%v|%v`, databaseRoleId, "SHARE", shareId)),
 				),
 			},
 			// test import
 			{
 				ConfigDirectory:   config.StaticDirectory("testdata/TestAcc_GrantDatabaseRole/share"),
-				ConfigVariables:   m(),
+				ConfigVariables:   configVariables(),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -138,7 +140,6 @@ func TestAcc_GrantDatabaseRole_share(t *testing.T) {
 		},
 	})
 }
-*/
 
 func testAccCheckGrantDatabaseRoleDestroy(s *terraform.State) error {
 	db := acc.TestAccProvider.Meta().(*sql.DB)

--- a/pkg/resources/testdata/TestAcc_GrantDatabaseRole/share/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantDatabaseRole/share/test.tf
@@ -11,7 +11,7 @@ variable "database" {
 }
 
 resource "snowflake_database" "test" {
-  name     = var.database
+  name = var.database
 }
 
 resource "snowflake_database_role" "test" {
@@ -24,9 +24,9 @@ resource "snowflake_share" "test" {
 }
 
 resource "snowflake_grant_privileges_to_share" "test" {
-  privileges = ["USAGE"]
+  privileges  = ["USAGE"]
   on_database = snowflake_database.test.name
-  to_share = snowflake_share.test.name
+  to_share    = snowflake_share.test.name
 }
 
 resource "snowflake_grant_database_role" "test" {

--- a/pkg/resources/testdata/TestAcc_GrantDatabaseRole/share/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantDatabaseRole/share/test.tf
@@ -10,18 +10,26 @@ variable "database" {
   type = string
 }
 
-resource "snowflake_database_role" "database_role" {
-  database = var.database
+resource "snowflake_database" "test" {
+  name     = var.database
+}
+
+resource "snowflake_database_role" "test" {
+  database = snowflake_database.test.name
   name     = var.database_role_name
 }
 
-resource "snowflake_share" "share" {
+resource "snowflake_share" "test" {
   name = var.share_name
 }
 
-// todo: add grant_privileges_to_share resource
+resource "snowflake_grant_privileges_to_share" "test" {
+  privileges = ["USAGE"]
+  on_database = snowflake_database.test.name
+  to_share = snowflake_share.test.name
+}
 
-resource "snowflake_grant_database_role" "g" {
-  database_role_name = snowflake_database_role.database_role.name
-  share_name         = snowflake_share.name
+resource "snowflake_grant_database_role" "test" {
+  database_role_name = "\"${snowflake_database.test.name}\".\"${snowflake_database_role.test.name}\""
+  share_name         = snowflake_share.test.name
 }

--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -223,8 +223,13 @@ func (row grantRow) convert() *Grant {
 	var granteeName AccountObjectIdentifier
 	if grantedTo == ObjectTypeShare {
 		parts := strings.Split(row.GranteeName, ".")
-		name := strings.Join(parts[1:], ".")
-		granteeName = NewAccountObjectIdentifier(name)
+		switch {
+		case len(parts) == 1:
+			granteeName = NewAccountObjectIdentifier(parts[0])
+		case len(parts) > 1:
+			name := strings.Join(parts[1:], ".")
+			granteeName = NewAccountObjectIdentifier(name)
+		}
 	} else {
 		granteeName = NewAccountObjectIdentifier(row.GranteeName)
 	}

--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -223,6 +223,7 @@ func (row grantRow) convert() *Grant {
 	grantTo := ObjectType(strings.ReplaceAll(row.GrantTo, "_", " "))
 	var granteeName AccountObjectIdentifier
 	if grantedTo == ObjectTypeShare {
+		// TODO(SNOW-1058419): Change this logic during identifiers rework
 		parts := strings.Split(row.GranteeName, ".")
 		switch {
 		case len(parts) == 1:

--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"log"
 	"strings"
 	"time"
 )
@@ -226,9 +227,10 @@ func (row grantRow) convert() *Grant {
 		switch {
 		case len(parts) == 1:
 			granteeName = NewAccountObjectIdentifier(parts[0])
-		case len(parts) > 1:
-			name := strings.Join(parts[1:], ".")
-			granteeName = NewAccountObjectIdentifier(name)
+		case len(parts) == 2:
+			granteeName = NewAccountObjectIdentifier(parts[1])
+		default:
+			log.Printf("unsupported case for share's grantee name: %s", row.GranteeName)
 		}
 	} else {
 		granteeName = NewAccountObjectIdentifier(row.GranteeName)


### PR DESCRIPTION
Fixes: https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2410
The root cause of the issue was that in SHOW GRANTS conversion from row representation to SDK object representation, we had a special case for shares that would split it on dot. Share may have only one part and this change adds support for such a situation. Additionally, it was covered by an existing test that was commented out and was waiting for the `snowflake_grant_privileges_to_share` resource.