### PR TITLE
chore: Initialize the SDK client in fewer places

### DIFF
--- a/pkg/acceptance/testing.go
+++ b/pkg/acceptance/testing.go
@@ -62,11 +62,22 @@ func init() {
 		log.Panicf("Cannot instantiate new client, err: %v", err)
 	}
 	atc.client = client
+
+	cfg, err := sdk.ProfileConfig(testprofiles.Secondary)
+	if err != nil {
+		log.Panicf("Config for the secondary client is needed to run acceptance tests, err: %v", err)
+	}
+	secondaryClient, err := sdk.NewClient(cfg)
+	if err != nil {
+		log.Panicf("Cannot instantiate new secondary client, err: %v", err)
+	}
+	atc.secondaryClient = secondaryClient
 }
 
 type acceptanceTestContext struct {
-	config *gosnowflake.Config
-	client *sdk.Client
+	config          *gosnowflake.Config
+	client          *sdk.Client
+	secondaryClient *sdk.Client
 }
 
 var TestAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
@@ -140,6 +151,11 @@ func ConfigurationDirectory(directory string) func(config.TestStepConfigRequest)
 }
 
 func Client(t *testing.T) *sdk.Client {
+	t.Helper()
+	return atc.client
+}
+
+func SecondaryClient(t *testing.T) *sdk.Client {
 	t.Helper()
 	return atc.client
 }

