### PR TITLE
Do not escape table column name.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,23 +1,23 @@
 builds:
-- env:
-  - >-
-    {{- if or (eq .Os "windows") (eq .Os "darwin") -}}
-      CGO_ENABLED=1
-    {{- else -}}
-      CGO_ENABLED=0
-    {{- end -}}
-  goos:
-    - windows
-    - linux
-    - darwin
-    - freebsd
-  goarch:
-    - amd64
-    - arm64
-    - '386'
-  flags:
-    - -trimpath
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
+  - env:
+      - >-
+        {{- if or (eq .Os "windows") (eq .Os "darwin") -}}
+          CGO_ENABLED=1
+        {{- else -}}
+          CGO_ENABLED=0
+        {{- end -}}
+    goos:
+      - windows
+      - linux
+      - darwin
+      - freebsd
+    goarch:
+      - amd64
+      - arm64
+      - '386'
+    flags:
+      - -trimpath
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
 
 archives:
   - format: zip
@@ -33,17 +33,17 @@ checksum:
 signs:
   - artifacts: checksum
     args:
-      - "--batch"
-      - "--local-user"
-      - "{{ .Env.GPG_FINGERPRINT }}"
-      - "--output"
-      - "${signature}"
-      - "--detach-sign"
-      - "${artifact}"
+      - '--batch'
+      - '--local-user'
+      - '{{ .Env.GPG_FINGERPRINT }}'
+      - '--output'
+      - '${signature}'
+      - '--detach-sign'
+      - '${artifact}'
 
 release:
   github:
-    owner: Snowflake-Labs
+    owner: chronicled
     name: terraform-provider-snowflake
   extra_files:
     - glob: 'terraform-registry-manifest.json'

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -385,7 +385,7 @@ func getTableColumnRequest(from interface{}) *sdk.TableColumnRequest {
 	c := from.(map[string]interface{})
 	_type := c["type"].(string)
 
-	nameInQuotes := fmt.Sprintf(`"%v"`, snowflake.EscapeString(c["name"].(string)))
+	nameInQuotes := fmt.Sprintf(`"%v"`, c["name"].(string))
 	request := sdk.NewTableColumnRequest(nameInQuotes, sdk.DataType(_type))
 
 	_default := c["default"].([]interface{})


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
Snowflake allows a table column to have the char `'` in its name (e.g. `my'column`). The terraform-provider currently escapes it, making creating such a column name impossible (e.g. it will create `my\'column` instead).

This PR removes the escaping logic, which shouldn't be needed since the column name is wrapped around double quotes.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* Issue: https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2844