### PR TITLE
fix: Add fix for model grants

### DIFF
--- a/pkg/acceptance/helpers/database_role_client.go
+++ b/pkg/acceptance/helpers/database_role_client.go
@@ -62,7 +62,7 @@ func (c *DatabaseRoleClient) CleanupDatabaseRoleFunc(t *testing.T, id sdk.Databa
 	return func() {
 		// to prevent error when db was removed before the role
 		_, err := c.context.client.Databases.ShowByID(ctx, id.DatabaseId())
-		if errors.Is(err, sdk.ErrObjectNotExistOrAuthorized) {
+		if errors.Is(err, sdk.ErrObjectNotFound) {
 			return
 		}
 

--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -237,6 +237,9 @@ func (row grantRow) convert() *Grant {
 	if row.GrantedOn == "VOLUME" {
 		grantedOn = ObjectTypeExternalVolume
 	}
+	if row.GrantedOn == "MODULE" {
+		grantedOn = ObjectTypeModel
+	}
 
 	var grantOn ObjectType
 	// true for future grants
@@ -245,6 +248,9 @@ func (row grantRow) convert() *Grant {
 	}
 	if row.GrantOn == "VOLUME" {
 		grantOn = ObjectTypeExternalVolume
+	}
+	if row.GrantOn == "MODULE" {
+		grantOn = ObjectTypeModel
 	}
 
 	var name ObjectIdentifier


### PR DESCRIPTION
## Changes
- Address the issue: https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/3050 about granting usage on future models (I couldn't provide the test on non-future model because the only way of creating such model is with python snowpark and it's not that easy, I tried).
- Fix other failing test in grants.