### PR TITLE
fix: support procedure grant_ownership

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -128,7 +128,8 @@ func DecodeSnowflakeID(id string) sdk.ObjectIdentifier {
 // The following configuration { "some_identifier": "db.name" } will be parsed as an object called "name" that lives
 // inside database called "db", not a database called "db.name". In this case quotes should be used.
 func DecodeSnowflakeParameterID(identifier string) (sdk.ObjectIdentifier, error) {
-	reader := csv.NewReader(strings.NewReader(identifier))
+	identifierWithoutArgs, args := sdk.SplitObjectNameArgument(identifier)
+	reader := csv.NewReader(strings.NewReader(identifierWithoutArgs))
 	reader.Comma = ParameterIDDelimiter
 	lines, err := reader.ReadAll()
 	if err != nil {
@@ -144,7 +145,7 @@ func DecodeSnowflakeParameterID(identifier string) (sdk.ObjectIdentifier, error)
 	case 2:
 		return sdk.NewDatabaseObjectIdentifier(parts[0], parts[1]), nil
 	case 3:
-		return sdk.NewSchemaObjectIdentifier(parts[0], parts[1], parts[2]), nil
+		return sdk.NewSchemaObjectIdentifierWithArguments(parts[0], parts[1], parts[2], args), nil
 	case 4:
 		return sdk.NewTableColumnIdentifier(parts[0], parts[1], parts[2], parts[3]), nil
 	default:

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -25,6 +25,14 @@ func TestDecodeSnowflakeParameterID(t *testing.T) {
 			id:                 `"db"."schema"."test.name"`,
 			fullyQualifiedName: `"db"."schema"."test.name"`,
 		},
+		"decodes quoted schema object identifier with arguments": {
+			id:                 `"db"."schema"."test.name"(varchar, number)`,
+			fullyQualifiedName: `"db"."schema"."test.name"(VARCHAR, NUMBER)`,
+		},
+		"decodes quoted schema object identifier with empty arguments": {
+			id:                 `"db"."schema"."test.name"()`,
+			fullyQualifiedName: `"db"."schema"."test.name"()`,
+		},
 		"decodes quoted table column identifier": {
 			id:                 `"db"."schema"."table.name"."test.name"`,
 			fullyQualifiedName: `"db"."schema"."table.name"."test.name"`,
@@ -40,6 +48,14 @@ func TestDecodeSnowflakeParameterID(t *testing.T) {
 		"decodes unquoted schema object identifier": {
 			id:                 `db.schema.name`,
 			fullyQualifiedName: `"db"."schema"."name"`,
+		},
+		"decodes unquoted schema object identifier with arguments": {
+			id:                 `db.schema.name(varchar, number)`,
+			fullyQualifiedName: `"db"."schema"."name"(VARCHAR, NUMBER)`,
+		},
+		"decodes unquoted schema object identifier with empty arguments": {
+			id:                 `db.schema.name()`,
+			fullyQualifiedName: `"db"."schema"."name"()`,
 		},
 		"decodes unquoted table column identifier": {
 			id:                 `db.schema.table.name`,

--- a/pkg/resources/grant_ownership_acceptance_test.go
+++ b/pkg/resources/grant_ownership_acceptance_test.go
@@ -317,6 +317,146 @@ func TestAcc_GrantOwnership_OnObject_Table_ToDatabaseRole(t *testing.T) {
 	})
 }
 
+func TestAcc_GrantOwnership_OnObject_Procedure_ToAccountRole(t *testing.T) {
+	databaseId := acc.TestClient().Ids.RandomAccountObjectIdentifier()
+	databaseName := databaseId.Name()
+	schemaName := acc.TestClient().Ids.Alpha()
+	withArgProcedureName := sdk.NewSchemaObjectIdentifierWithArguments(databaseName, schemaName, acc.TestClient().Ids.Alpha(), []sdk.DataType{sdk.DataTypeVARCHAR})
+	withoutArgProcedureName := sdk.NewSchemaObjectIdentifierWithArguments(databaseName, schemaName, acc.TestClient().Ids.Alpha(), []sdk.DataType{})
+
+	accountRoleId := acc.TestClient().Ids.RandomAccountObjectIdentifier()
+	accountRoleName := accountRoleId.Name()
+	accountRoleFullyQualifiedName := accountRoleId.FullyQualifiedName()
+
+	configVariables := config.Variables{
+		"account_role_name":          config.StringVariable(accountRoleName),
+		"database_name":              config.StringVariable(databaseName),
+		"schema_name":                config.StringVariable(schemaName),
+		"with_arg_procedure_name":    config.StringVariable(withArgProcedureName.Name()),
+		"without_arg_procedure_name": config.StringVariable(withoutArgProcedureName.Name()),
+	}
+	withArgResourceName := "snowflake_grant_ownership.with_arguments"
+	withoutArgResourceName := "snowflake_grant_ownership.without_arguments"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { acc.TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: acc.ConfigurationDirectory("TestAcc_GrantOwnership/OnObject_Procedure_ToAccountRole"),
+				ConfigVariables: configVariables,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(withArgResourceName, "account_role_name", accountRoleName),
+					resource.TestCheckResourceAttr(withArgResourceName, "on.0.object_type", "PROCEDURE"),
+					resource.TestCheckResourceAttr(withArgResourceName, "on.0.object_name", withArgProcedureName.FullyQualifiedName()),
+					resource.TestCheckResourceAttr(withArgResourceName, "id", fmt.Sprintf("ToAccountRole|%s||OnObject|PROCEDURE|%s", accountRoleFullyQualifiedName, withArgProcedureName.FullyQualifiedName())),
+					checkResourceOwnershipIsGranted(&sdk.ShowGrantOptions{
+						To: &sdk.ShowGrantsTo{
+							Role: accountRoleId,
+						},
+					}, sdk.ObjectTypeProcedure, accountRoleName, fmt.Sprintf("%s.%s.\"%s(ARG1 VARCHAR):VARCHAR(16777216)", databaseName, schemaName, withArgProcedureName.Name())),
+					resource.TestCheckResourceAttr(withoutArgResourceName, "account_role_name", accountRoleName),
+					resource.TestCheckResourceAttr(withoutArgResourceName, "on.0.object_type", "PROCEDURE"),
+					resource.TestCheckResourceAttr(withoutArgResourceName, "on.0.object_name", withoutArgProcedureName.FullyQualifiedName()),
+					resource.TestCheckResourceAttr(withoutArgResourceName, "id", fmt.Sprintf("ToAccountRole|%s||OnObject|PROCEDURE|%s", accountRoleFullyQualifiedName, withoutArgProcedureName.FullyQualifiedName())),
+					checkResourceOwnershipIsGranted(&sdk.ShowGrantOptions{
+						To: &sdk.ShowGrantsTo{
+							Role: accountRoleId,
+						},
+					}, sdk.ObjectTypeProcedure, accountRoleName, fmt.Sprintf("%s.%s.\"%s():VARCHAR(16777216)", databaseName, schemaName, withoutArgProcedureName.Name())),
+				),
+			},
+			{
+				ConfigDirectory:   acc.ConfigurationDirectory("TestAcc_GrantOwnership/OnObject_Procedure_ToAccountRole"),
+				ConfigVariables:   configVariables,
+				ResourceName:      withArgResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ConfigDirectory:   acc.ConfigurationDirectory("TestAcc_GrantOwnership/OnObject_Procedure_ToAccountRole"),
+				ConfigVariables:   configVariables,
+				ResourceName:      withoutArgResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAcc_GrantOwnership_OnObject_Procedure_ToDatabaseRole(t *testing.T) {
+	databaseId := acc.TestClient().Ids.RandomAccountObjectIdentifier()
+	databaseName := databaseId.Name()
+	schemaName := acc.TestClient().Ids.Alpha()
+	withArgProcedureName := sdk.NewSchemaObjectIdentifierWithArguments(databaseName, schemaName, acc.TestClient().Ids.Alpha(), []sdk.DataType{sdk.DataTypeVARCHAR})
+	withoutArgProcedureName := sdk.NewSchemaObjectIdentifierWithArguments(databaseName, schemaName, acc.TestClient().Ids.Alpha(), []sdk.DataType{})
+
+	databaseRoleId := acc.TestClient().Ids.RandomAccountObjectIdentifier()
+	databaseRoleName := databaseRoleId.Name()
+	databaseRoleFullyQualifiedName := sdk.NewDatabaseObjectIdentifier(databaseName, databaseRoleName).FullyQualifiedName()
+
+	configVariables := config.Variables{
+		"database_role_name":         config.StringVariable(databaseRoleName),
+		"database_name":              config.StringVariable(databaseName),
+		"schema_name":                config.StringVariable(schemaName),
+		"with_arg_procedure_name":    config.StringVariable(withArgProcedureName.Name()),
+		"without_arg_procedure_name": config.StringVariable(withoutArgProcedureName.Name()),
+	}
+	withArgResourceName := "snowflake_grant_ownership.with_arguments"
+	withoutArgResourceName := "snowflake_grant_ownership.without_arguments"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { acc.TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: acc.ConfigurationDirectory("TestAcc_GrantOwnership/OnObject_Procedure_ToDatabaseRole"),
+				ConfigVariables: configVariables,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(withArgResourceName, "database_role_name", databaseRoleFullyQualifiedName),
+					resource.TestCheckResourceAttr(withArgResourceName, "on.0.object_type", "PROCEDURE"),
+					resource.TestCheckResourceAttr(withArgResourceName, "on.0.object_name", withArgProcedureName.FullyQualifiedName()),
+					resource.TestCheckResourceAttr(withArgResourceName, "id", fmt.Sprintf("ToDatabaseRole|%s||OnObject|PROCEDURE|%s", databaseRoleFullyQualifiedName, withArgProcedureName.FullyQualifiedName())),
+					checkResourceOwnershipIsGranted(&sdk.ShowGrantOptions{
+						To: &sdk.ShowGrantsTo{
+							DatabaseRole: sdk.NewDatabaseObjectIdentifier(databaseName, databaseRoleName),
+						},
+					}, sdk.ObjectTypeProcedure, databaseRoleName, fmt.Sprintf("%s.%s.\"%s(ARG1 VARCHAR):VARCHAR(16777216)", databaseName, schemaName, withArgProcedureName.Name())),
+					resource.TestCheckResourceAttr(withoutArgResourceName, "database_role_name", databaseRoleFullyQualifiedName),
+					resource.TestCheckResourceAttr(withoutArgResourceName, "on.0.object_type", "PROCEDURE"),
+					resource.TestCheckResourceAttr(withoutArgResourceName, "on.0.object_name", withoutArgProcedureName.FullyQualifiedName()),
+					resource.TestCheckResourceAttr(withoutArgResourceName, "id", fmt.Sprintf("ToDatabaseRole|%s||OnObject|PROCEDURE|%s", databaseRoleFullyQualifiedName, withoutArgProcedureName.FullyQualifiedName())),
+					checkResourceOwnershipIsGranted(&sdk.ShowGrantOptions{
+						To: &sdk.ShowGrantsTo{
+							DatabaseRole: sdk.NewDatabaseObjectIdentifier(databaseName, databaseRoleName),
+						},
+					}, sdk.ObjectTypeProcedure, databaseRoleName, fmt.Sprintf("%s.%s.\"%s():VARCHAR(16777216)", databaseName, schemaName, withoutArgProcedureName.Name())),
+				),
+			},
+			{
+				ConfigDirectory:   acc.ConfigurationDirectory("TestAcc_GrantOwnership/OnObject_Procedure_ToDatabaseRole"),
+				ConfigVariables:   configVariables,
+				ResourceName:      withArgResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ConfigDirectory:   acc.ConfigurationDirectory("TestAcc_GrantOwnership/OnObject_Procedure_ToDatabaseRole"),
+				ConfigVariables:   configVariables,
+				ResourceName:      withoutArgResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAcc_GrantOwnership_OnAll_InDatabase_ToAccountRole(t *testing.T) {
 	databaseId := acc.TestClient().Ids.RandomAccountObjectIdentifier()
 	databaseName := databaseId.Name()

--- a/pkg/resources/procedure_acceptance_test.go
+++ b/pkg/resources/procedure_acceptance_test.go
@@ -231,7 +231,7 @@ func TestAcc_Procedure_migrateFromVersion085(t *testing.T) {
 					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "id", sdk.NewSchemaObjectIdentifier(acc.TestDatabaseName, acc.TestSchemaName, name).FullyQualifiedName()),
+					resource.TestCheckResourceAttr(resourceName, "id", sdk.NewSchemaObjectIdentifierWithArguments(acc.TestDatabaseName, acc.TestSchemaName, name, []sdk.DataType{}).FullyQualifiedName()),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "database", acc.TestDatabaseName),
 					resource.TestCheckResourceAttr(resourceName, "schema", acc.TestSchemaName),

--- a/pkg/resources/testdata/TestAcc_GrantOwnership/OnObject_Procedure_ToAccountRole/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantOwnership/OnObject_Procedure_ToAccountRole/test.tf
@@ -1,0 +1,56 @@
+resource "snowflake_database" "test" {
+  name = var.database_name
+}
+
+resource "snowflake_schema" "test" {
+  name     = var.schema_name
+  database = snowflake_database.test.name
+}
+
+resource "snowflake_role" "test" {
+  name = var.account_role_name
+}
+
+# Without this, DESC PROCEDURE cannot get the procedure body, and the plan will always generate a difference.
+resource "snowflake_grant_account_role" "test" {
+  role_name = snowflake_role.test.name
+  parent_role_name = "SYSADMIN"
+}
+
+resource "snowflake_procedure" "with_arguments" {
+  name     = var.with_arg_procedure_name
+  database = snowflake_database.test.name
+  schema   = snowflake_schema.test.name
+  language = "JAVASCRIPT"
+  arguments {
+    name = "ARG1"
+    type = "VARCHAR"
+  }
+  return_type = "VARCHAR"
+  statement   = "return ARG1"
+}
+
+resource "snowflake_grant_ownership" "with_arguments" {
+  account_role_name   = snowflake_role.test.name
+  on {
+    object_type = "PROCEDURE"
+    object_name = "\"${snowflake_database.test.name}\".\"${snowflake_schema.test.name}\".\"${snowflake_procedure.with_arguments.name}\"(VARCHAR)"
+  }
+}
+
+resource "snowflake_procedure" "without_arguments" {
+  name        = var.without_arg_procedure_name
+  database    = snowflake_database.test.name
+  schema      = snowflake_schema.test.name
+  language    = "JAVASCRIPT"
+  return_type = "VARCHAR"
+  statement   = "return 'Hi'"
+}
+
+resource "snowflake_grant_ownership" "without_arguments" {
+  account_role_name   = snowflake_role.test.name
+  on {
+    object_type = "PROCEDURE"
+    object_name = "\"${snowflake_database.test.name}\".\"${snowflake_schema.test.name}\".\"${snowflake_procedure.without_arguments.name}\"()"
+  }
+}

--- a/pkg/resources/testdata/TestAcc_GrantOwnership/OnObject_Procedure_ToAccountRole/variables.tf
+++ b/pkg/resources/testdata/TestAcc_GrantOwnership/OnObject_Procedure_ToAccountRole/variables.tf
@@ -1,0 +1,19 @@
+variable "account_role_name" {
+  type = string
+}
+
+variable "database_name" {
+  type = string
+}
+
+variable "schema_name" {
+  type = string
+}
+
+variable "with_arg_procedure_name" {
+  type = string
+}
+
+variable "without_arg_procedure_name" {
+  type = string
+}

--- a/pkg/resources/testdata/TestAcc_GrantOwnership/OnObject_Procedure_ToDatabaseRole/test.tf
+++ b/pkg/resources/testdata/TestAcc_GrantOwnership/OnObject_Procedure_ToDatabaseRole/test.tf
@@ -1,0 +1,57 @@
+resource "snowflake_database" "test" {
+  name = var.database_name
+}
+
+resource "snowflake_schema" "test" {
+  name     = var.schema_name
+  database = snowflake_database.test.name
+}
+
+resource "snowflake_database_role" "test" {
+  name     = var.database_role_name
+  database = snowflake_database.test.name
+}
+
+# Without this, DESC PROCEDURE cannot get the procedure body, and the plan will always generate a difference.
+resource "snowflake_grant_database_role" "test" {
+  database_role_name = "\"${snowflake_database.test.name}\".\"${snowflake_database_role.test.name}\""
+  parent_role_name = "SYSADMIN"
+}
+
+resource "snowflake_procedure" "with_arguments" {
+  name     = var.with_arg_procedure_name
+  database = snowflake_database.test.name
+  schema   = snowflake_schema.test.name
+  language = "JAVASCRIPT"
+  arguments {
+    name = "ARG1"
+    type = "VARCHAR"
+  }
+  return_type = "VARCHAR"
+  statement   = "return ARG1"
+}
+
+resource "snowflake_grant_ownership" "with_arguments" {
+  database_role_name  = "\"${snowflake_database.test.name}\".\"${snowflake_database_role.test.name}\""
+  on {
+    object_type = "PROCEDURE"
+    object_name = "\"${snowflake_database.test.name}\".\"${snowflake_schema.test.name}\".\"${snowflake_procedure.with_arguments.name}\"(VARCHAR)"
+  }
+}
+
+resource "snowflake_procedure" "without_arguments" {
+  name        = var.without_arg_procedure_name
+  database    = snowflake_database.test.name
+  schema      = snowflake_schema.test.name
+  language    = "JAVASCRIPT"
+  return_type = "VARCHAR"
+  statement   = "return 'Hi'"
+}
+
+resource "snowflake_grant_ownership" "without_arguments" {
+  database_role_name  = "\"${snowflake_database.test.name}\".\"${snowflake_database_role.test.name}\""
+  on {
+    object_type = "PROCEDURE"
+    object_name = "\"${snowflake_database.test.name}\".\"${snowflake_schema.test.name}\".\"${snowflake_procedure.without_arguments.name}\"()"
+  }
+}

--- a/pkg/resources/testdata/TestAcc_GrantOwnership/OnObject_Procedure_ToDatabaseRole/variables.tf
+++ b/pkg/resources/testdata/TestAcc_GrantOwnership/OnObject_Procedure_ToDatabaseRole/variables.tf
@@ -1,0 +1,19 @@
+variable "database_role_name" {
+  type = string
+}
+
+variable "database_name" {
+  type = string
+}
+
+variable "schema_name" {
+  type = string
+}
+
+variable "with_arg_procedure_name" {
+  type = string
+}
+
+variable "without_arg_procedure_name" {
+  type = string
+}

--- a/pkg/sdk/identifier_helpers.go
+++ b/pkg/sdk/identifier_helpers.go
@@ -275,7 +275,7 @@ func (i SchemaObjectIdentifier) FullyQualifiedName() string {
 	if i.schemaName == "" && i.databaseName == "" && i.name == "" {
 		return ""
 	}
-	if len(i.arguments) == 0 {
+	if i.arguments == nil {
 		return fmt.Sprintf(`"%v"."%v"."%v"`, i.databaseName, i.schemaName, i.name)
 	}
 	// if this is a function or procedure, we need to include the arguments

--- a/pkg/sdk/identifier_helpers_test.go
+++ b/pkg/sdk/identifier_helpers_test.go
@@ -47,6 +47,64 @@ func TestNewSchemaObjectIdentifierFromFullyQualifiedName(t *testing.T) {
 	}
 }
 
+func TestSplitObjectNameArgument(t *testing.T) {
+	type test struct {
+		input    string
+		wantArgs []DataType
+		wantId   string
+	}
+
+	tests := []test{
+		{
+			input:    "\"MY_DB\".\"MY_SCHEMA\".\"multiply\"(number, number)",
+			wantId:   "\"MY_DB\".\"MY_SCHEMA\".\"multiply\"",
+			wantArgs: []DataType{DataTypeNumber, DataTypeNumber},
+		},
+		{
+			input:    "\"multiply\"(number, number)",
+			wantId:   "\"multiply\"",
+			wantArgs: []DataType{DataTypeNumber, DataTypeNumber},
+		},
+		{
+			input:    "MY_DB.MY_SCHEMA.add(number, number)",
+			wantId:   "MY_DB.MY_SCHEMA.add",
+			wantArgs: []DataType{DataTypeNumber, DataTypeNumber},
+		},
+		{
+			input:    "add(number, number)",
+			wantId:   "add",
+			wantArgs: []DataType{DataTypeNumber, DataTypeNumber},
+		},
+		{
+			input:    "\"MY_DB\".\"MY_SCHEMA\".\"MY_UDF\"()",
+			wantId:   "\"MY_DB\".\"MY_SCHEMA\".\"MY_UDF\"",
+			wantArgs: []DataType{},
+		},
+		{
+			input:    "\"MY_UDF\"()",
+			wantId:   "\"MY_UDF\"",
+			wantArgs: []DataType{},
+		},
+		{
+			input:    "\"MY_DB\".\"MY_SCHEMA\".\"MY_PIPE\"",
+			wantId:   "\"MY_DB\".\"MY_SCHEMA\".\"MY_PIPE\"",
+			wantArgs: nil,
+		},
+		{
+			input:    "MY_DB.MY_SCHEMA.MY_STAGE",
+			wantId:   "MY_DB.MY_SCHEMA.MY_STAGE",
+			wantArgs: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			id, args := SplitObjectNameArgument(tc.input)
+			require.Equal(t, tc.wantId, id)
+			require.Equal(t, tc.wantArgs, args)
+		})
+	}
+}
+
 func TestDatabaseObjectIdentifier(t *testing.T) {
 	t.Run("create from strings", func(t *testing.T) {
 		identifier := NewDatabaseObjectIdentifier("aaa", "bbb")


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
I'm not good at English, so please feel free to point out any code comments or function names that are unnatural :pray:.

- Fixed problem with grant_ownership resource not working for procedures.
  - This was caused by a lack of support for the fully qalified name signature part.
- Fixed incorrect behavior of FullyQualifiedName method of SchemaObjectIdentifier for signatures with no arguments
  - before: `db.schema.some_function()` -> `"db"."schema"."some_function"`
  - after: `db.schema.some_function()` -> `"db"."schema"."some_function"()`
- DecodeSnowflakeParameterID now also works with procedure and UDF identifiers
  - However, it still does not support strings with return values or named arguments
    - ex: `db.schema."func(ARG1 VARCHAR):VARCHAR(16777216)"`


## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* 