### PR TITLE
fix: Adds case statement for ObjectTypeUser in ShowObjectParameter.

### DIFF
--- a/pkg/acceptance/testing.go
+++ b/pkg/acceptance/testing.go
@@ -24,7 +24,6 @@ const (
 	TestSchemaName     = "terraform_test_schema"
 	TestWarehouseName  = "terraform_test_warehouse"
 	TestWarehouseName2 = "terraform_test_warehouse_2"
-	TestUserName       = "terraform_test_user"
 )
 
 var (
@@ -117,13 +116,6 @@ func TestAccPreCheck(t *testing.T) {
 
 		warehouseId2 := sdk.NewAccountObjectIdentifier(TestWarehouseName2)
 		if err := atc.client.Warehouses.Create(ctx, warehouseId2, &sdk.CreateWarehouseOptions{
-			IfNotExists: sdk.Bool(true),
-		}); err != nil {
-			t.Fatal(err)
-		}
-
-		userId := sdk.NewAccountObjectIdentifier(TestUserName)
-		if err := atc.client.Users.Create(ctx, userId, &sdk.CreateUserOptions{
 			IfNotExists: sdk.Bool(true),
 		}); err != nil {
 			t.Fatal(err)

--- a/pkg/acceptance/testing.go
+++ b/pkg/acceptance/testing.go
@@ -24,6 +24,7 @@ const (
 	TestSchemaName     = "terraform_test_schema"
 	TestWarehouseName  = "terraform_test_warehouse"
 	TestWarehouseName2 = "terraform_test_warehouse_2"
+	TestUserName       = "terraform_test_user"
 )
 
 var (
@@ -116,6 +117,13 @@ func TestAccPreCheck(t *testing.T) {
 
 		warehouseId2 := sdk.NewAccountObjectIdentifier(TestWarehouseName2)
 		if err := atc.client.Warehouses.Create(ctx, warehouseId2, &sdk.CreateWarehouseOptions{
+			IfNotExists: sdk.Bool(true),
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		userId := sdk.NewAccountObjectIdentifier(TestUserName)
+		if err := atc.client.Users.Create(ctx, userId, &sdk.CreateUserOptions{
 			IfNotExists: sdk.Bool(true),
 		}); err != nil {
 			t.Fatal(err)

--- a/pkg/resources/object_parameter_acceptance_test.go
+++ b/pkg/resources/object_parameter_acceptance_test.go
@@ -52,6 +52,27 @@ func TestAcc_ObjectParameterAccount(t *testing.T) {
 	})
 }
 
+func TestAcc_UserParameter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: userParameterConfigBasic("ENABLE_UNREDACTED_QUERY_SYNTAX_ERROR", "true", acc.TestUserName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_object_parameter.p", "key", "ENABLE_UNREDACTED_QUERY_SYNTAX_ERROR"),
+					resource.TestCheckResourceAttr("snowflake_object_parameter.p", "value", "true"),
+					resource.TestCheckResourceAttr("snowflake_object_parameter.p", "on_account", "false"),
+				),
+			},
+		},
+	})
+}
+
 func objectParameterConfigOnAccount(key, value string) string {
 	s := `
 resource "snowflake_object_parameter" "p" {
@@ -75,4 +96,18 @@ resource "snowflake_object_parameter" "p" {
 }
 `
 	return fmt.Sprintf(s, key, value, databaseName)
+}
+
+func userParameterConfigBasic(key, value, username string) string {
+	s := `
+resource "snowflake_object_parameter" "p" {
+	key = "%s"
+	value = "%s"
+	object_type = "USER"
+	object_identifier {
+		name = "%s"
+	}
+}
+`
+	return fmt.Sprintf(s, key, value, username)
 }

--- a/pkg/sdk/parameters.go
+++ b/pkg/sdk/parameters.go
@@ -1004,6 +1004,8 @@ func (v *parameters) ShowObjectParameter(ctx context.Context, parameter ObjectPa
 		opts.In.Task = object.Name.(SchemaObjectIdentifier)
 	case ObjectTypeTable:
 		opts.In.Table = object.Name.(SchemaObjectIdentifier)
+	case ObjectTypeUser:
+		opts.In.User = object.Name.(AccountObjectIdentifier)
 	default:
 		return nil, fmt.Errorf("unsupported object type %s", object.Name)
 	}


### PR DESCRIPTION
When issuing `object_type = "USER"` via the `snowflake_object_parameter` resource  the `ShowObjectParameter` function did not handle the `ObjectTypeUser` which led to invalid ObjectType errors.

## Test Plan
* [x] acceptance tests


## References
* ~~Fixes #2669~~ Actually, I re-reading this issue I don't think it fixes this error.