### PR TITLE
fix: diffs always occurring when multiple columns exist

### DIFF
--- a/pkg/resources/masking_policy.go
+++ b/pkg/resources/masking_policy.go
@@ -227,16 +227,15 @@ func ReadMaskingPolicy(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	signature := []map[string]interface{}{}
+	columns := []map[string]interface{}{}
 	for _, s := range maskingPolicyDetails.Signature {
-		signature = append(signature, map[string]interface{}{
-			"column": []map[string]interface{}{
-				{
-					"name": s.Name,
-					"type": s.Type,
-				},
-			},
+		columns = append(columns, map[string]interface{}{
+			"name": s.Name,
+			"type": s.Type,
 		})
+	}
+	signature := []map[string]interface{}{
+		{"column": columns},
 	}
 	if err := d.Set("signature", signature); err != nil {
 		return err

--- a/pkg/resources/masking_policy_acceptance_test.go
+++ b/pkg/resources/masking_policy_acceptance_test.go
@@ -2,6 +2,7 @@ package resources_test
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"strings"
 	"testing"
 
@@ -132,6 +133,11 @@ func TestAcc_MaskingPolicyMultiColumns(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: maskingPolicyConfigMultiColumn(accName, accName, acc.TestDatabaseName, acc.TestSchemaName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_masking_policy.test", "name", accName),
 					resource.TestCheckResourceAttr("snowflake_masking_policy.test", "database", acc.TestDatabaseName),

--- a/pkg/resources/masking_policy_acceptance_test.go
+++ b/pkg/resources/masking_policy_acceptance_test.go
@@ -118,3 +118,57 @@ func maskingPolicyConfigMultiline(n string, name string, databaseName string, sc
 	}
 	`, name, databaseName, schemaName)
 }
+
+func TestAcc_MaskingPolicyMultiColumns(t *testing.T) {
+	accName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: maskingPolicyConfigMultiColumn(accName, accName, acc.TestDatabaseName, acc.TestSchemaName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_masking_policy.test", "name", accName),
+					resource.TestCheckResourceAttr("snowflake_masking_policy.test", "database", acc.TestDatabaseName),
+					resource.TestCheckResourceAttr("snowflake_masking_policy.test", "schema", acc.TestSchemaName),
+					resource.TestCheckResourceAttr("snowflake_masking_policy.test", "masking_expression", "case when current_role() in ('ANALYST') then val else sha2(val, 512) end"),
+					resource.TestCheckResourceAttr("snowflake_masking_policy.test", "return_data_type", "VARCHAR"),
+					resource.TestCheckResourceAttr("snowflake_masking_policy.test", "signature.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_masking_policy.test", "signature.0.column.#", "2"),
+					resource.TestCheckResourceAttr("snowflake_masking_policy.test", "signature.0.column.0.name", "val"),
+					resource.TestCheckResourceAttr("snowflake_masking_policy.test", "signature.0.column.0.type", "VARCHAR"),
+					resource.TestCheckResourceAttr("snowflake_masking_policy.test", "signature.0.column.1.name", "val2"),
+					resource.TestCheckResourceAttr("snowflake_masking_policy.test", "signature.0.column.1.type", "VARCHAR"),
+				),
+			},
+		},
+	})
+}
+
+func maskingPolicyConfigMultiColumn(n string, name string, databaseName string, schemaName string) string {
+	return fmt.Sprintf(`
+resource "snowflake_masking_policy" "test" {
+	name = "%s"
+	database = "%s"
+	schema = "%s"
+	signature {
+		column {
+			name = "val"
+			type = "VARCHAR"
+		}
+
+		column {
+			name = "val2"
+			type = "VARCHAR"
+		}
+	}
+	masking_expression = "case when current_role() in ('ANALYST') then val else sha2(val, 512) end"
+	return_data_type = "VARCHAR"
+}
+`, name, databaseName, schemaName)
+}


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

ReadMaskingPolicy function increased signature by the number of columns when there were multiple columns in the Masking Policy.
Therefore, a masking policy with multiple columns was always in a state where differences occurred.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->

## References
<!-- issues documentation links, etc  -->

* fixes #2054