### PR TITLE
fix: default_role should ignore diffs of the form "thing" -> "\"thing\""

### DIFF
--- a/pkg/resources/user.go
+++ b/pkg/resources/user.go
@@ -18,6 +18,11 @@ var diffCaseInsensitive = func(k, old, new string, d *schema.ResourceData) bool 
 	return strings.EqualFold(old, new)
 }
 
+var diffDefaultRole = func(k, old, new string, d *schema.ResourceData) bool {
+	return diffCaseInsensitive(k, old, new, d) || suppressEscapeQuotes(k, old, new, d)
+}
+
+
 var userSchema = map[string]*schema.Schema{
 	"name": {
 		Type:        schema.TypeString,
@@ -66,7 +71,7 @@ var userSchema = map[string]*schema.Schema{
 		Type:             schema.TypeString,
 		Optional:         true,
 		Computed:         true,
-		DiffSuppressFunc: diffCaseInsensitive,
+		DiffSuppressFunc: diffDefaultRole,
 		Description:      "Specifies the role that is active by default for the user’s session upon login.",
 	},
 	"default_secondary_roles": {


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
We have a few roles in our org that have spaces or other special characters in them. We can't get around this, so we decided default_role should be escaped. In our Terragrunt module, we wrap it in "\\"${role_name}\\"", and everyone's happy. However, it means that we get a permanent diff of the form "${role_name} -> "\\"${role_name}\\"".

Before we started wrapping them like this, we got gnarly SQL errors on apply. Perhaps the real issue was that the provider should have been handling sending default_role wrapped in escaped quotes, as I can see occurs for other fields? In any case, this patch only suppresses diffs of the form mentioned, and doesn't alter anything else in that way.


## Test Plan
This PR is UNTESTED!. It needs to be tested on my other machine before being considered for merge, but I wanted to check first to make sure I'm not going about this in the wrong way. Thanks! 

## References
<!-- issues documentation links, etc  -->

* 