### PR TITLE
docs: improving the documentation of the snowflake_database resource (new PR)

### DIFF
--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -49,7 +49,7 @@ resource "snowflake_database" "from_share" {
 
 ### Required
 
-- `name` (String) Specifies the identifier for the database; must be unique database name.
+- `name` (String) Specifies the identifier for the database; must be unique for your account.
 
 ### Optional
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -49,14 +49,14 @@ resource "snowflake_database" "from_share" {
 
 ### Required
 
-- `name` (String)
+- `name` (String) Specifies the identifier for the database; must be unique database name.
 
 ### Optional
 
-- `comment` (String)
-- `data_retention_time_in_days` (Number) Number of days for which Snowflake retains historical data for performing Time Travel actions (SELECT, CLONE, UNDROP) on the object. A value of 0 effectively disables Time Travel for the specified database. Default value for this field is set to -1, which is a fallback to use Snowflake default. For more information, see Understanding & Using Time Travel.
+- `comment` (String) Specifies a comment for the database.
+- `data_retention_time_in_days` (Number) Number of days for which Snowflake retains historical data for performing Time Travel actions (SELECT, CLONE, UNDROP) on the object. A value of 0 effectively disables Time Travel for the specified database. Default value for this field is set to -1, which is a fallback to use Snowflake default. For more information, see [Understanding & Using Time Travel](https://docs.snowflake.com/en/user-guide/data-time-travel).
 - `from_database` (String) Specify a database to create a clone from.
-- `from_replica` (String) Specify a fully-qualified path to a database to create a replica from. A fully qualified path follows the format of "<organization_name>"."<account_name>"."<db_name>". An example would be: "myorg1"."account1"."db1"
+- `from_replica` (String) Specify a fully-qualified path to a database to create a replica from. A fully qualified path follows the format of `"<organization_name>"."<account_name>"."<db_name>"`. An example would be: `"myorg1"."account1"."db1"`
 - `from_share` (Map of String) Specify a provider and a share in this map to create a database from a share.
 - `is_transient` (Boolean) Specifies a database as transient. Transient databases do not have a Fail-safe period so they do not incur additional storage costs once they leave Time Travel; however, this means they are also not protected by Fail-safe in the event of a data loss.
 - `replication_configuration` (Block List, Max: 1) When set, specifies the configurations for database replication. (see [below for nested schema](#nestedblock--replication_configuration))

--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -19,7 +19,7 @@ var databaseSchema = map[string]*schema.Schema{
 	"name": {
 		Type:     schema.TypeString,
 		Required: true,
-		Description: "Specifies the identifier for the database; must be unique database name.",
+		Description: "Specifies the identifier for the database; must be unique for your account.",
 	},
 	"comment": {
 		Type:     schema.TypeString,

--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -19,11 +19,13 @@ var databaseSchema = map[string]*schema.Schema{
 	"name": {
 		Type:     schema.TypeString,
 		Required: true,
+		Description: "Specifies the identifier for the database; must be unique database name.",
 	},
 	"comment": {
 		Type:     schema.TypeString,
 		Optional: true,
 		Default:  "",
+		Description: "Specifies a comment for the database.",
 	},
 	"is_transient": {
 		Type:        schema.TypeBool,
@@ -36,7 +38,7 @@ var databaseSchema = map[string]*schema.Schema{
 		Type:         schema.TypeInt,
 		Optional:     true,
 		Default:      -1,
-		Description:  "Number of days for which Snowflake retains historical data for performing Time Travel actions (SELECT, CLONE, UNDROP) on the object. A value of 0 effectively disables Time Travel for the specified database. Default value for this field is set to -1, which is a fallback to use Snowflake default. For more information, see Understanding & Using Time Travel.",
+		Description:  "Number of days for which Snowflake retains historical data for performing Time Travel actions (SELECT, CLONE, UNDROP) on the object. A value of 0 effectively disables Time Travel for the specified database. Default value for this field is set to -1, which is a fallback to use Snowflake default. For more information, see [Understanding & Using Time Travel](https://docs.snowflake.com/en/user-guide/data-time-travel).",
 		ValidateFunc: validation.IntBetween(-1, 90),
 	},
 	"from_share": {
@@ -56,7 +58,7 @@ var databaseSchema = map[string]*schema.Schema{
 	},
 	"from_replica": {
 		Type:          schema.TypeString,
-		Description:   "Specify a fully-qualified path to a database to create a replica from. A fully qualified path follows the format of \"<organization_name>\".\"<account_name>\".\"<db_name>\". An example would be: \"myorg1\".\"account1\".\"db1\"",
+		Description:   "Specify a fully-qualified path to a database to create a replica from. A fully qualified path follows the format of `\"<organization_name>\".\"<account_name>\".\"<db_name>\"`. An example would be: `\"myorg1\".\"account1\".\"db1\"`",
 		Optional:      true,
 		ForceNew:      true,
 		ConflictsWith: []string{"from_share", "from_database"},


### PR DESCRIPTION
Added information in the `name` and `comment` fields of the snowflake_database resource. As well as improved display of options in the `from_replica` and `data_retention_time_in_days` fields.

## References
https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/database

## Before
![image](https://github.com/Snowflake-Labs/terraform-provider-snowflake/assets/76587948/7aef0245-1a2a-4b0c-9e29-568dbd429766)

## After
![image](https://github.com/Snowflake-Labs/terraform-provider-snowflake/assets/76587948/b01c26ce-b6e3-442d-9edc-31c88334894a)
