### PR TITLE
chore: Cleanup helpers poc

### DIFF
--- a/pkg/acceptance/helpers/database_client.go
+++ b/pkg/acceptance/helpers/database_client.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,35 @@ func (d *DatabaseClient) CreateDatabaseWithOptions(t *testing.T, id sdk.AccountO
 	return database, func() {
 		err := d.client().Drop(ctx, id, &sdk.DropDatabaseOptions{IfExists: sdk.Bool(true)})
 		require.NoError(t, err)
+		err = d.context.client.Sessions.UseSchema(ctx, sdk.NewDatabaseObjectIdentifier(d.context.database, d.context.schema))
+		require.NoError(t, err)
+	}
+}
+
+func (d *DatabaseClient) CreateSecondaryDatabaseWithOptions(t *testing.T, id sdk.AccountObjectIdentifier, externalId sdk.ExternalObjectIdentifier, opts *sdk.CreateSecondaryDatabaseOptions) (*sdk.Database, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	// TODO [926148]: make this wait better with tests stabilization
+	// waiting because sometimes creating secondary db right after primary creation resulted in error
+	time.Sleep(1 * time.Second)
+
+	err := d.client().CreateSecondary(ctx, id, externalId, opts)
+	require.NoError(t, err)
+
+	// TODO [926148]: make this wait better with tests stabilization
+	// waiting because sometimes secondary database is not shown as SHOW REPLICATION DATABASES results right after creation
+	time.Sleep(1 * time.Second)
+
+	database, err := d.client().ShowByID(ctx, id)
+	require.NoError(t, err)
+	return database, func() {
+		err := d.client().Drop(ctx, id, nil)
+		require.NoError(t, err)
+
+		// TODO [926148]: make this wait better with tests stabilization
+		// waiting because sometimes dropping primary db right after dropping the secondary resulted in error
+		time.Sleep(1 * time.Second)
 		err = d.context.client.Sessions.UseSchema(ctx, sdk.NewDatabaseObjectIdentifier(d.context.database, d.context.schema))
 		require.NoError(t, err)
 	}

--- a/pkg/acceptance/helpers/database_client.go
+++ b/pkg/acceptance/helpers/database_client.go
@@ -27,6 +27,11 @@ func (d *DatabaseClient) CreateDatabase(t *testing.T) (*sdk.Database, func()) {
 	return d.CreateDatabaseWithOptions(t, sdk.RandomAccountObjectIdentifier(), &sdk.CreateDatabaseOptions{})
 }
 
+func (d *DatabaseClient) CreateDatabaseWithName(t *testing.T, name string) (*sdk.Database, func()) {
+	t.Helper()
+	return d.CreateDatabaseWithOptions(t, sdk.NewAccountObjectIdentifier(name), &sdk.CreateDatabaseOptions{})
+}
+
 func (d *DatabaseClient) CreateDatabaseWithOptions(t *testing.T, id sdk.AccountObjectIdentifier, opts *sdk.CreateDatabaseOptions) (*sdk.Database, func()) {
 	t.Helper()
 	ctx := context.Background()
@@ -35,7 +40,7 @@ func (d *DatabaseClient) CreateDatabaseWithOptions(t *testing.T, id sdk.AccountO
 	database, err := d.client().ShowByID(ctx, id)
 	require.NoError(t, err)
 	return database, func() {
-		err := d.client().Drop(ctx, id, nil)
+		err := d.client().Drop(ctx, id, &sdk.DropDatabaseOptions{IfExists: sdk.Bool(true)})
 		require.NoError(t, err)
 		err = d.context.client.Sessions.UseSchema(ctx, sdk.NewDatabaseObjectIdentifier(d.context.database, d.context.schema))
 		require.NoError(t, err)

--- a/pkg/acceptance/helpers/database_client.go
+++ b/pkg/acceptance/helpers/database_client.go
@@ -40,7 +40,14 @@ func (d *DatabaseClient) CreateDatabaseWithOptions(t *testing.T, id sdk.AccountO
 	require.NoError(t, err)
 	database, err := d.client().ShowByID(ctx, id)
 	require.NoError(t, err)
-	return database, func() {
+	return database, d.DropDatabaseFunc(t, id)
+}
+
+func (d *DatabaseClient) DropDatabaseFunc(t *testing.T, id sdk.AccountObjectIdentifier) func() {
+	t.Helper()
+	ctx := context.Background()
+
+	return func() {
 		err := d.client().Drop(ctx, id, &sdk.DropDatabaseOptions{IfExists: sdk.Bool(true)})
 		require.NoError(t, err)
 		err = d.context.client.Sessions.UseSchema(ctx, sdk.NewDatabaseObjectIdentifier(d.context.database, d.context.schema))

--- a/pkg/acceptance/helpers/database_client.go
+++ b/pkg/acceptance/helpers/database_client.go
@@ -1,0 +1,43 @@
+package helpers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/stretchr/testify/require"
+)
+
+type DatabaseClient struct {
+	context *TestClientContext
+}
+
+func NewDatabaseClient(context *TestClientContext) *DatabaseClient {
+	return &DatabaseClient{
+		context: context,
+	}
+}
+
+func (d *DatabaseClient) client() sdk.Databases {
+	return d.context.client.Databases
+}
+
+func (d *DatabaseClient) CreateDatabase(t *testing.T) (*sdk.Database, func()) {
+	t.Helper()
+	return d.CreateDatabaseWithOptions(t, sdk.RandomAccountObjectIdentifier(), &sdk.CreateDatabaseOptions{})
+}
+
+func (d *DatabaseClient) CreateDatabaseWithOptions(t *testing.T, id sdk.AccountObjectIdentifier, opts *sdk.CreateDatabaseOptions) (*sdk.Database, func()) {
+	t.Helper()
+	ctx := context.Background()
+	err := d.client().Create(ctx, id, opts)
+	require.NoError(t, err)
+	database, err := d.client().ShowByID(ctx, id)
+	require.NoError(t, err)
+	return database, func() {
+		err := d.client().Drop(ctx, id, nil)
+		require.NoError(t, err)
+		err = d.context.client.Sessions.UseSchema(ctx, sdk.NewDatabaseObjectIdentifier(d.context.database, d.context.schema))
+		require.NoError(t, err)
+	}
+}

--- a/pkg/acceptance/helpers/test_client.go
+++ b/pkg/acceptance/helpers/test_client.go
@@ -1,0 +1,29 @@
+package helpers
+
+import "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+
+type TestClient struct {
+	context *TestClientContext
+
+	Database *DatabaseClient
+}
+
+func NewTestClient(c *sdk.Client, database string, schema string, warehouse string) *TestClient {
+	context := &TestClientContext{
+		client:    c,
+		database:  database,
+		schema:    schema,
+		warehouse: warehouse,
+	}
+	return &TestClient{
+		context:  context,
+		Database: NewDatabaseClient(context),
+	}
+}
+
+type TestClientContext struct {
+	client    *sdk.Client
+	database  string
+	schema    string
+	warehouse string
+}

--- a/pkg/acceptance/testing.go
+++ b/pkg/acceptance/testing.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testprofiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -72,12 +73,15 @@ func init() {
 		log.Panicf("Cannot instantiate new secondary client, err: %v", err)
 	}
 	atc.secondaryClient = secondaryClient
+
+	atc.testClient = helpers.NewTestClient(client, TestDatabaseName, TestSchemaName, TestWarehouseName)
 }
 
 type acceptanceTestContext struct {
 	config          *gosnowflake.Config
 	client          *sdk.Client
 	secondaryClient *sdk.Client
+	testClient      *helpers.TestClient
 }
 
 var TestAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
@@ -163,4 +167,8 @@ func SecondaryClient(t *testing.T) *sdk.Client {
 func DefaultConfig(t *testing.T) *gosnowflake.Config {
 	t.Helper()
 	return atc.config
+}
+
+func TestClient() *helpers.TestClient {
+	return atc.testClient
 }

--- a/pkg/acceptance/testing.go
+++ b/pkg/acceptance/testing.go
@@ -75,13 +75,15 @@ func init() {
 	atc.secondaryClient = secondaryClient
 
 	atc.testClient = helpers.NewTestClient(client, TestDatabaseName, TestSchemaName, TestWarehouseName)
+	atc.secondaryTestClient = helpers.NewTestClient(secondaryClient, TestDatabaseName, TestSchemaName, TestWarehouseName)
 }
 
 type acceptanceTestContext struct {
-	config          *gosnowflake.Config
-	client          *sdk.Client
-	secondaryClient *sdk.Client
-	testClient      *helpers.TestClient
+	config              *gosnowflake.Config
+	client              *sdk.Client
+	secondaryClient     *sdk.Client
+	testClient          *helpers.TestClient
+	secondaryTestClient *helpers.TestClient
 }
 
 var TestAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
@@ -170,5 +172,9 @@ func DefaultConfig(t *testing.T) *gosnowflake.Config {
 }
 
 func TestClient() *helpers.TestClient {
+	return atc.testClient
+}
+
+func SecondaryTestClient() *helpers.TestClient {
 	return atc.testClient
 }

--- a/pkg/acceptance/testing.go
+++ b/pkg/acceptance/testing.go
@@ -176,5 +176,5 @@ func TestClient() *helpers.TestClient {
 }
 
 func SecondaryTestClient() *helpers.TestClient {
-	return atc.testClient
+	return atc.secondaryTestClient
 }

--- a/pkg/resources/database_acceptance_test.go
+++ b/pkg/resources/database_acceptance_test.go
@@ -477,25 +477,3 @@ func checkAccountAndDatabaseDataRetentionTime(id sdk.AccountObjectIdentifier, ex
 		return nil
 	}
 }
-
-func createDatabaseOutsideTerraform(t *testing.T, name string) func() {
-	t.Helper()
-	client := acc.Client(t)
-	ctx := context.Background()
-
-	if err := client.Databases.Create(ctx, sdk.NewAccountObjectIdentifier(name), new(sdk.CreateDatabaseOptions)); err != nil {
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	return func() {
-		opts := new(sdk.DropDatabaseOptions)
-		opts.IfExists = sdk.Bool(true)
-		if err := client.Databases.Drop(ctx, sdk.NewAccountObjectIdentifier(name), opts); err != nil {
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-	}
-}

--- a/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_account_role_acceptance_test.go
@@ -1377,7 +1377,7 @@ func TestAcc_GrantPrivilegesToAccountRole_RemoveGrantedObjectOutsideTerraform(t 
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
-					databaseCleanup = createDatabaseOutsideTerraform(t, databaseName)
+					_, databaseCleanup = acc.TestClient().Database.CreateDatabaseWithName(t, databaseName)
 					t.Cleanup(createAccountRoleOutsideTerraform(t, name))
 				},
 				ConfigDirectory: acc.ConfigurationDirectory("TestAcc_GrantPrivilegesToAccountRole/OnAccountObject"),
@@ -1420,7 +1420,8 @@ func TestAcc_GrantPrivilegesToAccountRole_RemoveAccountRoleOutsideTerraform(t *t
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
-					t.Cleanup(createDatabaseOutsideTerraform(t, databaseName))
+					_, dbCleanup := acc.TestClient().Database.CreateDatabaseWithName(t, databaseName)
+					t.Cleanup(dbCleanup)
 					roleCleanup = createAccountRoleOutsideTerraform(t, name)
 					t.Cleanup(roleCleanup)
 				},

--- a/pkg/resources/grant_privileges_to_database_role_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_database_role_acceptance_test.go
@@ -1053,7 +1053,7 @@ func TestAcc_GrantPrivilegesToDatabaseRole_RemoveGrantedObjectOutsideTerraform(t
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
-					databaseCleanup = createDatabaseOutsideTerraform(t, databaseName)
+					_, databaseCleanup = acc.TestClient().Database.CreateDatabaseWithName(t, databaseName)
 					t.Cleanup(databaseCleanup)
 					// no need to clean the role, because database will be dropped
 					createDatabaseRoleOutsideTerraform(t, databaseName, name)
@@ -1096,7 +1096,8 @@ func TestAcc_GrantPrivilegesToDatabaseRole_RemoveDatabaseRoleOutsideTerraform(t 
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
-					t.Cleanup(createDatabaseOutsideTerraform(t, databaseName))
+					_, dbCleanup := acc.TestClient().Database.CreateDatabaseWithName(t, databaseName)
+					t.Cleanup(dbCleanup)
 					databaseRoleCleanup = createDatabaseRoleOutsideTerraform(t, databaseName, name)
 				},
 				ConfigDirectory: acc.ConfigurationDirectory("TestAcc_GrantPrivilegesToDatabaseRole/OnDatabase"),

--- a/pkg/resources/schema_acceptance_test.go
+++ b/pkg/resources/schema_acceptance_test.go
@@ -357,7 +357,8 @@ func TestAcc_Schema_RemoveSchemaOutsideOfTerraform(t *testing.T) {
 		"database_name": config.StringVariable(databaseName),
 	}
 
-	_, cleanupDatabase := acc.TestClient().Database.CreateDatabaseWithOptions(t, sdk.NewAccountObjectIdentifier(databaseName), &sdk.CreateDatabaseOptions{})
+	_, cleanupDatabase := acc.TestClient().Database.CreateDatabaseWithName(t, databaseName)
+	t.Cleanup(cleanupDatabase)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,

--- a/pkg/resources/schema_acceptance_test.go
+++ b/pkg/resources/schema_acceptance_test.go
@@ -357,7 +357,7 @@ func TestAcc_Schema_RemoveSchemaOutsideOfTerraform(t *testing.T) {
 		"database_name": config.StringVariable(databaseName),
 	}
 
-	cleanupDatabase := createDatabaseOutsideTerraform(t, databaseName)
+	_, cleanupDatabase := acc.TestClient().Database.CreateDatabaseWithOptions(t, sdk.NewAccountObjectIdentifier(databaseName), &sdk.CreateDatabaseOptions{})
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,

--- a/pkg/sdk/testint/client_unsafe_extensions_integration_test.go
+++ b/pkg/sdk/testint/client_unsafe_extensions_integration_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,11 +30,11 @@ func TestInt_Client_UnsafeQuery(t *testing.T) {
 	})
 
 	t.Run("test more results", func(t *testing.T) {
-		db1, db1Cleanup := acc.TestClient().Database.CreateDatabase(t)
+		db1, db1Cleanup := testClientHelper().Database.CreateDatabase(t)
 		t.Cleanup(db1Cleanup)
-		db2, db2Cleanup := acc.TestClient().Database.CreateDatabase(t)
+		db2, db2Cleanup := testClientHelper().Database.CreateDatabase(t)
 		t.Cleanup(db2Cleanup)
-		db3, db3Cleanup := acc.TestClient().Database.CreateDatabase(t)
+		db3, db3Cleanup := testClientHelper().Database.CreateDatabase(t)
 		t.Cleanup(db3Cleanup)
 
 		sql := "SHOW DATABASES"

--- a/pkg/sdk/testint/client_unsafe_extensions_integration_test.go
+++ b/pkg/sdk/testint/client_unsafe_extensions_integration_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,11 +32,11 @@ func TestInt_Client_UnsafeQuery(t *testing.T) {
 	})
 
 	t.Run("test more results", func(t *testing.T) {
-		db1, db1Cleanup := createDatabase(t, client)
+		db1, db1Cleanup := acc.TestClient().Database.CreateDatabase(t)
 		t.Cleanup(db1Cleanup)
-		db2, db2Cleanup := createDatabase(t, client)
+		db2, db2Cleanup := acc.TestClient().Database.CreateDatabase(t)
 		t.Cleanup(db2Cleanup)
-		db3, db3Cleanup := createDatabase(t, client)
+		db3, db3Cleanup := acc.TestClient().Database.CreateDatabase(t)
 		t.Cleanup(db3Cleanup)
 
 		sql := "SHOW DATABASES"

--- a/pkg/sdk/testint/context_functions_integration_test.go
+++ b/pkg/sdk/testint/context_functions_integration_test.go
@@ -3,8 +3,6 @@ package testint
 import (
 	"testing"
 
-	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,7 +66,7 @@ func TestInt_CurrentSessionDetails(t *testing.T) {
 func TestInt_CurrentDatabase(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
+	databaseTest, databaseCleanup := testClientHelper().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 	err := client.Sessions.UseDatabase(ctx, databaseTest.ID())
 	require.NoError(t, err)
@@ -82,7 +80,7 @@ func TestInt_CurrentSchema(t *testing.T) {
 	ctx := testContext(t)
 
 	// new database and schema created on purpose
-	databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
+	databaseTest, databaseCleanup := testClientHelper().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
 	t.Cleanup(schemaCleanup)

--- a/pkg/sdk/testint/context_functions_integration_test.go
+++ b/pkg/sdk/testint/context_functions_integration_test.go
@@ -3,6 +3,8 @@ package testint
 import (
 	"testing"
 
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,7 +68,7 @@ func TestInt_CurrentSessionDetails(t *testing.T) {
 func TestInt_CurrentDatabase(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
+	databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 	err := client.Sessions.UseDatabase(ctx, databaseTest.ID())
 	require.NoError(t, err)
@@ -80,7 +82,7 @@ func TestInt_CurrentSchema(t *testing.T) {
 	ctx := testContext(t)
 
 	// new database and schema created on purpose
-	databaseTest, databaseCleanup := createDatabase(t, client)
+	databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
 	t.Cleanup(schemaCleanup)

--- a/pkg/sdk/testint/database_role_integration_test.go
+++ b/pkg/sdk/testint/database_role_integration_test.go
@@ -3,8 +3,6 @@ package testint
 import (
 	"testing"
 
-	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
@@ -156,7 +154,7 @@ func TestInt_DatabaseRoles(t *testing.T) {
 	})
 
 	t.Run("alter database_role: rename to other database", func(t *testing.T) {
-		secondDatabase, secondDatabaseCleanup := acc.TestClient().Database.CreateDatabase(t)
+		secondDatabase, secondDatabaseCleanup := testClientHelper().Database.CreateDatabase(t)
 		t.Cleanup(secondDatabaseCleanup)
 
 		name := random.String()

--- a/pkg/sdk/testint/database_role_integration_test.go
+++ b/pkg/sdk/testint/database_role_integration_test.go
@@ -3,6 +3,8 @@ package testint
 import (
 	"testing"
 
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
@@ -154,7 +156,7 @@ func TestInt_DatabaseRoles(t *testing.T) {
 	})
 
 	t.Run("alter database_role: rename to other database", func(t *testing.T) {
-		secondDatabase, secondDatabaseCleanup := createDatabase(t, client)
+		secondDatabase, secondDatabaseCleanup := acc.TestClient().Database.CreateDatabase(t)
 		t.Cleanup(secondDatabaseCleanup)
 
 		name := random.String()

--- a/pkg/sdk/testint/databases_integration_test.go
+++ b/pkg/sdk/testint/databases_integration_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/assert"
@@ -54,7 +56,7 @@ func TestInt_DatabasesCreate(t *testing.T) {
 		databaseID := sdk.RandomAccountObjectIdentifier()
 
 		// new database and schema created on purpose
-		databaseTest, databaseCleanup := createDatabase(t, client)
+		databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
 		t.Cleanup(databaseCleanup)
 		schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
 		t.Cleanup(schemaCleanup)
@@ -113,7 +115,7 @@ func TestInt_CreateShared(t *testing.T) {
 	secondaryClient := testSecondaryClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := createDatabase(t, secondaryClient)
+	databaseTest, databaseCleanup := acc.SecondaryTestClient().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 
 	shareTest, shareCleanup := createShare(t, secondaryClient)
@@ -164,7 +166,7 @@ func TestInt_DatabasesCreateSecondary(t *testing.T) {
 func TestInt_DatabasesDrop(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, _ := createDatabase(t, client)
+	databaseTest, _ := acc.TestClient().Database.CreateDatabase(t)
 	databaseID := databaseTest.ID()
 	t.Run("drop with nil options", func(t *testing.T) {
 		err := client.Databases.Drop(ctx, databaseID, nil)
@@ -196,7 +198,7 @@ func TestInt_DatabasesDescribe(t *testing.T) {
 	client := testClient(t)
 
 	// new database and schema created on purpose
-	databaseTest, databaseCleanup := createDatabase(t, client)
+	databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
 	t.Cleanup(schemaCleanup)
@@ -218,7 +220,7 @@ func TestInt_DatabasesAlter(t *testing.T) {
 	ctx := testContext(t)
 
 	t.Run("renaming", func(t *testing.T) {
-		databaseTest, _ := createDatabase(t, client)
+		databaseTest, _ := acc.TestClient().Database.CreateDatabase(t)
 		newName := sdk.RandomAccountObjectIdentifier()
 		err := client.Databases.Alter(ctx, databaseTest.ID(), &sdk.AlterDatabaseOptions{
 			NewName: newName,
@@ -233,9 +235,9 @@ func TestInt_DatabasesAlter(t *testing.T) {
 	})
 
 	t.Run("swap with another database", func(t *testing.T) {
-		databaseTest, databaseCleanup := createDatabase(t, client)
+		databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
 		t.Cleanup(databaseCleanup)
-		databaseTest2, databaseCleanup2 := createDatabase(t, client)
+		databaseTest2, databaseCleanup2 := acc.TestClient().Database.CreateDatabase(t)
 		t.Cleanup(databaseCleanup2)
 		err := client.Databases.Alter(ctx, databaseTest.ID(), &sdk.AlterDatabaseOptions{
 			SwapWith: databaseTest2.ID(),
@@ -244,7 +246,7 @@ func TestInt_DatabasesAlter(t *testing.T) {
 	})
 
 	t.Run("setting and unsetting retention time + comment ", func(t *testing.T) {
-		databaseTest, _ := createDatabase(t, client)
+		databaseTest, _ := acc.TestClient().Database.CreateDatabase(t)
 		err := client.Databases.Alter(ctx, databaseTest.ID(), &sdk.AlterDatabaseOptions{
 			Set: &sdk.DatabaseSet{
 				DataRetentionTimeInDays: sdk.Int(42),
@@ -279,7 +281,7 @@ func TestInt_AlterFailover(t *testing.T) {
 	secondaryClient := testSecondaryClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := createDatabase(t, secondaryClient)
+	databaseTest, databaseCleanup := acc.SecondaryTestClient().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 
 	toAccounts := []sdk.AccountIdentifier{
@@ -315,10 +317,10 @@ func TestInt_AlterFailover(t *testing.T) {
 func TestInt_DatabasesShow(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := createDatabase(t, client)
+	databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 
-	databaseTest2, databaseCleanup2 := createDatabase(t, client)
+	databaseTest2, databaseCleanup2 := acc.TestClient().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup2)
 	t.Run("without show options", func(t *testing.T) {
 		databases, err := client.Databases.Show(ctx, nil)

--- a/pkg/sdk/testint/databases_integration_test.go
+++ b/pkg/sdk/testint/databases_integration_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/assert"
@@ -56,7 +54,7 @@ func TestInt_DatabasesCreate(t *testing.T) {
 		databaseID := sdk.RandomAccountObjectIdentifier()
 
 		// new database and schema created on purpose
-		databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
+		databaseTest, databaseCleanup := testClientHelper().Database.CreateDatabase(t)
 		t.Cleanup(databaseCleanup)
 		schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
 		t.Cleanup(schemaCleanup)
@@ -115,7 +113,7 @@ func TestInt_CreateShared(t *testing.T) {
 	secondaryClient := testSecondaryClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := acc.SecondaryTestClient().Database.CreateDatabase(t)
+	databaseTest, databaseCleanup := secondaryTestClientHelper().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 
 	shareTest, shareCleanup := createShare(t, secondaryClient)
@@ -166,7 +164,7 @@ func TestInt_DatabasesCreateSecondary(t *testing.T) {
 func TestInt_DatabasesDrop(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, _ := acc.TestClient().Database.CreateDatabase(t)
+	databaseTest, _ := testClientHelper().Database.CreateDatabase(t)
 	databaseID := databaseTest.ID()
 	t.Run("drop with nil options", func(t *testing.T) {
 		err := client.Databases.Drop(ctx, databaseID, nil)
@@ -198,7 +196,7 @@ func TestInt_DatabasesDescribe(t *testing.T) {
 	client := testClient(t)
 
 	// new database and schema created on purpose
-	databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
+	databaseTest, databaseCleanup := testClientHelper().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
 	t.Cleanup(schemaCleanup)
@@ -220,7 +218,7 @@ func TestInt_DatabasesAlter(t *testing.T) {
 	ctx := testContext(t)
 
 	t.Run("renaming", func(t *testing.T) {
-		databaseTest, _ := acc.TestClient().Database.CreateDatabase(t)
+		databaseTest, _ := testClientHelper().Database.CreateDatabase(t)
 		newName := sdk.RandomAccountObjectIdentifier()
 		err := client.Databases.Alter(ctx, databaseTest.ID(), &sdk.AlterDatabaseOptions{
 			NewName: newName,
@@ -235,9 +233,9 @@ func TestInt_DatabasesAlter(t *testing.T) {
 	})
 
 	t.Run("swap with another database", func(t *testing.T) {
-		databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
+		databaseTest, databaseCleanup := testClientHelper().Database.CreateDatabase(t)
 		t.Cleanup(databaseCleanup)
-		databaseTest2, databaseCleanup2 := acc.TestClient().Database.CreateDatabase(t)
+		databaseTest2, databaseCleanup2 := testClientHelper().Database.CreateDatabase(t)
 		t.Cleanup(databaseCleanup2)
 		err := client.Databases.Alter(ctx, databaseTest.ID(), &sdk.AlterDatabaseOptions{
 			SwapWith: databaseTest2.ID(),
@@ -246,7 +244,7 @@ func TestInt_DatabasesAlter(t *testing.T) {
 	})
 
 	t.Run("setting and unsetting retention time + comment ", func(t *testing.T) {
-		databaseTest, _ := acc.TestClient().Database.CreateDatabase(t)
+		databaseTest, _ := testClientHelper().Database.CreateDatabase(t)
 		err := client.Databases.Alter(ctx, databaseTest.ID(), &sdk.AlterDatabaseOptions{
 			Set: &sdk.DatabaseSet{
 				DataRetentionTimeInDays: sdk.Int(42),
@@ -281,7 +279,7 @@ func TestInt_AlterFailover(t *testing.T) {
 	secondaryClient := testSecondaryClient(t)
 	ctx := testContext(t)
 
-	databaseTest, databaseCleanup := acc.SecondaryTestClient().Database.CreateDatabase(t)
+	databaseTest, databaseCleanup := secondaryTestClientHelper().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 
 	toAccounts := []sdk.AccountIdentifier{
@@ -317,10 +315,10 @@ func TestInt_AlterFailover(t *testing.T) {
 func TestInt_DatabasesShow(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-	databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
+	databaseTest, databaseCleanup := testClientHelper().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 
-	databaseTest2, databaseCleanup2 := acc.TestClient().Database.CreateDatabase(t)
+	databaseTest2, databaseCleanup2 := testClientHelper().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup2)
 	t.Run("without show options", func(t *testing.T) {
 		databases, err := client.Databases.Show(ctx, nil)

--- a/pkg/sdk/testint/databases_integration_test.go
+++ b/pkg/sdk/testint/databases_integration_test.go
@@ -28,7 +28,7 @@ func TestInt_DatabasesCreate(t *testing.T) {
 	})
 
 	t.Run("as clone", func(t *testing.T) {
-		cloneDatabase, cloneDatabaseCleanup := createDatabase(t, client)
+		cloneDatabase, cloneDatabaseCleanup := testClientHelper().Database.CreateDatabase(t)
 		t.Cleanup(cloneDatabaseCleanup)
 		databaseID := sdk.RandomAccountObjectIdentifier()
 		opts := &sdk.CreateDatabaseOptions{

--- a/pkg/sdk/testint/external_functions_integration_test.go
+++ b/pkg/sdk/testint/external_functions_integration_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/require"
@@ -222,7 +220,7 @@ func TestInt_ExternalFunctions(t *testing.T) {
 	})
 
 	t.Run("show external function: with in", func(t *testing.T) {
-		otherDb, otherDbCleanup := acc.TestClient().Database.CreateDatabase(t)
+		otherDb, otherDbCleanup := testClientHelper().Database.CreateDatabase(t)
 		t.Cleanup(otherDbCleanup)
 
 		e1 := createExternalFunction(t)

--- a/pkg/sdk/testint/external_functions_integration_test.go
+++ b/pkg/sdk/testint/external_functions_integration_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/require"
@@ -220,7 +222,7 @@ func TestInt_ExternalFunctions(t *testing.T) {
 	})
 
 	t.Run("show external function: with in", func(t *testing.T) {
-		otherDb, otherDbCleanup := createDatabase(t, testClient(t))
+		otherDb, otherDbCleanup := acc.TestClient().Database.CreateDatabase(t)
 		t.Cleanup(otherDbCleanup)
 
 		e1 := createExternalFunction(t)

--- a/pkg/sdk/testint/failover_groups_integration_test.go
+++ b/pkg/sdk/testint/failover_groups_integration_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
@@ -615,7 +613,7 @@ func TestInt_FailoverGroupsAlterSource(t *testing.T) {
 		require.NoError(t, err)
 
 		// create a temp database
-		databaseTest, cleanupDatabase := acc.TestClient().Database.CreateDatabase(t)
+		databaseTest, cleanupDatabase := testClientHelper().Database.CreateDatabase(t)
 		t.Cleanup(cleanupDatabase)
 
 		// now add database to allowed databases of failover group 1
@@ -664,7 +662,7 @@ func TestInt_FailoverGroupsAlterTarget(t *testing.T) {
 	secondaryClientID := getAccountIdentifier(t, secondaryClient)
 
 	// create a temp database
-	databaseTest, cleanupDatabase := acc.TestClient().Database.CreateDatabase(t)
+	databaseTest, cleanupDatabase := testClientHelper().Database.CreateDatabase(t)
 	t.Cleanup(cleanupDatabase)
 
 	// create a failover group in primary account and share with target account

--- a/pkg/sdk/testint/failover_groups_integration_test.go
+++ b/pkg/sdk/testint/failover_groups_integration_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
@@ -613,7 +615,7 @@ func TestInt_FailoverGroupsAlterSource(t *testing.T) {
 		require.NoError(t, err)
 
 		// create a temp database
-		databaseTest, cleanupDatabase := createDatabase(t, client)
+		databaseTest, cleanupDatabase := acc.TestClient().Database.CreateDatabase(t)
 		t.Cleanup(cleanupDatabase)
 
 		// now add database to allowed databases of failover group 1
@@ -662,7 +664,7 @@ func TestInt_FailoverGroupsAlterTarget(t *testing.T) {
 	secondaryClientID := getAccountIdentifier(t, secondaryClient)
 
 	// create a temp database
-	databaseTest, cleanupDatabase := createDatabase(t, client)
+	databaseTest, cleanupDatabase := acc.TestClient().Database.CreateDatabase(t)
 	t.Cleanup(cleanupDatabase)
 
 	// create a failover group in primary account and share with target account

--- a/pkg/sdk/testint/file_format_integration_test.go
+++ b/pkg/sdk/testint/file_format_integration_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/assert"
@@ -504,7 +506,7 @@ func TestInt_FileFormatsShowById(t *testing.T) {
 	t.Cleanup(cleanupFileFormat)
 
 	// new database and schema created on purpose
-	databaseTest2, cleanupDatabase2 := createDatabase(t, client)
+	databaseTest2, cleanupDatabase2 := acc.TestClient().Database.CreateDatabase(t)
 	t.Cleanup(cleanupDatabase2)
 	schemaTest2, cleanupSchema2 := createSchema(t, client, databaseTest2)
 	t.Cleanup(cleanupSchema2)

--- a/pkg/sdk/testint/file_format_integration_test.go
+++ b/pkg/sdk/testint/file_format_integration_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/assert"
@@ -506,7 +504,7 @@ func TestInt_FileFormatsShowById(t *testing.T) {
 	t.Cleanup(cleanupFileFormat)
 
 	// new database and schema created on purpose
-	databaseTest2, cleanupDatabase2 := acc.TestClient().Database.CreateDatabase(t)
+	databaseTest2, cleanupDatabase2 := testClientHelper().Database.CreateDatabase(t)
 	t.Cleanup(cleanupDatabase2)
 	schemaTest2, cleanupSchema2 := createSchema(t, client, databaseTest2)
 	t.Cleanup(cleanupSchema2)

--- a/pkg/sdk/testint/helpers_test.go
+++ b/pkg/sdk/testint/helpers_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
 
@@ -45,25 +44,6 @@ func useWarehouse(t *testing.T, client *sdk.Client, warehouseID sdk.AccountObjec
 	require.NoError(t, err)
 	return func() {
 		err = client.Sessions.UseWarehouse(ctx, testWarehouse(t).ID())
-		require.NoError(t, err)
-	}
-}
-
-func createSecondaryDatabaseWithOptions(t *testing.T, client *sdk.Client, id sdk.AccountObjectIdentifier, externalId sdk.ExternalObjectIdentifier, opts *sdk.CreateSecondaryDatabaseOptions) (*sdk.Database, func()) {
-	t.Helper()
-	ctx := context.Background()
-	err := client.Databases.CreateSecondary(ctx, id, externalId, opts)
-	require.NoError(t, err)
-	database, err := client.Databases.ShowByID(ctx, id)
-	require.NoError(t, err)
-	return database, func() {
-		err := client.Databases.Drop(ctx, id, nil)
-		require.NoError(t, err)
-
-		// TODO [926148]: make this wait better with tests stabilization
-		// waiting because sometimes dropping primary db right after dropping the secondary resulted in error
-		time.Sleep(1 * time.Second)
-		err = client.Sessions.UseSchema(ctx, sdk.NewDatabaseObjectIdentifier(TestDatabaseName, TestSchemaName))
 		require.NoError(t, err)
 	}
 }

--- a/pkg/sdk/testint/helpers_test.go
+++ b/pkg/sdk/testint/helpers_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/require"
@@ -45,31 +47,6 @@ func useWarehouse(t *testing.T, client *sdk.Client, warehouseID sdk.AccountObjec
 		err = client.Sessions.UseWarehouse(ctx, testWarehouse(t).ID())
 		require.NoError(t, err)
 	}
-}
-
-func createDatabase(t *testing.T, client *sdk.Client) (*sdk.Database, func()) {
-	t.Helper()
-	return createDatabaseWithOptions(t, client, sdk.RandomAccountObjectIdentifier(), &sdk.CreateDatabaseOptions{})
-}
-
-func createDatabaseWithOptions(t *testing.T, client *sdk.Client, id sdk.AccountObjectIdentifier, opts *sdk.CreateDatabaseOptions) (*sdk.Database, func()) {
-	t.Helper()
-	ctx := context.Background()
-	err := client.Databases.Create(ctx, id, opts)
-	require.NoError(t, err)
-	database, err := client.Databases.ShowByID(ctx, id)
-	require.NoError(t, err)
-	return database, func() {
-		err := client.Databases.Drop(ctx, id, nil)
-		require.NoError(t, err)
-		err = client.Sessions.UseSchema(ctx, sdk.NewDatabaseObjectIdentifier(TestDatabaseName, TestSchemaName))
-		require.NoError(t, err)
-	}
-}
-
-func createSecondaryDatabase(t *testing.T, client *sdk.Client, externalId sdk.ExternalObjectIdentifier) (*sdk.Database, func()) {
-	t.Helper()
-	return createSecondaryDatabaseWithOptions(t, client, sdk.RandomAccountObjectIdentifier(), externalId, &sdk.CreateSecondaryDatabaseOptions{})
 }
 
 func createSecondaryDatabaseWithOptions(t *testing.T, client *sdk.Client, id sdk.AccountObjectIdentifier, externalId sdk.ExternalObjectIdentifier, opts *sdk.CreateSecondaryDatabaseOptions) (*sdk.Database, func()) {
@@ -203,7 +180,7 @@ func createDynamicTableWithOptions(t *testing.T, client *sdk.Client, warehouse *
 	}
 	var databaseCleanup func()
 	if database == nil {
-		database, databaseCleanup = createDatabase(t, client)
+		database, databaseCleanup = acc.TestClient().Database.CreateDatabase(t)
 	}
 	var schemaCleanup func()
 	if schema == nil {
@@ -338,7 +315,7 @@ func createPasswordPolicyWithOptions(t *testing.T, client *sdk.Client, database 
 	t.Helper()
 	var databaseCleanup func()
 	if database == nil {
-		database, databaseCleanup = createDatabase(t, client)
+		database, databaseCleanup = acc.TestClient().Database.CreateDatabase(t)
 	}
 	var schemaCleanup func()
 	if schema == nil {
@@ -475,7 +452,7 @@ func createMaskingPolicyWithOptions(t *testing.T, client *sdk.Client, database *
 	t.Helper()
 	var databaseCleanup func()
 	if database == nil {
-		database, databaseCleanup = createDatabase(t, client)
+		database, databaseCleanup = acc.TestClient().Database.CreateDatabase(t)
 	}
 	var schemaCleanup func()
 	if schema == nil {
@@ -522,7 +499,7 @@ func createAlertWithOptions(t *testing.T, client *sdk.Client, database *sdk.Data
 	t.Helper()
 	var databaseCleanup func()
 	if database == nil {
-		database, databaseCleanup = createDatabase(t, client)
+		database, databaseCleanup = acc.TestClient().Database.CreateDatabase(t)
 	}
 	var schemaCleanup func()
 	if schema == nil {

--- a/pkg/sdk/testint/helpers_test.go
+++ b/pkg/sdk/testint/helpers_test.go
@@ -9,8 +9,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/require"
@@ -160,7 +158,7 @@ func createDynamicTableWithOptions(t *testing.T, client *sdk.Client, warehouse *
 	}
 	var databaseCleanup func()
 	if database == nil {
-		database, databaseCleanup = acc.TestClient().Database.CreateDatabase(t)
+		database, databaseCleanup = testClientHelper().Database.CreateDatabase(t)
 	}
 	var schemaCleanup func()
 	if schema == nil {
@@ -295,7 +293,7 @@ func createPasswordPolicyWithOptions(t *testing.T, client *sdk.Client, database 
 	t.Helper()
 	var databaseCleanup func()
 	if database == nil {
-		database, databaseCleanup = acc.TestClient().Database.CreateDatabase(t)
+		database, databaseCleanup = testClientHelper().Database.CreateDatabase(t)
 	}
 	var schemaCleanup func()
 	if schema == nil {
@@ -432,7 +430,7 @@ func createMaskingPolicyWithOptions(t *testing.T, client *sdk.Client, database *
 	t.Helper()
 	var databaseCleanup func()
 	if database == nil {
-		database, databaseCleanup = acc.TestClient().Database.CreateDatabase(t)
+		database, databaseCleanup = testClientHelper().Database.CreateDatabase(t)
 	}
 	var schemaCleanup func()
 	if schema == nil {
@@ -479,7 +477,7 @@ func createAlertWithOptions(t *testing.T, client *sdk.Client, database *sdk.Data
 	t.Helper()
 	var databaseCleanup func()
 	if database == nil {
-		database, databaseCleanup = acc.TestClient().Database.CreateDatabase(t)
+		database, databaseCleanup = testClientHelper().Database.CreateDatabase(t)
 	}
 	var schemaCleanup func()
 	if schema == nil {

--- a/pkg/sdk/testint/replication_functions_integration_test.go
+++ b/pkg/sdk/testint/replication_functions_integration_test.go
@@ -3,8 +3,6 @@ package testint
 import (
 	"testing"
 
-	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/assert"
@@ -37,9 +35,9 @@ func TestInt_ShowReplicationDatabases(t *testing.T) {
 	db1Name := random.AlphaN(10)
 	db2Name := random.AlphaN(10)
 	db3Name := random.AlphaN(10)
-	db, dbCleanup := acc.TestClient().Database.CreateDatabaseWithName(t, db1Name)
+	db, dbCleanup := testClientHelper().Database.CreateDatabaseWithName(t, db1Name)
 	t.Cleanup(dbCleanup)
-	db2, dbCleanup2 := acc.TestClient().Database.CreateDatabaseWithName(t, db2Name)
+	db2, dbCleanup2 := testClientHelper().Database.CreateDatabaseWithName(t, db2Name)
 	t.Cleanup(dbCleanup2)
 
 	err = client.Databases.AlterReplication(ctx, db.ID(), &sdk.AlterDatabaseReplicationOptions{EnableReplication: &sdk.EnableReplication{ToAccounts: []sdk.AccountIdentifier{secondaryAccountId}}})
@@ -47,7 +45,7 @@ func TestInt_ShowReplicationDatabases(t *testing.T) {
 	err = client.Databases.AlterReplication(ctx, db2.ID(), &sdk.AlterDatabaseReplicationOptions{EnableReplication: &sdk.EnableReplication{ToAccounts: []sdk.AccountIdentifier{secondaryAccountId}}})
 	require.NoError(t, err)
 
-	db3, dbCleanup3 := acc.SecondaryTestClient().Database.CreateSecondaryDatabaseWithOptions(t, sdk.NewAccountObjectIdentifier(db3Name), sdk.NewExternalObjectIdentifier(accountId, db.ID()), &sdk.CreateSecondaryDatabaseOptions{})
+	db3, dbCleanup3 := testClientHelper().Database.CreateSecondaryDatabaseWithOptions(t, sdk.NewAccountObjectIdentifier(db3Name), sdk.NewExternalObjectIdentifier(accountId, db.ID()), &sdk.CreateSecondaryDatabaseOptions{})
 	t.Cleanup(dbCleanup3)
 
 	getByName := func(replicationDatabases []sdk.ReplicationDatabase, name sdk.AccountObjectIdentifier) *sdk.ReplicationDatabase {

--- a/pkg/sdk/testint/replication_functions_integration_test.go
+++ b/pkg/sdk/testint/replication_functions_integration_test.go
@@ -2,7 +2,6 @@ package testint
 
 import (
 	"testing"
-	"time"
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
 
@@ -48,15 +47,8 @@ func TestInt_ShowReplicationDatabases(t *testing.T) {
 	err = client.Databases.AlterReplication(ctx, db2.ID(), &sdk.AlterDatabaseReplicationOptions{EnableReplication: &sdk.EnableReplication{ToAccounts: []sdk.AccountIdentifier{secondaryAccountId}}})
 	require.NoError(t, err)
 
-	// TODO [926148]: make this wait better with tests stabilization
-	// waiting because sometimes creating secondary db right after primary creation resulted in error
-	time.Sleep(1 * time.Second)
-	db3, dbCleanup3 := createSecondaryDatabaseWithOptions(t, secondaryClient, sdk.NewAccountObjectIdentifier(db3Name), sdk.NewExternalObjectIdentifier(accountId, db.ID()), &sdk.CreateSecondaryDatabaseOptions{})
+	db3, dbCleanup3 := acc.SecondaryTestClient().Database.CreateSecondaryDatabaseWithOptions(t, sdk.NewAccountObjectIdentifier(db3Name), sdk.NewExternalObjectIdentifier(accountId, db.ID()), &sdk.CreateSecondaryDatabaseOptions{})
 	t.Cleanup(dbCleanup3)
-
-	// TODO [926148]: make this wait better with tests stabilization
-	// waiting because sometimes secondary database is not shown as SHOW REPLICATION DATABASES results right after creation
-	time.Sleep(1 * time.Second)
 
 	getByName := func(replicationDatabases []sdk.ReplicationDatabase, name sdk.AccountObjectIdentifier) *sdk.ReplicationDatabase {
 		for _, rdb := range replicationDatabases {

--- a/pkg/sdk/testint/replication_functions_integration_test.go
+++ b/pkg/sdk/testint/replication_functions_integration_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/assert"
@@ -36,9 +38,9 @@ func TestInt_ShowReplicationDatabases(t *testing.T) {
 	db1Name := random.AlphaN(10)
 	db2Name := random.AlphaN(10)
 	db3Name := random.AlphaN(10)
-	db, dbCleanup := createDatabaseWithOptions(t, client, sdk.NewAccountObjectIdentifier(db1Name), &sdk.CreateDatabaseOptions{})
+	db, dbCleanup := acc.TestClient().Database.CreateDatabaseWithName(t, db1Name)
 	t.Cleanup(dbCleanup)
-	db2, dbCleanup2 := createDatabaseWithOptions(t, client, sdk.NewAccountObjectIdentifier(db2Name), &sdk.CreateDatabaseOptions{})
+	db2, dbCleanup2 := acc.TestClient().Database.CreateDatabaseWithName(t, db2Name)
 	t.Cleanup(dbCleanup2)
 
 	err = client.Databases.AlterReplication(ctx, db.ID(), &sdk.AlterDatabaseReplicationOptions{EnableReplication: &sdk.EnableReplication{ToAccounts: []sdk.AccountIdentifier{secondaryAccountId}}})

--- a/pkg/sdk/testint/sessions_integration_test.go
+++ b/pkg/sdk/testint/sessions_integration_test.go
@@ -3,8 +3,6 @@ package testint
 import (
 	"testing"
 
-	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -126,7 +124,7 @@ func TestInt_UseDatabase(t *testing.T) {
 		require.NoError(t, err)
 	})
 	// new database created on purpose
-	database, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
+	database, databaseCleanup := testClientHelper().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 	err := client.Sessions.UseDatabase(ctx, database.ID())
 	require.NoError(t, err)
@@ -145,7 +143,7 @@ func TestInt_UseSchema(t *testing.T) {
 		require.NoError(t, err)
 	})
 	// new database and schema created on purpose
-	database, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
+	database, databaseCleanup := testClientHelper().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 	schema, schemaCleanup := createSchema(t, client, database)
 	t.Cleanup(schemaCleanup)

--- a/pkg/sdk/testint/sessions_integration_test.go
+++ b/pkg/sdk/testint/sessions_integration_test.go
@@ -3,6 +3,8 @@ package testint
 import (
 	"testing"
 
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -124,7 +126,7 @@ func TestInt_UseDatabase(t *testing.T) {
 		require.NoError(t, err)
 	})
 	// new database created on purpose
-	database, databaseCleanup := createDatabase(t, client)
+	database, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 	err := client.Sessions.UseDatabase(ctx, database.ID())
 	require.NoError(t, err)
@@ -143,7 +145,7 @@ func TestInt_UseSchema(t *testing.T) {
 		require.NoError(t, err)
 	})
 	// new database and schema created on purpose
-	database, databaseCleanup := createDatabase(t, client)
+	database, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 	schema, schemaCleanup := createSchema(t, client, database)
 	t.Cleanup(schemaCleanup)

--- a/pkg/sdk/testint/setup_test.go
+++ b/pkg/sdk/testint/setup_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testprofiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
@@ -83,6 +84,8 @@ type integrationTestContext struct {
 	secondarySchemaCleanup    func()
 	secondaryWarehouse        *sdk.Warehouse
 	secondaryWarehouseCleanup func()
+
+	testClient *helpers.TestClient
 }
 
 func (itc *integrationTestContext) initialize() error {
@@ -157,6 +160,8 @@ func (itc *integrationTestContext) initialize() error {
 	}
 	itc.secondaryWarehouse = secondaryWarehouse
 	itc.secondaryWarehouseCleanup = secondaryWarehouseCleanup
+
+	itc.testClient = helpers.NewTestClient(c, TestDatabaseName, TestSchemaName, TestWarehouseName)
 
 	return nil
 }
@@ -261,4 +266,8 @@ func testSecondaryWarehouse(t *testing.T) *sdk.Warehouse {
 func testConfig(t *testing.T) *gosnowflake.Config {
 	t.Helper()
 	return itc.config
+}
+
+func testClientHelper() *helpers.TestClient {
+	return itc.testClient
 }

--- a/pkg/sdk/testint/setup_test.go
+++ b/pkg/sdk/testint/setup_test.go
@@ -85,7 +85,8 @@ type integrationTestContext struct {
 	secondaryWarehouse        *sdk.Warehouse
 	secondaryWarehouseCleanup func()
 
-	testClient *helpers.TestClient
+	testClient          *helpers.TestClient
+	secondaryTestClient *helpers.TestClient
 }
 
 func (itc *integrationTestContext) initialize() error {
@@ -162,6 +163,7 @@ func (itc *integrationTestContext) initialize() error {
 	itc.secondaryWarehouseCleanup = secondaryWarehouseCleanup
 
 	itc.testClient = helpers.NewTestClient(c, TestDatabaseName, TestSchemaName, TestWarehouseName)
+	itc.secondaryTestClient = helpers.NewTestClient(secondaryClient, TestDatabaseName, TestSchemaName, TestWarehouseName)
 
 	return nil
 }
@@ -270,4 +272,8 @@ func testConfig(t *testing.T) *gosnowflake.Config {
 
 func testClientHelper() *helpers.TestClient {
 	return itc.testClient
+}
+
+func secondaryTestClientHelper() *helpers.TestClient {
+	return itc.secondaryTestClient
 }

--- a/pkg/sdk/testint/shares_integration_test.go
+++ b/pkg/sdk/testint/shares_integration_test.go
@@ -3,6 +3,8 @@ package testint
 import (
 	"testing"
 
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/assert"
@@ -183,7 +185,7 @@ func TestInt_SharesAlter(t *testing.T) {
 	})
 
 	t.Run("set accounts", func(t *testing.T) {
-		db, dbCleanup := createDatabase(t, secondaryClient)
+		db, dbCleanup := acc.SecondaryTestClient().Database.CreateDatabase(t)
 		t.Cleanup(dbCleanup)
 
 		shareTest, shareCleanup := createShare(t, secondaryClient)
@@ -372,7 +374,7 @@ func TestInt_ShareDescribeConsumer(t *testing.T) {
 	consumerClient := testClient(t)
 
 	t.Run("describe share", func(t *testing.T) {
-		db, dbCleanup := createDatabase(t, providerClient)
+		db, dbCleanup := acc.SecondaryTestClient().Database.CreateDatabase(t)
 		t.Cleanup(dbCleanup)
 
 		shareTest, shareCleanup := createShare(t, providerClient)

--- a/pkg/sdk/testint/shares_integration_test.go
+++ b/pkg/sdk/testint/shares_integration_test.go
@@ -3,8 +3,6 @@ package testint
 import (
 	"testing"
 
-	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
 	"github.com/stretchr/testify/assert"
@@ -185,7 +183,7 @@ func TestInt_SharesAlter(t *testing.T) {
 	})
 
 	t.Run("set accounts", func(t *testing.T) {
-		db, dbCleanup := acc.SecondaryTestClient().Database.CreateDatabase(t)
+		db, dbCleanup := secondaryTestClientHelper().Database.CreateDatabase(t)
 		t.Cleanup(dbCleanup)
 
 		shareTest, shareCleanup := createShare(t, secondaryClient)
@@ -374,7 +372,7 @@ func TestInt_ShareDescribeConsumer(t *testing.T) {
 	consumerClient := testClient(t)
 
 	t.Run("describe share", func(t *testing.T) {
-		db, dbCleanup := acc.SecondaryTestClient().Database.CreateDatabase(t)
+		db, dbCleanup := secondaryTestClientHelper().Database.CreateDatabase(t)
 		t.Cleanup(dbCleanup)
 
 		shareTest, shareCleanup := createShare(t, providerClient)

--- a/pkg/sdk/testint/tags_integration_test.go
+++ b/pkg/sdk/testint/tags_integration_test.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
@@ -18,7 +16,7 @@ func TestInt_Tags(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
+	databaseTest, databaseCleanup := secondaryTestClientHelper().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
 	t.Cleanup(schemaCleanup)

--- a/pkg/sdk/testint/tags_integration_test.go
+++ b/pkg/sdk/testint/tags_integration_test.go
@@ -16,7 +16,7 @@ func TestInt_Tags(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	databaseTest, databaseCleanup := secondaryTestClientHelper().Database.CreateDatabase(t)
+	databaseTest, databaseCleanup := testClientHelper().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
 	t.Cleanup(schemaCleanup)

--- a/pkg/sdk/testint/tags_integration_test.go
+++ b/pkg/sdk/testint/tags_integration_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/internal/random"
@@ -16,7 +18,7 @@ func TestInt_Tags(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	databaseTest, databaseCleanup := createDatabase(t, client)
+	databaseTest, databaseCleanup := acc.TestClient().Database.CreateDatabase(t)
 	t.Cleanup(databaseCleanup)
 	schemaTest, schemaCleanup := createSchema(t, client, databaseTest)
 	t.Cleanup(schemaCleanup)


### PR DESCRIPTION
- Extract helpers in a separate package, where acceptance (both resource and datasource ones) and integration tests have access
- Prepare a file structure for different helpers to reduce the clutter
- Move database related helper methods and remove some from acceptance tests