### PR TITLE
fix: Fix failover group alter syntax and suppression for pipe statement

### DIFF
--- a/pkg/acceptance/testenvs/testing_environment_variables.go
+++ b/pkg/acceptance/testenvs/testing_environment_variables.go
@@ -14,6 +14,8 @@ const (
 	Account  env = "TEST_SF_TF_ACCOUNT"
 	Role     env = "TEST_SF_TF_ROLE"
 	Host     env = "TEST_SF_TF_HOST"
+
+	BusinessCriticalAccount env = "SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT"
 )
 
 func GetOrSkipTest(t *testing.T, envName Env) string {

--- a/pkg/resources/failover_group_acceptance_test.go
+++ b/pkg/resources/failover_group_acceptance_test.go
@@ -2,12 +2,12 @@ package resources_test
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -16,10 +16,7 @@ import (
 func TestAcc_FailoverGroupBasic(t *testing.T) {
 	randomCharacters := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
-	if _, ok := os.LookupEnv("SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT"); !ok {
-		t.Skip("Skipping TestAcc_FailoverGroup since not a business critical account")
-	}
-	accountName := os.Getenv("SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT")
+	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -54,10 +51,7 @@ func TestAcc_FailoverGroupBasic(t *testing.T) {
 func TestAcc_FailoverGroupRemoveObjectTypes(t *testing.T) {
 	randomCharacters := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
-	if _, ok := os.LookupEnv("SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT"); !ok {
-		t.Skip("Skipping TestAcc_FailoverGroup since not a business critical account")
-	}
-	accountName := os.Getenv("SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT")
+	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -95,10 +89,7 @@ func TestAcc_FailoverGroupRemoveObjectTypes(t *testing.T) {
 func TestAcc_FailoverGroupInterval(t *testing.T) {
 	randomCharacters := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
-	if _, ok := os.LookupEnv("SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT"); !ok {
-		t.Skip("Skipping TestAcc_FailoverGroup since not a business critical account")
-	}
-	accountName := os.Getenv("SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT")
+	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -194,10 +185,7 @@ func TestAcc_FailoverGroupInterval(t *testing.T) {
 func TestAcc_FailoverGroup_issue2517(t *testing.T) {
 	randomCharacters := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
-	if _, ok := os.LookupEnv("SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT"); !ok {
-		t.Skip("Skipping TestAcc_FailoverGroup since not a business critical account")
-	}
-	accountName := os.Getenv("SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT")
+	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },

--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -101,8 +101,8 @@ func pipeCopyStatementDiffSuppress(_, o, n string, _ *schema.ResourceData) bool 
 	o = strings.ReplaceAll(o, "\r\n", "\n")
 	n = strings.ReplaceAll(n, "\r\n", "\n")
 
-	// trim off any trailing line endings
-	return strings.TrimRight(o, ";\r\n") == strings.TrimRight(n, ";\r\n")
+	// trim off any trailing line endings and leading/trailing whitespace
+	return strings.TrimSpace(strings.TrimRight(o, ";\r\n")) == strings.TrimSpace(strings.TrimRight(n, ";\r\n"))
 }
 
 // CreatePipe implements schema.CreateFunc.

--- a/pkg/resources/pipe_acceptance_test.go
+++ b/pkg/resources/pipe_acceptance_test.go
@@ -2,24 +2,25 @@ package resources_test
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func TestAcc_Pipe(t *testing.T) {
-	if _, ok := os.LookupEnv("SKIP_PIPE_TESTS"); ok {
-		t.Skip("Skipping TestAcc_Pipe")
-	}
 	accName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	resource.Test(t, resource.TestCase{
-		Providers:    acc.TestAccProviders(),
-		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { acc.TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
@@ -37,6 +38,7 @@ func TestAcc_Pipe(t *testing.T) {
 	})
 }
 
+// whitespace in copy_statement matters for the tests, change with caution!
 func pipeConfig(name string, databaseName string, schemaName string) string {
 	s := `
 resource "snowflake_table" "test" {
@@ -69,7 +71,7 @@ resource "snowflake_pipe" "test" {
   name           = "%s"
   comment        = "Terraform acceptance test"
   copy_statement = <<CMD
-COPY INTO "${snowflake_table.test.database}"."${snowflake_table.test.schema}"."${snowflake_table.test.name}"
+  	COPY INTO "${snowflake_table.test.database}"."${snowflake_table.test.schema}"."${snowflake_table.test.name}"
   FROM @"${snowflake_stage.test.database}"."${snowflake_stage.test.schema}"."${snowflake_stage.test.name}"
   FILE_FORMAT = (TYPE = CSV)
 CMD

--- a/pkg/sdk/failover_groups.go
+++ b/pkg/sdk/failover_groups.go
@@ -183,8 +183,8 @@ func (opts *AlterSourceFailoverGroupOptions) validate() error {
 
 type FailoverGroupSet struct {
 	ObjectTypes             []PluralObjectType `ddl:"parameter" sql:"OBJECT_TYPES"`
-	ReplicationSchedule     *string            `ddl:"parameter,single_quotes" sql:"REPLICATION_SCHEDULE"`
 	AllowedIntegrationTypes []IntegrationType  `ddl:"parameter" sql:"ALLOWED_INTEGRATION_TYPES"`
+	ReplicationSchedule     *string            `ddl:"parameter,single_quotes" sql:"REPLICATION_SCHEDULE"`
 }
 
 func (v *FailoverGroupSet) validate() error {

--- a/pkg/sdk/failover_groups.go
+++ b/pkg/sdk/failover_groups.go
@@ -574,15 +574,17 @@ func (v *failoverGroups) ShowShares(ctx context.Context, id AccountObjectIdentif
 		return nil, err
 	}
 	dest := []struct {
-		Name string `db:"name"`
+		Name         string `db:"name"`
+		OwnerAccount string `db:"owner_account"`
 	}{}
 	err = v.client.query(ctx, &dest, sql)
 	if err != nil {
 		return nil, err
 	}
 	resultList := make([]AccountObjectIdentifier, len(dest))
-	for i, row := range dest {
-		resultList[i] = NewExternalObjectIdentifierFromFullyQualifiedName(row.Name).objectIdentifier.(AccountObjectIdentifier)
+	for i, r := range dest {
+		// TODO [SNOW-999049]: this was not working correctly with identifiers containing `.` character
+		resultList[i] = NewExternalObjectIdentifier(NewAccountIdentifierFromFullyQualifiedName(r.OwnerAccount), NewAccountObjectIdentifier(r.Name)).objectIdentifier.(AccountObjectIdentifier)
 	}
 	return resultList, nil
 }

--- a/pkg/sdk/testint/failover_groups_integration_test.go
+++ b/pkg/sdk/testint/failover_groups_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/avast/retry-go"
@@ -20,6 +21,9 @@ func TestInt_FailoverGroupsCreate(t *testing.T) {
 	shareTest, shareCleanup := createShare(t, client)
 	t.Cleanup(shareCleanup)
 
+	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
+	businessCriticalAccountId := sdk.NewAccountIdentifierFromFullyQualifiedName(accountName)
+
 	t.Run("test complete", func(t *testing.T) {
 		id := sdk.RandomAccountObjectIdentifier()
 		objectTypes := []sdk.PluralObjectType{
@@ -27,7 +31,7 @@ func TestInt_FailoverGroupsCreate(t *testing.T) {
 			sdk.PluralObjectTypeDatabases,
 		}
 		allowedAccounts := []sdk.AccountIdentifier{
-			getAccountIdentifier(t, testSecondaryClient(t)),
+			businessCriticalAccountId,
 		}
 		replicationSchedule := "10 MINUTE"
 		err := client.FailoverGroups.Create(ctx, id, objectTypes, allowedAccounts, &sdk.CreateFailoverGroupOptions{
@@ -83,7 +87,7 @@ func TestInt_FailoverGroupsCreate(t *testing.T) {
 			sdk.PluralObjectTypeShares,
 		}
 		allowedAccounts := []sdk.AccountIdentifier{
-			getAccountIdentifier(t, testSecondaryClient(t)),
+			businessCriticalAccountId,
 		}
 		err := client.FailoverGroups.Create(ctx, id, objectTypes, allowedAccounts, &sdk.CreateFailoverGroupOptions{
 			AllowedShares: []sdk.AccountObjectIdentifier{
@@ -110,7 +114,7 @@ func TestInt_FailoverGroupsCreate(t *testing.T) {
 			sdk.PluralObjectTypeIntegrations,
 		}
 		allowedAccounts := []sdk.AccountIdentifier{
-			getAccountIdentifier(t, testSecondaryClient(t)),
+			businessCriticalAccountId,
 		}
 		allowedIntegrationTypes := []sdk.IntegrationType{
 			sdk.IntegrationTypeAPIIntegrations,
@@ -138,6 +142,9 @@ func TestInt_Issue2544(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
+	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
+	businessCriticalAccountId := sdk.NewAccountIdentifierFromFullyQualifiedName(accountName)
+
 	t.Run("alter object types, replication schedule, and allowed integration types at the same time", func(t *testing.T) {
 		id := sdk.RandomAccountObjectIdentifier()
 		objectTypes := []sdk.PluralObjectType{
@@ -145,7 +152,7 @@ func TestInt_Issue2544(t *testing.T) {
 			sdk.PluralObjectTypeDatabases,
 		}
 		allowedAccounts := []sdk.AccountIdentifier{
-			getAccountIdentifier(t, testSecondaryClient(t)),
+			businessCriticalAccountId,
 		}
 		allowedIntegrationTypes := []sdk.IntegrationType{
 			sdk.IntegrationTypeAPIIntegrations,

--- a/pkg/sdk/testint/failover_groups_integration_test.go
+++ b/pkg/sdk/testint/failover_groups_integration_test.go
@@ -213,8 +213,8 @@ func TestInt_Issue2544(t *testing.T) {
 	})
 }
 
+// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
 func TestInt_CreateSecondaryReplicationGroup(t *testing.T) {
-	// TODO: Business Critical Snowflake Edition (SNOW-1002023)
 	if os.Getenv("SNOWFLAKE_TEST_BUSINESS_CRITICAL_FEATURES") != "1" {
 		t.Skip("Skipping TestInt_FailoverGroupsCreate")
 	}
@@ -290,6 +290,7 @@ func TestInt_CreateSecondaryReplicationGroup(t *testing.T) {
 	assert.Equal(t, 2, len(failoverGroups))
 }
 
+// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
 func TestInt_FailoverGroupsAlterSource(t *testing.T) {
 	if os.Getenv("SNOWFLAKE_TEST_BUSINESS_CRITICAL_FEATURES") != "1" {
 		t.Skip("Skipping TestInt_FailoverGroupsCreate")
@@ -647,8 +648,8 @@ func TestInt_FailoverGroupsAlterSource(t *testing.T) {
 	})
 }
 
+// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
 func TestInt_FailoverGroupsAlterTarget(t *testing.T) {
-	// TODO: Business Critical Snowflake Edition (SNOW-1002023)
 	if os.Getenv("SNOWFLAKE_TEST_BUSINESS_CRITICAL_FEATURES") != "1" {
 		t.Skip("Skipping TestInt_FailoverGroupsCreate")
 	}
@@ -773,6 +774,7 @@ func TestInt_FailoverGroupsAlterTarget(t *testing.T) {
 	})
 }
 
+// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
 func TestInt_FailoverGroupsDrop(t *testing.T) {
 	if os.Getenv("SNOWFLAKE_TEST_BUSINESS_CRITICAL_FEATURES") != "1" {
 		t.Skip("Skipping TestInt_FailoverGroupsCreate")
@@ -795,6 +797,7 @@ func TestInt_FailoverGroupsDrop(t *testing.T) {
 	})
 }
 
+// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
 func TestInt_FailoverGroupsShow(t *testing.T) {
 	if os.Getenv("SNOWFLAKE_TEST_BUSINESS_CRITICAL_FEATURES") != "1" {
 		t.Skip("Skipping TestInt_FailoverGroupsCreate")
@@ -827,6 +830,7 @@ func TestInt_FailoverGroupsShow(t *testing.T) {
 	})
 }
 
+// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
 func TestInt_FailoverGroupsShowDatabases(t *testing.T) {
 	if os.Getenv("SNOWFLAKE_TEST_BUSINESS_CRITICAL_FEATURES") != "1" {
 		t.Skip("Skipping TestInt_FailoverGroupsCreate")
@@ -860,6 +864,7 @@ func TestInt_FailoverGroupsShowDatabases(t *testing.T) {
 	assert.Equal(t, testDb(t).ID(), databases[0])
 }
 
+// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
 func TestInt_FailoverGroupsShowShares(t *testing.T) {
 	if _, ok := os.LookupEnv("SNOWFLAKE_TEST_BUSINESS_CRITICAL_FEATURES"); !ok {
 		t.Skip("Skipping TestInt_FailoverGroupsCreate")

--- a/pkg/sdk/testint/helpers_test.go
+++ b/pkg/sdk/testint/helpers_test.go
@@ -656,12 +656,12 @@ func createFailoverGroupWithOptions(t *testing.T, client *sdk.Client, objectType
 
 func createShare(t *testing.T, client *sdk.Client) (*sdk.Share, func()) {
 	t.Helper()
-	return createShareWithOptions(t, client, &sdk.CreateShareOptions{})
+	id := sdk.RandomAccountObjectIdentifier()
+	return createShareWithOptions(t, client, id, &sdk.CreateShareOptions{})
 }
 
-func createShareWithOptions(t *testing.T, client *sdk.Client, opts *sdk.CreateShareOptions) (*sdk.Share, func()) {
+func createShareWithOptions(t *testing.T, client *sdk.Client, id sdk.AccountObjectIdentifier, opts *sdk.CreateShareOptions) (*sdk.Share, func()) {
 	t.Helper()
-	id := sdk.RandomAccountObjectIdentifier()
 	ctx := context.Background()
 	err := client.Shares.Create(ctx, id, opts)
 	require.NoError(t, err)


### PR DESCRIPTION
- Run two separate alters in failover group resource
- Handle `.` in failover ids
- Trim leading and trailing space for pipe statement diff suppression
- Unskip part of the integration tests for failover groups

References: #2544 #2560