### PR TITLE
fix: use suppressQuoting to fix stage file_format permadiff

### DIFF
--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -43,7 +43,7 @@ func suppressIdentifierQuoting(_, oldValue, newValue string, _ *schema.ResourceD
 }
 
 // TODO [SNOW-1325214]: address during stage resource rework
-func suppressCopyOptionsQuoting(_, oldValue, newValue string, _ *schema.ResourceData) bool {
+func suppressQuoting(_, oldValue, newValue string, _ *schema.ResourceData) bool {
 	if oldValue == "" || newValue == "" {
 		return false
 	} else {

--- a/pkg/resources/stage.go
+++ b/pkg/resources/stage.go
@@ -50,9 +50,10 @@ var stageSchema = map[string]*schema.Schema{
 		Description: "Specifies the name of the storage integration used to delegate authentication responsibility for external cloud storage to a Snowflake identity and access management (IAM) entity.",
 	},
 	"file_format": {
-		Type:        schema.TypeString,
-		Optional:    true,
-		Description: "Specifies the file format for the stage.",
+		Type:             schema.TypeString,
+		Optional:         true,
+		Description:      "Specifies the file format for the stage.",
+		DiffSuppressFunc: suppressQuoting,
 	},
 	"copy_options": {
 		Type:             schema.TypeString,

--- a/pkg/resources/stage.go
+++ b/pkg/resources/stage.go
@@ -58,7 +58,7 @@ var stageSchema = map[string]*schema.Schema{
 		Type:             schema.TypeString,
 		Optional:         true,
 		Description:      "Specifies the copy options for the stage.",
-		DiffSuppressFunc: suppressCopyOptionsQuoting,
+		DiffSuppressFunc: suppressQuoting,
 	},
 	"encryption": {
 		Type:        schema.TypeString,

--- a/pkg/resources/stage_acceptance_test.go
+++ b/pkg/resources/stage_acceptance_test.go
@@ -64,6 +64,7 @@ func TestAcc_Stage_CreateAndAlter(t *testing.T) {
 	changedStorageIntegration := ids.PrecreatedS3StorageIntegration
 	changedEncryption := "TYPE = 'AWS_SSE_S3'"
 	changedFileFormat := "TYPE = JSON NULL_IF = []"
+	changedFileFormatWithQuotes := "FIELD_DELIMITER = '|' PARSE_HEADER = true"
 	changedComment := random.Comment()
 	copyOptionsWithoutQuotes := "ON_ERROR = CONTINUE"
 
@@ -121,6 +122,25 @@ func TestAcc_Stage_CreateAndAlter(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "credentials", credentials),
 					resource.TestCheckResourceAttr(resourceName, "encryption", changedEncryption),
 					resource.TestCheckResourceAttr(resourceName, "file_format", changedFileFormat),
+					resource.TestCheckResourceAttr(resourceName, "copy_options", copyOptionsWithoutQuotes),
+					resource.TestCheckResourceAttr(resourceName, "url", changedUrl),
+					resource.TestCheckResourceAttr(resourceName, "comment", changedComment),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: configVariables(changedUrl, changedStorageIntegration.Name(), credentials, changedEncryption, changedFileFormatWithQuotes, changedComment, copyOptionsWithoutQuotes),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "database", databaseName),
+					resource.TestCheckResourceAttr(resourceName, "schema", schemaName),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "storage_integration", changedStorageIntegration.Name()),
+					resource.TestCheckResourceAttr(resourceName, "credentials", credentials),
+					resource.TestCheckResourceAttr(resourceName, "encryption", changedEncryption),
+					resource.TestCheckResourceAttr(resourceName, "file_format", changedFileFormatWithQuotes),
 					resource.TestCheckResourceAttr(resourceName, "copy_options", copyOptionsWithoutQuotes),
 					resource.TestCheckResourceAttr(resourceName, "url", changedUrl),
 					resource.TestCheckResourceAttr(resourceName, "comment", changedComment),


### PR DESCRIPTION
We are getting permadiff on stage `file_format` parameter when it contains quotes, as it used to be the case with `copy_options` (see https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2679)

To fix it, re-using the same `DiffSuppressFunc` seems to do the trick.

## Test Plan
* [x] acceptance tests
* [x] locally built tested
