### PR TITLE
docs: fix the link to .title-lint.yml file in CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ For further instructions, please check the official [Terraform Plugin Developmen
 ## Contributing
 
 We use [Conventional Commits](https://www.conventionalcommits.org/) for commit message formatting and PR titles. Please try to adhere to the standard.
-Refer to the [regular expression](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/.github/workflows/titleLint.yml#L17) for PR title validation.
+Refer to the [regular expression](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/.github/workflows/title-lint.yml#L17) for PR title validation.
 
 ## Releasing
 


### PR DESCRIPTION
Fixing the link to `.github/workflows/title-lint.yml` file from CONTRIBUTING.md in regular expression text.

## References
**Broken link**
[regular expression](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/.github/workflows/titleLint.yml#L17)
**Fixed link**
[regular expression](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/.github/workflows/title-lint.yml#L17)