### PR TITLE
docs: update  documentation in snowflake_database resource (#2708)

### DIFF
--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -38,7 +38,7 @@ resource "snowflake_database" "from_share" {
   name    = "testing_4"
   comment = "test comment"
   from_share = {
-    provider = "org1.account1"
+    provider = "account_locator"
     share    = "share1"
   }
 }
@@ -57,7 +57,7 @@ resource "snowflake_database" "from_share" {
 - `data_retention_time_in_days` (Number) Number of days for which Snowflake retains historical data for performing Time Travel actions (SELECT, CLONE, UNDROP) on the object. A value of 0 effectively disables Time Travel for the specified database. Default value for this field is set to -1, which is a fallback to use Snowflake default. For more information, see [Understanding & Using Time Travel](https://docs.snowflake.com/en/user-guide/data-time-travel).
 - `from_database` (String) Specify a database to create a clone from.
 - `from_replica` (String) Specify a fully-qualified path to a database to create a replica from. A fully qualified path follows the format of `"<organization_name>"."<account_name>"."<db_name>"`. An example would be: `"myorg1"."account1"."db1"`
-- `from_share` (Map of String) Specify a provider and a share in this map to create a database from a share.
+- `from_share` (Map of String) Specify a `provider` and a `share` in this map to create a database from a share. As of version 0.87.0, the `provider` field requires the format of `"<account_locator>"`, which is now case-sensitive.
 - `is_transient` (Boolean) Specifies a database as transient. Transient databases do not have a Fail-safe period so they do not incur additional storage costs once they leave Time Travel; however, this means they are also not protected by Fail-safe in the event of a data loss.
 - `replication_configuration` (Block List, Max: 1) When set, specifies the configurations for database replication. (see [below for nested schema](#nestedblock--replication_configuration))
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -57,7 +57,7 @@ resource "snowflake_database" "from_share" {
 - `data_retention_time_in_days` (Number) Number of days for which Snowflake retains historical data for performing Time Travel actions (SELECT, CLONE, UNDROP) on the object. A value of 0 effectively disables Time Travel for the specified database. Default value for this field is set to -1, which is a fallback to use Snowflake default. For more information, see [Understanding & Using Time Travel](https://docs.snowflake.com/en/user-guide/data-time-travel).
 - `from_database` (String) Specify a database to create a clone from.
 - `from_replica` (String) Specify a fully-qualified path to a database to create a replica from. A fully qualified path follows the format of `"<organization_name>"."<account_name>"."<db_name>"`. An example would be: `"myorg1"."account1"."db1"`
-- `from_share` (Map of String) Specify a `provider` and a `share` in this map to create a database from a share. As of version 0.87.0, the `provider` field requires the format of `"<account_locator>"`, which is now case-sensitive.
+- `from_share` (Map of String) Specify a provider and a share in this map to create a database from a share. As of version 0.87.0, the provider field requires the format of account_locator.
 - `is_transient` (Boolean) Specifies a database as transient. Transient databases do not have a Fail-safe period so they do not incur additional storage costs once they leave Time Travel; however, this means they are also not protected by Fail-safe in the event of a data loss.
 - `replication_configuration` (Block List, Max: 1) When set, specifies the configurations for database replication. (see [below for nested schema](#nestedblock--replication_configuration))
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -38,7 +38,7 @@ resource "snowflake_database" "from_share" {
   name    = "testing_4"
   comment = "test comment"
   from_share = {
-    provider = "account_locator"
+    provider = "account1_locator"
     share    = "share1"
   }
 }

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -57,7 +57,7 @@ resource "snowflake_database" "from_share" {
 - `data_retention_time_in_days` (Number) Number of days for which Snowflake retains historical data for performing Time Travel actions (SELECT, CLONE, UNDROP) on the object. A value of 0 effectively disables Time Travel for the specified database. Default value for this field is set to -1, which is a fallback to use Snowflake default. For more information, see [Understanding & Using Time Travel](https://docs.snowflake.com/en/user-guide/data-time-travel).
 - `from_database` (String) Specify a database to create a clone from.
 - `from_replica` (String) Specify a fully-qualified path to a database to create a replica from. A fully qualified path follows the format of `"<organization_name>"."<account_name>"."<db_name>"`. An example would be: `"myorg1"."account1"."db1"`
-- `from_share` (Map of String) Specify a provider and a share in this map to create a database from a share. As of version 0.87.0, the provider field requires the format of account_locator.
+- `from_share` (Map of String) Specify a provider and a share in this map to create a database from a share. As of version 0.87.0, the provider field is the account locator.
 - `is_transient` (Boolean) Specifies a database as transient. Transient databases do not have a Fail-safe period so they do not incur additional storage costs once they leave Time Travel; however, this means they are also not protected by Fail-safe in the event of a data loss.
 - `replication_configuration` (Block List, Max: 1) When set, specifies the configurations for database replication. (see [below for nested schema](#nestedblock--replication_configuration))
 

--- a/examples/resources/snowflake_database/resource.tf
+++ b/examples/resources/snowflake_database/resource.tf
@@ -24,7 +24,7 @@ resource "snowflake_database" "from_share" {
   name    = "testing_4"
   comment = "test comment"
   from_share = {
-    provider = "org1.account1"
+    provider = "account1_locator"
     share    = "share1"
   }
 }

--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -44,7 +44,7 @@ var databaseSchema = map[string]*schema.Schema{
 	"from_share": {
 		Type:          schema.TypeMap,
 		Elem:          &schema.Schema{Type: schema.TypeString},
-		Description:   "Specify a provider and a share in this map to create a database from a share.",
+		Description:   "Specify a provider and a share in this map to create a database from a share. As of version 0.87.0, the provider field requires the format of account_locator.",
 		Optional:      true,
 		ForceNew:      true,
 		ConflictsWith: []string{"from_database", "from_replica"},

--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -44,7 +44,7 @@ var databaseSchema = map[string]*schema.Schema{
 	"from_share": {
 		Type:          schema.TypeMap,
 		Elem:          &schema.Schema{Type: schema.TypeString},
-		Description:   "Specify a provider and a share in this map to create a database from a share. As of version 0.87.0, the provider field requires the format of account_locator.",
+		Description:   "Specify a provider and a share in this map to create a database from a share. As of version 0.87.0, the provider field is the account locator.",
 		Optional:      true,
 		ForceNew:      true,
 		ConflictsWith: []string{"from_database", "from_replica"},

--- a/pkg/resources/testdata/TestAcc_GrantOwnership/OnObject_DatabaseRole_ToAccountRole/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantOwnership/OnObject_DatabaseRole_ToAccountRole/test.tf
@@ -7,7 +7,7 @@ resource "snowflake_database" "test" {
 }
 
 resource "snowflake_database_role" "test" {
-  name = var.database_role_name
+  name     = var.database_role_name
   database = snowflake_database.test.name
 }
 


### PR DESCRIPTION
The documentation for the `snowflake_database` resource's `from_share` property has been updated to reflect the necessary changes described in the migration guide v0.86.0 to v0.87.0. This update addresses the modification in the configuration format from `<org_name>.<account_name>` to `<account_locator>`, ensuring consistency with identifier types across the platform.

## References
* issue: https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2708
* https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/docs/resources/database.md
* https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#v0860--v0870