### PR TITLE
fix: loosen identifier field validation for account object identifiers

### DIFF
--- a/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
@@ -929,6 +929,49 @@ func TestAcc_GrantPrivilegesToAccountRole_ImportedPrivileges(t *testing.T) {
 	})
 }
 
+func TestAcc_GrantPrivilegesToAccountRole_MultiplePartsInRoleName(t *testing.T) {
+	nameBytes := []byte(strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)))
+	nameBytes[3] = '.'
+	nameBytes[6] = '.'
+	name := string(nameBytes)
+	roleName := sdk.NewAccountObjectIdentifier(name).FullyQualifiedName()
+	configVariables := config.Variables{
+		"name": config.StringVariable(roleName),
+		"privileges": config.ListVariable(
+			config.StringVariable(string(sdk.GlobalPrivilegeCreateDatabase)),
+			config.StringVariable(string(sdk.GlobalPrivilegeCreateRole)),
+		),
+		"with_grant_option": config.BoolVariable(true),
+	}
+	resourceName := "snowflake_grant_privileges_to_account_role.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { acc.TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: testAccCheckAccountRolePrivilegesRevoked(name),
+		Steps: []resource.TestStep{
+			{
+				PreConfig:       func() { createAccountRoleOutsideTerraform(t, name) },
+				ConfigDirectory: acc.ConfigurationDirectory("TestAcc_GrantPrivilegesToAccountRole/OnAccount"),
+				ConfigVariables: configVariables,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "account_role_name", roleName),
+				),
+			},
+			{
+				ConfigDirectory:   acc.ConfigurationDirectory("TestAcc_GrantPrivilegesToAccountRole/OnAccount"),
+				ConfigVariables:   configVariables,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func getSecondaryAccountName(t *testing.T) (string, error) {
 	t.Helper()
 	config, err := sdk.ProfileConfig(testprofiles.Secondary)

--- a/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
@@ -934,9 +934,8 @@ func TestAcc_GrantPrivilegesToAccountRole_MultiplePartsInRoleName(t *testing.T) 
 	nameBytes[3] = '.'
 	nameBytes[6] = '.'
 	name := string(nameBytes)
-	roleName := sdk.NewAccountObjectIdentifier(name).FullyQualifiedName()
 	configVariables := config.Variables{
-		"name": config.StringVariable(roleName),
+		"name": config.StringVariable(name),
 		"privileges": config.ListVariable(
 			config.StringVariable(string(sdk.GlobalPrivilegeCreateDatabase)),
 			config.StringVariable(string(sdk.GlobalPrivilegeCreateRole)),
@@ -958,15 +957,8 @@ func TestAcc_GrantPrivilegesToAccountRole_MultiplePartsInRoleName(t *testing.T) 
 				ConfigDirectory: acc.ConfigurationDirectory("TestAcc_GrantPrivilegesToAccountRole/OnAccount"),
 				ConfigVariables: configVariables,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "account_role_name", roleName),
+					resource.TestCheckResourceAttr(resourceName, "account_role_name", name),
 				),
-			},
-			{
-				ConfigDirectory:   acc.ConfigurationDirectory("TestAcc_GrantPrivilegesToAccountRole/OnAccount"),
-				ConfigVariables:   configVariables,
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})

--- a/pkg/resources/grant_privileges_to_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_role_acceptance_test.go
@@ -1090,3 +1090,38 @@ func TestAcc_GrantPrivilegesToRole_ImportedPrivileges(t *testing.T) {
 		},
 	})
 }
+
+func TestAcc_GrantPrivilegesToRole_MultiplePartsInRoleName(t *testing.T) {
+	nameBytes := []byte(strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)))
+	nameBytes[3] = '.'
+	nameBytes[6] = '.'
+	name := string(nameBytes)
+	configVariables := config.Variables{
+		"name": config.StringVariable(name),
+		"privileges": config.ListVariable(
+			config.StringVariable(string(sdk.GlobalPrivilegeCreateDatabase)),
+			config.StringVariable(string(sdk.GlobalPrivilegeCreateRole)),
+		),
+		"with_grant_option": config.BoolVariable(true),
+	}
+	resourceName := "snowflake_grant_privileges_to_role.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { acc.TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: testAccCheckAccountRolePrivilegesRevoked(name),
+		Steps: []resource.TestStep{
+			{
+				PreConfig:       func() { createAccountRoleOutsideTerraform(t, name) },
+				ConfigDirectory: acc.ConfigurationDirectory("TestAcc_GrantPrivilegesToRole/OnAccount"),
+				ConfigVariables: configVariables,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "role_name", name),
+				),
+			},
+		},
+	})
+}

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToRole/OnAccount/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToRole/OnAccount/test.tf
@@ -1,0 +1,6 @@
+resource "snowflake_grant_privileges_to_role" "test" {
+  role_name = var.name
+  privileges        = var.privileges
+  on_account        = true
+  with_grant_option = var.with_grant_option
+}

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToRole/OnAccount/variables.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToRole/OnAccount/variables.tf
@@ -1,0 +1,11 @@
+variable "name" {
+  type = string
+}
+
+variable "privileges" {
+  type = list(string)
+}
+
+variable "with_grant_option" {
+  type = bool
+}

--- a/pkg/resources/validators_test.go
+++ b/pkg/resources/validators_test.go
@@ -70,18 +70,6 @@ func TestIsValidIdentifier(t *testing.T) {
 			CheckingFn: accountObjectIdentifierCheck,
 		},
 		{
-			Name:       "validation: invalid identifier representation",
-			Value:      "",
-			Error:      "Unable to parse the identifier: ",
-			CheckingFn: accountObjectIdentifierCheck,
-		},
-		{
-			Name:       "validation: incorrect form for account object identifier",
-			Value:      "a.b",
-			Error:      "<name>, but was <database_name>.<name>",
-			CheckingFn: accountObjectIdentifierCheck,
-		},
-		{
 			Name:       "validation: incorrect form for database object identifier",
 			Value:      "a.b.c",
 			Error:      "<database_name>.<name>, but was <database_name>.<schema_name>.<name>",
@@ -102,6 +90,16 @@ func TestIsValidIdentifier(t *testing.T) {
 		{
 			Name:       "correct form for account object identifier",
 			Value:      "a",
+			CheckingFn: accountObjectIdentifierCheck,
+		},
+		{
+			Name:       "correct form for account object identifier - multiple parts",
+			Value:      "a.b",
+			CheckingFn: accountObjectIdentifierCheck,
+		},
+		{
+			Name:       "correct form for account object identifier - quoted",
+			Value:      "\"a.b\"",
 			CheckingFn: accountObjectIdentifierCheck,
 		},
 		{


### PR DESCRIPTION
Fixes: https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2548

Fails because identifier validation doesn't work well for account object identifiers (that may contain dots).

## Test Plan
* [x] Acceptance test recreating role name with dots + unit tests for validation function