### PR TITLE
fix: Fix handling secure views read and import

### DIFF
--- a/docs/resources/view.md
+++ b/docs/resources/view.md
@@ -41,7 +41,7 @@ SQL
 
 - `comment` (String) Specifies a comment for the view.
 - `copy_grants` (Boolean) Retains the access permissions from the original view when a new view is created using the OR REPLACE clause. OR REPLACE must be set when COPY GRANTS is set.
-- `is_secure` (Boolean) Specifies that the view is secure.
+- `is_secure` (Boolean) Specifies that the view is secure. By design, the Snowflake's `SHOW VIEWS` command does not provide information about secure views (consult [view usage notes](https://docs.snowflake.com/en/sql-reference/sql/create-view#usage-notes)) which is essential to manage/import view with Terraform. Use the role owning the view while managing secure views.
 - `or_replace` (Boolean) Overwrites the View if it exists.
 - `tag` (Block List, Deprecated) Definitions of a tag to associate with the resource. (see [below for nested schema](#nestedblock--tag))
 

--- a/pkg/snowflake/parser_test.go
+++ b/pkg/snowflake/parser_test.go
@@ -31,6 +31,7 @@ from bar;`
 	identifier := `create view "foo"."bar"."bam" comment='asdf\'s are fun' as select * from bar;`
 
 	full := `CREATE SECURE VIEW "rgdxfmnfhh"."PUBLIC"."rgdxfmnfhh" COMMENT = 'Terraform test resource' AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES`
+	issue2640 := `CREATE OR REPLACE SECURE VIEW "CLASSIFICATION" comment = 'Classification View of the union of classification tables' AS select * from AB1_SUBSCRIPTION.CLASSIFICATION.CLASSIFICATION    union   select * from AB2_SUBSCRIPTION.CLASSIFICATION.CLASSIFICATION`
 
 	type args struct {
 		input string
@@ -55,6 +56,7 @@ from bar;`
 		{"commentEscape", args{commentEscape}, "select * from bar;", false},
 		{"identifier", args{identifier}, "select * from bar;", false},
 		{"full", args{full}, "SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES", false},
+		{"issue2640", args{issue2640}, "select * from AB1_SUBSCRIPTION.CLASSIFICATION.CLASSIFICATION    union   select * from AB2_SUBSCRIPTION.CLASSIFICATION.CLASSIFICATION", false},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
To import the secure view the role owning the view is needed. As https://docs.snowflake.com/en/sql-reference/sql/create-view#usage-notes state:
> By design, the [SHOW VIEWS](https://docs.snowflake.com/en/sql-reference/sql/show-views) command does not provide information about secure views. To view information about a secure view, you must use the [VIEWS](https://docs.snowflake.com/en/sql-reference/info-schema/views) view in the Information Schema and you must use the role that owns the view.

This change:
- tests and proves #2640 
- checks the parser for view using union statement (that was the first idea for the source of error)
- handles the empty `text` from `SHOW VIEWS` command gracefully (no panic like before)
- adds a proper description with documentation link to the `snowflake_view` documentation

References: https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2640#issuecomment-2020739114