### PR TITLE
feat: user password policy attachment

### DIFF
--- a/pkg/resources/user_password_policy_attachment.go
+++ b/pkg/resources/user_password_policy_attachment.go
@@ -78,13 +78,20 @@ func ReadUserPasswordPolicyAttachment(d *schema.ResourceData, meta any) error {
 		return err
 	}
 
+	passwordPolicyReferences := make([]sdk.PolicyReference, 0)
+	for _, policyReference := range policyReferences {
+		if policyReference.PolicyKind == "PASSWORD_POLICY" {
+			passwordPolicyReferences = append(passwordPolicyReferences, policyReference)
+		}
+	}
+
 	// Note: this should never happen, but just in case: so far, Snowflake only allows one Password Policy per user.
-	if len(policyReferences) > 1 {
+	if len(passwordPolicyReferences) > 1 {
 		return fmt.Errorf("internal error: multiple policy references attached to a user. This should never happen")
 	}
 
 	// Note: this means the resource has been deleted outside of Terraform.
-	if len(policyReferences) == 0 {
+	if len(passwordPolicyReferences) == 0 {
 		d.SetId("")
 		return nil
 	}
@@ -95,9 +102,9 @@ func ReadUserPasswordPolicyAttachment(d *schema.ResourceData, meta any) error {
 	if err := d.Set(
 		"password_policy_name",
 		sdk.NewSchemaObjectIdentifier(
-			*policyReferences[0].PolicyDb,
-			*policyReferences[0].PolicySchema,
-			policyReferences[0].PolicyName,
+			*passwordPolicyReferences[0].PolicyDb,
+			*passwordPolicyReferences[0].PolicySchema,
+			passwordPolicyReferences[0].PolicyName,
 		).FullyQualifiedName()); err != nil {
 		return err
 	}

--- a/pkg/resources/user_password_policy_attachment_acceptance_test.go
+++ b/pkg/resources/user_password_policy_attachment_acceptance_test.go
@@ -35,7 +35,6 @@ func TestAcc_UserPasswordPolicyAttachment(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_user_password_policy_attachment.ppa", "password_policy_name", sdk.NewSchemaObjectIdentifier(acc.TestDatabaseName, acc.TestSchemaName, passwordPolicyName).FullyQualifiedName()),
 					resource.TestCheckResourceAttr("snowflake_user_password_policy_attachment.ppa", "id", fmt.Sprintf("%s|%s", sdk.NewAccountObjectIdentifier(userName).FullyQualifiedName(), sdk.NewSchemaObjectIdentifier(acc.TestDatabaseName, acc.TestSchemaName, passwordPolicyName).FullyQualifiedName())),
 				),
-				Destroy: false,
 			},
 			// UPDATE
 			{
@@ -86,6 +85,7 @@ func userPasswordPolicyAttachmentConfig(userName, databaseName, schemaName, pass
 resource "snowflake_user" "user" {
 	name = "%s"
 }
+
 resource "snowflake_password_policy" "pp" {
 	database   = "%s"
 	schema     = "%s"

--- a/pkg/sdk/policy_references.go
+++ b/pkg/sdk/policy_references.go
@@ -51,7 +51,7 @@ type PolicyReference struct {
 	TagDatabase       *string
 	TagSchema         *string
 	TagName           *string
-	PolicyStatus      string
+	PolicyStatus      *string
 }
 
 type policyReferenceDBRow struct {
@@ -68,7 +68,7 @@ type policyReferenceDBRow struct {
 	TagDatabase       sql.NullString `db:"TAG_DATABASE"`
 	TagSchema         sql.NullString `db:"TAG_SCHEMA"`
 	TagName           sql.NullString `db:"TAG_NAME"`
-	PolicyStatus      string         `db:"POLICY_STATUS"`
+	PolicyStatus      sql.NullString `db:"POLICY_STATUS"`
 }
 
 func (row policyReferenceDBRow) convert() *PolicyReference {
@@ -77,7 +77,6 @@ func (row policyReferenceDBRow) convert() *PolicyReference {
 		PolicyKind:      row.PolicyKind,
 		RefEntityName:   row.RefEntityName,
 		RefEntityDomain: row.RefEntityDomain,
-		PolicyStatus:    row.PolicyStatus,
 	}
 	if row.PolicyDb.Valid {
 		policyReference.PolicyDb = &row.PolicyDb.String
@@ -105,6 +104,9 @@ func (row policyReferenceDBRow) convert() *PolicyReference {
 	}
 	if row.TagName.Valid {
 		policyReference.TagName = &row.TagName.String
+	}
+	if row.TagName.Valid {
+		policyReference.PolicyStatus = &row.PolicyStatus.String
 	}
 	return &policyReference
 }


### PR DESCRIPTION
Our test for the user password policy attachment resource started failing. It detected two issues with current implementation that were changed:
- POLICY_STATUS should be a nullable field (this is something new because the test started failing just recently)
- policyReferences returned by GetForEntity should be filtered by `PASSWORD_POLICY` PolicyKind to resolve clashes with other policy types