### PR TITLE
chore: accept non-pointer values in the generated builder methods

### DIFF
--- a/pkg/datasources/external_tables.go
+++ b/pkg/datasources/external_tables.go
@@ -67,7 +67,7 @@ func ReadExternalTables(d *schema.ResourceData, meta interface{}) error {
 
 	schemaId := sdk.NewDatabaseObjectIdentifier(databaseName, schemaName)
 	showIn := sdk.NewShowExternalTableInRequest().WithSchema(schemaId)
-	externalTables, err := client.ExternalTables.Show(ctx, sdk.NewShowExternalTableRequest().WithIn(showIn))
+	externalTables, err := client.ExternalTables.Show(ctx, sdk.NewShowExternalTableRequest().WithIn(*showIn))
 	if err != nil {
 		log.Printf("[DEBUG] failed when searching external tables in schema (%s), err = %s", schemaId.FullyQualifiedName(), err.Error())
 		d.SetId("")

--- a/pkg/resources/external_table.go
+++ b/pkg/resources/external_table.go
@@ -184,20 +184,9 @@ func CreateExternalTable(d *schema.ResourceData, meta any) error {
 		partitionBy = expandStringList(v.([]any))
 	}
 
-	var pattern string
-	if v, ok := d.GetOk("pattern"); ok {
-		pattern = v.(string)
-	}
-
-	var awsSnsTopic string
-	if v, ok := d.GetOk("aws_sns_topic"); ok {
-		awsSnsTopic = v.(string)
-	}
-
-	var comment string
-	if v, ok := d.GetOk("comment"); ok {
-		comment = v.(string)
-	}
+	pattern := d.Get("pattern").(string)
+	awsSnsTopic := d.Get("aws_sns_topic").(string)
+	comment := d.Get("comment").(string)
 
 	var tagAssociationRequests []*sdk.TagAssociationRequest
 	if _, ok := d.GetOk("tag"); ok {

--- a/pkg/resources/external_table.go
+++ b/pkg/resources/external_table.go
@@ -175,28 +175,28 @@ func CreateExternalTable(d *schema.ResourceData, meta any) error {
 			columnDef["as"],
 		)
 	}
-	autoRefresh := sdk.Bool(d.Get("auto_refresh").(bool))
-	refreshOnCreate := sdk.Bool(d.Get("refresh_on_create").(bool))
-	copyGrants := sdk.Bool(d.Get("copy_grants").(bool))
+	autoRefresh := d.Get("auto_refresh").(bool)
+	refreshOnCreate := d.Get("refresh_on_create").(bool)
+	copyGrants := d.Get("copy_grants").(bool)
 
 	var partitionBy []string
 	if v, ok := d.GetOk("partition_by"); ok {
 		partitionBy = expandStringList(v.([]any))
 	}
 
-	var pattern *string
+	var pattern string
 	if v, ok := d.GetOk("pattern"); ok {
-		pattern = sdk.String(v.(string))
+		pattern = v.(string)
 	}
 
-	var awsSnsTopic *string
+	var awsSnsTopic string
 	if v, ok := d.GetOk("aws_sns_topic"); ok {
-		awsSnsTopic = sdk.String(v.(string))
+		awsSnsTopic = v.(string)
 	}
 
-	var comment *string
+	var comment string
 	if v, ok := d.GetOk("comment"); ok {
-		comment = sdk.String(v.(string))
+		comment = v.(string)
 	}
 
 	var tagAssociationRequests []*sdk.TagAssociationRequest
@@ -217,7 +217,7 @@ func CreateExternalTable(d *schema.ResourceData, meta any) error {
 				WithPartitionBy(partitionBy).
 				WithRefreshOnCreate(refreshOnCreate).
 				WithAutoRefresh(autoRefresh).
-				WithRawFileFormat(&fileFormat).
+				WithRawFileFormat(fileFormat).
 				WithCopyGrants(copyGrants).
 				WithComment(comment).
 				WithTag(tagAssociationRequests),
@@ -234,7 +234,7 @@ func CreateExternalTable(d *schema.ResourceData, meta any) error {
 				WithRefreshOnCreate(refreshOnCreate).
 				WithAutoRefresh(autoRefresh).
 				WithPattern(pattern).
-				WithRawFileFormat(&fileFormat).
+				WithRawFileFormat(fileFormat).
 				WithAwsSnsTopic(awsSnsTopic).
 				WithCopyGrants(copyGrants).
 				WithComment(comment).

--- a/pkg/sdk/dto-builder-generator/main.go
+++ b/pkg/sdk/dto-builder-generator/main.go
@@ -207,11 +207,6 @@ func (gen *Generator) generateBuilderMethods(d *structDef) {
 		gen.printf("func (s *%s) With%s(%s %s) *%s {\n", d.name, toTitle(field.name), field.name, strings.TrimLeft(field.typeString, "*"), d.name)
 
 		switch {
-		case field.typeString == "*string":
-			// When the expected type is optional string (*string), we want to avoid assigning empty strings, because:
-			// 1. It's a rare (or non-existent) case to set something to an empty string in Snowflake (most of the cases are resolved by explicit UNSET commands).
-			// 2. Empty strings are treated as non-set values in Terraform, so no value set and empty string would have the same effect.
-			gen.printf("if len(%[1]s) > 0 {\ns.%[1]s = &%[1]s\n}\n", field.name)
 		case strings.HasPrefix(field.typeString, "*"):
 			// If the target field is a pointer, assign the address of input field because right now we always pass them by value
 			gen.printf("s.%s = &%s\n", field.name, field.name)

--- a/pkg/sdk/dto-builder-generator/main.go
+++ b/pkg/sdk/dto-builder-generator/main.go
@@ -208,8 +208,9 @@ func (gen *Generator) generateBuilderMethods(d *structDef) {
 
 		switch {
 		case field.typeString == "*string":
-			// When the expected type is optional string, we want to avoid assigning empty strings mostly,
-			// because of the dependency to Terraform and that empty strings are counted as non-set values.
+			// When the expected type is optional string (*string), we want to avoid assigning empty strings, because:
+			// 1. It's a rare (or non-existent) case to set something to an empty string in Snowflake (most of the cases are resolved by explicit UNSET commands).
+			// 2. Empty strings are treated as non-set values in Terraform, so no value set and empty string would have the same effect.
 			gen.printf("if len(%[1]s) > 0 {\ns.%[1]s = &%[1]s\n}\n", field.name)
 		case strings.HasPrefix(field.typeString, "*"):
 			// If the target field is a pointer, assign the address of input field because right now we always pass them by value

--- a/pkg/sdk/dto-builder-generator/main.go
+++ b/pkg/sdk/dto-builder-generator/main.go
@@ -204,8 +204,19 @@ func (gen *Generator) generateBuilderMethods(d *structDef) {
 	}
 
 	for _, field := range optionalFields {
-		gen.printf("func (s *%s) With%s(%s %s) *%s {\n", d.name, toTitle(field.name), field.name, field.typeString, d.name)
-		gen.printf("s.%s = %s\n", field.name, field.name)
+		gen.printf("func (s *%s) With%s(%s %s) *%s {\n", d.name, toTitle(field.name), field.name, strings.TrimLeft(field.typeString, "*"), d.name)
+
+		switch {
+		case field.typeString == "*string":
+			// When the expected type is optional string, we want to avoid assigning empty strings mostly,
+			// because of the dependency to Terraform and that empty strings are counted as non-set values.
+			gen.printf("if len(%[1]s) > 0 {\ns.%[1]s = &%[1]s\n}\n", field.name)
+		case strings.HasPrefix(field.typeString, "*"):
+			// If the target field is a pointer, assign the address of input field because right now we always pass them by value
+			gen.printf("s.%s = &%s\n", field.name, field.name)
+		default:
+			gen.printf("s.%s = %s\n", field.name, field.name)
+		}
 		gen.printf("return s\n")
 		gen.printf("}\n\n")
 	}

--- a/pkg/sdk/external_tables_dto_builders_gen.go
+++ b/pkg/sdk/external_tables_dto_builders_gen.go
@@ -14,13 +14,13 @@ func NewCreateExternalTableRequest(
 	return &s
 }
 
-func (s *CreateExternalTableRequest) WithOrReplace(orReplace *bool) *CreateExternalTableRequest {
-	s.orReplace = orReplace
+func (s *CreateExternalTableRequest) WithOrReplace(orReplace bool) *CreateExternalTableRequest {
+	s.orReplace = &orReplace
 	return s
 }
 
-func (s *CreateExternalTableRequest) WithIfNotExists(ifNotExists *bool) *CreateExternalTableRequest {
-	s.ifNotExists = ifNotExists
+func (s *CreateExternalTableRequest) WithIfNotExists(ifNotExists bool) *CreateExternalTableRequest {
+	s.ifNotExists = &ifNotExists
 	return s
 }
 
@@ -29,8 +29,8 @@ func (s *CreateExternalTableRequest) WithColumns(columns []*ExternalTableColumnR
 	return s
 }
 
-func (s *CreateExternalTableRequest) WithCloudProviderParams(cloudProviderParams *CloudProviderParamsRequest) *CreateExternalTableRequest {
-	s.cloudProviderParams = cloudProviderParams
+func (s *CreateExternalTableRequest) WithCloudProviderParams(cloudProviderParams CloudProviderParamsRequest) *CreateExternalTableRequest {
+	s.cloudProviderParams = &cloudProviderParams
 	return s
 }
 
@@ -39,48 +39,56 @@ func (s *CreateExternalTableRequest) WithPartitionBy(partitionBy []string) *Crea
 	return s
 }
 
-func (s *CreateExternalTableRequest) WithRefreshOnCreate(refreshOnCreate *bool) *CreateExternalTableRequest {
-	s.refreshOnCreate = refreshOnCreate
+func (s *CreateExternalTableRequest) WithRefreshOnCreate(refreshOnCreate bool) *CreateExternalTableRequest {
+	s.refreshOnCreate = &refreshOnCreate
 	return s
 }
 
-func (s *CreateExternalTableRequest) WithAutoRefresh(autoRefresh *bool) *CreateExternalTableRequest {
-	s.autoRefresh = autoRefresh
+func (s *CreateExternalTableRequest) WithAutoRefresh(autoRefresh bool) *CreateExternalTableRequest {
+	s.autoRefresh = &autoRefresh
 	return s
 }
 
-func (s *CreateExternalTableRequest) WithPattern(pattern *string) *CreateExternalTableRequest {
-	s.pattern = pattern
+func (s *CreateExternalTableRequest) WithPattern(pattern string) *CreateExternalTableRequest {
+	if len(pattern) > 0 {
+		s.pattern = &pattern
+	}
 	return s
 }
 
-func (s *CreateExternalTableRequest) WithRawFileFormat(rawFileFormat *string) *CreateExternalTableRequest {
-	s.rawFileFormat = rawFileFormat
+func (s *CreateExternalTableRequest) WithRawFileFormat(rawFileFormat string) *CreateExternalTableRequest {
+	if len(rawFileFormat) > 0 {
+		s.rawFileFormat = &rawFileFormat
+	}
 	return s
 }
 
-func (s *CreateExternalTableRequest) WithFileFormat(fileFormat *ExternalTableFileFormatRequest) *CreateExternalTableRequest {
-	s.fileFormat = fileFormat
+func (s *CreateExternalTableRequest) WithFileFormat(fileFormat ExternalTableFileFormatRequest) *CreateExternalTableRequest {
+	s.fileFormat = &fileFormat
 	return s
 }
 
-func (s *CreateExternalTableRequest) WithAwsSnsTopic(awsSnsTopic *string) *CreateExternalTableRequest {
-	s.awsSnsTopic = awsSnsTopic
+func (s *CreateExternalTableRequest) WithAwsSnsTopic(awsSnsTopic string) *CreateExternalTableRequest {
+	if len(awsSnsTopic) > 0 {
+		s.awsSnsTopic = &awsSnsTopic
+	}
 	return s
 }
 
-func (s *CreateExternalTableRequest) WithCopyGrants(copyGrants *bool) *CreateExternalTableRequest {
-	s.copyGrants = copyGrants
+func (s *CreateExternalTableRequest) WithCopyGrants(copyGrants bool) *CreateExternalTableRequest {
+	s.copyGrants = &copyGrants
 	return s
 }
 
-func (s *CreateExternalTableRequest) WithComment(comment *string) *CreateExternalTableRequest {
-	s.comment = comment
+func (s *CreateExternalTableRequest) WithComment(comment string) *CreateExternalTableRequest {
+	if len(comment) > 0 {
+		s.comment = &comment
+	}
 	return s
 }
 
-func (s *CreateExternalTableRequest) WithRowAccessPolicy(rowAccessPolicy *RowAccessPolicyRequest) *CreateExternalTableRequest {
-	s.rowAccessPolicy = rowAccessPolicy
+func (s *CreateExternalTableRequest) WithRowAccessPolicy(rowAccessPolicy RowAccessPolicyRequest) *CreateExternalTableRequest {
+	s.rowAccessPolicy = &rowAccessPolicy
 	return s
 }
 
@@ -101,13 +109,13 @@ func NewExternalTableColumnRequest(
 	return &s
 }
 
-func (s *ExternalTableColumnRequest) WithNotNull(notNull *bool) *ExternalTableColumnRequest {
-	s.notNull = notNull
+func (s *ExternalTableColumnRequest) WithNotNull(notNull bool) *ExternalTableColumnRequest {
+	s.notNull = &notNull
 	return s
 }
 
-func (s *ExternalTableColumnRequest) WithInlineConstraint(inlineConstraint *ColumnInlineConstraintRequest) *ExternalTableColumnRequest {
-	s.inlineConstraint = inlineConstraint
+func (s *ExternalTableColumnRequest) WithInlineConstraint(inlineConstraint ColumnInlineConstraintRequest) *ExternalTableColumnRequest {
+	s.inlineConstraint = &inlineConstraint
 	return s
 }
 
@@ -115,13 +123,17 @@ func NewCloudProviderParamsRequest() *CloudProviderParamsRequest {
 	return &CloudProviderParamsRequest{}
 }
 
-func (s *CloudProviderParamsRequest) WithGoogleCloudStorageIntegration(googleCloudStorageIntegration *string) *CloudProviderParamsRequest {
-	s.googleCloudStorageIntegration = googleCloudStorageIntegration
+func (s *CloudProviderParamsRequest) WithGoogleCloudStorageIntegration(googleCloudStorageIntegration string) *CloudProviderParamsRequest {
+	if len(googleCloudStorageIntegration) > 0 {
+		s.googleCloudStorageIntegration = &googleCloudStorageIntegration
+	}
 	return s
 }
 
-func (s *CloudProviderParamsRequest) WithMicrosoftAzureIntegration(microsoftAzureIntegration *string) *CloudProviderParamsRequest {
-	s.microsoftAzureIntegration = microsoftAzureIntegration
+func (s *CloudProviderParamsRequest) WithMicrosoftAzureIntegration(microsoftAzureIntegration string) *CloudProviderParamsRequest {
+	if len(microsoftAzureIntegration) > 0 {
+		s.microsoftAzureIntegration = &microsoftAzureIntegration
+	}
 	return s
 }
 
@@ -129,18 +141,20 @@ func NewExternalTableFileFormatRequest() *ExternalTableFileFormatRequest {
 	return &ExternalTableFileFormatRequest{}
 }
 
-func (s *ExternalTableFileFormatRequest) WithName(name *string) *ExternalTableFileFormatRequest {
-	s.name = name
+func (s *ExternalTableFileFormatRequest) WithName(name string) *ExternalTableFileFormatRequest {
+	if len(name) > 0 {
+		s.name = &name
+	}
 	return s
 }
 
-func (s *ExternalTableFileFormatRequest) WithFileFormatType(fileFormatType *ExternalTableFileFormatType) *ExternalTableFileFormatRequest {
-	s.fileFormatType = fileFormatType
+func (s *ExternalTableFileFormatRequest) WithFileFormatType(fileFormatType ExternalTableFileFormatType) *ExternalTableFileFormatRequest {
+	s.fileFormatType = &fileFormatType
 	return s
 }
 
-func (s *ExternalTableFileFormatRequest) WithOptions(options *ExternalTableFileFormatTypeOptionsRequest) *ExternalTableFileFormatRequest {
-	s.options = options
+func (s *ExternalTableFileFormatRequest) WithOptions(options ExternalTableFileFormatTypeOptionsRequest) *ExternalTableFileFormatRequest {
+	s.options = &options
 	return s
 }
 
@@ -148,123 +162,131 @@ func NewExternalTableFileFormatTypeOptionsRequest() *ExternalTableFileFormatType
 	return &ExternalTableFileFormatTypeOptionsRequest{}
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvCompression(csvCompression *ExternalTableCsvCompression) *ExternalTableFileFormatTypeOptionsRequest {
-	s.csvCompression = csvCompression
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvCompression(csvCompression ExternalTableCsvCompression) *ExternalTableFileFormatTypeOptionsRequest {
+	s.csvCompression = &csvCompression
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvRecordDelimiter(csvRecordDelimiter *string) *ExternalTableFileFormatTypeOptionsRequest {
-	s.csvRecordDelimiter = csvRecordDelimiter
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvRecordDelimiter(csvRecordDelimiter string) *ExternalTableFileFormatTypeOptionsRequest {
+	if len(csvRecordDelimiter) > 0 {
+		s.csvRecordDelimiter = &csvRecordDelimiter
+	}
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvFieldDelimiter(csvFieldDelimiter *string) *ExternalTableFileFormatTypeOptionsRequest {
-	s.csvFieldDelimiter = csvFieldDelimiter
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvFieldDelimiter(csvFieldDelimiter string) *ExternalTableFileFormatTypeOptionsRequest {
+	if len(csvFieldDelimiter) > 0 {
+		s.csvFieldDelimiter = &csvFieldDelimiter
+	}
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvSkipHeader(csvSkipHeader *int) *ExternalTableFileFormatTypeOptionsRequest {
-	s.csvSkipHeader = csvSkipHeader
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvSkipHeader(csvSkipHeader int) *ExternalTableFileFormatTypeOptionsRequest {
+	s.csvSkipHeader = &csvSkipHeader
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvSkipBlankLines(csvSkipBlankLines *bool) *ExternalTableFileFormatTypeOptionsRequest {
-	s.csvSkipBlankLines = csvSkipBlankLines
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvSkipBlankLines(csvSkipBlankLines bool) *ExternalTableFileFormatTypeOptionsRequest {
+	s.csvSkipBlankLines = &csvSkipBlankLines
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvEscapeUnenclosedField(csvEscapeUnenclosedField *string) *ExternalTableFileFormatTypeOptionsRequest {
-	s.csvEscapeUnenclosedField = csvEscapeUnenclosedField
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvEscapeUnenclosedField(csvEscapeUnenclosedField string) *ExternalTableFileFormatTypeOptionsRequest {
+	if len(csvEscapeUnenclosedField) > 0 {
+		s.csvEscapeUnenclosedField = &csvEscapeUnenclosedField
+	}
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvTrimSpace(csvTrimSpace *bool) *ExternalTableFileFormatTypeOptionsRequest {
-	s.csvTrimSpace = csvTrimSpace
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvTrimSpace(csvTrimSpace bool) *ExternalTableFileFormatTypeOptionsRequest {
+	s.csvTrimSpace = &csvTrimSpace
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvFieldOptionallyEnclosedBy(csvFieldOptionallyEnclosedBy *string) *ExternalTableFileFormatTypeOptionsRequest {
-	s.csvFieldOptionallyEnclosedBy = csvFieldOptionallyEnclosedBy
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvFieldOptionallyEnclosedBy(csvFieldOptionallyEnclosedBy string) *ExternalTableFileFormatTypeOptionsRequest {
+	if len(csvFieldOptionallyEnclosedBy) > 0 {
+		s.csvFieldOptionallyEnclosedBy = &csvFieldOptionallyEnclosedBy
+	}
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvNullIf(csvNullIf *[]NullStringRequest) *ExternalTableFileFormatTypeOptionsRequest {
-	s.csvNullIf = csvNullIf
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvNullIf(csvNullIf []NullStringRequest) *ExternalTableFileFormatTypeOptionsRequest {
+	s.csvNullIf = &csvNullIf
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvEmptyFieldAsNull(csvEmptyFieldAsNull *bool) *ExternalTableFileFormatTypeOptionsRequest {
-	s.csvEmptyFieldAsNull = csvEmptyFieldAsNull
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvEmptyFieldAsNull(csvEmptyFieldAsNull bool) *ExternalTableFileFormatTypeOptionsRequest {
+	s.csvEmptyFieldAsNull = &csvEmptyFieldAsNull
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvEncoding(csvEncoding *CSVEncoding) *ExternalTableFileFormatTypeOptionsRequest {
-	s.csvEncoding = csvEncoding
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvEncoding(csvEncoding CSVEncoding) *ExternalTableFileFormatTypeOptionsRequest {
+	s.csvEncoding = &csvEncoding
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithJsonCompression(jsonCompression *ExternalTableJsonCompression) *ExternalTableFileFormatTypeOptionsRequest {
-	s.jsonCompression = jsonCompression
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithJsonCompression(jsonCompression ExternalTableJsonCompression) *ExternalTableFileFormatTypeOptionsRequest {
+	s.jsonCompression = &jsonCompression
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithJsonAllowDuplicate(jsonAllowDuplicate *bool) *ExternalTableFileFormatTypeOptionsRequest {
-	s.jsonAllowDuplicate = jsonAllowDuplicate
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithJsonAllowDuplicate(jsonAllowDuplicate bool) *ExternalTableFileFormatTypeOptionsRequest {
+	s.jsonAllowDuplicate = &jsonAllowDuplicate
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithJsonStripOuterArray(jsonStripOuterArray *bool) *ExternalTableFileFormatTypeOptionsRequest {
-	s.jsonStripOuterArray = jsonStripOuterArray
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithJsonStripOuterArray(jsonStripOuterArray bool) *ExternalTableFileFormatTypeOptionsRequest {
+	s.jsonStripOuterArray = &jsonStripOuterArray
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithJsonStripNullValues(jsonStripNullValues *bool) *ExternalTableFileFormatTypeOptionsRequest {
-	s.jsonStripNullValues = jsonStripNullValues
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithJsonStripNullValues(jsonStripNullValues bool) *ExternalTableFileFormatTypeOptionsRequest {
+	s.jsonStripNullValues = &jsonStripNullValues
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithJsonReplaceInvalidCharacters(jsonReplaceInvalidCharacters *bool) *ExternalTableFileFormatTypeOptionsRequest {
-	s.jsonReplaceInvalidCharacters = jsonReplaceInvalidCharacters
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithJsonReplaceInvalidCharacters(jsonReplaceInvalidCharacters bool) *ExternalTableFileFormatTypeOptionsRequest {
+	s.jsonReplaceInvalidCharacters = &jsonReplaceInvalidCharacters
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithAvroCompression(avroCompression *ExternalTableAvroCompression) *ExternalTableFileFormatTypeOptionsRequest {
-	s.avroCompression = avroCompression
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithAvroCompression(avroCompression ExternalTableAvroCompression) *ExternalTableFileFormatTypeOptionsRequest {
+	s.avroCompression = &avroCompression
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithAvroReplaceInvalidCharacters(avroReplaceInvalidCharacters *bool) *ExternalTableFileFormatTypeOptionsRequest {
-	s.avroReplaceInvalidCharacters = avroReplaceInvalidCharacters
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithAvroReplaceInvalidCharacters(avroReplaceInvalidCharacters bool) *ExternalTableFileFormatTypeOptionsRequest {
+	s.avroReplaceInvalidCharacters = &avroReplaceInvalidCharacters
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithOrcTrimSpace(orcTrimSpace *bool) *ExternalTableFileFormatTypeOptionsRequest {
-	s.orcTrimSpace = orcTrimSpace
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithOrcTrimSpace(orcTrimSpace bool) *ExternalTableFileFormatTypeOptionsRequest {
+	s.orcTrimSpace = &orcTrimSpace
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithOrcReplaceInvalidCharacters(orcReplaceInvalidCharacters *bool) *ExternalTableFileFormatTypeOptionsRequest {
-	s.orcReplaceInvalidCharacters = orcReplaceInvalidCharacters
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithOrcReplaceInvalidCharacters(orcReplaceInvalidCharacters bool) *ExternalTableFileFormatTypeOptionsRequest {
+	s.orcReplaceInvalidCharacters = &orcReplaceInvalidCharacters
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithOrcNullIf(orcNullIf *[]NullStringRequest) *ExternalTableFileFormatTypeOptionsRequest {
-	s.orcNullIf = orcNullIf
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithOrcNullIf(orcNullIf []NullStringRequest) *ExternalTableFileFormatTypeOptionsRequest {
+	s.orcNullIf = &orcNullIf
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithParquetCompression(parquetCompression *ExternalTableParquetCompression) *ExternalTableFileFormatTypeOptionsRequest {
-	s.parquetCompression = parquetCompression
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithParquetCompression(parquetCompression ExternalTableParquetCompression) *ExternalTableFileFormatTypeOptionsRequest {
+	s.parquetCompression = &parquetCompression
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithParquetBinaryAsText(parquetBinaryAsText *bool) *ExternalTableFileFormatTypeOptionsRequest {
-	s.parquetBinaryAsText = parquetBinaryAsText
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithParquetBinaryAsText(parquetBinaryAsText bool) *ExternalTableFileFormatTypeOptionsRequest {
+	s.parquetBinaryAsText = &parquetBinaryAsText
 	return s
 }
 
-func (s *ExternalTableFileFormatTypeOptionsRequest) WithParquetReplaceInvalidCharacters(parquetReplaceInvalidCharacters *bool) *ExternalTableFileFormatTypeOptionsRequest {
-	s.parquetReplaceInvalidCharacters = parquetReplaceInvalidCharacters
+func (s *ExternalTableFileFormatTypeOptionsRequest) WithParquetReplaceInvalidCharacters(parquetReplaceInvalidCharacters bool) *ExternalTableFileFormatTypeOptionsRequest {
+	s.parquetReplaceInvalidCharacters = &parquetReplaceInvalidCharacters
 	return s
 }
 
@@ -287,13 +309,13 @@ func NewCreateWithManualPartitioningExternalTableRequest(
 	return &s
 }
 
-func (s *CreateWithManualPartitioningExternalTableRequest) WithOrReplace(orReplace *bool) *CreateWithManualPartitioningExternalTableRequest {
-	s.orReplace = orReplace
+func (s *CreateWithManualPartitioningExternalTableRequest) WithOrReplace(orReplace bool) *CreateWithManualPartitioningExternalTableRequest {
+	s.orReplace = &orReplace
 	return s
 }
 
-func (s *CreateWithManualPartitioningExternalTableRequest) WithIfNotExists(ifNotExists *bool) *CreateWithManualPartitioningExternalTableRequest {
-	s.ifNotExists = ifNotExists
+func (s *CreateWithManualPartitioningExternalTableRequest) WithIfNotExists(ifNotExists bool) *CreateWithManualPartitioningExternalTableRequest {
+	s.ifNotExists = &ifNotExists
 	return s
 }
 
@@ -302,8 +324,8 @@ func (s *CreateWithManualPartitioningExternalTableRequest) WithColumns(columns [
 	return s
 }
 
-func (s *CreateWithManualPartitioningExternalTableRequest) WithCloudProviderParams(cloudProviderParams *CloudProviderParamsRequest) *CreateWithManualPartitioningExternalTableRequest {
-	s.cloudProviderParams = cloudProviderParams
+func (s *CreateWithManualPartitioningExternalTableRequest) WithCloudProviderParams(cloudProviderParams CloudProviderParamsRequest) *CreateWithManualPartitioningExternalTableRequest {
+	s.cloudProviderParams = &cloudProviderParams
 	return s
 }
 
@@ -312,28 +334,32 @@ func (s *CreateWithManualPartitioningExternalTableRequest) WithPartitionBy(parti
 	return s
 }
 
-func (s *CreateWithManualPartitioningExternalTableRequest) WithRawFileFormat(rawFileFormat *string) *CreateWithManualPartitioningExternalTableRequest {
-	s.rawFileFormat = rawFileFormat
+func (s *CreateWithManualPartitioningExternalTableRequest) WithRawFileFormat(rawFileFormat string) *CreateWithManualPartitioningExternalTableRequest {
+	if len(rawFileFormat) > 0 {
+		s.rawFileFormat = &rawFileFormat
+	}
 	return s
 }
 
-func (s *CreateWithManualPartitioningExternalTableRequest) WithFileFormat(fileFormat *ExternalTableFileFormatRequest) *CreateWithManualPartitioningExternalTableRequest {
-	s.fileFormat = fileFormat
+func (s *CreateWithManualPartitioningExternalTableRequest) WithFileFormat(fileFormat ExternalTableFileFormatRequest) *CreateWithManualPartitioningExternalTableRequest {
+	s.fileFormat = &fileFormat
 	return s
 }
 
-func (s *CreateWithManualPartitioningExternalTableRequest) WithCopyGrants(copyGrants *bool) *CreateWithManualPartitioningExternalTableRequest {
-	s.copyGrants = copyGrants
+func (s *CreateWithManualPartitioningExternalTableRequest) WithCopyGrants(copyGrants bool) *CreateWithManualPartitioningExternalTableRequest {
+	s.copyGrants = &copyGrants
 	return s
 }
 
-func (s *CreateWithManualPartitioningExternalTableRequest) WithComment(comment *string) *CreateWithManualPartitioningExternalTableRequest {
-	s.comment = comment
+func (s *CreateWithManualPartitioningExternalTableRequest) WithComment(comment string) *CreateWithManualPartitioningExternalTableRequest {
+	if len(comment) > 0 {
+		s.comment = &comment
+	}
 	return s
 }
 
-func (s *CreateWithManualPartitioningExternalTableRequest) WithRowAccessPolicy(rowAccessPolicy *RowAccessPolicyRequest) *CreateWithManualPartitioningExternalTableRequest {
-	s.rowAccessPolicy = rowAccessPolicy
+func (s *CreateWithManualPartitioningExternalTableRequest) WithRowAccessPolicy(rowAccessPolicy RowAccessPolicyRequest) *CreateWithManualPartitioningExternalTableRequest {
+	s.rowAccessPolicy = &rowAccessPolicy
 	return s
 }
 
@@ -352,13 +378,13 @@ func NewCreateDeltaLakeExternalTableRequest(
 	return &s
 }
 
-func (s *CreateDeltaLakeExternalTableRequest) WithOrReplace(orReplace *bool) *CreateDeltaLakeExternalTableRequest {
-	s.orReplace = orReplace
+func (s *CreateDeltaLakeExternalTableRequest) WithOrReplace(orReplace bool) *CreateDeltaLakeExternalTableRequest {
+	s.orReplace = &orReplace
 	return s
 }
 
-func (s *CreateDeltaLakeExternalTableRequest) WithIfNotExists(ifNotExists *bool) *CreateDeltaLakeExternalTableRequest {
-	s.ifNotExists = ifNotExists
+func (s *CreateDeltaLakeExternalTableRequest) WithIfNotExists(ifNotExists bool) *CreateDeltaLakeExternalTableRequest {
+	s.ifNotExists = &ifNotExists
 	return s
 }
 
@@ -367,8 +393,8 @@ func (s *CreateDeltaLakeExternalTableRequest) WithColumns(columns []*ExternalTab
 	return s
 }
 
-func (s *CreateDeltaLakeExternalTableRequest) WithCloudProviderParams(cloudProviderParams *CloudProviderParamsRequest) *CreateDeltaLakeExternalTableRequest {
-	s.cloudProviderParams = cloudProviderParams
+func (s *CreateDeltaLakeExternalTableRequest) WithCloudProviderParams(cloudProviderParams CloudProviderParamsRequest) *CreateDeltaLakeExternalTableRequest {
+	s.cloudProviderParams = &cloudProviderParams
 	return s
 }
 
@@ -377,38 +403,42 @@ func (s *CreateDeltaLakeExternalTableRequest) WithPartitionBy(partitionBy []stri
 	return s
 }
 
-func (s *CreateDeltaLakeExternalTableRequest) WithRefreshOnCreate(refreshOnCreate *bool) *CreateDeltaLakeExternalTableRequest {
-	s.refreshOnCreate = refreshOnCreate
+func (s *CreateDeltaLakeExternalTableRequest) WithRefreshOnCreate(refreshOnCreate bool) *CreateDeltaLakeExternalTableRequest {
+	s.refreshOnCreate = &refreshOnCreate
 	return s
 }
 
-func (s *CreateDeltaLakeExternalTableRequest) WithAutoRefresh(autoRefresh *bool) *CreateDeltaLakeExternalTableRequest {
-	s.autoRefresh = autoRefresh
+func (s *CreateDeltaLakeExternalTableRequest) WithAutoRefresh(autoRefresh bool) *CreateDeltaLakeExternalTableRequest {
+	s.autoRefresh = &autoRefresh
 	return s
 }
 
-func (s *CreateDeltaLakeExternalTableRequest) WithRawFileFormat(rawFileFormat *string) *CreateDeltaLakeExternalTableRequest {
-	s.rawFileFormat = rawFileFormat
+func (s *CreateDeltaLakeExternalTableRequest) WithRawFileFormat(rawFileFormat string) *CreateDeltaLakeExternalTableRequest {
+	if len(rawFileFormat) > 0 {
+		s.rawFileFormat = &rawFileFormat
+	}
 	return s
 }
 
-func (s *CreateDeltaLakeExternalTableRequest) WithFileFormat(fileFormat *ExternalTableFileFormatRequest) *CreateDeltaLakeExternalTableRequest {
-	s.fileFormat = fileFormat
+func (s *CreateDeltaLakeExternalTableRequest) WithFileFormat(fileFormat ExternalTableFileFormatRequest) *CreateDeltaLakeExternalTableRequest {
+	s.fileFormat = &fileFormat
 	return s
 }
 
-func (s *CreateDeltaLakeExternalTableRequest) WithCopyGrants(copyGrants *bool) *CreateDeltaLakeExternalTableRequest {
-	s.copyGrants = copyGrants
+func (s *CreateDeltaLakeExternalTableRequest) WithCopyGrants(copyGrants bool) *CreateDeltaLakeExternalTableRequest {
+	s.copyGrants = &copyGrants
 	return s
 }
 
-func (s *CreateDeltaLakeExternalTableRequest) WithComment(comment *string) *CreateDeltaLakeExternalTableRequest {
-	s.comment = comment
+func (s *CreateDeltaLakeExternalTableRequest) WithComment(comment string) *CreateDeltaLakeExternalTableRequest {
+	if len(comment) > 0 {
+		s.comment = &comment
+	}
 	return s
 }
 
-func (s *CreateDeltaLakeExternalTableRequest) WithRowAccessPolicy(rowAccessPolicy *RowAccessPolicyRequest) *CreateDeltaLakeExternalTableRequest {
-	s.rowAccessPolicy = rowAccessPolicy
+func (s *CreateDeltaLakeExternalTableRequest) WithRowAccessPolicy(rowAccessPolicy RowAccessPolicyRequest) *CreateDeltaLakeExternalTableRequest {
+	s.rowAccessPolicy = &rowAccessPolicy
 	return s
 }
 
@@ -427,13 +457,13 @@ func NewCreateExternalTableUsingTemplateRequest(
 	return &s
 }
 
-func (s *CreateExternalTableUsingTemplateRequest) WithOrReplace(orReplace *bool) *CreateExternalTableUsingTemplateRequest {
-	s.orReplace = orReplace
+func (s *CreateExternalTableUsingTemplateRequest) WithOrReplace(orReplace bool) *CreateExternalTableUsingTemplateRequest {
+	s.orReplace = &orReplace
 	return s
 }
 
-func (s *CreateExternalTableUsingTemplateRequest) WithCopyGrants(copyGrants *bool) *CreateExternalTableUsingTemplateRequest {
-	s.copyGrants = copyGrants
+func (s *CreateExternalTableUsingTemplateRequest) WithCopyGrants(copyGrants bool) *CreateExternalTableUsingTemplateRequest {
+	s.copyGrants = &copyGrants
 	return s
 }
 
@@ -442,8 +472,8 @@ func (s *CreateExternalTableUsingTemplateRequest) WithQuery(query string) *Creat
 	return s
 }
 
-func (s *CreateExternalTableUsingTemplateRequest) WithCloudProviderParams(cloudProviderParams *CloudProviderParamsRequest) *CreateExternalTableUsingTemplateRequest {
-	s.cloudProviderParams = cloudProviderParams
+func (s *CreateExternalTableUsingTemplateRequest) WithCloudProviderParams(cloudProviderParams CloudProviderParamsRequest) *CreateExternalTableUsingTemplateRequest {
+	s.cloudProviderParams = &cloudProviderParams
 	return s
 }
 
@@ -452,43 +482,51 @@ func (s *CreateExternalTableUsingTemplateRequest) WithPartitionBy(partitionBy []
 	return s
 }
 
-func (s *CreateExternalTableUsingTemplateRequest) WithRefreshOnCreate(refreshOnCreate *bool) *CreateExternalTableUsingTemplateRequest {
-	s.refreshOnCreate = refreshOnCreate
+func (s *CreateExternalTableUsingTemplateRequest) WithRefreshOnCreate(refreshOnCreate bool) *CreateExternalTableUsingTemplateRequest {
+	s.refreshOnCreate = &refreshOnCreate
 	return s
 }
 
-func (s *CreateExternalTableUsingTemplateRequest) WithAutoRefresh(autoRefresh *bool) *CreateExternalTableUsingTemplateRequest {
-	s.autoRefresh = autoRefresh
+func (s *CreateExternalTableUsingTemplateRequest) WithAutoRefresh(autoRefresh bool) *CreateExternalTableUsingTemplateRequest {
+	s.autoRefresh = &autoRefresh
 	return s
 }
 
-func (s *CreateExternalTableUsingTemplateRequest) WithPattern(pattern *string) *CreateExternalTableUsingTemplateRequest {
-	s.pattern = pattern
+func (s *CreateExternalTableUsingTemplateRequest) WithPattern(pattern string) *CreateExternalTableUsingTemplateRequest {
+	if len(pattern) > 0 {
+		s.pattern = &pattern
+	}
 	return s
 }
 
-func (s *CreateExternalTableUsingTemplateRequest) WithRawFileFormat(rawFileFormat *string) *CreateExternalTableUsingTemplateRequest {
-	s.rawFileFormat = rawFileFormat
+func (s *CreateExternalTableUsingTemplateRequest) WithRawFileFormat(rawFileFormat string) *CreateExternalTableUsingTemplateRequest {
+	if len(rawFileFormat) > 0 {
+		s.rawFileFormat = &rawFileFormat
+	}
 	return s
 }
 
-func (s *CreateExternalTableUsingTemplateRequest) WithFileFormat(fileFormat *ExternalTableFileFormatRequest) *CreateExternalTableUsingTemplateRequest {
-	s.fileFormat = fileFormat
+func (s *CreateExternalTableUsingTemplateRequest) WithFileFormat(fileFormat ExternalTableFileFormatRequest) *CreateExternalTableUsingTemplateRequest {
+	s.fileFormat = &fileFormat
 	return s
 }
 
-func (s *CreateExternalTableUsingTemplateRequest) WithAwsSnsTopic(awsSnsTopic *string) *CreateExternalTableUsingTemplateRequest {
-	s.awsSnsTopic = awsSnsTopic
+func (s *CreateExternalTableUsingTemplateRequest) WithAwsSnsTopic(awsSnsTopic string) *CreateExternalTableUsingTemplateRequest {
+	if len(awsSnsTopic) > 0 {
+		s.awsSnsTopic = &awsSnsTopic
+	}
 	return s
 }
 
-func (s *CreateExternalTableUsingTemplateRequest) WithComment(comment *string) *CreateExternalTableUsingTemplateRequest {
-	s.comment = comment
+func (s *CreateExternalTableUsingTemplateRequest) WithComment(comment string) *CreateExternalTableUsingTemplateRequest {
+	if len(comment) > 0 {
+		s.comment = &comment
+	}
 	return s
 }
 
-func (s *CreateExternalTableUsingTemplateRequest) WithRowAccessPolicy(rowAccessPolicy *RowAccessPolicyRequest) *CreateExternalTableUsingTemplateRequest {
-	s.rowAccessPolicy = rowAccessPolicy
+func (s *CreateExternalTableUsingTemplateRequest) WithRowAccessPolicy(rowAccessPolicy RowAccessPolicyRequest) *CreateExternalTableUsingTemplateRequest {
+	s.rowAccessPolicy = &rowAccessPolicy
 	return s
 }
 
@@ -505,13 +543,13 @@ func NewAlterExternalTableRequest(
 	return &s
 }
 
-func (s *AlterExternalTableRequest) WithIfExists(ifExists *bool) *AlterExternalTableRequest {
-	s.ifExists = ifExists
+func (s *AlterExternalTableRequest) WithIfExists(ifExists bool) *AlterExternalTableRequest {
+	s.ifExists = &ifExists
 	return s
 }
 
-func (s *AlterExternalTableRequest) WithRefresh(refresh *RefreshExternalTableRequest) *AlterExternalTableRequest {
-	s.refresh = refresh
+func (s *AlterExternalTableRequest) WithRefresh(refresh RefreshExternalTableRequest) *AlterExternalTableRequest {
+	s.refresh = &refresh
 	return s
 }
 
@@ -525,8 +563,8 @@ func (s *AlterExternalTableRequest) WithRemoveFiles(removeFiles []*ExternalTable
 	return s
 }
 
-func (s *AlterExternalTableRequest) WithAutoRefresh(autoRefresh *bool) *AlterExternalTableRequest {
-	s.autoRefresh = autoRefresh
+func (s *AlterExternalTableRequest) WithAutoRefresh(autoRefresh bool) *AlterExternalTableRequest {
+	s.autoRefresh = &autoRefresh
 	return s
 }
 
@@ -564,8 +602,8 @@ func NewAlterExternalTablePartitionRequest(
 	return &s
 }
 
-func (s *AlterExternalTablePartitionRequest) WithIfExists(ifExists *bool) *AlterExternalTablePartitionRequest {
-	s.ifExists = ifExists
+func (s *AlterExternalTablePartitionRequest) WithIfExists(ifExists bool) *AlterExternalTablePartitionRequest {
+	s.ifExists = &ifExists
 	return s
 }
 
@@ -574,8 +612,8 @@ func (s *AlterExternalTablePartitionRequest) WithAddPartitions(addPartitions []*
 	return s
 }
 
-func (s *AlterExternalTablePartitionRequest) WithDropPartition(dropPartition *bool) *AlterExternalTablePartitionRequest {
-	s.dropPartition = dropPartition
+func (s *AlterExternalTablePartitionRequest) WithDropPartition(dropPartition bool) *AlterExternalTablePartitionRequest {
+	s.dropPartition = &dropPartition
 	return s
 }
 
@@ -602,13 +640,13 @@ func NewDropExternalTableRequest(
 	return &s
 }
 
-func (s *DropExternalTableRequest) WithIfExists(ifExists *bool) *DropExternalTableRequest {
-	s.ifExists = ifExists
+func (s *DropExternalTableRequest) WithIfExists(ifExists bool) *DropExternalTableRequest {
+	s.ifExists = &ifExists
 	return s
 }
 
-func (s *DropExternalTableRequest) WithDropOption(dropOption *ExternalTableDropOptionRequest) *DropExternalTableRequest {
-	s.dropOption = dropOption
+func (s *DropExternalTableRequest) WithDropOption(dropOption ExternalTableDropOptionRequest) *DropExternalTableRequest {
+	s.dropOption = &dropOption
 	return s
 }
 
@@ -616,13 +654,13 @@ func NewExternalTableDropOptionRequest() *ExternalTableDropOptionRequest {
 	return &ExternalTableDropOptionRequest{}
 }
 
-func (s *ExternalTableDropOptionRequest) WithRestrict(restrict *bool) *ExternalTableDropOptionRequest {
-	s.restrict = restrict
+func (s *ExternalTableDropOptionRequest) WithRestrict(restrict bool) *ExternalTableDropOptionRequest {
+	s.restrict = &restrict
 	return s
 }
 
-func (s *ExternalTableDropOptionRequest) WithCascade(cascade *bool) *ExternalTableDropOptionRequest {
-	s.cascade = cascade
+func (s *ExternalTableDropOptionRequest) WithCascade(cascade bool) *ExternalTableDropOptionRequest {
+	s.cascade = &cascade
 	return s
 }
 
@@ -630,28 +668,32 @@ func NewShowExternalTableRequest() *ShowExternalTableRequest {
 	return &ShowExternalTableRequest{}
 }
 
-func (s *ShowExternalTableRequest) WithTerse(terse *bool) *ShowExternalTableRequest {
-	s.terse = terse
+func (s *ShowExternalTableRequest) WithTerse(terse bool) *ShowExternalTableRequest {
+	s.terse = &terse
 	return s
 }
 
-func (s *ShowExternalTableRequest) WithLike(like *string) *ShowExternalTableRequest {
-	s.like = like
+func (s *ShowExternalTableRequest) WithLike(like string) *ShowExternalTableRequest {
+	if len(like) > 0 {
+		s.like = &like
+	}
 	return s
 }
 
-func (s *ShowExternalTableRequest) WithIn(in *ShowExternalTableInRequest) *ShowExternalTableRequest {
-	s.in = in
+func (s *ShowExternalTableRequest) WithIn(in ShowExternalTableInRequest) *ShowExternalTableRequest {
+	s.in = &in
 	return s
 }
 
-func (s *ShowExternalTableRequest) WithStartsWith(startsWith *string) *ShowExternalTableRequest {
-	s.startsWith = startsWith
+func (s *ShowExternalTableRequest) WithStartsWith(startsWith string) *ShowExternalTableRequest {
+	if len(startsWith) > 0 {
+		s.startsWith = &startsWith
+	}
 	return s
 }
 
-func (s *ShowExternalTableRequest) WithLimitFrom(limitFrom *LimitFromRequest) *ShowExternalTableRequest {
-	s.limitFrom = limitFrom
+func (s *ShowExternalTableRequest) WithLimitFrom(limitFrom LimitFromRequest) *ShowExternalTableRequest {
+	s.limitFrom = &limitFrom
 	return s
 }
 
@@ -659,8 +701,8 @@ func NewShowExternalTableInRequest() *ShowExternalTableInRequest {
 	return &ShowExternalTableInRequest{}
 }
 
-func (s *ShowExternalTableInRequest) WithAccount(account *bool) *ShowExternalTableInRequest {
-	s.account = account
+func (s *ShowExternalTableInRequest) WithAccount(account bool) *ShowExternalTableInRequest {
+	s.account = &account
 	return s
 }
 

--- a/pkg/sdk/external_tables_dto_builders_gen.go
+++ b/pkg/sdk/external_tables_dto_builders_gen.go
@@ -50,16 +50,12 @@ func (s *CreateExternalTableRequest) WithAutoRefresh(autoRefresh bool) *CreateEx
 }
 
 func (s *CreateExternalTableRequest) WithPattern(pattern string) *CreateExternalTableRequest {
-	if len(pattern) > 0 {
-		s.pattern = &pattern
-	}
+	s.pattern = &pattern
 	return s
 }
 
 func (s *CreateExternalTableRequest) WithRawFileFormat(rawFileFormat string) *CreateExternalTableRequest {
-	if len(rawFileFormat) > 0 {
-		s.rawFileFormat = &rawFileFormat
-	}
+	s.rawFileFormat = &rawFileFormat
 	return s
 }
 
@@ -69,9 +65,7 @@ func (s *CreateExternalTableRequest) WithFileFormat(fileFormat ExternalTableFile
 }
 
 func (s *CreateExternalTableRequest) WithAwsSnsTopic(awsSnsTopic string) *CreateExternalTableRequest {
-	if len(awsSnsTopic) > 0 {
-		s.awsSnsTopic = &awsSnsTopic
-	}
+	s.awsSnsTopic = &awsSnsTopic
 	return s
 }
 
@@ -81,9 +75,7 @@ func (s *CreateExternalTableRequest) WithCopyGrants(copyGrants bool) *CreateExte
 }
 
 func (s *CreateExternalTableRequest) WithComment(comment string) *CreateExternalTableRequest {
-	if len(comment) > 0 {
-		s.comment = &comment
-	}
+	s.comment = &comment
 	return s
 }
 
@@ -124,16 +116,12 @@ func NewCloudProviderParamsRequest() *CloudProviderParamsRequest {
 }
 
 func (s *CloudProviderParamsRequest) WithGoogleCloudStorageIntegration(googleCloudStorageIntegration string) *CloudProviderParamsRequest {
-	if len(googleCloudStorageIntegration) > 0 {
-		s.googleCloudStorageIntegration = &googleCloudStorageIntegration
-	}
+	s.googleCloudStorageIntegration = &googleCloudStorageIntegration
 	return s
 }
 
 func (s *CloudProviderParamsRequest) WithMicrosoftAzureIntegration(microsoftAzureIntegration string) *CloudProviderParamsRequest {
-	if len(microsoftAzureIntegration) > 0 {
-		s.microsoftAzureIntegration = &microsoftAzureIntegration
-	}
+	s.microsoftAzureIntegration = &microsoftAzureIntegration
 	return s
 }
 
@@ -142,9 +130,7 @@ func NewExternalTableFileFormatRequest() *ExternalTableFileFormatRequest {
 }
 
 func (s *ExternalTableFileFormatRequest) WithName(name string) *ExternalTableFileFormatRequest {
-	if len(name) > 0 {
-		s.name = &name
-	}
+	s.name = &name
 	return s
 }
 
@@ -168,16 +154,12 @@ func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvCompression(csvCompre
 }
 
 func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvRecordDelimiter(csvRecordDelimiter string) *ExternalTableFileFormatTypeOptionsRequest {
-	if len(csvRecordDelimiter) > 0 {
-		s.csvRecordDelimiter = &csvRecordDelimiter
-	}
+	s.csvRecordDelimiter = &csvRecordDelimiter
 	return s
 }
 
 func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvFieldDelimiter(csvFieldDelimiter string) *ExternalTableFileFormatTypeOptionsRequest {
-	if len(csvFieldDelimiter) > 0 {
-		s.csvFieldDelimiter = &csvFieldDelimiter
-	}
+	s.csvFieldDelimiter = &csvFieldDelimiter
 	return s
 }
 
@@ -192,9 +174,7 @@ func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvSkipBlankLines(csvSki
 }
 
 func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvEscapeUnenclosedField(csvEscapeUnenclosedField string) *ExternalTableFileFormatTypeOptionsRequest {
-	if len(csvEscapeUnenclosedField) > 0 {
-		s.csvEscapeUnenclosedField = &csvEscapeUnenclosedField
-	}
+	s.csvEscapeUnenclosedField = &csvEscapeUnenclosedField
 	return s
 }
 
@@ -204,9 +184,7 @@ func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvTrimSpace(csvTrimSpac
 }
 
 func (s *ExternalTableFileFormatTypeOptionsRequest) WithCsvFieldOptionallyEnclosedBy(csvFieldOptionallyEnclosedBy string) *ExternalTableFileFormatTypeOptionsRequest {
-	if len(csvFieldOptionallyEnclosedBy) > 0 {
-		s.csvFieldOptionallyEnclosedBy = &csvFieldOptionallyEnclosedBy
-	}
+	s.csvFieldOptionallyEnclosedBy = &csvFieldOptionallyEnclosedBy
 	return s
 }
 
@@ -335,9 +313,7 @@ func (s *CreateWithManualPartitioningExternalTableRequest) WithPartitionBy(parti
 }
 
 func (s *CreateWithManualPartitioningExternalTableRequest) WithRawFileFormat(rawFileFormat string) *CreateWithManualPartitioningExternalTableRequest {
-	if len(rawFileFormat) > 0 {
-		s.rawFileFormat = &rawFileFormat
-	}
+	s.rawFileFormat = &rawFileFormat
 	return s
 }
 
@@ -352,9 +328,7 @@ func (s *CreateWithManualPartitioningExternalTableRequest) WithCopyGrants(copyGr
 }
 
 func (s *CreateWithManualPartitioningExternalTableRequest) WithComment(comment string) *CreateWithManualPartitioningExternalTableRequest {
-	if len(comment) > 0 {
-		s.comment = &comment
-	}
+	s.comment = &comment
 	return s
 }
 
@@ -414,9 +388,7 @@ func (s *CreateDeltaLakeExternalTableRequest) WithAutoRefresh(autoRefresh bool) 
 }
 
 func (s *CreateDeltaLakeExternalTableRequest) WithRawFileFormat(rawFileFormat string) *CreateDeltaLakeExternalTableRequest {
-	if len(rawFileFormat) > 0 {
-		s.rawFileFormat = &rawFileFormat
-	}
+	s.rawFileFormat = &rawFileFormat
 	return s
 }
 
@@ -431,9 +403,7 @@ func (s *CreateDeltaLakeExternalTableRequest) WithCopyGrants(copyGrants bool) *C
 }
 
 func (s *CreateDeltaLakeExternalTableRequest) WithComment(comment string) *CreateDeltaLakeExternalTableRequest {
-	if len(comment) > 0 {
-		s.comment = &comment
-	}
+	s.comment = &comment
 	return s
 }
 
@@ -493,16 +463,12 @@ func (s *CreateExternalTableUsingTemplateRequest) WithAutoRefresh(autoRefresh bo
 }
 
 func (s *CreateExternalTableUsingTemplateRequest) WithPattern(pattern string) *CreateExternalTableUsingTemplateRequest {
-	if len(pattern) > 0 {
-		s.pattern = &pattern
-	}
+	s.pattern = &pattern
 	return s
 }
 
 func (s *CreateExternalTableUsingTemplateRequest) WithRawFileFormat(rawFileFormat string) *CreateExternalTableUsingTemplateRequest {
-	if len(rawFileFormat) > 0 {
-		s.rawFileFormat = &rawFileFormat
-	}
+	s.rawFileFormat = &rawFileFormat
 	return s
 }
 
@@ -512,16 +478,12 @@ func (s *CreateExternalTableUsingTemplateRequest) WithFileFormat(fileFormat Exte
 }
 
 func (s *CreateExternalTableUsingTemplateRequest) WithAwsSnsTopic(awsSnsTopic string) *CreateExternalTableUsingTemplateRequest {
-	if len(awsSnsTopic) > 0 {
-		s.awsSnsTopic = &awsSnsTopic
-	}
+	s.awsSnsTopic = &awsSnsTopic
 	return s
 }
 
 func (s *CreateExternalTableUsingTemplateRequest) WithComment(comment string) *CreateExternalTableUsingTemplateRequest {
-	if len(comment) > 0 {
-		s.comment = &comment
-	}
+	s.comment = &comment
 	return s
 }
 
@@ -674,9 +636,7 @@ func (s *ShowExternalTableRequest) WithTerse(terse bool) *ShowExternalTableReque
 }
 
 func (s *ShowExternalTableRequest) WithLike(like string) *ShowExternalTableRequest {
-	if len(like) > 0 {
-		s.like = &like
-	}
+	s.like = &like
 	return s
 }
 
@@ -686,9 +646,7 @@ func (s *ShowExternalTableRequest) WithIn(in ShowExternalTableInRequest) *ShowEx
 }
 
 func (s *ShowExternalTableRequest) WithStartsWith(startsWith string) *ShowExternalTableRequest {
-	if len(startsWith) > 0 {
-		s.startsWith = &startsWith
-	}
+	s.startsWith = &startsWith
 	return s
 }
 

--- a/pkg/sdk/external_tables_impl.go
+++ b/pkg/sdk/external_tables_impl.go
@@ -55,8 +55,8 @@ func (v *externalTables) ShowByID(ctx context.Context, id SchemaObjectIdentifier
 	}
 
 	externalTables, err := v.client.ExternalTables.Show(ctx, NewShowExternalTableRequest().
-		WithIn(NewShowExternalTableInRequest().WithSchema(NewDatabaseObjectIdentifier(id.DatabaseName(), id.SchemaName()))).
-		WithLike(String(id.Name())))
+		WithIn(*NewShowExternalTableInRequest().WithSchema(NewDatabaseObjectIdentifier(id.DatabaseName(), id.SchemaName()))).
+		WithLike(id.Name()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sdk/poc/README.md
+++ b/pkg/sdk/poc/README.md
@@ -40,7 +40,6 @@ make clean-generator-session_policies run-generator-session_policies
 
 ### Next steps
 ##### Essentials
-- fix builder generation (`With`s for optional fields should have required param, optional fields should not be exported in `Request` structs)
 - generate each branch of alter in tests (instead of basic and all options)
 - clean up predefined operations in generator (now casting to string)
 - (?) add mapping from db to plain struct (for now only "// TODO: Mapping" comment is generated)

--- a/pkg/sdk/testint/external_tables_integration_test.go
+++ b/pkg/sdk/testint/external_tables_integration_test.go
@@ -74,9 +74,7 @@ func TestInt_ExternalTables(t *testing.T) {
 	t.Run("Create: with raw file format", func(t *testing.T) {
 		name := random.AlphanumericN(32)
 		externalTableID := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, name)
-		err := client.ExternalTables.Create(ctx, minimalCreateExternalTableReq(name).
-			WithRawFileFormat("TYPE = JSON"),
-		)
+		err := client.ExternalTables.Create(ctx, sdk.NewCreateExternalTableRequest(sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, name), stageLocation).WithRawFileFormat("TYPE = JSON"))
 		require.NoError(t, err)
 
 		externalTable, err := client.ExternalTables.ShowByID(ctx, externalTableID)

--- a/pkg/sdk/testint/external_tables_integration_test.go
+++ b/pkg/sdk/testint/external_tables_integration_test.go
@@ -43,7 +43,7 @@ func TestInt_ExternalTables(t *testing.T) {
 		return sdk.NewCreateExternalTableRequest(
 			sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, name),
 			stageLocation,
-		).WithFileFormat(sdk.NewExternalTableFileFormatRequest().WithFileFormatType(&sdk.ExternalTableFileFormatTypeJSON))
+		).WithFileFormat(*sdk.NewExternalTableFileFormatRequest().WithFileFormatType(sdk.ExternalTableFileFormatTypeJSON))
 	}
 
 	createExternalTableWithManualPartitioningReq := func(name string) *sdk.CreateWithManualPartitioningExternalTableRequest {
@@ -51,12 +51,12 @@ func TestInt_ExternalTables(t *testing.T) {
 			sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, name),
 			stageLocation,
 		).
-			WithFileFormat(sdk.NewExternalTableFileFormatRequest().WithFileFormatType(&sdk.ExternalTableFileFormatTypeJSON)).
-			WithOrReplace(sdk.Bool(true)).
+			WithFileFormat(*sdk.NewExternalTableFileFormatRequest().WithFileFormatType(sdk.ExternalTableFileFormatTypeJSON)).
+			WithOrReplace(true).
 			WithColumns(columnsWithPartition).
 			WithPartitionBy([]string{"part_date"}).
-			WithCopyGrants(sdk.Bool(true)).
-			WithComment(sdk.String("some_comment")).
+			WithCopyGrants(true).
+			WithComment("some_comment").
 			WithTag([]*sdk.TagAssociationRequest{sdk.NewTagAssociationRequest(tag.ID(), "tag-value")})
 	}
 
@@ -75,8 +75,7 @@ func TestInt_ExternalTables(t *testing.T) {
 		name := random.AlphanumericN(32)
 		externalTableID := sdk.NewSchemaObjectIdentifier(testDb(t).Name, testSchema(t).Name, name)
 		err := client.ExternalTables.Create(ctx, minimalCreateExternalTableReq(name).
-			WithFileFormat(nil).
-			WithRawFileFormat(sdk.String("TYPE = JSON")),
+			WithRawFileFormat("TYPE = JSON"),
 		)
 		require.NoError(t, err)
 
@@ -94,15 +93,15 @@ func TestInt_ExternalTables(t *testing.T) {
 				externalTableID,
 				stageLocation,
 			).
-				WithFileFormat(sdk.NewExternalTableFileFormatRequest().WithFileFormatType(&sdk.ExternalTableFileFormatTypeJSON)).
-				WithOrReplace(sdk.Bool(true)).
+				WithFileFormat(*sdk.NewExternalTableFileFormatRequest().WithFileFormatType(sdk.ExternalTableFileFormatTypeJSON)).
+				WithOrReplace(true).
 				WithColumns(columns).
 				WithPartitionBy([]string{"filename"}).
-				WithRefreshOnCreate(sdk.Bool(false)).
-				WithAutoRefresh(sdk.Bool(false)).
-				WithPattern(sdk.String("weather-nyc/weather_2_3_0.json.gz")).
-				WithCopyGrants(sdk.Bool(true)).
-				WithComment(sdk.String("some_comment")).
+				WithRefreshOnCreate(false).
+				WithAutoRefresh(false).
+				WithPattern("weather-nyc/weather_2_3_0.json.gz").
+				WithCopyGrants(true).
+				WithComment("some_comment").
 				WithTag([]*sdk.TagAssociationRequest{sdk.NewTagAssociationRequest(tag.ID(), "tag-value")}),
 		)
 		require.NoError(t, err)
@@ -128,9 +127,9 @@ func TestInt_ExternalTables(t *testing.T) {
 				id,
 				stageLocation,
 			).
-				WithFileFormat(sdk.NewExternalTableFileFormatRequest().WithName(sdk.String(fileFormat.ID().FullyQualifiedName()))).
+				WithFileFormat(*sdk.NewExternalTableFileFormatRequest().WithName(fileFormat.ID().FullyQualifiedName())).
 				WithQuery(query).
-				WithAutoRefresh(sdk.Bool(false)))
+				WithAutoRefresh(false))
 		require.NoError(t, err)
 
 		_, err = client.ExternalTables.ShowByID(ctx, id)
@@ -157,14 +156,14 @@ func TestInt_ExternalTables(t *testing.T) {
 				externalTableID,
 				stageLocation,
 			).
-				WithFileFormat(sdk.NewExternalTableFileFormatRequest().WithFileFormatType(&sdk.ExternalTableFileFormatTypeParquet)).
-				WithOrReplace(sdk.Bool(true)).
+				WithFileFormat(*sdk.NewExternalTableFileFormatRequest().WithFileFormatType(sdk.ExternalTableFileFormatTypeParquet)).
+				WithOrReplace(true).
 				WithColumns(columnsWithPartition).
 				WithPartitionBy([]string{"filename"}).
-				WithAutoRefresh(sdk.Bool(false)).
-				WithRefreshOnCreate(sdk.Bool(false)).
-				WithCopyGrants(sdk.Bool(true)).
-				WithComment(sdk.String("some_comment")).
+				WithAutoRefresh(false).
+				WithRefreshOnCreate(false).
+				WithCopyGrants(true).
+				WithComment("some_comment").
 				WithTag([]*sdk.TagAssociationRequest{sdk.NewTagAssociationRequest(tag.ID(), "tag-value")}),
 		)
 		require.NoError(t, err)
@@ -183,8 +182,8 @@ func TestInt_ExternalTables(t *testing.T) {
 		err = client.ExternalTables.Alter(
 			ctx,
 			sdk.NewAlterExternalTableRequest(externalTableID).
-				WithIfExists(sdk.Bool(true)).
-				WithRefresh(sdk.NewRefreshExternalTableRequest("weather-nyc")),
+				WithIfExists(true).
+				WithRefresh(*sdk.NewRefreshExternalTableRequest("weather-nyc")),
 		)
 		require.NoError(t, err)
 	})
@@ -195,14 +194,14 @@ func TestInt_ExternalTables(t *testing.T) {
 		err := client.ExternalTables.Create(
 			ctx,
 			minimalCreateExternalTableReq(name).
-				WithPattern(sdk.String("weather-nyc/weather_2_3_0.json.gz")),
+				WithPattern("weather-nyc/weather_2_3_0.json.gz"),
 		)
 		require.NoError(t, err)
 
 		err = client.ExternalTables.Alter(
 			ctx,
 			sdk.NewAlterExternalTableRequest(externalTableID).
-				WithIfExists(sdk.Bool(true)).
+				WithIfExists(true).
 				WithAddFiles([]*sdk.ExternalTableFileRequest{sdk.NewExternalTableFileRequest("weather-nyc/weather_0_0_0.json.gz")}),
 		)
 		require.NoError(t, err)
@@ -214,14 +213,14 @@ func TestInt_ExternalTables(t *testing.T) {
 		err := client.ExternalTables.Create(
 			ctx,
 			minimalCreateExternalTableReq(name).
-				WithPattern(sdk.String("weather-nyc/weather_2_3_0.json.gz")),
+				WithPattern("weather-nyc/weather_2_3_0.json.gz"),
 		)
 		require.NoError(t, err)
 
 		err = client.ExternalTables.Alter(
 			ctx,
 			sdk.NewAlterExternalTableRequest(externalTableID).
-				WithIfExists(sdk.Bool(true)).
+				WithIfExists(true).
 				WithAddFiles([]*sdk.ExternalTableFileRequest{sdk.NewExternalTableFileRequest("weather-nyc/weather_0_0_0.json.gz")}),
 		)
 		require.NoError(t, err)
@@ -229,7 +228,7 @@ func TestInt_ExternalTables(t *testing.T) {
 		err = client.ExternalTables.Alter(
 			ctx,
 			sdk.NewAlterExternalTableRequest(externalTableID).
-				WithIfExists(sdk.Bool(true)).
+				WithIfExists(true).
 				WithRemoveFiles([]*sdk.ExternalTableFileRequest{sdk.NewExternalTableFileRequest("weather-nyc/weather_0_0_0.json.gz")}),
 		)
 		require.NoError(t, err)
@@ -244,8 +243,8 @@ func TestInt_ExternalTables(t *testing.T) {
 		err = client.ExternalTables.Alter(
 			ctx,
 			sdk.NewAlterExternalTableRequest(externalTableID).
-				WithIfExists(sdk.Bool(true)).
-				WithAutoRefresh(sdk.Bool(true)),
+				WithIfExists(true).
+				WithAutoRefresh(true),
 		)
 		require.NoError(t, err)
 	})
@@ -304,7 +303,7 @@ func TestInt_ExternalTables(t *testing.T) {
 		err = client.ExternalTables.AlterPartitions(
 			ctx,
 			sdk.NewAlterExternalTablePartitionRequest(externalTableID).
-				WithIfExists(sdk.Bool(true)).
+				WithIfExists(true).
 				WithAddPartitions([]*sdk.PartitionRequest{sdk.NewPartitionRequest("part_date", "2019-06-25")}).
 				WithLocation("2019/06"),
 		)
@@ -320,7 +319,7 @@ func TestInt_ExternalTables(t *testing.T) {
 		err = client.ExternalTables.AlterPartitions(
 			ctx,
 			sdk.NewAlterExternalTablePartitionRequest(externalTableID).
-				WithIfExists(sdk.Bool(true)).
+				WithIfExists(true).
 				WithAddPartitions([]*sdk.PartitionRequest{sdk.NewPartitionRequest("part_date", "2019-06-25")}).
 				WithLocation("2019/06"),
 		)
@@ -329,8 +328,8 @@ func TestInt_ExternalTables(t *testing.T) {
 		err = client.ExternalTables.AlterPartitions(
 			ctx,
 			sdk.NewAlterExternalTablePartitionRequest(externalTableID).
-				WithIfExists(sdk.Bool(true)).
-				WithDropPartition(sdk.Bool(true)).
+				WithIfExists(true).
+				WithDropPartition(true).
 				WithLocation("2019/06"),
 		)
 		require.NoError(t, err)
@@ -345,8 +344,8 @@ func TestInt_ExternalTables(t *testing.T) {
 		err = client.ExternalTables.Drop(
 			ctx,
 			sdk.NewDropExternalTableRequest(externalTableID).
-				WithIfExists(sdk.Bool(true)).
-				WithDropOption(sdk.NewExternalTableDropOptionRequest().WithCascade(sdk.Bool(true))),
+				WithIfExists(true).
+				WithDropOption(*sdk.NewExternalTableDropOptionRequest().WithCascade(true)),
 		)
 		require.NoError(t, err)
 
@@ -363,11 +362,11 @@ func TestInt_ExternalTables(t *testing.T) {
 		et, err := client.ExternalTables.Show(
 			ctx,
 			sdk.NewShowExternalTableRequest().
-				WithTerse(sdk.Bool(true)).
-				WithLike(sdk.String(name)).
-				WithIn(sdk.NewShowExternalTableInRequest().WithDatabase(testDb(t).ID())).
-				WithStartsWith(sdk.String(name)).
-				WithLimitFrom(sdk.NewLimitFromRequest().WithRows(sdk.Int(1))),
+				WithTerse(true).
+				WithLike(name).
+				WithIn(*sdk.NewShowExternalTableInRequest().WithDatabase(testDb(t).ID())).
+				WithStartsWith(name).
+				WithLimitFrom(*sdk.NewLimitFromRequest().WithRows(sdk.Int(1))),
 		)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(et))
@@ -443,7 +442,7 @@ func TestInt_ExternalTablesShowByID(t *testing.T) {
 	createExternalTableHandle := func(t *testing.T, id sdk.SchemaObjectIdentifier) {
 		t.Helper()
 
-		request := sdk.NewCreateExternalTableRequest(id, stageLocation).WithFileFormat(sdk.NewExternalTableFileFormatRequest().WithFileFormatType(&sdk.ExternalTableFileFormatTypeJSON))
+		request := sdk.NewCreateExternalTableRequest(id, stageLocation).WithFileFormat(*sdk.NewExternalTableFileFormatRequest().WithFileFormatType(sdk.ExternalTableFileFormatTypeJSON))
 		err := client.ExternalTables.Create(ctx, request)
 		require.NoError(t, err)
 		t.Cleanup(cleanupExternalTableHandle(t, id))

--- a/pkg/sdk/testint/streams_gen_integration_test.go
+++ b/pkg/sdk/testint/streams_gen_integration_test.go
@@ -59,7 +59,7 @@ func TestInt_Streams(t *testing.T) {
 		t.Cleanup(stageCleanup)
 
 		externalTableId := sdk.NewSchemaObjectIdentifier(db.Name, schema.Name, random.AlphanumericN(32))
-		err := client.ExternalTables.Create(ctx, sdk.NewCreateExternalTableRequest(externalTableId, stageLocation).WithFileFormat(sdk.NewExternalTableFileFormatRequest().WithFileFormatType(&sdk.ExternalTableFileFormatTypeJSON)))
+		err := client.ExternalTables.Create(ctx, sdk.NewCreateExternalTableRequest(externalTableId, stageLocation).WithFileFormat(*sdk.NewExternalTableFileFormatRequest().WithFileFormatType(sdk.ExternalTableFileFormatTypeJSON)))
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			err := client.ExternalTables.Drop(ctx, sdk.NewDropExternalTableRequest(externalTableId))


### PR DESCRIPTION
Accept non-pointer values in the generated builder methods. Now the nested requests have to be explicitly unreferenced, but two additional cases could be added to resolve this "issue". There's only a special case for strings which shouldn't be set whenever they're optional and the input value is equal to an empty string, because: 
1. that would be a rare case to have an empty string in Snowflake.
2. empty strings are treated as non-set values in Terraform.

The improved generator was tested and used as an example on the external table.