### PR TITLE
chore: Bump golang-ci lint to 1.61

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export TERRAFORM_PLUGIN_LOCAL_INSTALL=$(TERRAFORM_PLUGINS_DIR)/$(BASE_BINARY_NAM
 default: help
 
 dev-setup: ## setup development dependencies
-	@which ./bin/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v1.55.2
+	@which ./bin/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v1.61.0
 	cd tools && mkdir -p bin/
 	cd tools && env GOBIN=$$PWD/bin go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 	cd tools && env GOBIN=$$PWD/bin go install mvdan.cc/gofumpt

--- a/main.go
+++ b/main.go
@@ -56,7 +56,6 @@ func main() {
 		muxServer.ProviderServer,
 		serveOpts...,
 	)
-
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/sdk/views_gen_test.go
+++ b/pkg/sdk/views_gen_test.go
@@ -1,7 +1,6 @@
 package sdk
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -530,7 +529,7 @@ func TestViews_Show(t *testing.T) {
 				Database: id,
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, fmt.Sprintf("SHOW VIEWS IN DATABASE %s", id.FullyQualifiedName()))
+		assertOptsValidAndSQLEquals(t, opts, "SHOW VIEWS IN DATABASE %s", id.FullyQualifiedName())
 	})
 
 	t.Run("in schema", func(t *testing.T) {
@@ -541,7 +540,7 @@ func TestViews_Show(t *testing.T) {
 				Schema: id,
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, fmt.Sprintf("SHOW VIEWS IN SCHEMA %s", id.FullyQualifiedName()))
+		assertOptsValidAndSQLEquals(t, opts, "SHOW VIEWS IN SCHEMA %s", id.FullyQualifiedName())
 	})
 
 	t.Run("in application", func(t *testing.T) {
@@ -550,7 +549,7 @@ func TestViews_Show(t *testing.T) {
 		opts.In = &ExtendedIn{
 			Application: id,
 		}
-		assertOptsValidAndSQLEquals(t, opts, fmt.Sprintf("SHOW VIEWS IN APPLICATION %s", id.FullyQualifiedName()))
+		assertOptsValidAndSQLEquals(t, opts, "SHOW VIEWS IN APPLICATION %s", id.FullyQualifiedName())
 	})
 
 	t.Run("in application package", func(t *testing.T) {
@@ -559,7 +558,7 @@ func TestViews_Show(t *testing.T) {
 		opts.In = &ExtendedIn{
 			ApplicationPackage: id,
 		}
-		assertOptsValidAndSQLEquals(t, opts, fmt.Sprintf("SHOW VIEWS IN APPLICATION PACKAGE %s", id.FullyQualifiedName()))
+		assertOptsValidAndSQLEquals(t, opts, "SHOW VIEWS IN APPLICATION PACKAGE %s", id.FullyQualifiedName())
 	})
 
 	t.Run("all options", func(t *testing.T) {


### PR DESCRIPTION
To be able to run successfully with go 1.23.2.