### PR TITLE
fix: Demote warning to info and set volatility for procedures and functions

### DIFF
--- a/pkg/resources/function.go
+++ b/pkg/resources/function.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 
@@ -594,10 +595,12 @@ func ReadContextFunction(ctx context.Context, d *schema.ResourceData, meta inter
 				diag.FromErr(err)
 			}
 		case "language":
-			if snowflake.Contains(languages, desc.Value) {
+			if snowflake.Contains(languages, strings.ToLower(desc.Value)) {
 				if err := d.Set("language", desc.Value); err != nil {
 					diag.FromErr(err)
 				}
+			} else {
+				log.Printf("[INFO] Unexpected language for function %v returned from Snowflake", desc.Value)
 			}
 		case "packages":
 			value := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(desc.Value, "[", ""), "]", ""), "'", "")
@@ -628,11 +631,7 @@ func ReadContextFunction(ctx context.Context, d *schema.ResourceData, meta inter
 				diag.FromErr(err)
 			}
 		default:
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  "Unexpected function property returned from Snowflake",
-				Detail:   fmt.Sprintf("Unexpected function property %v returned from Snowflake", desc.Property),
-			})
+			log.Printf("[INFO] Unexpected function property %v returned from Snowflake with value %v", desc.Property, desc.Value)
 		}
 	}
 

--- a/pkg/resources/function_acceptance_test.go
+++ b/pkg/resources/function_acceptance_test.go
@@ -77,9 +77,7 @@ func testAccFunction(t *testing.T, configDirectory string) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"language",
 					"null_input_behavior",
-					"return_behavior",
 				},
 			},
 		},

--- a/pkg/resources/function_acceptance_test.go
+++ b/pkg/resources/function_acceptance_test.go
@@ -33,6 +33,11 @@ func testAccFunction(t *testing.T, configDirectory string) {
 	variableSet2 := m()
 	variableSet2["comment"] = config.StringVariable("Terraform acceptance test - updated")
 
+	ignoreDuringImport := []string{"null_input_behavior"}
+	if strings.Contains(configDirectory, "/sql") {
+		ignoreDuringImport = append(ignoreDuringImport, "return_behavior")
+	}
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -71,14 +76,12 @@ func testAccFunction(t *testing.T, configDirectory string) {
 
 			// test - import
 			{
-				ConfigDirectory:   acc.ConfigurationDirectory(configDirectory),
-				ConfigVariables:   variableSet2,
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"null_input_behavior",
-				},
+				ConfigDirectory:         acc.ConfigurationDirectory(configDirectory),
+				ConfigVariables:         variableSet2,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: ignoreDuringImport,
 			},
 		},
 	})
@@ -144,7 +147,7 @@ func TestAcc_Function_complex(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "arguments.0.type", "FLOAT"),
 					resource.TestCheckResourceAttr(resourceName, "return_behavior", "VOLATILE"),
 					resource.TestCheckResourceAttr(resourceName, "return_type", "FLOAT"),
-					resource.TestCheckResourceAttr(resourceName, "language", "javascript"),
+					resource.TestCheckResourceAttr(resourceName, "language", "JAVASCRIPT"),
 					resource.TestCheckResourceAttr(resourceName, "null_input_behavior", "CALLED ON NULL INPUT"),
 
 					// computed attributes

--- a/pkg/resources/procedure.go
+++ b/pkg/resources/procedure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"regexp"
 	"slices"
 	"strings"
@@ -622,12 +623,12 @@ func ReadContextProcedure(ctx context.Context, d *schema.ResourceData, meta inte
 			if err := d.Set("handler", desc.Value); err != nil {
 				return diag.FromErr(err)
 			}
+		case "volatility":
+			if err := d.Set("return_behavior", desc.Value); err != nil {
+				return diag.FromErr(err)
+			}
 		default:
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  "Unexpected procedure property returned from Snowflake",
-				Detail:   fmt.Sprintf("Unexpected procedure property %v returned from Snowflake", desc.Property),
-			})
+			log.Printf("[INFO] Unexpected procedure property %v returned from Snowflake with value %v", desc.Property, desc.Value)
 		}
 	}
 

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -47,6 +47,7 @@ func testAccProcedure(t *testing.T, configDirectory string) {
 					resource.TestCheckResourceAttr(resourceName, "database", acc.TestDatabaseName),
 					resource.TestCheckResourceAttr(resourceName, "schema", acc.TestSchemaName),
 					resource.TestCheckResourceAttr(resourceName, "comment", "Terraform acceptance test"),
+					resource.TestCheckResourceAttr(resourceName, "return_behavior", "VOLATILE"),
 
 					// computed attributes
 					resource.TestCheckResourceAttrSet(resourceName, "return_type"),
@@ -77,7 +78,6 @@ func testAccProcedure(t *testing.T, configDirectory string) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"null_input_behavior",
-					"return_behavior",
 				},
 			},
 		},

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -31,6 +31,11 @@ func testAccProcedure(t *testing.T, configDirectory string) {
 	variableSet2 := m()
 	variableSet2["comment"] = config.StringVariable("Terraform acceptance test - updated")
 
+	ignoreDuringImport := []string{"null_input_behavior"}
+	if strings.Contains(configDirectory, "/sql") {
+		ignoreDuringImport = append(ignoreDuringImport, "return_behavior")
+	}
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -71,14 +76,12 @@ func testAccProcedure(t *testing.T, configDirectory string) {
 
 			// test - import
 			{
-				ConfigDirectory:   acc.ConfigurationDirectory(configDirectory),
-				ConfigVariables:   variableSet2,
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"null_input_behavior",
-				},
+				ConfigDirectory:         acc.ConfigurationDirectory(configDirectory),
+				ConfigVariables:         variableSet2,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: ignoreDuringImport,
 			},
 		},
 	})


### PR DESCRIPTION
- Demote warning to info for procedures and functions
- use returned volatility
- fix import tests

References: #2536 