### PR TITLE
fix: alter table column data type

### DIFF
--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -818,7 +818,11 @@ func UpdateTable(d *schema.ResourceData, meta interface{}) error {
 		}
 		for _, cA := range changed {
 			if cA.changedDataType || cA.changedCollate {
-				err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithAlter([]sdk.TableColumnAlterActionRequest{*sdk.NewTableColumnAlterActionRequest(fmt.Sprintf("\"%s\"", cA.newColumn.name)).WithType(sdk.Pointer(sdk.DataType(cA.newColumn.dataType))).WithCollate(sdk.String(cA.newColumn.collate))})))
+				var newCollation *string
+				if sdk.IsStringType(cA.newColumn.dataType) && cA.newColumn.collate != "" {
+					newCollation = sdk.String(cA.newColumn.collate)
+				}
+				err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithAlter([]sdk.TableColumnAlterActionRequest{*sdk.NewTableColumnAlterActionRequest(fmt.Sprintf("\"%s\"", cA.newColumn.name)).WithType(sdk.Pointer(sdk.DataType(cA.newColumn.dataType))).WithCollate(newCollation)})))
 				if err != nil {
 					return fmt.Errorf("error changing property on %v: err %w", d.Id(), err)
 				}


### PR DESCRIPTION
Fix for #2588
In the alter column call collate was always added which caused the error non-text (and probably text too) data types

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] test case for data type alter

## References
* [ALTER TABLE](https://docs.snowflake.com/en/sql-reference/sql/alter-table)