### PR TITLE
fix: `SHOW USERS` output with insufficient privileges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ dist/
 
 # Test environment variables
 test.env
+
+# deps
+vendor/

--- a/pkg/sdk/users.go
+++ b/pkg/sdk/users.go
@@ -62,7 +62,7 @@ type User struct {
 type userDBRow struct {
 	Name                  string         `db:"name"`
 	CreatedOn             time.Time      `db:"created_on"`
-	LoginName             string         `db:"login_name"`
+	LoginName             sql.NullString `db:"login_name"`
 	DisplayName           sql.NullString `db:"display_name"`
 	FirstName             sql.NullString `db:"first_name"`
 	LastName              sql.NullString `db:"last_name"`
@@ -70,41 +70,31 @@ type userDBRow struct {
 	MinsToUnlock          sql.NullString `db:"mins_to_unlock"`
 	DaysToExpiry          sql.NullString `db:"days_to_expiry"`
 	Comment               sql.NullString `db:"comment"`
-	Disabled              bool           `db:"disabled"`
-	MustChangePassword    bool           `db:"must_change_password"`
-	SnowflakeLock         bool           `db:"snowflake_lock"`
+	Disabled              sql.NullBool   `db:"disabled"`
+	MustChangePassword    sql.NullBool   `db:"must_change_password"`
+	SnowflakeLock         sql.NullBool   `db:"snowflake_lock"`
 	DefaultWarehouse      sql.NullString `db:"default_warehouse"`
-	DefaultNamespace      string         `db:"default_namespace"`
-	DefaultRole           string         `db:"default_role"`
-	DefaultSecondaryRoles string         `db:"default_secondary_roles"`
-	ExtAuthnDuo           bool           `db:"ext_authn_duo"`
-	ExtAuthnUid           string         `db:"ext_authn_uid"`
-	MinsToBypassMfa       string         `db:"mins_to_bypass_mfa"`
-	Owner                 string         `db:"owner"`
+	DefaultNamespace      sql.NullString `db:"default_namespace"`
+	DefaultRole           sql.NullString `db:"default_role"`
+	DefaultSecondaryRoles sql.NullString `db:"default_secondary_roles"`
+	ExtAuthnDuo           sql.NullBool   `db:"ext_authn_duo"`
+	ExtAuthnUid           sql.NullString `db:"ext_authn_uid"`
+	MinsToBypassMfa       sql.NullString `db:"mins_to_bypass_mfa"`
+	Owner                 sql.NullString `db:"owner"`
 	LastSuccessLogin      sql.NullTime   `db:"last_success_login"`
 	ExpiresAtTime         sql.NullTime   `db:"expires_at_time"`
 	LockedUntilTime       sql.NullTime   `db:"locked_until_time"`
-	HasPassword           bool           `db:"has_password"`
-	HasRsaPublicKey       bool           `db:"has_rsa_public_key"`
+	HasPassword           sql.NullBool   `db:"has_password"`
+	HasRsaPublicKey       sql.NullBool   `db:"has_rsa_public_key"`
 }
 
 func (row userDBRow) convert() *User {
 	user := &User{
-		Name:                  row.Name,
-		CreatedOn:             row.CreatedOn,
-		LoginName:             row.LoginName,
-		Disabled:              row.Disabled,
-		MustChangePassword:    row.MustChangePassword,
-		SnowflakeLock:         row.SnowflakeLock,
-		DefaultNamespace:      row.DefaultNamespace,
-		DefaultRole:           row.DefaultRole,
-		DefaultSecondaryRoles: row.DefaultSecondaryRoles,
-		ExtAuthnDuo:           row.ExtAuthnDuo,
-		ExtAuthnUid:           row.ExtAuthnUid,
-		MinsToBypassMfa:       row.MinsToBypassMfa,
-		Owner:                 row.Owner,
-		HasPassword:           row.HasPassword,
-		HasRsaPublicKey:       row.HasRsaPublicKey,
+		Name:      row.Name,
+		CreatedOn: row.CreatedOn,
+	}
+	if row.LoginName.Valid {
+		user.LoginName = row.LoginName.String
 	}
 	if row.DisplayName.Valid {
 		user.DisplayName = row.DisplayName.String
@@ -127,8 +117,38 @@ func (row userDBRow) convert() *User {
 	if row.Comment.Valid {
 		user.Comment = row.Comment.String
 	}
+	if row.Disabled.Valid {
+		user.Disabled = row.Disabled.Bool
+	}
+	if row.MustChangePassword.Valid {
+		user.MustChangePassword = row.MustChangePassword.Bool
+	}
+	if row.SnowflakeLock.Valid {
+		user.SnowflakeLock = row.SnowflakeLock.Bool
+	}
 	if row.DefaultWarehouse.Valid {
 		user.DefaultWarehouse = row.DefaultWarehouse.String
+	}
+	if row.DefaultNamespace.Valid {
+		user.DefaultNamespace = row.DefaultNamespace.String
+	}
+	if row.DefaultRole.Valid {
+		user.DefaultRole = row.DefaultRole.String
+	}
+	if row.DefaultSecondaryRoles.Valid {
+		user.DefaultSecondaryRoles = row.DefaultSecondaryRoles.String
+	}
+	if row.ExtAuthnDuo.Valid {
+		user.ExtAuthnDuo = row.ExtAuthnDuo.Bool
+	}
+	if row.ExtAuthnUid.Valid {
+		user.ExtAuthnUid = row.ExtAuthnUid.String
+	}
+	if row.MinsToBypassMfa.Valid {
+		user.MinsToBypassMfa = row.MinsToBypassMfa.String
+	}
+	if row.Owner.Valid {
+		user.Owner = row.Owner.String
 	}
 	if row.LastSuccessLogin.Valid {
 		user.LastSuccessLogin = row.LastSuccessLogin.Time
@@ -138,6 +158,12 @@ func (row userDBRow) convert() *User {
 	}
 	if row.LockedUntilTime.Valid {
 		user.LockedUntilTime = row.LockedUntilTime.Time
+	}
+	if row.HasPassword.Valid {
+		user.HasPassword = row.HasPassword.Bool
+	}
+	if row.HasRsaPublicKey.Valid {
+		user.HasRsaPublicKey = row.HasRsaPublicKey.Bool
 	}
 	return user
 }


### PR DESCRIPTION
## Test Plan
* [ ] credentials that don't have both `OWNERSHIP` & `MANAGE GRANTS` privilege (as required for full output in [docs](https://docs.snowflake.com/en/sql-reference/sql/show-users#usage-notes)

## References

We have an internal issue when scanning `Users.Show` output:
```
2024/05/15 15:27:31 [DEBUG] err: sql: Scan error on column index 10, name "disabled": sql/driver: couldn't convert "null" into type bool
```