### PR TITLE
fix: Prove problems with procedure resource data types

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -9,6 +9,10 @@ across different versions.
 #### *(behavior change)* Validation to column type added
 While solving issue [#2733](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2733) we have introduced diff suppression for `column.type`. To make it work correctly we have also added a validation to it. It should not cause any problems, but it's worth noting in case of any data types used that the provider is not aware of.
 
+### snowflake_procedure resource changes
+#### *(behavior change)* Validation to arguments type added
+Diff suppression for `arguments.type` is needed for the same reason as above for `snowflake_table` resource.
+
 ## v0.88.0 ➞ v0.89.0
 #### *(behavior change)* ForceNew removed
 The `ForceNew` field was removed in favor of in-place Update for `name` parameter in:

--- a/pkg/resources/procedure.go
+++ b/pkg/resources/procedure.go
@@ -55,14 +55,11 @@ var procedureSchema = map[string]*schema.Schema{
 					Description: "The argument name",
 				},
 				"type": {
-					Type:     schema.TypeString,
-					Required: true,
-					// Suppress the diff shown if the values are equal when both compared in lower case.
-					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-						return strings.EqualFold(old, new)
-					},
-					ValidateFunc: IsDataType(),
-					Description:  "The argument type",
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateFunc:     dataTypeValidateFunc,
+					DiffSuppressFunc: dataTypeDiffSuppressFunc,
+					Description:      "The argument type",
 				},
 			},
 		},


### PR DESCRIPTION
Introduce a fix for arguments but not for the return_type