### PR TITLE
fix: Fix QUOTED_IDENTIFIERS_IGNORE_CASE parameter test

### DIFF
--- a/pkg/acceptance/helpers/common.go
+++ b/pkg/acceptance/helpers/common.go
@@ -1,0 +1,21 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+)
+
+func EnsureQuotedIdentifiersIgnoreCaseIsSetToFalse(client *sdk.Client, ctx context.Context) error {
+	log.Printf("[DEBUG] Making sure QUOTED_IDENTIFIERS_IGNORE_CASE parameter is set correctly")
+	param, err := client.Parameters.ShowAccountParameter(ctx, sdk.AccountParameterQuotedIdentifiersIgnoreCase)
+	if err != nil {
+		return fmt.Errorf("checking QUOTED_IDENTIFIERS_IGNORE_CASE resulted in error: %w", err)
+	}
+	if param.Value != "false" {
+		return fmt.Errorf("parameter QUOTED_IDENTIFIERS_IGNORE_CASE has value %s, expected: false", param.Value)
+	}
+	return nil
+}

--- a/pkg/acceptance/testing.go
+++ b/pkg/acceptance/testing.go
@@ -148,6 +148,14 @@ func TestAccPreCheck(t *testing.T) {
 		if err := atc.secondaryClient.Warehouses.Create(ctx, warehouseId, &sdk.CreateWarehouseOptions{IfNotExists: sdk.Bool(true)}); err != nil {
 			t.Fatal(err)
 		}
+
+		if err := helpers.EnsureQuotedIdentifiersIgnoreCaseIsSetToFalse(atc.client, ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := helpers.EnsureQuotedIdentifiersIgnoreCaseIsSetToFalse(atc.secondaryClient, ctx); err != nil {
+			t.Fatal(err)
+		}
 	})
 }
 

--- a/pkg/sdk/testint/setup_test.go
+++ b/pkg/sdk/testint/setup_test.go
@@ -181,6 +181,15 @@ func (itc *integrationTestContext) initialize() error {
 	itc.testClient = helpers.NewTestClient(c, TestDatabaseName, TestSchemaName, TestWarehouseName, random.IntegrationTestsSuffix)
 	itc.secondaryTestClient = helpers.NewTestClient(secondaryClient, TestDatabaseName, TestSchemaName, TestWarehouseName, random.IntegrationTestsSuffix)
 
+	err = helpers.EnsureQuotedIdentifiersIgnoreCaseIsSetToFalse(itc.client, itc.ctx)
+	if err != nil {
+		return err
+	}
+	err = helpers.EnsureQuotedIdentifiersIgnoreCaseIsSetToFalse(itc.secondaryClient, itc.secondaryCtx)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Setting `QUOTED_IDENTIFIERS_IGNORE_CASE` in `TestAcc_Parameters_QuotedIdentifiersIgnoreCaseCanBeSet` was interfering with the tests being run on other branches. It resulted in seemingly random `Database 'XYZ' does not exist or not authorized` errors for database that exists, works moments before and moments after. Sequence of example statements:
```
-- 2024-05-28 11:28:34.634 +0000
-- CREATE MATERIALIZED VIEW "int_test_db_IT_C0E0DFE82EF6223390C3723866862A273A406F10"."int_test_sc_IT_C0E0DFE82EF6223390C3723866862A273A406F10"."AFKRZIIT_C0E0DFE82EF6223390C3723866862A273A406F10" CLUSTER BY ("ID") AS SELECT id FROM "int_test_db_IT_C0E0DFE82EF6223390C3723866862A273A406F10"."int_test_sc_IT_C0E0DFE82EF6223390C3723866862A273A406F10"."VYODPJIT_C0E0DFE82EF6223390C3723866862A273A406F10"
...
-- 2024-05-28 11:28:35.019 +0000
-- ALTER ACCOUNT SET QUOTED_IDENTIFIERS_IGNORE_CASE = true
...
-- 2024-05-28 11:28:35.123 +0000
-- SHOW MATERIALIZED VIEWS LIKE 'AFKRZIIT_C0E0DFE82EF6223390C3723866862A273A406F10' IN SCHEMA "int_test_db_IT_C0E0DFE82EF6223390C3723866862A273A406F10"."int_test_sc_IT_C0E0DFE82EF6223390C3723866862A273A406F10"
```

What was done:
- test `TestAcc_Parameters_QuotedIdentifiersIgnoreCaseCanBeSet` creates new user and sets the `QUOTED_IDENTIFIERS_IGNORE_CASE` parameter on it
- fail-fast guards added to integration and acceptance tests setups to prevent running tests when `QUOTED_IDENTIFIERS_IGNORE_CASE` is set to true initially