### PR TITLE
feat: Use secondary roles in provider config [FOR LATER]

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -807,8 +807,9 @@ func ConfigureProvider(s *schema.ResourceData) (interface{}, error) {
 	return &provider.Context{Client: cl}, nil
 
 	if v, ok := s.GetOk("use_secondary_roles"); ok && v.(bool) {
-		err := client.Sessions.UseSecondaryRoles(context.Background(), sdk.SecondaryRolesAll)
-		return nil, err
+		if err := client.Sessions.UseSecondaryRoles(context.Background(), sdk.SecondaryRolesAll); err != nil {
+			return nil, err
+		}
 	}
 
 	return client.GetConn().DB, nil

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -800,17 +800,19 @@ func ConfigureProvider(s *schema.ResourceData) (interface{}, error) {
 		configureClientError = nil
 	}
 
+	if v, ok := s.GetOk("use_secondary_roles"); ok && v.(bool) {
+		if err := cl.Sessions.UseSecondaryRoles(context.Background(), sdk.SecondaryRolesAll); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := cl.Sessions.UseSecondaryRoles(context.Background(), sdk.SecondaryRolesNone); err != nil {
+			return nil, err
+		}
+	}
+
 	if clErr != nil {
 		return nil, clErr
 	}
 
 	return &provider.Context{Client: cl}, nil
-
-	if v, ok := s.GetOk("use_secondary_roles"); ok && v.(bool) {
-		if err := client.Sessions.UseSecondaryRoles(context.Background(), sdk.SecondaryRolesAll); err != nil {
-			return nil, err
-		}
-	}
-
-	return client.GetConn().DB, nil
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -81,6 +82,12 @@ func Provider() *schema.Provider {
 				Description: "Specifies the role to use by default for accessing Snowflake objects in the client session. Can also be sourced from the `SNOWFLAKE_ROLE` environment variable. .",
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SNOWFLAKE_ROLE", nil),
+			},
+			"use_secondary_roles": {
+				Type:        schema.TypeBool,
+				Description: "TODO",
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SNOWFLAKE_USE_SECONDARY_ROLES", nil),
 			},
 			"validate_default_parameters": {
 				Type:        schema.TypeBool,
@@ -798,4 +805,11 @@ func ConfigureProvider(s *schema.ResourceData) (interface{}, error) {
 	}
 
 	return &provider.Context{Client: cl}, nil
+
+	if v, ok := s.GetOk("use_secondary_roles"); ok && v.(bool) {
+		err := client.Sessions.UseSecondaryRoles(context.Background(), sdk.SecondaryRolesAll)
+		return nil, err
+	}
+
+	return client.GetConn().DB, nil
 }

--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -108,6 +108,13 @@ func CreateDatabase(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	id := sdk.NewAccountObjectIdentifier(name)
 
+	cr, _ := client.ContextFunctions.CurrentRole(ctx)
+	sr, _ := client.ContextFunctions.CurrentSecondaryRoles(ctx)
+	res, _ := client.Grants.Show(ctx, &sdk.ShowGrantOptions{To: &sdk.ShowGrantsTo{Role: sr.Roles[0]}})
+	_ = cr
+	_ = res
+	_ = client.Sessions.UseSecondaryRoles(context.Background(), sdk.SecondaryRolesAll)
+
 	// Is it a Shared Database?
 	if fromShare, ok := d.GetOk("from_share"); ok {
 		account := fromShare.(map[string]interface{})["provider"].(string)

--- a/pkg/resources/provider_acceptance_test.go
+++ b/pkg/resources/provider_acceptance_test.go
@@ -1,0 +1,113 @@
+package resources_test
+
+import (
+	"context"
+	"fmt"
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestAcc_Provider_UseSecondaryRoles(t *testing.T) {
+	providerRole := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	providerUseSecondaryRolesSetup(t, providerRole)
+
+	databaseName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	providerConfigVariables := config.Variables{
+		"profile":             config.StringVariable("default"),
+		"role":                config.StringVariable(providerRole),
+		"use_secondary_roles": config.BoolVariable(true),
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { acc.TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: providerUseSecondarySchemaConfig(providerConfig(t, providerConfigVariables), databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_database.test", "name", databaseName),
+				),
+			},
+		},
+	})
+}
+
+func providerUseSecondarySchemaConfig(providerConfig string, databaseName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "snowflake_database" "test" {
+  name = "%s"
+}`, providerConfig, databaseName)
+}
+
+func providerConfig(t *testing.T, variables config.Variables) string {
+	var builder strings.Builder
+	for k, v := range variables {
+		builder.WriteString(k)
+		builder.WriteString(" = ")
+		value, err := v.MarshalJSON()
+		require.NoError(t, err)
+		builder.Write(value)
+		builder.WriteByte('\n')
+	}
+	return fmt.Sprintf(`provider "snowflake" {
+%s
+}`, builder.String())
+}
+
+func providerUseSecondaryRolesSetup(t *testing.T, providerRoleName string) {
+	t.Helper()
+
+	client, err := sdk.NewDefaultClient()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	secondaryRoleName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	userName, err := client.ContextFunctions.CurrentUser(ctx)
+	require.NoError(t, err)
+
+	createTestRole(t, client, ctx, secondaryRoleName, userName)
+	createTestRole(t, client, ctx, providerRoleName, userName)
+
+	err = client.Grants.GrantPrivilegesToAccountRole(ctx, &sdk.AccountRoleGrantPrivileges{
+		GlobalPrivileges: []sdk.GlobalPrivilege{
+			sdk.GlobalPrivilegeCreateDatabase,
+		},
+	},
+		&sdk.AccountRoleGrantOn{
+			Account: sdk.Bool(true),
+		},
+		sdk.NewAccountObjectIdentifier(secondaryRoleName),
+		&sdk.GrantPrivilegesToAccountRoleOptions{},
+	)
+	require.NoError(t, err)
+}
+
+func createTestRole(t *testing.T, client *sdk.Client, ctx context.Context, roleName string, currentUserName string) {
+	id := sdk.NewAccountObjectIdentifier(roleName)
+
+	err := client.Roles.Create(ctx, sdk.NewCreateRoleRequest(id))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := client.Roles.Drop(ctx, sdk.NewDropRoleRequest(id))
+		require.NoError(t, err)
+	})
+
+	err = client.Roles.Grant(ctx, sdk.NewGrantRoleRequest(id, sdk.GrantRole{
+		User: sdk.Pointer(sdk.NewAccountObjectIdentifier(currentUserName)),
+	}))
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Implements: https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2504
Add the `use_secondary_roles` parameter to the provider config. Added acceptance tests, which showed that before introducing this change we should use client object instead of db connection as resource metadata to keep the same session between provider config and resource operation. Right now, it seems provider config or operation = 1 session.