### PR TITLE
chore: Fix env variables for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,16 @@ jobs:
 
       - run: make test
         if: steps.create_config.conclusion == 'success'
+        env:
+          SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT: ${{ secrets.SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT }}
+          TEST_SF_TF_AWS_EXTERNAL_BUCKET_URL: ${{ secrets.TEST_SF_TF_AWS_EXTERNAL_BUCKET_URL }}
+          TEST_SF_TF_AWS_EXTERNAL_KEY_ID: ${{ secrets.TEST_SF_TF_AWS_EXTERNAL_KEY_ID }}
+          TEST_SF_TF_AWS_EXTERNAL_ROLE_ARN: ${{ secrets.TEST_SF_TF_AWS_EXTERNAL_ROLE_ARN }}
+          TEST_SF_TF_AWS_EXTERNAL_SECRET_KEY: ${{ secrets.TEST_SF_TF_AWS_EXTERNAL_SECRET_KEY }}
+          TEST_SF_TF_AZURE_EXTERNAL_BUCKET_URL: ${{ secrets.TEST_SF_TF_AZURE_EXTERNAL_BUCKET_URL }}
+          TEST_SF_TF_AZURE_EXTERNAL_SAS_TOKEN: ${{ secrets.TEST_SF_TF_AZURE_EXTERNAL_SAS_TOKEN }}
+          TEST_SF_TF_AZURE_EXTERNAL_TENANT_ID: ${{ secrets.TEST_SF_TF_AZURE_EXTERNAL_TENANT_ID }}
+          TEST_SF_TF_GCS_EXTERNAL_BUCKET_URL: ${{ secrets.TEST_SF_TF_GCS_EXTERNAL_BUCKET_URL }}
 
       - name: Setup Terraform
         if: steps.create_config.conclusion == 'success'
@@ -53,6 +63,16 @@ jobs:
 
       - run: make test-acceptance
         if: steps.create_config.conclusion == 'success'
+        env:
+          SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT: ${{ secrets.SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT }}
+          TEST_SF_TF_AWS_EXTERNAL_BUCKET_URL: ${{ secrets.TEST_SF_TF_AWS_EXTERNAL_BUCKET_URL }}
+          TEST_SF_TF_AWS_EXTERNAL_KEY_ID: ${{ secrets.TEST_SF_TF_AWS_EXTERNAL_KEY_ID }}
+          TEST_SF_TF_AWS_EXTERNAL_ROLE_ARN: ${{ secrets.TEST_SF_TF_AWS_EXTERNAL_ROLE_ARN }}
+          TEST_SF_TF_AWS_EXTERNAL_SECRET_KEY: ${{ secrets.TEST_SF_TF_AWS_EXTERNAL_SECRET_KEY }}
+          TEST_SF_TF_AZURE_EXTERNAL_BUCKET_URL: ${{ secrets.TEST_SF_TF_AZURE_EXTERNAL_BUCKET_URL }}
+          TEST_SF_TF_AZURE_EXTERNAL_SAS_TOKEN: ${{ secrets.TEST_SF_TF_AZURE_EXTERNAL_SAS_TOKEN }}
+          TEST_SF_TF_AZURE_EXTERNAL_TENANT_ID: ${{ secrets.TEST_SF_TF_AZURE_EXTERNAL_TENANT_ID }}
+          TEST_SF_TF_GCS_EXTERNAL_BUCKET_URL: ${{ secrets.TEST_SF_TF_GCS_EXTERNAL_BUCKET_URL }}
 
       - name: sweepers cleanup
         if: ${{ always() }}

