### PR TITLE
fix: Fix the deprecation message for snowflake_role_grants

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -242,7 +242,7 @@ The Snowflake provider will use the following order of precedence when determini
 - [snowflake_pipe_grant](./docs/resources/pipe_grant) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead
 - [snowflake_procedure_grant](./docs/resources/procedure_grant) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead
 - [snowflake_resource_monitor_grant](./docs/resources/resource_monitor_grant) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead
-- [snowflake_role_grants](./docs/resources/role_grants) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead
+- [snowflake_role_grants](./docs/resources/role_grants) - use [snowflake_grant_account_role](./docs/resources/grant_account_role) instead
 - [snowflake_row_access_policy_grant](./docs/resources/row_access_policy_grant) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead
 - [snowflake_schema_grant](./docs/resources/schema_grant) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead
 - [snowflake_sequence_grant](./docs/resources/sequence_grant) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead

--- a/docs/resources/role_grants.md
+++ b/docs/resources/role_grants.md
@@ -7,7 +7,7 @@ description: |-
 
 # snowflake_role_grants (Resource)
 
-~> **Deprecation** This resource is deprecated and will be removed in a future major version release. Please use [snowflake_grant_privileges_to_account_role](./grant_privileges_to_account_role) instead. <deprecation>
+~> **Deprecation** This resource is deprecated and will be removed in a future major version release. Please use [snowflake_grant_account_role](./grant_account_role) instead. <deprecation>
 
 ## Example Usage
 

--- a/examples/additional/deprecated_resources.MD
+++ b/examples/additional/deprecated_resources.MD
@@ -13,7 +13,7 @@
 - [snowflake_pipe_grant](./docs/resources/pipe_grant) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead
 - [snowflake_procedure_grant](./docs/resources/procedure_grant) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead
 - [snowflake_resource_monitor_grant](./docs/resources/resource_monitor_grant) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead
-- [snowflake_role_grants](./docs/resources/role_grants) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead
+- [snowflake_role_grants](./docs/resources/role_grants) - use [snowflake_grant_account_role](./docs/resources/grant_account_role) instead
 - [snowflake_row_access_policy_grant](./docs/resources/row_access_policy_grant) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead
 - [snowflake_schema_grant](./docs/resources/schema_grant) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead
 - [snowflake_sequence_grant](./docs/resources/sequence_grant) - use [snowflake_grant_privileges_to_account_role](./docs/resources/grant_privileges_to_account_role) instead

--- a/pkg/resources/role_grants.go
+++ b/pkg/resources/role_grants.go
@@ -25,7 +25,7 @@ func RoleGrants() *schema.Resource {
 		Read:               ReadRoleGrants,
 		Delete:             DeleteRoleGrants,
 		Update:             UpdateRoleGrants,
-		DeprecationMessage: "This resource is deprecated and will be removed in a future major version release. Please use snowflake_grant_privileges_to_account_role instead.",
+		DeprecationMessage: "This resource is deprecated and will be removed in a future major version release. Please use snowflake_grant_account_role instead.",
 
 		Schema: map[string]*schema.Schema{
 			"role_name": {


### PR DESCRIPTION
Fix the wrong resource being referenced for deprecated snowflake_role_grants

Ref: #2599 #2600