### PR TITLE
feat: Introduce shared function to suspend task roots

### DIFF
--- a/pkg/resources/task.go
+++ b/pkg/resources/task.go
@@ -353,7 +353,6 @@ func CreateTask(d *schema.ResourceData, meta interface{}) (returnedErr error) {
 			if suspendErrs != nil {
 				return suspendErrs
 			}
-			// This can affect the read?
 			defer func() {
 				resumeErr := resumeSuspended()
 				if returnedErr != nil {
@@ -415,7 +414,6 @@ func UpdateTask(d *schema.ResourceData, meta interface{}) (returnedErr error) {
 	if err != nil {
 		return err
 	}
-	// TODO: This can affect the read?
 	defer func() {
 		resumeErr := resumeSuspended()
 		if returnedErr != nil {
@@ -666,7 +664,6 @@ func UpdateTask(d *schema.ResourceData, meta interface{}) (returnedErr error) {
 		}
 	}
 
-	// TODO Desc
 	enabled := d.Get("enabled").(bool)
 	if enabled {
 		if waitForTaskStart(ctx, client, taskId) != nil {
@@ -674,12 +671,10 @@ func UpdateTask(d *schema.ResourceData, meta interface{}) (returnedErr error) {
 		}
 	} else {
 		if err := client.Tasks.Alter(ctx, sdk.NewAlterTaskRequest(taskId).WithSuspend(sdk.Bool(true))); err != nil {
-			log.Printf("[WARN] failed to suspend task %s", taskId.FullyQualifiedName())
-			// TODO: Should it return anything or error ?????
-			// Previously it returned, but it's saying it's a warning
-			// return fmt.Errorf("[WARN] failed to suspend task %s", taskId.FullyQualifiedName())
+			return fmt.Errorf("failed to suspend task %s", taskId.FullyQualifiedName())
 		}
 	}
+
 	return ReadTask(d, meta)
 }
 

--- a/pkg/resources/task.go
+++ b/pkg/resources/task.go
@@ -349,16 +349,16 @@ func CreateTask(d *schema.ResourceData, meta interface{}) (returnedErr error) {
 		precedingTasks := make([]sdk.SchemaObjectIdentifier, 0)
 		for _, dep := range after {
 			precedingTaskId := sdk.NewSchemaObjectIdentifier(databaseName, schemaName, dep)
-			resumeSuspended, suspendErrs := client.Tasks.TemporarilySuspendRootTasks(ctx, precedingTaskId, taskId)
-			if suspendErrs != nil {
-				return suspendErrs
+			resumeSuspended, err := client.Tasks.TemporarilySuspendRootTasks(ctx, precedingTaskId, taskId)
+			if err != nil {
+				return err
 			}
 			defer func() {
-				resumeErr := resumeSuspended()
+				err := resumeSuspended()
 				if returnedErr != nil {
-					returnedErr = errors.Join(returnedErr, resumeErr)
+					returnedErr = errors.Join(returnedErr, err)
 				} else {
-					returnedErr = resumeErr
+					returnedErr = err
 				}
 			}()
 			precedingTasks = append(precedingTasks, precedingTaskId)
@@ -415,11 +415,11 @@ func UpdateTask(d *schema.ResourceData, meta interface{}) (returnedErr error) {
 		return err
 	}
 	defer func() {
-		resumeErr := resumeSuspended()
+		err := resumeSuspended()
 		if returnedErr != nil {
-			returnedErr = errors.Join(returnedErr, resumeErr)
+			returnedErr = errors.Join(returnedErr, err)
 		} else {
-			returnedErr = resumeErr
+			returnedErr = err
 		}
 	}()
 
@@ -514,11 +514,11 @@ func UpdateTask(d *schema.ResourceData, meta interface{}) (returnedErr error) {
 					return err
 				}
 				defer func() {
-					resumeErr := resumeSuspended()
+					err := resumeSuspended()
 					if returnedErr != nil {
-						returnedErr = errors.Join(returnedErr, resumeErr)
+						returnedErr = errors.Join(returnedErr, err)
 					} else {
-						returnedErr = resumeErr
+						returnedErr = err
 					}
 				}()
 			}

--- a/pkg/sdk/tasks_gen.go
+++ b/pkg/sdk/tasks_gen.go
@@ -14,6 +14,7 @@ type Tasks interface {
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Task, error)
 	Describe(ctx context.Context, id SchemaObjectIdentifier) (*Task, error)
 	Execute(ctx context.Context, request *ExecuteTaskRequest) error
+	TemporarilySuspendRootTasks(ctx context.Context, depId SchemaObjectIdentifier, id SchemaObjectIdentifier) (func() error, error)
 }
 
 // CreateTaskOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-task.

--- a/pkg/sdk/tasks_gen.go
+++ b/pkg/sdk/tasks_gen.go
@@ -14,7 +14,7 @@ type Tasks interface {
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Task, error)
 	Describe(ctx context.Context, id SchemaObjectIdentifier) (*Task, error)
 	Execute(ctx context.Context, request *ExecuteTaskRequest) error
-	SuspendRootTasks(ctx context.Context, depId SchemaObjectIdentifier, id SchemaObjectIdentifier) ([]SchemaObjectIdentifier, error)
+	SuspendRootTasks(ctx context.Context, taskId SchemaObjectIdentifier, id SchemaObjectIdentifier) ([]SchemaObjectIdentifier, error)
 	ResumeTasks(ctx context.Context, ids []SchemaObjectIdentifier) error
 }
 

--- a/pkg/sdk/tasks_gen.go
+++ b/pkg/sdk/tasks_gen.go
@@ -14,7 +14,8 @@ type Tasks interface {
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Task, error)
 	Describe(ctx context.Context, id SchemaObjectIdentifier) (*Task, error)
 	Execute(ctx context.Context, request *ExecuteTaskRequest) error
-	TemporarilySuspendRootTasks(ctx context.Context, depId SchemaObjectIdentifier, id SchemaObjectIdentifier) (func() error, error)
+	SuspendRootTasks(ctx context.Context, depId SchemaObjectIdentifier, id SchemaObjectIdentifier) ([]SchemaObjectIdentifier, error)
+	ResumeTasks(ctx context.Context, ids []SchemaObjectIdentifier) error
 }
 
 // CreateTaskOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-task.

--- a/pkg/sdk/tasks_impl_gen.go
+++ b/pkg/sdk/tasks_impl_gen.go
@@ -68,8 +68,8 @@ func (v *tasks) Execute(ctx context.Context, request *ExecuteTaskRequest) error 
 }
 
 // TODO(SNOW-1277135): See if depId is necessary or could be removed
-func (v *tasks) SuspendRootTasks(ctx context.Context, depId SchemaObjectIdentifier, id SchemaObjectIdentifier) ([]SchemaObjectIdentifier, error) {
-	rootTasks, err := GetRootTasks(v.client.Tasks, ctx, depId)
+func (v *tasks) SuspendRootTasks(ctx context.Context, taskId SchemaObjectIdentifier, id SchemaObjectIdentifier) ([]SchemaObjectIdentifier, error) {
+	rootTasks, err := GetRootTasks(v.client.Tasks, ctx, taskId)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sdk/testint/tasks_gen_integration_test.go
+++ b/pkg/sdk/testint/tasks_gen_integration_test.go
@@ -605,17 +605,122 @@ func TestInt_Tasks(t *testing.T) {
 			require.NoError(t, client.Tasks.Alter(ctx, sdk.NewAlterTaskRequest(rootTask.ID()).WithSuspend(sdk.Bool(true))))
 		})
 
-		resumeRoots, err := client.Tasks.TemporarilySuspendRootTasks(ctx, task.ID(), task.ID())
+		tasksToResume, err := client.Tasks.SuspendRootTasks(ctx, task.ID(), task.ID())
 		require.NoError(t, err)
+		require.NotEmpty(t, tasksToResume)
 
-		rt, err := client.Tasks.ShowByID(ctx, rootTask.ID())
+		rootTaskStatus, err := client.Tasks.ShowByID(ctx, rootTask.ID())
 		require.NoError(t, err)
-		require.Equal(t, sdk.TaskStateSuspended, rt.State)
+		require.Equal(t, sdk.TaskStateSuspended, rootTaskStatus.State)
 
-		require.NoError(t, resumeRoots())
+		require.NoError(t, client.Tasks.ResumeTasks(ctx, tasksToResume))
 
-		rt, err = client.Tasks.ShowByID(ctx, rootTask.ID())
+		rootTaskStatus, err = client.Tasks.ShowByID(ctx, rootTask.ID())
 		require.NoError(t, err)
-		require.Equal(t, sdk.TaskStateStarted, rt.State)
+		require.Equal(t, sdk.TaskStateStarted, rootTaskStatus.State)
 	})
+
+	t.Run("resume root tasks within a graph containing more than one root task", func(t *testing.T) {
+		rootTaskId := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.String())
+		rootTask := createTaskWithRequest(t, sdk.NewCreateTaskRequest(rootTaskId, sql).WithSchedule(sdk.String("60 minutes")))
+
+		secondRootTaskId := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.String())
+		secondRootTask := createTaskWithRequest(t, sdk.NewCreateTaskRequest(secondRootTaskId, sql).WithSchedule(sdk.String("60 minutes")))
+
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.String())
+		_ = createTaskWithRequest(t, sdk.NewCreateTaskRequest(id, sql).WithAfter([]sdk.SchemaObjectIdentifier{rootTask.ID(), secondRootTask.ID()}))
+
+		require.ErrorContains(t, client.Tasks.Alter(ctx, sdk.NewAlterTaskRequest(rootTask.ID()).WithResume(sdk.Bool(true))), "The graph has more than one root task (one without predecessors)")
+		require.ErrorContains(t, client.Tasks.Alter(ctx, sdk.NewAlterTaskRequest(secondRootTask.ID()).WithResume(sdk.Bool(true))), "The graph has more than one root task (one without predecessors)")
+	})
+
+	t.Run("suspend root tasks temporarily with three sequentially connected tasks - last in DAG", func(t *testing.T) {
+		rootTaskId := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.String())
+		rootTask := createTaskWithRequest(t, sdk.NewCreateTaskRequest(rootTaskId, sql).WithSchedule(sdk.String("60 minutes")))
+
+		middleTaskId := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.String())
+		middleTask := createTaskWithRequest(t, sdk.NewCreateTaskRequest(middleTaskId, sql).WithAfter([]sdk.SchemaObjectIdentifier{rootTask.ID()}))
+
+		id := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.String())
+		task := createTaskWithRequest(t, sdk.NewCreateTaskRequest(id, sql).WithAfter([]sdk.SchemaObjectIdentifier{middleTask.ID()}))
+
+		require.NoError(t, client.Tasks.Alter(ctx, sdk.NewAlterTaskRequest(middleTask.ID()).WithResume(sdk.Bool(true))))
+		t.Cleanup(func() {
+			require.NoError(t, client.Tasks.Alter(ctx, sdk.NewAlterTaskRequest(middleTask.ID()).WithSuspend(sdk.Bool(true))))
+		})
+
+		require.NoError(t, client.Tasks.Alter(ctx, sdk.NewAlterTaskRequest(rootTask.ID()).WithResume(sdk.Bool(true))))
+		t.Cleanup(func() {
+			require.NoError(t, client.Tasks.Alter(ctx, sdk.NewAlterTaskRequest(rootTask.ID()).WithSuspend(sdk.Bool(true))))
+		})
+
+		tasksToResume, err := client.Tasks.SuspendRootTasks(ctx, task.ID(), task.ID())
+		require.NoError(t, err)
+		require.NotEmpty(t, tasksToResume)
+		require.Contains(t, tasksToResume, rootTask.ID())
+
+		rootTaskStatus, err := client.Tasks.ShowByID(ctx, rootTask.ID())
+		require.NoError(t, err)
+		require.Equal(t, sdk.TaskStateSuspended, rootTaskStatus.State)
+
+		middleTaskStatus, err := client.Tasks.ShowByID(ctx, middleTask.ID())
+		require.NoError(t, err)
+		require.Equal(t, sdk.TaskStateStarted, middleTaskStatus.State)
+
+		require.NoError(t, client.Tasks.ResumeTasks(ctx, tasksToResume))
+
+		rootTaskStatus, err = client.Tasks.ShowByID(ctx, rootTask.ID())
+		require.NoError(t, err)
+		require.Equal(t, sdk.TaskStateStarted, rootTaskStatus.State)
+
+		middleTaskStatus, err = client.Tasks.ShowByID(ctx, middleTask.ID())
+		require.NoError(t, err)
+		require.Equal(t, sdk.TaskStateStarted, middleTaskStatus.State)
+	})
+
+	t.Run("suspend root tasks temporarily with three sequentially connected tasks - middle in DAG", func(t *testing.T) {
+		rootTaskId := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.String())
+		rootTask := createTaskWithRequest(t, sdk.NewCreateTaskRequest(rootTaskId, sql).WithSchedule(sdk.String("60 minutes")))
+
+		middleTaskId := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.String())
+		middleTask := createTaskWithRequest(t, sdk.NewCreateTaskRequest(middleTaskId, sql).WithAfter([]sdk.SchemaObjectIdentifier{rootTask.ID()}))
+
+		childTaskId := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, random.String())
+		childTask := createTaskWithRequest(t, sdk.NewCreateTaskRequest(childTaskId, sql).WithAfter([]sdk.SchemaObjectIdentifier{middleTask.ID()}))
+
+		require.NoError(t, client.Tasks.Alter(ctx, sdk.NewAlterTaskRequest(childTask.ID()).WithResume(sdk.Bool(true))))
+		t.Cleanup(func() {
+			require.NoError(t, client.Tasks.Alter(ctx, sdk.NewAlterTaskRequest(childTask.ID()).WithSuspend(sdk.Bool(true))))
+		})
+
+		require.NoError(t, client.Tasks.Alter(ctx, sdk.NewAlterTaskRequest(rootTask.ID()).WithResume(sdk.Bool(true))))
+		t.Cleanup(func() {
+			require.NoError(t, client.Tasks.Alter(ctx, sdk.NewAlterTaskRequest(rootTask.ID()).WithSuspend(sdk.Bool(true))))
+		})
+
+		tasksToResume, err := client.Tasks.SuspendRootTasks(ctx, middleTask.ID(), middleTask.ID())
+		require.NoError(t, err)
+		require.NotEmpty(t, tasksToResume)
+
+		rootTaskStatus, err := client.Tasks.ShowByID(ctx, rootTask.ID())
+		require.NoError(t, err)
+		require.Equal(t, sdk.TaskStateSuspended, rootTaskStatus.State)
+
+		childTaskStatus, err := client.Tasks.ShowByID(ctx, childTask.ID())
+		require.NoError(t, err)
+		require.Equal(t, sdk.TaskStateStarted, childTaskStatus.State)
+
+		require.NoError(t, client.Tasks.ResumeTasks(ctx, tasksToResume))
+
+		rootTaskStatus, err = client.Tasks.ShowByID(ctx, rootTask.ID())
+		require.NoError(t, err)
+		require.Equal(t, sdk.TaskStateStarted, rootTaskStatus.State)
+
+		childTaskStatus, err = client.Tasks.ShowByID(ctx, childTask.ID())
+		require.NoError(t, err)
+		require.Equal(t, sdk.TaskStateStarted, childTaskStatus.State)
+	})
+
+	// TODO(SNOW-1277135): Create more tests with different sets of roots/children and see if the current implementation
+	// acts correctly in certain situations/edge cases.
 }


### PR DESCRIPTION
Refactor previously planned function for task suspension, which is also necessary to push the grant ownership resource forward.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests - tested on exiting tests (had to adjust new suspension code to mimic what was previously, otherwise I got a Snowflake error indicating that the root tasks were not suspended and the logic was wrong).
* [x] integration test to test new SDK function

## Reference
[CREATE TASK](https://docs.snowflake.com/en/sql-reference/sql/create-task)