### PR TITLE
fix: migration guide for databases created from share

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -5,6 +5,16 @@ describe deprecations or breaking changes and help you to change your configurat
 across different versions.
 
 ## v0.86.0 ➞ v0.87.0
+### snowflake_database resource changes
+#### *(behavior change)* External object identifier changes
+
+Previously, in `snowflake_database` when creating a database form share, it was possible to provide `from_share.provider`
+in the format of `<org_name>.<account_name>`. It worked even though we expected account locator because our "external" identifier wasn't quoting its string representation.
+To be consistent with other identifier types, we quoted the output of "external" identifiers which makes such configurations break 
+(previously, they were working "by accident"). To fix it, the previous format of `<org_name>.<account_name>` has to be changed
+to account locator format `<account_locator>` (mind that it's now case-sensitive). The account locator can be retrieved by calling `select current_account();` on the sharing account.
+In the future we would like to eventually come back to the `<org_name>.<account_name>` format as it's recommended by Snowflake.
+
 ### Provider configuration changes
 
 #### **IMPORTANT** *(bug fix)* Configuration hierarchy


### PR DESCRIPTION
Adjusting migration guide to mention that in the `snowflake_database.from_share.provider` we were/are expecting an account locator format. Previously it was possible to use orgname+accountname format, but now (from version 0.87.0) it won't be, and now only the account locator should be used.