### PR TITLE
fix: do not drop dynamic tables when query changes

### DIFF
--- a/docs/resources/dynamic_table.md
+++ b/docs/resources/dynamic_table.md
@@ -42,7 +42,7 @@ resource "snowflake_dynamic_table" "dt" {
 
 - `comment` (String) Specifies a comment for the dynamic table.
 - `initialize` (String) Initialize trigger for the dynamic table. Can only be set on creation. Available options are ON_CREATE and ON_SCHEDULE.
-- `or_replace` (Boolean) Specifies whether to replace the dynamic table if it already exists.
+- `or_replace` (Boolean) This argument is deprecated and setting it has no effect. All dynamic tables are created with `CREATE OR REPLACE`
 - `refresh_mode` (String) INCREMENTAL to use incremental refreshes, FULL to recompute the whole table on every refresh, or AUTO to let Snowflake decide.
 
 ### Read-Only

--- a/pkg/sdk/dynamic_table.go
+++ b/pkg/sdk/dynamic_table.go
@@ -17,8 +17,7 @@ type DynamicTables interface {
 
 // createDynamicTableOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-dynamic-table
 type createDynamicTableOptions struct {
-	create       bool                     `ddl:"static" sql:"CREATE"`
-	OrReplace    *bool                    `ddl:"keyword" sql:"OR REPLACE"`
+	create       bool                     `ddl:"static" sql:"CREATE OR REPLACE"`
 	dynamicTable bool                     `ddl:"static" sql:"DYNAMIC TABLE"`
 	name         SchemaObjectIdentifier   `ddl:"identifier"`
 	targetLag    TargetLag                `ddl:"parameter,no_quotes" sql:"TARGET_LAG"`

--- a/pkg/sdk/dynamic_table_dto.go
+++ b/pkg/sdk/dynamic_table_dto.go
@@ -10,8 +10,6 @@ var (
 )
 
 type CreateDynamicTableRequest struct {
-	orReplace bool
-
 	name      SchemaObjectIdentifier  // required
 	warehouse AccountObjectIdentifier // required
 	targetLag TargetLag               // required

--- a/pkg/sdk/dynamic_table_dto_builders.go
+++ b/pkg/sdk/dynamic_table_dto_builders.go
@@ -14,11 +14,6 @@ func NewCreateDynamicTableRequest(
 	return &s
 }
 
-func (s *CreateDynamicTableRequest) WithOrReplace(orReplace bool) *CreateDynamicTableRequest {
-	s.orReplace = orReplace
-	return s
-}
-
 func (s *CreateDynamicTableRequest) WithComment(comment *string) *CreateDynamicTableRequest {
 	s.comment = comment
 	return s

--- a/pkg/sdk/dynamic_table_impl.go
+++ b/pkg/sdk/dynamic_table_impl.go
@@ -57,7 +57,6 @@ func (v *dynamicTables) ShowByID(ctx context.Context, id SchemaObjectIdentifier)
 
 func (s *CreateDynamicTableRequest) toOpts() *createDynamicTableOptions {
 	return &createDynamicTableOptions{
-		OrReplace:   Bool(s.orReplace),
 		name:        s.name,
 		warehouse:   s.warehouse,
 		targetLag:   s.targetLag,

--- a/pkg/sdk/dynamic_table_test.go
+++ b/pkg/sdk/dynamic_table_test.go
@@ -31,13 +31,11 @@ func TestDynamicTableCreate(t *testing.T) {
 
 	t.Run("basic", func(t *testing.T) {
 		opts := defaultOpts()
-		opts.OrReplace = Bool(true)
 		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE DYNAMIC TABLE %s TARGET_LAG = '1 minutes' WAREHOUSE = "warehouse_name" AS SELECT product_id, product_name FROM staging_table`, id.FullyQualifiedName())
 	})
 
 	t.Run("all optional", func(t *testing.T) {
 		opts := defaultOpts()
-		opts.OrReplace = Bool(true)
 		opts.Comment = String("comment")
 		opts.RefreshMode = DynamicTableRefreshModeFull.ToPointer()
 		opts.Initialize = DynamicTableInitializeOnSchedule.ToPointer()

--- a/pkg/sdk/testint/dynamic_table_integration_test.go
+++ b/pkg/sdk/testint/dynamic_table_integration_test.go
@@ -24,7 +24,7 @@ func TestInt_DynamicTableCreateAndDrop(t *testing.T) {
 		}
 		query := "select id from " + tableTest.ID().FullyQualifiedName()
 		comment := random.Comment()
-		err := client.DynamicTables.Create(ctx, sdk.NewCreateDynamicTableRequest(name, testWarehouse(t).ID(), targetLag, query).WithOrReplace(true).WithComment(&comment))
+		err := client.DynamicTables.Create(ctx, sdk.NewCreateDynamicTableRequest(name, testWarehouse(t).ID(), targetLag, query).WithComment(&comment))
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = client.DynamicTables.Drop(ctx, sdk.NewDropDynamicTableRequest(name))
@@ -54,7 +54,7 @@ func TestInt_DynamicTableCreateAndDrop(t *testing.T) {
 		}
 		query := "select id from " + tableTest.ID().FullyQualifiedName()
 		comment := random.Comment()
-		err := client.DynamicTables.Create(ctx, sdk.NewCreateDynamicTableRequest(name, testWarehouse(t).ID(), targetLag, query).WithOrReplace(true).WithComment(&comment))
+		err := client.DynamicTables.Create(ctx, sdk.NewCreateDynamicTableRequest(name, testWarehouse(t).ID(), targetLag, query).WithComment(&comment))
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = client.DynamicTables.Drop(ctx, sdk.NewDropDynamicTableRequest(name))
@@ -82,7 +82,7 @@ func TestInt_DynamicTableCreateAndDrop(t *testing.T) {
 		comment := random.Comment()
 		refreshMode := sdk.DynamicTableRefreshModeFull
 		initialize := sdk.DynamicTableInitializeOnSchedule
-		err := client.DynamicTables.Create(ctx, sdk.NewCreateDynamicTableRequest(name, testWarehouse(t).ID(), targetLag, query).WithOrReplace(true).WithInitialize(initialize).WithRefreshMode(refreshMode).WithComment(&comment))
+		err := client.DynamicTables.Create(ctx, sdk.NewCreateDynamicTableRequest(name, testWarehouse(t).ID(), targetLag, query).WithInitialize(initialize).WithRefreshMode(refreshMode).WithComment(&comment))
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err = client.DynamicTables.Drop(ctx, sdk.NewDropDynamicTableRequest(name))

--- a/pkg/sdk/testint/helpers_test.go
+++ b/pkg/sdk/testint/helpers_test.go
@@ -220,7 +220,7 @@ func createDynamicTableWithOptions(t *testing.T, client *sdk.Client, warehouse *
 	query := "select id from " + table.ID().FullyQualifiedName()
 	comment := random.Comment()
 	ctx := context.Background()
-	err := client.DynamicTables.Create(ctx, sdk.NewCreateDynamicTableRequest(name, warehouse.ID(), targetLag, query).WithOrReplace(true).WithComment(&comment))
+	err := client.DynamicTables.Create(ctx, sdk.NewCreateDynamicTableRequest(name, warehouse.ID(), targetLag, query).WithComment(&comment))
 	require.NoError(t, err)
 	entities, err := client.DynamicTables.Show(ctx, sdk.NewShowDynamicTableRequest().WithLike(&sdk.Like{Pattern: sdk.String(name.Name())}).WithIn(&sdk.In{Schema: schema.ID()}))
 	require.NoError(t, err)


### PR DESCRIPTION
Hi, it's me again. I'm proposing a "fix", but it may be considered a behavior change as the `or_replace` attribute on `snowflake_dynamic_table` becomes a no-op. 

## Summary of changes

This change allows dynamic tables with changed queries to be updated in-place.

Previously, there was a `or_replace` attribute on the snowflake_dynamic_table resource that was meant to specify whether `OR REPLACE` is meant to be used if the table already exists. However, this attribute was confusing to use because it often resulted in spurious changes in terraform plans after applying.

A separate issue with dynamic tables was that we have been dropping and recreating dynamic tables when the `query` or `refresh_mode` properties changed, when we could take a less destructive action by calling `CREATE OR REPLACE`. The presence of `or_replace` as a configured attribute made this more complicated.

This commit removes the ability for users to set `or_replace` on dynamic table configurations, and instead will always use `CREATE OR REPLACE` for dynamic table creation. With this simplification, we can then check for changes to the `query` and `refresh_mode` arguments when updating the dynamic table, and either use `CREATE OR REPLACE` or `ALTER DYNAMIC TABLE` depending on which attributes have changed. This allows users to update the query and refresh mode without causing temporary unavailability.

## Test Plan

I have tested this on our actual deployed stack and can confirm it executes a single `create or replace` statement instead of a `drop` and a `create`.

For acceptance tests, I was thinking of what acceptance test to write but it seems like the existing acceptance tests already test everything I want to test (the only behavioral difference between using `create or replace` instead of drop-then-create is that the former has less downtime)

## References
* I vaguely recall there was a thread on one of my PRs where we discussed `create or replace` vs. `ForceNew` and decided to proceed with `ForceNew` at the time. I can't find the conversation anymore, but after using the provider in production for awhile we are convinced `create or replace` is the superior option.