### PR TITLE
fix: renames in update operations

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -4,6 +4,13 @@ This document is meant to help you migrate your Terraform config to the new newe
 describe deprecations or breaking changes and help you to change your configuration to keep the same (or similar) behavior
 across different versions.
 
+## v0.88.0 ➞ v0.89.0
+#### *(behavior change)* ForceNew removed
+The `ForceNew` field was removed in favor of in-place Update for `name` parameter in:
+- `snowflake_file_format`
+- `snowflake_masking_policy`
+So from now, these objects won't be re-created when the `name` changes, but instead only the name will be updated with `ALTER .. RENAME TO` statements.
+
 ## v0.87.0 ➞ v0.88.0
 ### snowflake_procedure resource changes
 #### *(behavior change)* Execute as validation added

--- a/pkg/resources/file_format.go
+++ b/pkg/resources/file_format.go
@@ -778,7 +778,7 @@ func UpdateFileFormat(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error renaming file format: %w", err)
 		}
 
-		d.SetId(helpers.EncodeSnowflakeID(id))
+		d.SetId(helpers.EncodeSnowflakeID(newId))
 		id = newId
 	}
 

--- a/pkg/resources/file_format.go
+++ b/pkg/resources/file_format.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -93,7 +95,6 @@ var fileFormatSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Required:    true,
 		Description: "Specifies the identifier for the file format; must be unique for the database and schema in which the file format is created.",
