### PR TITLE
clarify that the provider source needs to be specified

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,14 @@ Coverage is focused on part of Snowflake related to access control.
 ## Example Provider Configuration
 
 ```terraform
+terraform {
+  required_providers {
+    snowflake = {
+      source = "Snowflake-Labs/snowflake"
+    }
+  }
+}
+
 provider "snowflake" {
   account                = "..." # required if not using profile. Can also be set via SNOWFLAKE_ACCOUNT env var
   username               = "..." # required if not using profile or token. Can also be set via SNOWFLAKE_USER env var


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] Try creating a Terraform root module with only the `provider`, no `source` — `terraform init` fails with `Could not retrieve the list of available versions for provider hashicorp/snowflake: provider registry registry.terraform.io does not have a provider named registry.terraform.io/hashicorp/snowflake`

  ```terraform
  provider "snowflake" {}
  ```

* [x] Try creating a Terraform root module with a `source` — `terraform init` succeeds

  ```terraform
  terraform {
    required_providers {
      snowflake = {
        source = "Snowflake-Labs/snowflake"
      }
    }
  }

  provider "snowflake" {}
  ```

## References
<!-- issues documentation links, etc  -->

* https://developer.hashicorp.com/terraform/language/providers/requirements#source-addresses