--- a/pkg/acceptance/testing.go
+++ b/pkg/acceptance/testing.go
@@ -157,7 +157,7 @@ func Client(t *testing.T) *sdk.Client {
 
 func SecondaryClient(t *testing.T) *sdk.Client {
 	t.Helper()
-	return atc.client
+	return atc.secondaryClient
 }
 
 func DefaultConfig(t *testing.T) *gosnowflake.Config {

--- a/pkg/datasources/grants_acceptance_test.go
+++ b/pkg/datasources/grants_acceptance_test.go
@@ -373,10 +373,7 @@ func TestAcc_Grants_Of_Share(t *testing.T) {
 	getSecondaryAccountIdentifier := func(t *testing.T) *sdk.AccountIdentifier {
 		t.Helper()
 
-		client, err := sdk.NewDefaultClient()
-		if err != nil {
-			t.Fatal(err)
-		}
+		client := acc.Client(t)
 		cfg, err := sdk.ProfileConfig(testprofiles.Secondary)
 		if err != nil {
 			t.Fatal(err)
@@ -688,10 +685,7 @@ func checkAtLeastOneGrantPresentLimited() resource.TestCheckFunc {
 
 func getCurrentUser(t *testing.T) string {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := acc.Client(t)
 	user, err := client.ContextFunctions.CurrentUser(context.Background())
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/datasources/grants_acceptance_test.go
+++ b/pkg/datasources/grants_acceptance_test.go
@@ -8,7 +8,6 @@ import (
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testprofiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -374,14 +373,7 @@ func TestAcc_Grants_Of_Share(t *testing.T) {
 		t.Helper()
 
 		client := acc.Client(t)
-		cfg, err := sdk.ProfileConfig(testprofiles.Secondary)
-		if err != nil {
-			t.Fatal(err)
-		}
-		secondaryClient, err := sdk.NewClient(cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
+		secondaryClient := acc.SecondaryClient(t)
 		ctx := context.Background()
 
 		replicationAccounts, err := client.ReplicationFunctions.ShowReplicationAccounts(ctx)

--- a/pkg/resources/database_acceptance_test.go
+++ b/pkg/resources/database_acceptance_test.go
@@ -198,8 +198,7 @@ func TestAcc_Database_DefaultDataRetentionTime(t *testing.T) {
 		return vars
 	}
 
-	client, err := sdk.NewDefaultClient()
-	require.NoError(t, err)
+	client := acc.Client(t)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
@@ -288,8 +287,7 @@ func TestAcc_Database_DefaultDataRetentionTime_SetOutsideOfTerraform(t *testing.
 		return vars
 	}
 
-	client, err := sdk.NewDefaultClient()
-	require.NoError(t, err)
+	client := acc.Client(t)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
@@ -310,7 +308,7 @@ func TestAcc_Database_DefaultDataRetentionTime_SetOutsideOfTerraform(t *testing.
 			},
 			{
 				PreConfig: func() {
-					err = client.Databases.Alter(context.Background(), id, &sdk.AlterDatabaseOptions{
+					err := client.Databases.Alter(context.Background(), id, &sdk.AlterDatabaseOptions{
 						Set: &sdk.DatabaseSet{
 							DataRetentionTimeInDays: sdk.Int(20),
 						},
@@ -382,11 +380,10 @@ resource "snowflake_database" "db" {
 func dropDatabaseOutsideTerraform(t *testing.T, id string) {
 	t.Helper()
 
-	client, err := sdk.NewDefaultClient()
-	require.NoError(t, err)
+	client := acc.Client(t)
 	ctx := context.Background()
 
-	err = client.Databases.Drop(ctx, sdk.NewAccountObjectIdentifier(id), &sdk.DropDatabaseOptions{})
+	err := client.Databases.Drop(ctx, sdk.NewAccountObjectIdentifier(id), &sdk.DropDatabaseOptions{})
 	require.NoError(t, err)
 }
 
@@ -410,11 +407,10 @@ func getSecondaryAccount(t *testing.T) string {
 func testAccCheckDatabaseExistence(t *testing.T, id string, shouldExist bool) func(state *terraform.State) error {
 	t.Helper()
 	return func(state *terraform.State) error {
-		client, err := sdk.NewDefaultClient()
-		require.NoError(t, err)
+		client := acc.Client(t)
 		ctx := context.Background()
 
-		_, err = client.Databases.ShowByID(ctx, sdk.NewAccountObjectIdentifier(id))
+		_, err := client.Databases.ShowByID(ctx, sdk.NewAccountObjectIdentifier(id))
 		if shouldExist {
 			if err != nil {
 				return fmt.Errorf("error while retrieving database %s, err = %w", id, err)
@@ -431,10 +427,7 @@ func testAccCheckDatabaseExistence(t *testing.T, id string, shouldExist bool) fu
 func testAccCheckIfDatabaseIsReplicated(t *testing.T, id string) func(state *terraform.State) error {
 	t.Helper()
 	return func(state *terraform.State) error {
-		client, err := sdk.NewDefaultClient()
-		if err != nil {
-			return err
-		}
+		client := acc.Client(t)
 
 		ctx := context.Background()
 		replicationDatabases, err := client.ReplicationFunctions.ShowReplicationDatabases(ctx, nil)
@@ -492,10 +485,7 @@ func checkAccountAndDatabaseDataRetentionTime(id sdk.AccountObjectIdentifier, ex
 
 func createDatabaseOutsideTerraform(t *testing.T, name string) func() {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := acc.Client(t)
 	ctx := context.Background()
 
 	if err := client.Databases.Create(ctx, sdk.NewAccountObjectIdentifier(name), new(sdk.CreateDatabaseOptions)); err != nil {

--- a/pkg/resources/database_acceptance_test.go
+++ b/pkg/resources/database_acceptance_test.go
@@ -11,7 +11,6 @@ import (
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testprofiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -390,12 +389,7 @@ func dropDatabaseOutsideTerraform(t *testing.T, id string) {
 func getSecondaryAccount(t *testing.T) string {
 	t.Helper()
 
-	secondaryConfig, err := sdk.ProfileConfig(testprofiles.Secondary)
-	require.NoError(t, err)
-
-	secondaryClient, err := sdk.NewClient(secondaryConfig)
-	require.NoError(t, err)
-
+	secondaryClient := acc.SecondaryClient(t)
 	ctx := context.Background()
 
 	account, err := secondaryClient.ContextFunctions.CurrentAccount(ctx)

--- a/pkg/resources/dynamic_table_acceptance_test.go
+++ b/pkg/resources/dynamic_table_acceptance_test.go
@@ -446,10 +446,7 @@ func testAccCheckDynamicTableDestroy(s *terraform.State) error {
 // TODO [SNOW-926148]: currently this dynamic table is not cleaned in the test; it is removed when the whole database is removed - this currently happens in a sweeper
 func createDynamicTableOutsideTerraform(t *testing.T, schemaName string, dynamicTableName string, query string) {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := acc.Client(t)
 	ctx := context.Background()
 
 	dynamicTableId := sdk.NewSchemaObjectIdentifier(acc.TestDatabaseName, schemaName, dynamicTableName)

--- a/pkg/resources/external_table_acceptance_test.go
+++ b/pkg/resources/external_table_acceptance_test.go
@@ -73,7 +73,7 @@ func TestAcc_ExternalTable_basic(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					publishExternalTablesTestData(sdk.NewSchemaObjectIdentifier(acc.TestDatabaseName, acc.TestSchemaName, name), data)
+					publishExternalTablesTestData(t, sdk.NewSchemaObjectIdentifier(acc.TestDatabaseName, acc.TestSchemaName, name), data)
 				},
 				ConfigDirectory: config.TestStepDirectory(),
 				ConfigVariables: configVariables,
@@ -344,14 +344,12 @@ func externalTableContainsData(name string, contains func(rows []map[string]*any
 	}
 }
 
-func publishExternalTablesTestData(stageName sdk.SchemaObjectIdentifier, data []byte) {
-	client, err := sdk.NewDefaultClient()
-	if err != nil {
-		log.Fatal(err)
-	}
+func publishExternalTablesTestData(t *testing.T, stageName sdk.SchemaObjectIdentifier, data []byte) {
+	t.Helper()
+	client := acc.Client(t)
 	ctx := context.Background()
 
-	_, err = client.ExecForTests(ctx, fmt.Sprintf(`copy into @%s/external_tables_test_data/test_data from (select parse_json('%s')) overwrite = true`, stageName.FullyQualifiedName(), string(data)))
+	_, err := client.ExecForTests(ctx, fmt.Sprintf(`copy into @%s/external_tables_test_data/test_data from (select parse_json('%s')) overwrite = true`, stageName.FullyQualifiedName(), string(data)))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/resources/function_acceptance_test.go
+++ b/pkg/resources/function_acceptance_test.go
@@ -2,7 +2,6 @@ package resources_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -44,7 +43,7 @@ func testAccFunction(t *testing.T, configDirectory string) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
-		CheckDestroy: testAccCheckFunctionDestroy,
+		CheckDestroy: testAccCheckFunctionDestroy(t),
 		Steps: []resource.TestStep{
 			{
 				ConfigDirectory: acc.ConfigurationDirectory(configDirectory),
@@ -131,7 +130,7 @@ func TestAcc_Function_complex(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
-		CheckDestroy: testAccCheckFunctionDestroy,
+		CheckDestroy: testAccCheckFunctionDestroy(t),
 		Steps: []resource.TestStep{
 			{
 				ConfigDirectory: acc.ConfigurationDirectory("TestAcc_Function/complex"),
@@ -194,7 +193,7 @@ func TestAcc_Function_migrateFromVersion085(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
-		CheckDestroy: testAccCheckFunctionDestroy,
+		CheckDestroy: testAccCheckFunctionDestroy(t),
 
 		// Using the string config because of the validation in teststep_validate.go:
 		// teststep.Config.HasConfigurationFiles() returns true both for ConfigFile and ConfigDirectory.
@@ -248,22 +247,21 @@ resource "snowflake_function" "f" {
 `, database, schema, name)
 }
 
-func testAccCheckFunctionDestroy(s *terraform.State) error {
-	client, err := sdk.NewDefaultClient()
-	if err != nil {
-		return errors.New("client could not be instantiated")
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "snowflake_function" {
-			continue
+func testAccCheckFunctionDestroy(t *testing.T) func(s *terraform.State) error {
+	t.Helper()
+	client := acc.Client(t)
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "snowflake_function" {
+				continue
+			}
+			ctx := context.Background()
+			id := sdk.NewSchemaObjectIdentifier(rs.Primary.Attributes["database"], rs.Primary.Attributes["schema"], rs.Primary.Attributes["name"])
+			function, err := client.Functions.ShowByID(ctx, id)
+			if err == nil {
+				return fmt.Errorf("function %v still exists", function.Name)
+			}
 		}
-		ctx := context.Background()
-		id := sdk.NewSchemaObjectIdentifier(rs.Primary.Attributes["database"], rs.Primary.Attributes["schema"], rs.Primary.Attributes["name"])
-		function, err := client.Functions.ShowByID(ctx, id)
-		if err == nil {
-			return fmt.Errorf("function %v still exists", function.Name)
-		}
+		return nil
 	}
-	return nil
 }

--- a/pkg/resources/grant_ownership_acceptance_test.go
+++ b/pkg/resources/grant_ownership_acceptance_test.go
@@ -1078,14 +1078,12 @@ func TestAcc_GrantOwnership_OnAllTasks(t *testing.T) {
 
 func createDatabaseWithRoleAsOwner(t *testing.T, roleName string, databaseName string) func() {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	assert.NoError(t, err)
-
+	client := acc.Client(t)
 	ctx := context.Background()
 	databaseId := sdk.NewAccountObjectIdentifier(databaseName)
 	assert.NoError(t, client.Databases.Create(ctx, databaseId, &sdk.CreateDatabaseOptions{}))
 
-	err = client.Grants.GrantOwnership(
+	err := client.Grants.GrantOwnership(
 		ctx,
 		sdk.OwnershipGrantOn{
 			Object: &sdk.Object{
@@ -1108,11 +1106,9 @@ func createDatabaseWithRoleAsOwner(t *testing.T, roleName string, databaseName s
 func moveResourceOwnershipToAccountRole(t *testing.T, objectType sdk.ObjectType, objectName sdk.ObjectIdentifier, accountRoleName sdk.AccountObjectIdentifier) {
 	t.Helper()
 
-	client, err := sdk.NewDefaultClient()
-	assert.NoError(t, err)
-
+	client := acc.Client(t)
 	ctx := context.Background()
-	err = client.Grants.GrantOwnership(
+	err := client.Grants.GrantOwnership(
 		ctx,
 		sdk.OwnershipGrantOn{
 			Object: &sdk.Object{
@@ -1158,9 +1154,7 @@ func checkResourceOwnershipIsGranted(opts *sdk.ShowGrantOptions, grantOn sdk.Obj
 
 func createAccountRole(t *testing.T, name string) func() {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	assert.NoError(t, err)
-
+	client := acc.Client(t)
 	ctx := context.Background()
 	roleId := sdk.NewAccountObjectIdentifier(name)
 	assert.NoError(t, client.Roles.Create(ctx, sdk.NewCreateRoleRequest(roleId)))
@@ -1172,8 +1166,7 @@ func createAccountRole(t *testing.T, name string) func() {
 
 func createDatabase(t *testing.T, name string) func() {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	assert.NoError(t, err)
+	client := acc.Client(t)
 
 	ctx := context.Background()
 	roleId := sdk.NewAccountObjectIdentifier(name)
@@ -1186,8 +1179,7 @@ func createDatabase(t *testing.T, name string) func() {
 
 func grantOwnershipToTheCurrentRole(t *testing.T, on sdk.OwnershipGrantOn) {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	assert.NoError(t, err)
+	client := acc.Client(t)
 
 	ctx := context.Background()
 	currentRole, err := client.ContextFunctions.CurrentRole(ctx)
@@ -1206,8 +1198,7 @@ func grantOwnershipToTheCurrentRole(t *testing.T, on sdk.OwnershipGrantOn) {
 
 func getCurrentUser(t *testing.T) string {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	assert.NoError(t, err)
+	client := acc.Client(t)
 	currentUser, err := client.ContextFunctions.CurrentUser(context.Background())
 	assert.NoError(t, err)
 	return currentUser

--- a/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
@@ -1310,12 +1310,9 @@ func revokeAndGrantPrivilegesOnTableToAccountRole(
 	withGrantOption bool,
 ) {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := acc.Client(t)
 	ctx := context.Background()
-	err = client.Grants.RevokePrivilegesFromAccountRole(
+	err := client.Grants.RevokePrivilegesFromAccountRole(
 		ctx,
 		&sdk.AccountRoleGrantPrivileges{
 			SchemaObjectPrivileges: privileges,
@@ -1459,10 +1456,7 @@ func getSecondaryAccountName(t *testing.T) (string, error) {
 
 func getAccountName(t *testing.T) (string, error) {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := acc.Client(t)
 	return client.ContextFunctions.CurrentAccount(context.Background())
 }
 
@@ -1508,10 +1502,7 @@ func dropSharedDatabaseOnSecondaryAccount(t *testing.T, databaseName string, sha
 
 func createAccountRoleOutsideTerraform(t *testing.T, name string) func() {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := acc.Client(t)
 	ctx := context.Background()
 	roleId := sdk.NewAccountObjectIdentifier(name)
 	if err := client.Roles.Create(ctx, sdk.NewCreateRoleRequest(roleId).WithOrReplace(true)); err != nil {
@@ -1589,11 +1580,9 @@ func queriedAccountRolePrivilegesContainAtLeast(roleName sdk.AccountObjectIdenti
 func createExternalVolume(t *testing.T, externalVolumeName string) func() {
 	t.Helper()
 
-	client, err := sdk.NewDefaultClient()
-	require.NoError(t, err)
-
+	client := acc.Client(t)
 	ctx := context.Background()
-	_, err = client.ExecForTests(ctx, fmt.Sprintf(`create external volume "%s" storage_locations = (
+	_, err := client.ExecForTests(ctx, fmt.Sprintf(`create external volume "%s" storage_locations = (
     (
         name = 'test' 
         storage_provider = 's3' 

--- a/pkg/resources/grant_privileges_to_database_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_database_role_acceptance_test.go
@@ -1115,10 +1115,7 @@ func TestAcc_GrantPrivilegesToDatabaseRole_RemoveDatabaseRoleOutsideTerraform(t 
 
 func createDatabaseRoleOutsideTerraform(t *testing.T, databaseName string, name string) func() {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := acc.Client(t)
 	ctx := context.Background()
 	databaseRoleId := sdk.NewDatabaseObjectIdentifier(databaseName, name)
 	if err := client.DatabaseRoles.Create(ctx, sdk.NewCreateDatabaseRoleRequest(databaseRoleId).WithOrReplace(true)); err != nil {
@@ -1191,12 +1188,9 @@ func revokeAndGrantPrivilegesOnDatabaseToDatabaseRole(
 	withGrantOption bool,
 ) {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := acc.Client(t)
 	ctx := context.Background()
-	err = client.Grants.RevokePrivilegesFromDatabaseRole(
+	err := client.Grants.RevokePrivilegesFromDatabaseRole(
 		ctx,
 		&sdk.DatabaseRoleGrantPrivileges{
 			DatabasePrivileges: privileges,

--- a/pkg/resources/grant_privileges_to_share_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_share_acceptance_test.go
@@ -594,10 +594,7 @@ func testAccCheckSharePrivilegesRevoked() func(*terraform.State) error {
 
 func createShareOutsideTerraform(t *testing.T, name string) func() {
 	t.Helper()
-	client, err := sdk.NewDefaultClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := acc.Client(t)
 	ctx := context.Background()
 
 	if err := client.Shares.Create(ctx, sdk.NewAccountObjectIdentifier(name), new(sdk.CreateShareOptions)); err != nil {

--- a/pkg/resources/materialized_view_acceptance_test.go
+++ b/pkg/resources/materialized_view_acceptance_test.go
@@ -277,11 +277,10 @@ func testAccCheckMaterializedViewDestroy(s *terraform.State) error {
 func alterMaterializedViewQueryExternally(t *testing.T, id sdk.SchemaObjectIdentifier, query string, warehouse string) {
 	t.Helper()
 
-	client, err := sdk.NewDefaultClient()
-	require.NoError(t, err)
+	client := acc.Client(t)
 	ctx := context.Background()
 
-	err = client.Sessions.UseWarehouse(ctx, sdk.NewAccountObjectIdentifier(warehouse))
+	err := client.Sessions.UseWarehouse(ctx, sdk.NewAccountObjectIdentifier(warehouse))
 	require.NoError(t, err)
 
 	err = client.MaterializedViews.Create(ctx, sdk.NewCreateMaterializedViewRequest(id, query).WithOrReplace(sdk.Bool(true)))

--- a/pkg/resources/schema_acceptance_test.go
+++ b/pkg/resources/schema_acceptance_test.go
@@ -424,11 +424,10 @@ func setSchemaDataRetentionTime(t *testing.T, id sdk.DatabaseObjectIdentifier, d
 	t.Helper()
 
 	return func() {
-		client, err := sdk.NewDefaultClient()
-		require.NoError(t, err)
+		client := acc.Client(t)
 		ctx := context.Background()
 
-		err = client.Schemas.Alter(ctx, id, &sdk.AlterSchemaOptions{
+		err := client.Schemas.Alter(ctx, id, &sdk.AlterSchemaOptions{
 			Set: &sdk.SchemaSet{
 				DataRetentionTimeInDays: sdk.Int(days),
 			},
@@ -456,10 +455,9 @@ func testAccCheckSchemaDestroy(s *terraform.State) error {
 func removeSchemaOutsideOfTerraform(t *testing.T, databaseName string, schemaName string) {
 	t.Helper()
 
-	client, err := sdk.NewDefaultClient()
-	require.NoError(t, err)
+	client := acc.Client(t)
 	ctx := context.Background()
 
-	err = client.Schemas.Drop(ctx, sdk.NewDatabaseObjectIdentifier(databaseName, schemaName), new(sdk.DropSchemaOptions))
+	err := client.Schemas.Drop(ctx, sdk.NewDatabaseObjectIdentifier(databaseName, schemaName), new(sdk.DropSchemaOptions))
 	require.NoError(t, err)
 }

--- a/pkg/resources/table_acceptance_test.go
+++ b/pkg/resources/table_acceptance_test.go
@@ -1949,11 +1949,10 @@ func setTableDataRetentionTime(t *testing.T, id sdk.SchemaObjectIdentifier, days
 	t.Helper()
 
 	return func() {
-		client, err := sdk.NewDefaultClient()
-		require.NoError(t, err)
+		client := acc.Client(t)
 		ctx := context.Background()
 
-		err = client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithSet(sdk.NewTableSetRequest().WithDataRetentionTimeInDays(sdk.Int(days))))
+		err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithSet(sdk.NewTableSetRequest().WithDataRetentionTimeInDays(sdk.Int(days))))
 		require.NoError(t, err)
 	}
 }

--- a/pkg/resources/tag_masking_policy_association_acceptance_test.go
+++ b/pkg/resources/tag_masking_policy_association_acceptance_test.go
@@ -53,7 +53,7 @@ func TestAcc_TagMaskingPolicyAssociationsystem_functions_integration_testComplet
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
-		CheckDestroy: testAccCheckFunctionDestroy,
+		CheckDestroy: testAccCheckFunctionDestroy(t),
 		Steps: []resource.TestStep{
 			{
 				ConfigDirectory: acc.ConfigurationDirectory("TestAcc_TagMaskingPolicyAssociation/basic"),

--- a/pkg/resources/unsafe_execute_acceptance_test.go
+++ b/pkg/resources/unsafe_execute_acceptance_test.go
@@ -718,11 +718,10 @@ func generateUnsafeExecuteTestRoleName(t *testing.T) string {
 func createResourcesForExecuteUnsafeTestCaseForGrants(t *testing.T, dbId string, roleId string) {
 	t.Helper()
 
-	client, err := sdk.NewDefaultClient()
-	require.NoError(t, err)
+	client := acc.Client(t)
 	ctx := context.Background()
 
-	err = client.Databases.Create(ctx, sdk.NewAccountObjectIdentifier(dbId), &sdk.CreateDatabaseOptions{})
+	err := client.Databases.Create(ctx, sdk.NewAccountObjectIdentifier(dbId), &sdk.CreateDatabaseOptions{})
 	require.NoError(t, err)
 
 	err = client.Roles.Create(ctx, sdk.NewCreateRoleRequest(sdk.NewAccountObjectIdentifier(roleId)))
@@ -732,11 +731,10 @@ func createResourcesForExecuteUnsafeTestCaseForGrants(t *testing.T, dbId string,
 func dropResourcesForUnsafeExecuteTestCaseForGrants(t *testing.T, dbId string, roleId string) {
 	t.Helper()
 
-	client, err := sdk.NewDefaultClient()
-	require.NoError(t, err)
+	client := acc.Client(t)
 	ctx := context.Background()
 
-	err = client.Databases.Drop(ctx, sdk.NewAccountObjectIdentifier(dbId), &sdk.DropDatabaseOptions{})
+	err := client.Databases.Drop(ctx, sdk.NewAccountObjectIdentifier(dbId), &sdk.DropDatabaseOptions{})
 	assert.NoError(t, err)
 
 	err = client.Roles.Drop(ctx, sdk.NewDropRoleRequest(sdk.NewAccountObjectIdentifier(roleId)))
@@ -746,8 +744,7 @@ func dropResourcesForUnsafeExecuteTestCaseForGrants(t *testing.T, dbId string, r
 func verifyGrantExists(t *testing.T, roleId string, privilege sdk.AccountObjectPrivilege, shouldExist bool) func(state *terraform.State) error {
 	t.Helper()
 	return func(state *terraform.State) error {
-		client, err := sdk.NewDefaultClient()
-		require.NoError(t, err)
+		client := acc.Client(t)
 		ctx := context.Background()
 
 		grants, err := client.Grants.Show(ctx, &sdk.ShowGrantOptions{

--- a/pkg/resources/user_acceptance_test.go
+++ b/pkg/resources/user_acceptance_test.go
@@ -173,10 +173,7 @@ resource "snowflake_user" "test" {
 func removeUserOutsideOfTerraform(t *testing.T, name sdk.AccountObjectIdentifier) func() {
 	t.Helper()
 	return func() {
-		client, err := sdk.NewDefaultClient()
-		if err != nil {
-			t.Fatal(err)
-		}
+		client := acc.Client(t)
 		ctx := context.Background()
 		if err := client.Users.Drop(ctx, name); err != nil {
 			t.Fatalf("failed to drop user: %s", name.FullyQualifiedName())

--- a/pkg/resources/view_acceptance_test.go
+++ b/pkg/resources/view_acceptance_test.go
@@ -583,11 +583,10 @@ func testAccCheckViewDestroy(s *terraform.State) error {
 func alterViewQueryExternally(t *testing.T, id sdk.SchemaObjectIdentifier, query string) {
 	t.Helper()
 
-	client, err := sdk.NewDefaultClient()
-	require.NoError(t, err)
+	client := acc.Client(t)
 	ctx := context.Background()
 
-	err = client.Views.Create(ctx, sdk.NewCreateViewRequest(id, query).WithOrReplace(sdk.Bool(true)))
+	err := client.Views.Create(ctx, sdk.NewCreateViewRequest(id, query).WithOrReplace(sdk.Bool(true)))
 	require.NoError(t, err)
 }
 
@@ -596,14 +595,13 @@ func registerAccountRoleCleanup(t *testing.T, roleName string) {
 
 	roleId := sdk.NewAccountObjectIdentifier(roleName)
 
-	client, err := sdk.NewDefaultClient()
-	require.NoError(t, err)
+	client := acc.Client(t)
 	ctx := context.Background()
 
 	t.Cleanup(func() {
 		t.Logf("dropping account role (%s)", roleName)
 		// We remove the role, so the ownership will be changed back. The view will be deleted with db cleanup.
-		err = client.Roles.Drop(ctx, sdk.NewDropRoleRequest(roleId).WithIfExists(true))
+		err := client.Roles.Drop(ctx, sdk.NewDropRoleRequest(roleId).WithIfExists(true))
 		if err != nil {
 			t.Logf("failed to drop account role (%s), err = %s\n", roleName, err.Error())
 		}
@@ -617,8 +615,7 @@ func alterViewOwnershipExternally(t *testing.T, viewName string, roleName string
 	viewId := sdk.NewSchemaObjectIdentifier(acc.TestDatabaseName, acc.TestSchemaName, viewName)
 	roleId := sdk.NewAccountObjectIdentifier(roleName)
 
-	client, err := sdk.NewDefaultClient()
-	require.NoError(t, err)
+	client := acc.Client(t)
 	ctx := context.Background()
 
 	on := sdk.OwnershipGrantOn{
@@ -633,6 +630,6 @@ func alterViewOwnershipExternally(t *testing.T, viewName string, roleName string
 	currentGrants := sdk.OwnershipCurrentGrants{
 		OutboundPrivileges: sdk.Revoke,
 	}
-	err = client.Grants.GrantOwnership(ctx, on, to, &sdk.GrantOwnershipOptions{CurrentGrants: &currentGrants})
+	err := client.Grants.GrantOwnership(ctx, on, to, &sdk.GrantOwnershipOptions{CurrentGrants: &currentGrants})
 	require.NoError(t, err)
 }

--- a/pkg/resources/warehouse_acceptance_test.go
+++ b/pkg/resources/warehouse_acceptance_test.go
@@ -182,10 +182,9 @@ resource "snowflake_warehouse" "w2" {
 func alterWarehouseMaxConcurrencyLevelExternally(t *testing.T, warehouseId string, level int) {
 	t.Helper()
 
-	client, err := sdk.NewDefaultClient()
-	require.NoError(t, err)
+	client := acc.Client(t)
 	ctx := context.Background()
 
-	err = client.Warehouses.Alter(ctx, sdk.NewAccountObjectIdentifier(warehouseId), &sdk.AlterWarehouseOptions{Set: &sdk.WarehouseSet{MaxConcurrencyLevel: sdk.Int(level)}})
+	err := client.Warehouses.Alter(ctx, sdk.NewAccountObjectIdentifier(warehouseId), &sdk.AlterWarehouseOptions{Set: &sdk.WarehouseSet{MaxConcurrencyLevel: sdk.Int(level)}})
 	require.NoError(t, err)
 }

--- a/pkg/sdk/helper_test.go
+++ b/pkg/sdk/helper_test.go
@@ -20,19 +20,14 @@ func testClient(t *testing.T) *Client {
 func testSecondaryClient(t *testing.T) *Client {
 	t.Helper()
 
-	client, err := testClientFromProfile(t, testprofiles.Secondary)
+	config, err := ProfileConfig(testprofiles.Secondary)
+	if err != nil {
+		t.Skipf("Snowflake secondary account not configured. Must be set in ~./snowflake/config.yml with profile name: %s", testprofiles.Secondary)
+	}
+	client, err := NewClient(config)
 	if err != nil {
 		t.Skipf("Snowflake secondary account not configured. Must be set in ~./snowflake/config.yml with profile name: %s", testprofiles.Secondary)
 	}
 
 	return client
-}
-
-func testClientFromProfile(t *testing.T, profile string) (*Client, error) {
-	t.Helper()
-	config, err := ProfileConfig(profile)
-	if err != nil {
-		return nil, err
-	}
-	return NewClient(config)
 }


### PR DESCRIPTION
Result of SNOW-935947.

- the SDK default client was already setup earlier in the acceptance tests context; used in all valid places
- added secondary client setup to acceptance tests context and used in valid places