-		ForceNew:    true,
 	},
 	"database": {
 		Type:        schema.TypeString,
@@ -767,6 +768,7 @@ func UpdateFileFormat(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("name") {
 		newId := sdk.NewSchemaObjectIdentifier(id.DatabaseName(), id.SchemaName(), d.Get("name").(string))
+
 		err := client.FileFormats.Alter(ctx, id, &sdk.AlterFileFormatOptions{
 			Rename: &sdk.AlterFileFormatRenameOptions{
 				NewName: newId,
@@ -775,6 +777,8 @@ func UpdateFileFormat(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("error renaming file format: %w", err)
 		}
+
+		d.SetId(helpers.EncodeSnowflakeID(id))
 		id = newId
 	}
 

--- a/pkg/resources/file_format_acceptance_test.go
+++ b/pkg/resources/file_format_acceptance_test.go
@@ -446,6 +446,8 @@ func TestAcc_FileFormat_issue1947(t *testing.T) {
 	})
 }
 
+// TODO: Tescik
+
 func fileFormatConfigCSV(n string, databaseName string, schemaName string, fieldDelimiter string, fieldOptionallyEnclosedBy string, comment string) string {
 	return fmt.Sprintf(`
 resource "snowflake_file_format" "test" {

--- a/pkg/resources/file_format_acceptance_test.go
+++ b/pkg/resources/file_format_acceptance_test.go
@@ -463,6 +463,7 @@ func TestAcc_FileFormat_Rename(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
+		CheckDestroy: acc.CheckDestroy(t, resources.FileFormat),
 		Steps: []resource.TestStep{
 			{
 				Config: fileFormatConfigWithComment(name, acc.TestDatabaseName, acc.TestSchemaName, comment),

--- a/pkg/resources/file_format_acceptance_test.go
+++ b/pkg/resources/file_format_acceptance_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -446,7 +448,45 @@ func TestAcc_FileFormat_issue1947(t *testing.T) {
 	})
 }
 
-// TODO: Tescik
+func TestAcc_FileFormat_Rename(t *testing.T) {
+	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	newName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	comment := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	newComment := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	resourceName := "snowflake_file_format.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { acc.TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: fileFormatConfigWithComment(name, acc.TestDatabaseName, acc.TestSchemaName, comment),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "comment", comment),
+				),
+			},
+			{
+				Config: fileFormatConfigWithComment(newName, acc.TestDatabaseName, acc.TestSchemaName, newComment),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", newName),
+					resource.TestCheckResourceAttr(resourceName, "comment", newComment),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
 
 func fileFormatConfigCSV(n string, databaseName string, schemaName string, fieldDelimiter string, fieldOptionallyEnclosedBy string, comment string) string {
 	return fmt.Sprintf(`
@@ -579,6 +619,18 @@ resource "snowflake_file_format" "test" {
 	format_type = "%s"
 }
 `, n, databaseName, schemaName, formatType)
+}
+
+func fileFormatConfigWithComment(n string, databaseName string, schemaName string, comment string) string {
+	return fmt.Sprintf(`
+resource "snowflake_file_format" "test" {
+	name = "%v"
+	database = "%s"
+	schema = "%s"
+	format_type = "XML"
+	comment = "%s"
+}
+`, n, databaseName, schemaName, comment)
 }
 
 func fileFormatConfigFullDefaultsWithAdditionalParam(n string, formatType string, databaseName string, schemaName string) string {

--- a/pkg/resources/function.go
+++ b/pkg/resources/function.go
@@ -658,14 +658,14 @@ func UpdateContextFunction(ctx context.Context, d *schema.ResourceData, meta int
 	id := sdk.NewSchemaObjectIdentifierFromFullyQualifiedName(d.Id())
 	if d.HasChange("name") {
 		name := d.Get("name").(string)
-		newId := sdk.NewSchemaObjectIdentifier(id.DatabaseName(), id.SchemaName(), name)
+		newId := sdk.NewSchemaObjectIdentifierWithArguments(id.DatabaseName(), id.SchemaName(), name, id.Arguments())
 
-		if err := client.Functions.Alter(ctx, sdk.NewAlterFunctionRequest(id.WithoutArguments(), id.Arguments()).WithRenameTo(&newId)); err != nil {
+		if err := client.Functions.Alter(ctx, sdk.NewAlterFunctionRequest(id.WithoutArguments(), id.Arguments()).WithRenameTo(sdk.Pointer(newId.WithoutArguments()))); err != nil {
 			return diag.FromErr(err)
 		}
 
-		d.SetId(id.FullyQualifiedName())
-		id = sdk.NewSchemaObjectIdentifierWithArguments(id.DatabaseName(), id.SchemaName(), name, id.Arguments())
+		d.SetId(newId.FullyQualifiedName())
+		id = newId
 	}
 
 	if d.HasChange("is_secure") {

--- a/pkg/resources/function_acceptance_test.go
+++ b/pkg/resources/function_acceptance_test.go
@@ -245,7 +245,7 @@ func TestAcc_Function_Rename(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
-		CheckDestroy: testAccCheckFunctionDestroy,
+		CheckDestroy: testAccCheckFunctionDestroy(t),
 		Steps: []resource.TestStep{
 			{
 				Config: functionConfig(acc.TestDatabaseName, acc.TestSchemaName, name, comment),
@@ -279,7 +279,7 @@ resource "snowflake_function" "f" {
   database        = "%[1]s"
   schema          = "%[2]s"
   name            = "%[3]s"
-  comment 		  = "%[4]s"
+  comment         = "%[4]s"
   return_type     = "VARCHAR"
   return_behavior = "IMMUTABLE"
   statement       = "SELECT PARAM"

--- a/pkg/resources/function_acceptance_test.go
+++ b/pkg/resources/function_acceptance_test.go
@@ -244,7 +244,7 @@ func TestAcc_Function_Rename(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
-		CheckDestroy: testAccCheckFunctionDestroy(t),
+		CheckDestroy: acc.CheckDestroy(t, resources.Function),
 		Steps: []resource.TestStep{
 			{
 				Config: functionConfig(acc.TestDatabaseName, acc.TestSchemaName, name, comment),

--- a/pkg/resources/function_acceptance_test.go
+++ b/pkg/resources/function_acceptance_test.go
@@ -230,6 +230,8 @@ func TestAcc_Function_migrateFromVersion085(t *testing.T) {
 	})
 }
 
+// TODO: Tescik
+
 func functionConfig(database string, schema string, name string) string {
 	return fmt.Sprintf(`
 resource "snowflake_function" "f" {

--- a/pkg/resources/masking_policy.go
+++ b/pkg/resources/masking_policy.go
@@ -35,7 +35,6 @@ var maskingPolicySchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Required:    true,
 		Description: "Specifies the identifier for the masking policy; must be unique for the database and schema in which the masking policy is created.",
-		ForceNew:    true,
 	},
 	"database": {
 		Type:        schema.TypeString,

--- a/pkg/resources/masking_policy_acceptance_test.go
+++ b/pkg/resources/masking_policy_acceptance_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -73,6 +75,8 @@ func TestAcc_MaskingPolicy(t *testing.T) {
 		},
 	})
 }
+
+// TODO: Tescik
 
 func maskingPolicyConfig(n string, name string, comment string, databaseName string, schemaName string) string {
 	return fmt.Sprintf(`

--- a/pkg/resources/materialized_view.go
+++ b/pkg/resources/materialized_view.go
@@ -185,9 +185,7 @@ func UpdateMaterializedView(d *schema.ResourceData, meta interface{}) error {
 	id := helpers.DecodeSnowflakeID(d.Id()).(sdk.SchemaObjectIdentifier)
 
 	if d.HasChange("name") {
-		newName := d.Get("name").(string)
-
-		newId := sdk.NewSchemaObjectIdentifier(id.DatabaseName(), id.SchemaName(), newName)
+		newId := sdk.NewSchemaObjectIdentifier(id.DatabaseName(), id.SchemaName(), d.Get("name").(string))
 
 		err := client.MaterializedViews.Alter(ctx, sdk.NewAlterMaterializedViewRequest(id).WithRenameTo(&newId))
 		if err != nil {

--- a/pkg/resources/password_policy_acceptance_test.go
+++ b/pkg/resources/password_policy_acceptance_test.go
@@ -167,3 +167,5 @@ func TestAcc_PasswordPolicyMaxAgeDays(t *testing.T) {
 		},
 	})
 }
+
+// TODO: Tescik (rename + field change)

--- a/pkg/resources/password_policy_acceptance_test.go
+++ b/pkg/resources/password_policy_acceptance_test.go
@@ -180,5 +180,3 @@ func TestAcc_PasswordPolicyMaxAgeDays(t *testing.T) {
 		},
 	})
 }
-
-// TODO: Tescik (rename + field change)

--- a/pkg/resources/password_policy_acceptance_test.go
+++ b/pkg/resources/password_policy_acceptance_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -100,15 +102,20 @@ func TestAcc_PasswordPolicy(t *testing.T) {
 }
 
 func TestAcc_PasswordPolicyMaxAgeDays(t *testing.T) {
-	accName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	name := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	newName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
 	m := func(maxAgeDays int) map[string]config.Variable {
 		return map[string]config.Variable{
-			"name":         config.StringVariable(accName),
+			"name":         config.StringVariable(name),
 			"database":     config.StringVariable(acc.TestDatabaseName),
 			"schema":       config.StringVariable(acc.TestSchemaName),
 			"max_age_days": config.IntegerVariable(maxAgeDays),
 		}
 	}
+
+	configValueWithNewName := m(10)
+	configValueWithNewName["name"] = config.StringVariable(newName)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
@@ -141,22 +148,28 @@ func TestAcc_PasswordPolicyMaxAgeDays(t *testing.T) {
 					resource.TestCheckResourceAttr("snowflake_password_policy.pa", "max_age_days", "0"),
 				),
 			},
-			// Unsets properly
+			// Rename + Unsets properly
 			{
 				ConfigDirectory: acc.ConfigurationDirectory("TestAcc_PasswordPolicy_noOptionals"),
 				ConfigVariables: map[string]config.Variable{
-					"name":     config.StringVariable(accName),
+					"name":     config.StringVariable(newName),
 					"database": config.StringVariable(acc.TestDatabaseName),
 					"schema":   config.StringVariable(acc.TestSchemaName),
 				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("snowflake_password_policy.pa", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_password_policy.pa", "name", newName),
 					resource.TestCheckResourceAttr("snowflake_password_policy.pa", "max_age_days", "90"),
 				),
 			},
 			{
 				ConfigDirectory: acc.ConfigurationDirectory("TestAcc_PasswordPolicy_noOptionals"),
 				ConfigVariables: map[string]config.Variable{
-					"name":     config.StringVariable(accName),
+					"name":     config.StringVariable(name),
 					"database": config.StringVariable(acc.TestDatabaseName),
 					"schema":   config.StringVariable(acc.TestSchemaName),
 				},

--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -13,10 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const (
-	pipeIDDelimiter = '|'
-)
-
 var pipeSchema = map[string]*schema.Schema{
 	"name": {
 		Type:        schema.TypeString,

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -19,6 +19,8 @@ func testAccProcedure(t *testing.T, configDirectory string) {
 	t.Helper()
 
 	name := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	newName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
 	resourceName := "snowflake_procedure.p"
 	m := func() map[string]config.Variable {
 		return map[string]config.Variable{
@@ -30,6 +32,7 @@ func testAccProcedure(t *testing.T, configDirectory string) {
 		}
 	}
 	variableSet2 := m()
+	variableSet2["name"] = config.StringVariable(newName)
 	variableSet2["comment"] = config.StringVariable("Terraform acceptance test - updated")
 	variableSet2["execute_as"] = config.StringVariable("OWNER")
 
@@ -64,12 +67,17 @@ func testAccProcedure(t *testing.T, configDirectory string) {
 				),
 			},
 
-			// test - change comment and caller (proves https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2642)
+			// test - rename + change comment and caller (proves https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2642)
 			{
 				ConfigDirectory: acc.ConfigurationDirectory(configDirectory),
 				ConfigVariables: variableSet2,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", newName),
 					resource.TestCheckResourceAttr(resourceName, "database", acc.TestDatabaseName),
 					resource.TestCheckResourceAttr(resourceName, "schema", acc.TestSchemaName),
 					resource.TestCheckResourceAttr(resourceName, "comment", "Terraform acceptance test - updated"),

--- a/pkg/resources/schema_acceptance_test.go
+++ b/pkg/resources/schema_acceptance_test.go
@@ -69,7 +69,6 @@ func TestAcc_Schema(t *testing.T) {
 	})
 }
 
-// TODO: Rename + param change
 func TestAcc_Schema_Rename(t *testing.T) {
 	oldSchemaName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	newSchemaName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
@@ -104,6 +103,11 @@ func TestAcc_Schema_Rename(t *testing.T) {
 					"name":     config.StringVariable(newSchemaName),
 					"database": config.StringVariable(acc.TestDatabaseName),
 					"comment":  config.StringVariable(comment),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("snowflake_schema.test", plancheck.ResourceActionUpdate),
+					},
 				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_schema.test", "name", newSchemaName),
@@ -337,7 +341,7 @@ func TestAcc_Schema_RemoveDatabaseOutsideOfTerraform(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 				RefreshPlanChecks: resource.RefreshPlanChecks{
 					PostRefresh: []plancheck.PlanCheck{
-						expectsCreatePlan("snowflake_schema.test"),
+						plancheck.ExpectResourceAction("snowflake_schema.test", plancheck.ResourceActionCreate),
 					},
 				},
 			},

--- a/pkg/resources/schema_acceptance_test.go
+++ b/pkg/resources/schema_acceptance_test.go
@@ -69,6 +69,7 @@ func TestAcc_Schema(t *testing.T) {
 	})
 }
 
+// TODO: Rename + param change
 func TestAcc_Schema_Rename(t *testing.T) {
 	oldSchemaName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	newSchemaName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -43,7 +43,6 @@ var tableSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Description: "A list of one or more table columns/expressions to be used as clustering key(s) for the table",
 	},
-
 	"column": {
 		Type:        schema.TypeList,
 		Required:    true,
@@ -688,9 +687,7 @@ func UpdateTable(d *schema.ResourceData, meta interface{}) error {
 	id := helpers.DecodeSnowflakeID(d.Id()).(sdk.SchemaObjectIdentifier)
 
 	if d.HasChange("name") {
-		newName := d.Get("name").(string)
-
-		newId := sdk.NewSchemaObjectIdentifier(id.DatabaseName(), id.SchemaName(), newName)
+		newId := sdk.NewSchemaObjectIdentifier(id.DatabaseName(), id.SchemaName(), d.Get("name").(string))
 
 		err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newId))
 		if err != nil {

--- a/pkg/resources/table_acceptance_test.go
+++ b/pkg/resources/table_acceptance_test.go
@@ -1399,7 +1399,6 @@ resource "snowflake_table" "test_table" {
 	return fmt.Sprintf(s, name, databaseName, schemaName)
 }
 
-// TODO: Tescik
 func TestAcc_TableRename(t *testing.T) {
 	oldTableName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	newTableName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))

--- a/pkg/resources/table_acceptance_test.go
+++ b/pkg/resources/table_acceptance_test.go
@@ -1399,6 +1399,7 @@ resource "snowflake_table" "test_table" {
 	return fmt.Sprintf(s, name, databaseName, schemaName)
 }
 
+// TODO: Tescik
 func TestAcc_TableRename(t *testing.T) {
 	oldTableName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	newTableName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))

--- a/pkg/resources/table_constraint.go
+++ b/pkg/resources/table_constraint.go
@@ -374,13 +374,17 @@ func UpdateTableConstraint(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("name") {
-		_, n := d.GetChange("name")
-		constraintRequest := sdk.NewTableConstraintRenameActionRequest().WithOldName(tc.name).WithNewName(n.(string))
+		newName := d.Get("name").(string)
+		constraintRequest := sdk.NewTableConstraintRenameActionRequest().WithOldName(tc.name).WithNewName(newName)
 		alterStatement := sdk.NewAlterTableRequest(*tableIdentifier).WithConstraintAction(sdk.NewTableConstraintActionRequest().WithRename(constraintRequest))
+
 		err = client.Tables.Alter(ctx, alterStatement)
 		if err != nil {
 			return fmt.Errorf("error renaming table constraint %s err = %w", tc.name, err)
 		}
+
+		tc.name = newName
+		d.SetId(tc.String())
 	}
 
 	return ReadTableConstraint(d, meta)

--- a/pkg/resources/table_constraint.go
+++ b/pkg/resources/table_constraint.go
@@ -342,6 +342,7 @@ func CreateTableConstraint(d *schema.ResourceData, meta interface{}) error {
 
 // ReadTableConstraint implements schema.ReadFunc.
 func ReadTableConstraint(_ *schema.ResourceData, _ interface{}) error {
+	// TODO(issue-2683): Implement read operation
 	// commenting this out since it requires an active warehouse to be set which may not be intuitive.
 	// also it takes a while for the database to reflect changes. Would likely need to add a validation
 	// step like in tag association. People don't like waiting 40 minutes for Terraform to run.
@@ -362,6 +363,7 @@ func ReadTableConstraint(_ *schema.ResourceData, _ interface{}) error {
 
 // UpdateTableConstraint implements schema.UpdateFunc.
 func UpdateTableConstraint(d *schema.ResourceData, meta interface{}) error {
+	/* TODO(issue-2683): Update isn't be possible with non-existing Read operation. The Update logic is ready to be uncommented once the Read operation is ready.
 	client := meta.(*provider.Context).Client
 	ctx := context.Background()
 
@@ -373,19 +375,20 @@ func UpdateTableConstraint(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if d.HasChange("name") {
-		newName := d.Get("name").(string)
-		constraintRequest := sdk.NewTableConstraintRenameActionRequest().WithOldName(tc.name).WithNewName(newName)
-		alterStatement := sdk.NewAlterTableRequest(*tableIdentifier).WithConstraintAction(sdk.NewTableConstraintActionRequest().WithRename(constraintRequest))
+		if d.HasChange("name") {
+			newName := d.Get("name").(string)
+			constraintRequest := sdk.NewTableConstraintRenameActionRequest().WithOldName(tc.name).WithNewName(newName)
+			alterStatement := sdk.NewAlterTableRequest(*tableIdentifier).WithConstraintAction(sdk.NewTableConstraintActionRequest().WithRename(constraintRequest))
 
-		err = client.Tables.Alter(ctx, alterStatement)
-		if err != nil {
-			return fmt.Errorf("error renaming table constraint %s err = %w", tc.name, err)
+			err = client.Tables.Alter(ctx, alterStatement)
+			if err != nil {
+				return fmt.Errorf("error renaming table constraint %s err = %w", tc.name, err)
+			}
+
+			tc.name = newName
+			d.SetId(tc.String())
 		}
-
-		tc.name = newName
-		d.SetId(tc.String())
-	}
+	*/
 
 	return ReadTableConstraint(d, meta)
 }

--- a/pkg/resources/table_constraint_acceptance_test.go
+++ b/pkg/resources/table_constraint_acceptance_test.go
@@ -42,6 +42,8 @@ func TestAcc_TableConstraint_fk(t *testing.T) {
 	})
 }
 
+// TODO: Tescik
+
 func tableConstraintFKConfig(n string, databaseName string, schemaName string) string {
 	return fmt.Sprintf(`
 resource "snowflake_table" "t" {

--- a/pkg/resources/table_constraint_acceptance_test.go
+++ b/pkg/resources/table_constraint_acceptance_test.go
@@ -42,8 +42,6 @@ func TestAcc_TableConstraint_fk(t *testing.T) {
 	})
 }
 
-// TODO: Tescik
-
 func tableConstraintFKConfig(n string, databaseName string, schemaName string) string {
 	return fmt.Sprintf(`
 resource "snowflake_table" "t" {
@@ -301,6 +299,40 @@ func TestAcc_Table_issue2535_existingTable(t *testing.T) {
 	})
 }
 
+// TODO(issue-2683): Uncomment once the Update operation is ready
+// func TestAcc_TableConstraint_Rename(t *testing.T) {
+//	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+//	newName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+//
+//	resource.Test(t, resource.TestCase{
+//		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+//		PreCheck:                 func() { acc.TestAccPreCheck(t) },
+//		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+//			tfversion.RequireAbove(tfversion.Version1_5_0),
+//		},
+//		CheckDestroy: nil,
+//		Steps: []resource.TestStep{
+//			{
+//				Config: tableConstraintUniqueConfigUsingFullyQualifiedName(name, acc.TestDatabaseName, acc.TestSchemaName),
+//				Check: resource.ComposeTestCheckFunc(
+//					resource.TestCheckResourceAttr("snowflake_table_constraint.unique", "name", name),
+//				),
+//			},
+//			{
+//				Config: tableConstraintUniqueConfigUsingFullyQualifiedName(newName, acc.TestDatabaseName, acc.TestSchemaName),
+//				ConfigPlanChecks: resource.ConfigPlanChecks{
+//					PreApply: []plancheck.PlanCheck{
+//						plancheck.ExpectResourceAction("snowflake_table_constraint.unique", plancheck.ResourceActionUpdate),
+//					},
+//				},
+//				Check: resource.ComposeTestCheckFunc(
+//					resource.TestCheckResourceAttr("snowflake_table_constraint.unique", "name", newName),
+//				),
+//			},
+//		},
+//	})
+//}
+
 func tableConstraintUniqueConfigUsingFullyQualifiedName(n string, databaseName string, schemaName string) string {
 	return fmt.Sprintf(`
 resource "snowflake_table" "t" {
@@ -343,4 +375,27 @@ resource "snowflake_table_constraint" "unique" {
 	columns  = ["col1"]
 }
 `, n, databaseName, schemaName, n)
+}
+
+func tableConstraintWithNameAndComment(databaseName string, schemaName string, name string, comment string) string {
+	return fmt.Sprintf(`
+resource "snowflake_table" "t" {
+	name     = "%s"
+	database = "%s"
+	schema   = "%s"
+
+	column {
+		name = "col1"
+		type = "NUMBER(38,0)"
+	}
+}
+
+resource "snowflake_table_constraint" "test" {
+	name     = "%s"
+	comment  = "%s"
+	type     = "UNIQUE"
+	table_id = snowflake_table.t.id
+	columns  = ["col1"]
+}
+`, name, databaseName, schemaName, name, comment)
 }

--- a/pkg/resources/user.go
+++ b/pkg/resources/user.go
@@ -14,24 +14,6 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 )
 
-var userProperties = []string{
-	"comment",
-	"login_name",
-	"password",
-	"disabled",
-	"default_namespace",
-	"default_role",
-	"default_secondary_roles",
-	"default_warehouse",
-	"rsa_public_key",
-	"rsa_public_key_2",
-	"must_change_password",
-	"email",
-	"display_name",
-	"first_name",
-	"last_name",
-}
-
 var diffCaseInsensitive = func(k, old, new string, d *schema.ResourceData) bool {
 	return strings.EqualFold(old, new)
 }
@@ -311,19 +293,19 @@ func UpdateUser(d *schema.ResourceData, meta interface{}) error {
 	id := helpers.DecodeSnowflakeID(d.Id()).(sdk.AccountObjectIdentifier)
 
 	if d.HasChange("name") {
-		_, n := d.GetChange("name")
-		newName := n.(string)
-		newID := sdk.NewAccountObjectIdentifier(newName)
-		alterOptions := &sdk.AlterUserOptions{
+		newID := sdk.NewAccountObjectIdentifier(d.Get("name").(string))
+
+		err := client.Users.Alter(ctx, id, &sdk.AlterUserOptions{
 			NewName: newID,
-		}
-		err := client.Users.Alter(ctx, id, alterOptions)
+		})
 		if err != nil {
 			return err
 		}
+
 		d.SetId(helpers.EncodeSnowflakeID(newID))
 		id = newID
 	}
+
 	runSet := false
 	alterOptions := &sdk.AlterUserOptions{
 		Set: &sdk.UserSet{

--- a/pkg/resources/user_acceptance_test.go
+++ b/pkg/resources/user_acceptance_test.go
@@ -60,7 +60,7 @@ func TestAcc_User(t *testing.T) {
 		CheckDestroy: acc.CheckDestroy(t, resources.User),
 		Steps: []resource.TestStep{
 			{
-				Config: uConfig(prefix, comment, sshkey1, sshkey2),
+				Config: uConfig(prefix, sshkey1, sshkey2, comment),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_user.w", "name", prefix),
 					resource.TestCheckResourceAttr("snowflake_user.w", "comment", comment),
@@ -80,7 +80,7 @@ func TestAcc_User(t *testing.T) {
 			},
 			// RENAME
 			{
-				Config: uConfig(prefix2, newComment, sshkey1, sshkey2),
+				Config: uConfig(prefix2, sshkey1, sshkey2, newComment),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("snowflake_user.w", plancheck.ResourceActionUpdate),
@@ -262,7 +262,7 @@ func TestAcc_User_issue2058(t *testing.T) {
 		CheckDestroy: acc.CheckDestroy(t, resources.User),
 		Steps: []resource.TestStep{
 			{
-				Config: uConfig(prefix, "test_comment", sshkey1, sshkey2),
+				Config: uConfig(prefix, sshkey1, sshkey2, "test_comment"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_user.w", "name", prefix),
 				),

--- a/pkg/resources/user_acceptance_test.go
+++ b/pkg/resources/user_acceptance_test.go
@@ -76,6 +76,11 @@ func TestAcc_User(t *testing.T) {
 			// RENAME
 			{
 				Config: uConfig(prefix2, sshkey1, sshkey2),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("snowflake_user.w", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_user.w", "name", prefix2),
 					resource.TestCheckResourceAttr("snowflake_user.w", "comment", "test comment"),
@@ -169,8 +174,6 @@ resource "snowflake_user" "test" {
 		},
 	})
 }
-
-// TODO: Tescik (rename + param change)
 
 func removeUserOutsideOfTerraform(t *testing.T, name sdk.AccountObjectIdentifier) func() {
 	t.Helper()

--- a/pkg/resources/user_acceptance_test.go
+++ b/pkg/resources/user_acceptance_test.go
@@ -41,8 +41,13 @@ func TestAcc_User(t *testing.T) {
 	r := require.New(t)
 	prefix := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	prefix2 := "tst-terraform" + strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
+	comment := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+	newComment := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
+
 	sshkey1, err := testhelpers.Fixture("userkey1")
 	r.NoError(err)
+
 	sshkey2, err := testhelpers.Fixture("userkey2")
 	r.NoError(err)
 
@@ -55,10 +60,10 @@ func TestAcc_User(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: uConfig(prefix, sshkey1, sshkey2),
+				Config: uConfig(prefix, comment, sshkey1, sshkey2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_user.w", "name", prefix),
-					resource.TestCheckResourceAttr("snowflake_user.w", "comment", "test comment"),
+					resource.TestCheckResourceAttr("snowflake_user.w", "comment", comment),
 					resource.TestCheckResourceAttr("snowflake_user.w", "login_name", strings.ToUpper(fmt.Sprintf("%s_login", prefix))),
 					resource.TestCheckResourceAttr("snowflake_user.w", "display_name", "Display Name"),
 					resource.TestCheckResourceAttr("snowflake_user.w", "first_name", "Marcin"),
@@ -75,7 +80,7 @@ func TestAcc_User(t *testing.T) {
 			},
 			// RENAME
 			{
-				Config: uConfig(prefix2, sshkey1, sshkey2),
+				Config: uConfig(prefix2, newComment, sshkey1, sshkey2),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("snowflake_user.w", plancheck.ResourceActionUpdate),
@@ -83,7 +88,7 @@ func TestAcc_User(t *testing.T) {
 				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_user.w", "name", prefix2),
-					resource.TestCheckResourceAttr("snowflake_user.w", "comment", "test comment"),
+					resource.TestCheckResourceAttr("snowflake_user.w", "comment", newComment),
 					resource.TestCheckResourceAttr("snowflake_user.w", "login_name", strings.ToUpper(fmt.Sprintf("%s_login", prefix2))),
 					resource.TestCheckResourceAttr("snowflake_user.w", "display_name", "Display Name"),
 					resource.TestCheckResourceAttr("snowflake_user.w", "first_name", "Marcin"),
@@ -186,11 +191,11 @@ func removeUserOutsideOfTerraform(t *testing.T, name sdk.AccountObjectIdentifier
 	}
 }
 
-func uConfig(prefix, key1, key2 string) string {
+func uConfig(prefix, key1, key2, comment string) string {
 	s := `
 resource "snowflake_user" "w" {
 	name = "%s"
-	comment = "test comment"
+	comment = "%s"
 	login_name = "%s_login"
 	display_name = "Display Name"
 	first_name = "Marcin"
@@ -210,7 +215,7 @@ KEY
 	must_change_password = true
 }
 `
-	s = fmt.Sprintf(s, prefix, prefix, key1, key2)
+	s = fmt.Sprintf(s, prefix, comment, prefix, key1, key2)
 	log.Printf("[DEBUG] s %s", s)
 	return s
 }
@@ -257,7 +262,7 @@ func TestAcc_User_issue2058(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: uConfig(prefix, sshkey1, sshkey2),
+				Config: uConfig(prefix, "test_comment", sshkey1, sshkey2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_user.w", "name", prefix),
 				),

--- a/pkg/resources/user_acceptance_test.go
+++ b/pkg/resources/user_acceptance_test.go
@@ -170,6 +170,8 @@ resource "snowflake_user" "test" {
 	})
 }
 
+// TODO: Tescik (rename + param change)
+
 func removeUserOutsideOfTerraform(t *testing.T, name sdk.AccountObjectIdentifier) func() {
 	t.Helper()
 	return func() {

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -223,9 +223,7 @@ func UpdateView(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("name") {
-		newName := d.Get("name").(string)
-
-		newId := sdk.NewSchemaObjectIdentifier(id.DatabaseName(), id.SchemaName(), newName)
+		newId := sdk.NewSchemaObjectIdentifier(id.DatabaseName(), id.SchemaName(), d.Get("name").(string))
 
 		err := client.Views.Alter(ctx, sdk.NewAlterViewRequest(id).WithRenameTo(&newId))
 		if err != nil {

--- a/pkg/resources/view_acceptance_test.go
+++ b/pkg/resources/view_acceptance_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
@@ -184,7 +186,6 @@ func TestAcc_View_Tags(t *testing.T) {
 	})
 }
 
-// TODO: Tescik check
 func TestAcc_View_Rename(t *testing.T) {
 	viewName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	newViewName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
@@ -225,6 +226,11 @@ func TestAcc_View_Rename(t *testing.T) {
 			{
 				ConfigDirectory: acc.ConfigurationDirectory("TestAcc_View_basic"),
 				ConfigVariables: m2,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("snowflake_view.test", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_view.test", "name", newViewName),
 					resource.TestCheckResourceAttr("snowflake_view.test", "comment", "new comment"),

--- a/pkg/resources/view_acceptance_test.go
+++ b/pkg/resources/view_acceptance_test.go
@@ -184,6 +184,7 @@ func TestAcc_View_Tags(t *testing.T) {
 	})
 }
 
+// TODO: Tescik check
 func TestAcc_View_Rename(t *testing.T) {
 	viewName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 	newViewName := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -319,18 +319,17 @@ func UpdateWarehouse(d *schema.ResourceData, meta interface{}) error {
 
 	// Change name separately
 	if d.HasChange("name") {
-		if v, ok := d.GetOk("name"); ok {
-			newName := sdk.NewAccountObjectIdentifier(v.(string))
-			err := client.Warehouses.Alter(ctx, id, &sdk.AlterWarehouseOptions{
-				NewName: &newName,
-			})
-			if err != nil {
-				return err
-			}
-			d.SetId(helpers.EncodeSnowflakeID(newName))
-		} else {
-			panic("name has to be set")
+		newId := sdk.NewAccountObjectIdentifier(d.Get("name").(string))
+
+		err := client.Warehouses.Alter(ctx, id, &sdk.AlterWarehouseOptions{
+			NewName: &newId,
+		})
+		if err != nil {
+			return err
 		}
+
+		d.SetId(helpers.EncodeSnowflakeID(newId))
+		id = newId
 	}
 
 	// Batch SET operations and UNSET operations

--- a/pkg/resources/warehouse_acceptance_test.go
+++ b/pkg/resources/warehouse_acceptance_test.go
@@ -131,6 +131,8 @@ func TestAcc_WarehousePattern(t *testing.T) {
 	})
 }
 
+// TODO: Tescik (rename + param change)
+
 func wConfig(prefix string) string {
 	return fmt.Sprintf(`
 resource "snowflake_warehouse" "w" {


### PR DESCRIPTION
This change fixes all of the Updates that were performing re-names to always setId at the end of the rename operation as well as updating id that was used in the later operations. Also, the `ForceNew`s were removed in cases where rename was also handled in the Update. Test cases were added to show that rename is going through Update and not DeleteAndCreate operation + additional param is always changed to see if other operations are affected by the previous rename operation. The table constraint was adjusted and cannot support the rename for now (until the Read operation is working #2683). Migration guide updated for behavioral changes.