### PR TITLE
fix: #2700: update grantedOn check

### DIFF
--- a/pkg/resources/grant_ownership.go
+++ b/pkg/resources/grant_ownership.go
@@ -368,7 +368,7 @@ func ReadGrantOwnership(ctx context.Context, d *schema.ResourceData, meta any) d
 
 		// grant_on is for future grants, granted_on is for current grants.
 		// They function the same way though in a test for matching the object type
-		if grantedOn != grant.GrantedOn && grantedOn != grant.GrantOn {
+		if !strings.Contains(grantedOn.String(), grant.GrantedOn.String()) && !strings.Contains(grantedOn.String(), grant.GrantOn.String()) {
 			continue
 		}
 


### PR DESCRIPTION
Hello team,

Fixing MR for #2700 

The Grants.Show returns GrantedOn == "ROLE" even if the ownership is granted for a database role(same in Snowflake UI), This checks compares "DATABASE ROLE" to "ROLE" and it fails to create the ownership resource. I've changed the comparison method to fix this behavior.

Kind regards,
Szymon

<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

## References
#2700 