--- a/pkg/acceptance/testenvs/testenvs_test.go
+++ b/pkg/acceptance/testenvs/testenvs_test.go
@@ -18,14 +18,14 @@ func Test_GetOrSkipTest(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			env = testenvs.GetOrSkipTest(t, testenvs.User)
+			env = testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
 		}()
 		wg.Wait()
 		return env
 	}
 
 	t.Run("skip test if missing", func(t *testing.T) {
-		t.Setenv(string(testenvs.User), "")
+		t.Setenv(string(testenvs.BusinessCriticalAccount), "")
 
 		tut := &testing.T{}
 		env := runGetOrSkipInGoroutineAndWaitForCompletion(tut)
@@ -35,7 +35,7 @@ func Test_GetOrSkipTest(t *testing.T) {
 	})
 
 	t.Run("get env if exists", func(t *testing.T) {
-		t.Setenv(string(testenvs.User), "user")
+		t.Setenv(string(testenvs.BusinessCriticalAccount), "user")
 
 		tut := &testing.T{}
 		env := runGetOrSkipInGoroutineAndWaitForCompletion(tut)
@@ -60,19 +60,19 @@ func Test_SkipTestIfSet(t *testing.T) {
 	}
 
 	t.Run("skip test if env is set", func(t *testing.T) {
-		t.Setenv(string(testenvs.User), "1")
+		t.Setenv(string(testenvs.BusinessCriticalAccount), "1")
 
 		tut := &testing.T{}
-		runSkipTestIfSetInGoroutineAndWaitForCompletion(tut, testenvs.User)
+		runSkipTestIfSetInGoroutineAndWaitForCompletion(tut, testenvs.BusinessCriticalAccount)
 
 		require.True(t, tut.Skipped())
 	})
 
 	t.Run("do not skip if env not set", func(t *testing.T) {
-		t.Setenv(string(testenvs.User), "")
+		t.Setenv(string(testenvs.BusinessCriticalAccount), "")
 
 		tut := &testing.T{}
-		runSkipTestIfSetInGoroutineAndWaitForCompletion(tut, testenvs.User)
+		runSkipTestIfSetInGoroutineAndWaitForCompletion(tut, testenvs.BusinessCriticalAccount)
 
 		require.False(t, tut.Skipped())
 	})
@@ -92,26 +92,26 @@ func Test_Assertions(t *testing.T) {
 	}
 
 	t.Run("test if env does not exist", func(t *testing.T) {
-		t.Setenv(string(testenvs.User), "")
+		t.Setenv(string(testenvs.BusinessCriticalAccount), "")
 
 		tut1 := &testing.T{}
-		runAssertionInGoroutineAndWaitForCompletion(func() { testenvs.AssertEnvNotSet(tut1, string(testenvs.User)) })
+		runAssertionInGoroutineAndWaitForCompletion(func() { testenvs.AssertEnvNotSet(tut1, string(testenvs.BusinessCriticalAccount)) })
 
 		tut2 := &testing.T{}
-		runAssertionInGoroutineAndWaitForCompletion(func() { testenvs.AssertEnvSet(tut2, string(testenvs.User)) })
+		runAssertionInGoroutineAndWaitForCompletion(func() { testenvs.AssertEnvSet(tut2, string(testenvs.BusinessCriticalAccount)) })
 
 		require.False(t, tut1.Failed())
 		require.True(t, tut2.Failed())
 	})
 
 	t.Run("test if env exists", func(t *testing.T) {
-		t.Setenv(string(testenvs.User), "user")
+		t.Setenv(string(testenvs.BusinessCriticalAccount), "user")
 
 		tut1 := &testing.T{}
-		runAssertionInGoroutineAndWaitForCompletion(func() { testenvs.AssertEnvNotSet(tut1, string(testenvs.User)) })
+		runAssertionInGoroutineAndWaitForCompletion(func() { testenvs.AssertEnvNotSet(tut1, string(testenvs.BusinessCriticalAccount)) })
 
 		tut2 := &testing.T{}
-		runAssertionInGoroutineAndWaitForCompletion(func() { testenvs.AssertEnvSet(tut2, string(testenvs.User)) })
+		runAssertionInGoroutineAndWaitForCompletion(func() { testenvs.AssertEnvSet(tut2, string(testenvs.BusinessCriticalAccount)) })
 
 		require.True(t, tut1.Failed())
 		require.False(t, tut2.Failed())

--- a/pkg/acceptance/testenvs/testing_environment_variables.go
+++ b/pkg/acceptance/testenvs/testing_environment_variables.go
@@ -9,12 +9,6 @@ import (
 type env string
 
 const (
-	User     env = "TEST_SF_TF_USER"
-	Password env = "TEST_SF_TF_PASSWORD" // #nosec G101
-	Account  env = "TEST_SF_TF_ACCOUNT"
-	Role     env = "TEST_SF_TF_ROLE"
-	Host     env = "TEST_SF_TF_HOST"
-
 	BusinessCriticalAccount env = "SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT"
 
 	TestAccountCreate          env = "TEST_SF_TF_TEST_ACCOUNT_CREATE"

--- a/pkg/acceptance/testenvs/testing_environment_variables.go
+++ b/pkg/acceptance/testenvs/testing_environment_variables.go
@@ -27,7 +27,8 @@ const (
 	SkipManagedAccountTest  env = "TEST_SF_TF_SKIP_MANAGED_ACCOUNT_TEST"
 	SkipSamlIntegrationTest env = "TEST_SF_TF_SKIP_SAML_INTEGRATION_TEST"
 
-	EnableSweep env = "TEST_SF_TF_ENABLE_SWEEP"
+	EnableSweep         env = "TEST_SF_TF_ENABLE_SWEEP"
+	ConfigureClientOnce env = "SF_TF_ACC_TEST_CONFIGURE_CLIENT_ONCE"
 )
 
 func GetOrSkipTest(t *testing.T, envName Env) string {

--- a/pkg/datasources/failover_groups_acceptance_test.go
+++ b/pkg/datasources/failover_groups_acceptance_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestAcc_FailoverGroups(t *testing.T) {
+	// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
+	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
+
 	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
 
 	name := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -782,11 +782,20 @@ func ConfigureProvider(s *schema.ResourceData) (interface{}, error) {
 		}
 	}
 
-	configuredClient, configureClientError = sdk.NewClient(config)
+	cl, clErr := sdk.NewClient(config)
 
-	if configureClientError != nil {
-		return nil, configureClientError
+	// needed for tests verifying different provider setups
+	if os.Getenv("TF_ACC") != "" && os.Getenv("SF_TF_ACC_TEST_CONFIGURE_CLIENT_ONCE") == "true" {
+		configuredClient = cl
+		configureClientError = clErr
+	} else {
+		configuredClient = nil
+		configureClientError = nil
 	}
 
-	return &provider.Context{Client: configuredClient}, nil
+	if clErr != nil {
+		return nil, clErr
+	}
+
+	return &provider.Context{Client: cl}, nil
 }

--- a/pkg/provider/provider_acceptance_test.go
+++ b/pkg/provider/provider_acceptance_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestAcc_Provider_configHierarchy(t *testing.T) {
+	t.Setenv(string(testenvs.ConfigureClientOnce), "")
+
 	user := acc.DefaultConfig(t).User
 	pass := acc.DefaultConfig(t).Password
 	account := acc.DefaultConfig(t).Account

--- a/pkg/provider/provider_acceptance_test.go
+++ b/pkg/provider/provider_acceptance_test.go
@@ -17,11 +17,11 @@ import (
 )
 
 func TestAcc_Provider_configHierarchy(t *testing.T) {
-	user := testenvs.GetOrSkipTest(t, testenvs.User)
-	pass := testenvs.GetOrSkipTest(t, testenvs.Password)
-	account := testenvs.GetOrSkipTest(t, testenvs.Account)
-	role := testenvs.GetOrSkipTest(t, testenvs.Role)
-	host := testenvs.GetOrSkipTest(t, testenvs.Host)
+	user := acc.DefaultConfig(t).User
+	pass := acc.DefaultConfig(t).Password
+	account := acc.DefaultConfig(t).Account
+	role := acc.DefaultConfig(t).Role
+	host := acc.DefaultConfig(t).Host
 
 	nonExistingUser := "non-existing-user"
 

--- a/pkg/provider/provider_acceptance_test.go
+++ b/pkg/provider/provider_acceptance_test.go
@@ -121,7 +121,7 @@ func TestAcc_Provider_configHierarchy(t *testing.T) {
 	})
 }
 
-func TestAcc_Provider_(t *testing.T) {
+func TestAcc_Provider_configureClientOnceSwitching(t *testing.T) {
 	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 
 	resource.Test(t, resource.TestCase{
@@ -135,10 +135,12 @@ func TestAcc_Provider_(t *testing.T) {
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
 		Steps: []resource.TestStep{
+			// client setup is incorrect
 			{
 				Config:      providerConfig(testprofiles.IncorrectUserAndPassword),
 				ExpectError: regexp.MustCompile("Incorrect username or password was specified"),
 			},
+			// in this step we simulate the situation when we want to use client configured once, but it was faulty last time
 			{
 				PreConfig: func() {
 					t.Setenv(string(testenvs.ConfigureClientOnce), "true")

--- a/pkg/resources/failover_group_acceptance_test.go
+++ b/pkg/resources/failover_group_acceptance_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestAcc_FailoverGroupBasic(t *testing.T) {
+	// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
+	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
+
 	randomCharacters := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
@@ -49,6 +52,9 @@ func TestAcc_FailoverGroupBasic(t *testing.T) {
 }
 
 func TestAcc_FailoverGroupRemoveObjectTypes(t *testing.T) {
+	// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
+	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
+
 	randomCharacters := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
@@ -87,6 +93,9 @@ func TestAcc_FailoverGroupRemoveObjectTypes(t *testing.T) {
 }
 
 func TestAcc_FailoverGroupInterval(t *testing.T) {
+	// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
+	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
+
 	randomCharacters := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
@@ -183,6 +192,9 @@ func TestAcc_FailoverGroupInterval(t *testing.T) {
 }
 
 func TestAcc_FailoverGroup_issue2517(t *testing.T) {
+	// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
+	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
+
 	randomCharacters := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
@@ -211,6 +223,9 @@ func TestAcc_FailoverGroup_issue2517(t *testing.T) {
 }
 
 func TestAcc_FailoverGroup_issue2544(t *testing.T) {
+	// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
+	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
+
 	randomCharacters := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 
 	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)

--- a/pkg/resources/failover_group_grant_acceptance_test.go
+++ b/pkg/resources/failover_group_grant_acceptance_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestAcc_FailoverGroupGrant(t *testing.T) {
+	// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
+	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
+
 	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
 	name := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 

--- a/pkg/sdk/client_integration_test.go
+++ b/pkg/sdk/client_integration_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testprofiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeenvs"
 	"github.com/snowflakedb/gosnowflake"
@@ -41,14 +40,18 @@ func TestClient_NewClient(t *testing.T) {
 	})
 
 	t.Run("with missing config - should not care about correct env variables", func(t *testing.T) {
-		account := testenvs.GetOrSkipTest(t, testenvs.Account)
+		config, err := ProfileConfig(testprofiles.Default)
+		require.NoError(t, err)
+		require.NotNil(t, config)
+
+		account := config.Account
 		t.Setenv(snowflakeenvs.Account, account)
 
 		dir, err := os.UserHomeDir()
 		require.NoError(t, err)
 		t.Setenv(snowflakeenvs.ConfigPath, dir)
 
-		config := DefaultConfig()
+		config = DefaultConfig()
 		_, err = NewClient(config)
 		require.ErrorContains(t, err, "260000: account is empty")
 	})

--- a/pkg/sdk/testint/failover_groups_integration_test.go
+++ b/pkg/sdk/testint/failover_groups_integration_test.go
@@ -15,6 +15,9 @@ import (
 )
 
 func TestInt_FailoverGroupsCreate(t *testing.T) {
+	// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
+	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
+
 	client := testClient(t)
 	ctx := testContext(t)
 	shareTest, shareCleanup := createShare(t, client)
@@ -138,6 +141,9 @@ func TestInt_FailoverGroupsCreate(t *testing.T) {
 }
 
 func TestInt_Issue2544(t *testing.T) {
+	// TODO [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
+	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
+
 	client := testClient(t)
 	ctx := testContext(t)
 


### PR DESCRIPTION
- Introduce acceptance test context
- Expose default config in integration tests
- Remove not needed test envs
- Expose envs to test jobs (because of [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsenv) and [that](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow))
- Skip the tests requiring business critical account