### PR TITLE
fix: Adjust dynamic tables after BCR-1543

### DIFF
--- a/pkg/resources/dynamic_table.go
+++ b/pkg/resources/dynamic_table.go
@@ -133,7 +133,7 @@ var dynamicTableSchema = map[string]*schema.Schema{
 	},
 	"scheduling_state": {
 		Type:        schema.TypeString,
-		Description: "Displays RUNNING for dynamic tables that are actively scheduling refreshes and SUSPENDED for suspended dynamic tables.",
+		Description: "Displays ACTIVE for dynamic tables that are actively scheduling refreshes and SUSPENDED for suspended dynamic tables.",
 		Computed:    true,
 	},
 	"last_suspended_on": {

--- a/pkg/sdk/dynamic_table.go
+++ b/pkg/sdk/dynamic_table.go
@@ -98,7 +98,7 @@ var AllDynamicTableInitializes = []DynamicTableInitialize{DynamicTableInitialize
 type DynamicTableSchedulingState string
 
 const (
-	DynamicTableSchedulingStateRunning   DynamicTableSchedulingState = "RUNNING"
+	DynamicTableSchedulingStateActive    DynamicTableSchedulingState = "ACTIVE"
 	DynamicTableSchedulingStateSuspended DynamicTableSchedulingState = "SUSPENDED"
 )
 

--- a/pkg/sdk/testint/dynamic_table_integration_test.go
+++ b/pkg/sdk/testint/dynamic_table_integration_test.go
@@ -132,7 +132,7 @@ func TestInt_DynamicTableAlter(t *testing.T) {
 		entities, err := client.DynamicTables.Show(ctx, sdk.NewShowDynamicTableRequest().WithLike(&sdk.Like{Pattern: sdk.String(dynamicTable.Name)}))
 		require.NoError(t, err)
 		require.Equal(t, 1, len(entities))
-		require.Equal(t, sdk.DynamicTableSchedulingStateRunning, entities[0].SchedulingState)
+		require.Equal(t, sdk.DynamicTableSchedulingStateActive, entities[0].SchedulingState)
 
 		err = client.DynamicTables.Alter(ctx, sdk.NewAlterDynamicTableRequest(dynamicTable.ID()).WithSuspend(sdk.Bool(true)))
 		require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestInt_DynamicTableAlter(t *testing.T) {
 		entities, err = client.DynamicTables.Show(ctx, sdk.NewShowDynamicTableRequest().WithLike(&sdk.Like{Pattern: sdk.String(dynamicTable.Name)}))
 		require.NoError(t, err)
 		require.Equal(t, 1, len(entities))
-		require.Equal(t, sdk.DynamicTableSchedulingStateRunning, entities[0].SchedulingState)
+		require.Equal(t, sdk.DynamicTableSchedulingStateActive, entities[0].SchedulingState)
 	})
 
 	t.Run("alter with refresh", func(t *testing.T) {


### PR DESCRIPTION
[BCR-1543](https://docs.snowflake.com/en/release-notes/bcr-bundles/2024_02/bcr-1543#return-value-behavior-for-the-show-dynamic-table-function) introduced changes to the dynamic table output for `scheduling_state` column.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] Test that was failing before, now passes with newly added `ACTIVE` scheduling state