### PR TITLE
fix: support snowflake application as database

### DIFF
--- a/docs/resources/grant_privileges_to_account_role.md
+++ b/docs/resources/grant_privileges_to_account_role.md
@@ -11,6 +11,8 @@ description: |-
 
 !> **Warning** Be careful when using `always_apply` field. It will always produce a plan (even when no changes were made) and can be harmful in some setups. For more details why we decided to introduce it to go our document explaining those design decisions (coming soon).
 
+~> **Note** When granting privileges on applications (for example, the default "SNOWFLAKE" application) use `object_type = "DATABASE"` instead.
+
 # snowflake_grant_privileges_to_account_role (Resource)
 
 
@@ -88,6 +90,18 @@ resource "snowflake_grant_privileges_to_account_role" "example" {
 }
 
 ## ID: "\"role_name\"|true|false|ALL|OnAccountObject|DATABASE|\"database\""
+
+# grant IMPORTED PRIVILEGES on SNOWFLAKE application
+resource "snowflake_grant_privileges_to_account_role" "example" {
+  account_role_name = snowflake_role.db_role.name
+  privileges        = ["IMPORTED PRIVILEGES"]
+  on_account_object {
+    object_type = "DATABASE" # All applications should be using DATABASE object_type
+    object_name = "SNOWFLAKE"
+  }
+}
+
+## ID: "\"role_name\"|false|false|IMPORTED PRIVILEGES|OnAccountObject|DATABASE|\"SNOWFLAKE\""
 
 # all privileges + grant option + always apply
 resource "snowflake_grant_privileges_to_account_role" "example" {

--- a/docs/resources/grant_privileges_to_account_role.md
+++ b/docs/resources/grant_privileges_to_account_role.md
@@ -11,7 +11,7 @@ description: |-
 
 !> **Warning** Be careful when using `always_apply` field. It will always produce a plan (even when no changes were made) and can be harmful in some setups. For more details why we decided to introduce it to go our document explaining those design decisions (coming soon).
 
-~> **Note** When granting privileges on applications (for example, the default "SNOWFLAKE" application) use `object_type = "DATABASE"` instead.
+~> **Note** When granting privileges on applications (for example, the default "SNOWFLAKE" application) use `on_account_object.object_type = "DATABASE"` instead.
 
 # snowflake_grant_privileges_to_account_role (Resource)
 

--- a/docs/resources/task_grant.md
+++ b/docs/resources/task_grant.md
@@ -53,6 +53,6 @@ resource "snowflake_task_grant" "grant" {
 Import is supported using the following syntax:
 
 ```shell
-# format is database_name|schema_name|task_name|privilege|with_grant_option|on_future|on_all|roles"
-terraform import snowflake_task_grant.example "MY_DATABASE|MY_SCHEMA|MY_TASK|OPERATE|false|false|false|role1,role2"
+# format is database_name|schema_name|task_name|privilege|with_grant_option|on_future|roles"
+terraform import snowflake_task_grant.example "MY_DATABASE|MY_SCHEMA|MY_TASK|OPERATE|false|false|role1,role2"
 ```

--- a/docs/resources/task_grant.md
+++ b/docs/resources/task_grant.md
@@ -53,6 +53,6 @@ resource "snowflake_task_grant" "grant" {
 Import is supported using the following syntax:
 
 ```shell
-# format is database_name|schema_name|task_name|privilege|with_grant_option|on_future|roles"
-terraform import snowflake_task_grant.example "MY_DATABASE|MY_SCHEMA|MY_TASK|OPERATE|false|false|role1,role2"
+# format is database_name|schema_name|task_name|privilege|with_grant_option|on_future|on_all|roles"
+terraform import snowflake_task_grant.example "MY_DATABASE|MY_SCHEMA|MY_TASK|OPERATE|false|false|false|role1,role2"
 ```

--- a/examples/resources/snowflake_grant_privileges_to_account_role/resource.tf
+++ b/examples/resources/snowflake_grant_privileges_to_account_role/resource.tf
@@ -69,6 +69,18 @@ resource "snowflake_grant_privileges_to_account_role" "example" {
 
 ## ID: "\"role_name\"|true|false|ALL|OnAccountObject|DATABASE|\"database\""
 
+# grant IMPORTED PRIVILEGES on SNOWFLAKE application
+resource "snowflake_grant_privileges_to_account_role" "example" {
+  account_role_name = snowflake_role.db_role.name
+  privileges        = ["IMPORTED PRIVILEGES"]
+  on_account_object {
+    object_type = "DATABASE" # All applications should be using DATABASE object_type
+    object_name = "SNOWFLAKE"
+  }
+}
+
+## ID: "\"role_name\"|false|false|IMPORTED PRIVILEGES|OnAccountObject|DATABASE|\"SNOWFLAKE\""
+
 # all privileges + grant option + always apply
 resource "snowflake_grant_privileges_to_account_role" "example" {
   account_role_name = snowflake_role.db_role.name

--- a/examples/resources/snowflake_task_grant/import.sh
+++ b/examples/resources/snowflake_task_grant/import.sh
@@ -1,2 +1,2 @@
-# format is database_name|schema_name|task_name|privilege|with_grant_option|on_future|roles"
-terraform import snowflake_task_grant.example "MY_DATABASE|MY_SCHEMA|MY_TASK|OPERATE|false|false|role1,role2"
+# format is database_name|schema_name|task_name|privilege|with_grant_option|on_future|on_all|roles"
+terraform import snowflake_task_grant.example "MY_DATABASE|MY_SCHEMA|MY_TASK|OPERATE|false|false|false|role1,role2"

--- a/pkg/resources/grant_privileges_to_account_role.go
+++ b/pkg/resources/grant_privileges_to_account_role.go
@@ -759,13 +759,22 @@ func ReadGrantPrivilegesToAccountRole(ctx context.Context, d *schema.ResourceDat
 		}
 		if grant.GrantOption == id.WithGrantOption && grant.GranteeName.Name() == id.RoleName.Name() {
 			// Future grants do not have grantedBy, only current grants do.
-			// If grantedby is an empty string, it means terraform could not have created the grant
-			if (opts.Future == nil || !*opts.Future) && grant.GrantedBy.Name() == "" {
+			// If grantedby is an empty string, it means terraform could not have created the grant.
+			// The same goes for the default SNOWFLAKE database, but we don't want to skip in this case
+			if (opts.Future == nil || !*opts.Future) && grant.GrantedBy.Name() == "" && grant.Name.Name() != "SNOWFLAKE" {
 				continue
 			}
+
 			// grant_on is for future grants, granted_on is for current grants.
 			// They function the same way though in a test for matching the object type
-			if grantedOn == grant.GrantedOn || grantedOn == grant.GrantOn {
+			//
+			// To `grant privilege on application to a role` the user has to use `object_type = "DATABASE"`.
+			// It's because Snowflake treats applications as if they were databases. One exception to the rule is
+			// the default application named SNOWFLAKE that could be granted with `object_type = "APPLICATION"`.
+			// To make the logic simpler, we do not allow it and `object_type = "DATABASE"` should be used for all applications.
+			if grantedOn == sdk.ObjectTypeDatabase && (sdk.ObjectTypeApplication == grant.GrantedOn || sdk.ObjectTypeApplication == grant.GrantOn) {
+				actualPrivileges = append(actualPrivileges, grant.Privilege)
+			} else if grantedOn == grant.GrantedOn || grantedOn == grant.GrantOn {
 				actualPrivileges = append(actualPrivileges, grant.Privilege)
 			}
 		}

--- a/pkg/resources/grant_privileges_to_account_role.go
+++ b/pkg/resources/grant_privileges_to_account_role.go
@@ -772,6 +772,7 @@ func ReadGrantPrivilegesToAccountRole(ctx context.Context, d *schema.ResourceDat
 			// It's because Snowflake treats applications as if they were databases. One exception to the rule is
 			// the default application named SNOWFLAKE that could be granted with `object_type = "APPLICATION"`.
 			// To make the logic simpler, we do not allow it and `object_type = "DATABASE"` should be used for all applications.
+			// TODO When implementing SNOW-991421 see if logic added in SNOW-887897 could be moved to the SDK to simplify the resource implementation.
 			if grantedOn == sdk.ObjectTypeDatabase && (sdk.ObjectTypeApplication == grant.GrantedOn || sdk.ObjectTypeApplication == grant.GrantOn) {
 				actualPrivileges = append(actualPrivileges, grant.Privilege)
 			} else if grantedOn == grant.GrantedOn || grantedOn == grant.GrantOn {

--- a/pkg/resources/grant_privileges_to_account_role.go
+++ b/pkg/resources/grant_privileges_to_account_role.go
@@ -419,7 +419,7 @@ func CreateGrantPrivilegesToAccountRole(ctx context.Context, d *schema.ResourceD
 			diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "An error occurred when granting privileges to account role",
-				Detail:   fmt.Sprintf("Id: %s\nDatabase role name: %s\nError: %s", id.String(), id.RoleName, err.Error()),
+				Detail:   fmt.Sprintf("Id: %s\nAccount role name: %s\nError: %s", id.String(), id.RoleName, err.Error()),
 			},
 		}
 	}

--- a/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
@@ -950,6 +950,7 @@ func TestAcc_GrantPrivilegesToAccountRole_ImportedPrivilegesOnSnowflakeDatabase(
 		CheckDestroy: testAccCheckAccountRolePrivilegesRevoked(roleName),
 		Steps: []resource.TestStep{
 			{
+				PreConfig:       func() { createAccountRoleOutsideTerraform(t, roleName) },
 				ConfigDirectory: acc.ConfigurationDirectory("TestAcc_GrantPrivilegesToAccountRole/ImportedPrivilegesOnSnowflakeDatabase"),
 				ConfigVariables: configVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{

--- a/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
@@ -976,7 +976,7 @@ func TestAcc_GrantPrivilegesToAccountRole_ImportedPrivilegesOnSnowflakeDatabase(
 	})
 }
 
-// TODO(SNOW-1213622): Add test for custom applications using on_object.object_type = "DATABASE"
+// TODO(SNOW-1213622): Add test for custom applications using on_account_object.object_type = "DATABASE"
 
 func TestAcc_GrantPrivilegesToAccountRole_MultiplePartsInRoleName(t *testing.T) {
 	nameBytes := []byte(strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)))

--- a/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
@@ -976,7 +976,7 @@ func TestAcc_GrantPrivilegesToAccountRole_ImportedPrivilegesOnSnowflakeDatabase(
 	})
 }
 
-// TODO(): Test for other applications than the default SNOWFLAKE one
+// TODO(SNOW-1213622): Add test for custom applications using on_object.object_type = "DATABASE"
 
 func TestAcc_GrantPrivilegesToAccountRole_MultiplePartsInRoleName(t *testing.T) {
 	nameBytes := []byte(strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)))

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/ImportedPrivilegesOnSnowflakeDatabase/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/ImportedPrivilegesOnSnowflakeDatabase/test.tf
@@ -1,22 +1,13 @@
-resource "snowflake_database" "test" {
-  name                        = var.shared_database_name
-  data_retention_time_in_days = 0
-  from_share = {
-    provider = var.account_name
-    share    = var.share_name
-  }
-}
-
 resource "snowflake_role" "test" {
   name = var.role_name
 }
 
 resource "snowflake_grant_privileges_to_account_role" "test" {
-  depends_on        = [snowflake_database.test, snowflake_role.test]
+  depends_on        = [snowflake_role.test]
   account_role_name = "\"${var.role_name}\""
   privileges        = var.privileges
   on_account_object {
-    object_type = "APPLICATION"
-    object_name = "\"${var.shared_database_name}\""
+    object_type = "DATABASE"
+    object_name = "\"SNOWFLAKE\""
   }
 }

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/ImportedPrivilegesOnSnowflakeDatabase/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/ImportedPrivilegesOnSnowflakeDatabase/test.tf
@@ -1,9 +1,4 @@
-resource "snowflake_role" "test" {
-  name = var.role_name
-}
-
 resource "snowflake_grant_privileges_to_account_role" "test" {
-  depends_on        = [snowflake_role.test]
   account_role_name = "\"${var.role_name}\""
   privileges        = var.privileges
   on_account_object {

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/ImportedPrivilegesOnSnowflakeDatabase/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/ImportedPrivilegesOnSnowflakeDatabase/test.tf
@@ -1,0 +1,22 @@
+resource "snowflake_database" "test" {
+  name                        = var.shared_database_name
+  data_retention_time_in_days = 0
+  from_share = {
+    provider = var.account_name
+    share    = var.share_name
+  }
+}
+
+resource "snowflake_role" "test" {
+  name = var.role_name
+}
+
+resource "snowflake_grant_privileges_to_account_role" "test" {
+  depends_on        = [snowflake_database.test, snowflake_role.test]
+  account_role_name = "\"${var.role_name}\""
+  privileges        = var.privileges
+  on_account_object {
+    object_type = "APPLICATION"
+    object_name = "\"${var.shared_database_name}\""
+  }
+}

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/ImportedPrivilegesOnSnowflakeDatabase/variables.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/ImportedPrivilegesOnSnowflakeDatabase/variables.tf
@@ -1,0 +1,19 @@
+variable "privileges" {
+  type = list(string)
+}
+
+variable "role_name" {
+  type = string
+}
+
+variable "shared_database_name" {
+  type = string
+}
+
+variable "share_name" {
+  type = string
+}
+
+variable "account_name" {
+  type = string
+}

--- a/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/ImportedPrivilegesOnSnowflakeDatabase/variables.tf
+++ b/pkg/resources/testdata/TestAcc_GrantPrivilegesToAccountRole/ImportedPrivilegesOnSnowflakeDatabase/variables.tf
@@ -5,15 +5,3 @@ variable "privileges" {
 variable "role_name" {
   type = string
 }
-
-variable "shared_database_name" {
-  type = string
-}
-
-variable "share_name" {
-  type = string
-}
-
-variable "account_name" {
-  type = string
-}

--- a/templates/resources/grant_privileges_to_account_role.md.tmpl
+++ b/templates/resources/grant_privileges_to_account_role.md.tmpl
@@ -15,7 +15,7 @@ description: |-
 {{/* SNOW-990811 */}}
 !> **Warning** Be careful when using `always_apply` field. It will always produce a plan (even when no changes were made) and can be harmful in some setups. For more details why we decided to introduce it to go our document explaining those design decisions (coming soon).
 
-~> **Note** When granting privileges on applications (for example, the default "SNOWFLAKE" application) use `object_type = "DATABASE"` instead.
+~> **Note** When granting privileges on applications (for example, the default "SNOWFLAKE" application) use `on_account_object.object_type = "DATABASE"` instead.
 
 # {{.Name}} ({{.Type}})
 

--- a/templates/resources/grant_privileges_to_account_role.md.tmpl
+++ b/templates/resources/grant_privileges_to_account_role.md.tmpl
@@ -15,6 +15,8 @@ description: |-
 {{/* SNOW-990811 */}}
 !> **Warning** Be careful when using `always_apply` field. It will always produce a plan (even when no changes were made) and can be harmful in some setups. For more details why we decided to introduce it to go our document explaining those design decisions (coming soon).
 
+~> **Note** When granting privileges on applications (for example, the default "SNOWFLAKE" application) use `object_type = "DATABASE"` instead.
+
 # {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}


### PR DESCRIPTION
Fix for: #1998 and #2366

Changes
- Because it's the default database it fulfills our `if` checks for futures, so added a check for `name != SNOWFLAKE`
- The second check was added to make it possible to grant privileges on applications by setting object_type to DATABASE
- Those cases were added to the documentation for the `snowflake_grant_privilege_to_account_role` resource
- Added acceptance test that would check if SNOWFLAKE database could be made with `object_type = DATABASE`
- I also added a follow-up ticket to add additional tests for applications when they are available.