### PR TITLE
fix: Fix failing integration tests

### DIFF
--- a/pkg/sdk/testint/grants_integration_test.go
+++ b/pkg/sdk/testint/grants_integration_test.go
@@ -511,6 +511,7 @@ func TestInt_GrantAndRevokePrivilegesToDatabaseRole(t *testing.T) {
 		})
 		require.NoError(t, err)
 		// Expecting two grants because database role has usage on database by default
+		require.LessOrEqual(t, 2, len(returnedGrants))
 		usagePrivilege, err := collections.FindOne[sdk.Grant](returnedGrants, func(g sdk.Grant) bool { return g.Privilege == sdk.AccountObjectPrivilegeUsage.String() })
 		require.NoError(t, err)
 		assert.Equal(t, sdk.ObjectTypeDatabaseRole, usagePrivilege.GrantedTo)

--- a/pkg/sdk/testint/grants_integration_test.go
+++ b/pkg/sdk/testint/grants_integration_test.go
@@ -179,9 +179,9 @@ func TestInt_GrantAndRevokePrivilegesToAccountRole(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(grants))
-		assert.Equal(t, sdk.SchemaObjectPrivilegeSelect.String(), grants[0].Privilege)
-		assert.Equal(t, tableTest.ID().FullyQualifiedName(), grants[0].Name.FullyQualifiedName())
+		selectPrivilege, err := collections.FindOne[sdk.Grant](grants, func(g sdk.Grant) bool { return g.Privilege == sdk.SchemaObjectPrivilegeSelect.String() })
+		require.NoError(t, err)
+		assert.Equal(t, tableTest.ID().FullyQualifiedName(), selectPrivilege.Name.FullyQualifiedName())
 
 		// now revoke and verify that the grant(s) are gone
 		err = client.Grants.RevokePrivilegesFromAccountRole(ctx, privileges, on, roleTest.ID(), nil)
@@ -511,8 +511,6 @@ func TestInt_GrantAndRevokePrivilegesToDatabaseRole(t *testing.T) {
 		})
 		require.NoError(t, err)
 		// Expecting two grants because database role has usage on database by default
-		require.Equal(t, 2, len(returnedGrants))
-
 		usagePrivilege, err := collections.FindOne[sdk.Grant](returnedGrants, func(g sdk.Grant) bool { return g.Privilege == sdk.AccountObjectPrivilegeUsage.String() })
 		require.NoError(t, err)
 		assert.Equal(t, sdk.ObjectTypeDatabaseRole, usagePrivilege.GrantedTo)

--- a/pkg/sdk/testint/row_access_policies_gen_integration_test.go
+++ b/pkg/sdk/testint/row_access_policies_gen_integration_test.go
@@ -241,7 +241,7 @@ func TestInt_RowAccessPolicies(t *testing.T) {
 		showRequest := sdk.NewShowRowAccessPolicyRequest()
 		returnedRowAccessPolicies, err := client.RowAccessPolicies.Show(ctx, showRequest)
 		require.NoError(t, err)
-
+		require.LessOrEqual(t, 2, len(returnedRowAccessPolicies))
 		assert.Contains(t, returnedRowAccessPolicies, *rowAccessPolicy1)
 		assert.Contains(t, returnedRowAccessPolicies, *rowAccessPolicy2)
 	})

--- a/pkg/sdk/testint/row_access_policies_gen_integration_test.go
+++ b/pkg/sdk/testint/row_access_policies_gen_integration_test.go
@@ -242,7 +242,6 @@ func TestInt_RowAccessPolicies(t *testing.T) {
 		returnedRowAccessPolicies, err := client.RowAccessPolicies.Show(ctx, showRequest)
 		require.NoError(t, err)
 
-		assert.Equal(t, 2, len(returnedRowAccessPolicies))
 		assert.Contains(t, returnedRowAccessPolicies, *rowAccessPolicy1)
 		assert.Contains(t, returnedRowAccessPolicies, *rowAccessPolicy2)
 	})


### PR DESCRIPTION
Some tests failed in
https://github.com/Snowflake-Labs/terraform-provider-snowflake/actions/runs/9187815690/job/25266290438?pr=2830.

This probably happened because more resources were returned by Show. Slice length asserts are corrected.
`TestInt_EventTables/alter_event_table:_add_and_drop_row_access_policies` was not fixed for now.
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] integration tests