### PR TITLE
fix: Fix user resource import

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -167,6 +167,18 @@ Note: Because [bcr 2024_07](https://docs.snowflake.com/en/release-notes/bcr-bund
 
 Connected issues: [#3125](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/3125)
 
+### *(bugfix)* Handle user import correctly
+
+#### Context before the change
+
+Password is empty after the `snowflake_user` import; we can't read it from the config or from Snowflake.
+During the next terraform plan+apply it's updated to the "same" value.
+It results in an error on Snowflake side: `New password rejected by current password policy. Reason: 'PRIOR_USE'.`
+
+#### After the change
+
+The error will be ignored on the provider side (after all, it means that the password in state is the same as on Snowflake side). Still, plan+apply is needed after importing user.
+
 ## v0.96.0 ➞ v0.97.0
 
 ### *(new feature)* snowflake_stream_on_table, snowflake_stream_on_external_table resource

--- a/docs/resources/legacy_service_user.md
+++ b/docs/resources/legacy_service_user.md
@@ -1011,3 +1011,5 @@ Import is supported using the following syntax:
 ```shell
 terraform import snowflake_legacy_service_user.example '"<user_name>"'
 ```
+
+Note: terraform plan+apply may be needed after successful import to fill out all the missing fields (like `password`) in state.

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -1021,3 +1021,5 @@ Import is supported using the following syntax:
 ```shell
 terraform import snowflake_user.example '"<user_name>"'
 ```
+
+Note: terraform plan+apply may be needed after successful import to fill out all the missing fields (like `password`) in state.

--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/user_resource_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/user_resource_ext.go
@@ -19,6 +19,11 @@ func (u *UserResourceAssert) HasEmptyPassword() *UserResourceAssert {
 	return u
 }
 
+func (u *UserResourceAssert) HasNotEmptyPassword() *UserResourceAssert {
+	u.AddAssertion(assert.ValuePresent("password"))
+	return u
+}
+
 func (u *UserResourceAssert) HasMustChangePassword(expected bool) *UserResourceAssert {
 	u.AddAssertion(assert.ValueSet("must_change_password", strconv.FormatBool(expected)))
 	return u

--- a/templates/resources/legacy_service_user.md.tmpl
+++ b/templates/resources/legacy_service_user.md.tmpl
@@ -41,3 +41,5 @@ Import is supported using the following syntax:
 
 {{ codefile "shell" (printf "examples/resources/%s/import.sh" .Name)}}
 {{- end }}
+
+Note: terraform plan+apply may be needed after successful import to fill out all the missing fields (like `password`) in state.

--- a/templates/resources/user.md.tmpl
+++ b/templates/resources/user.md.tmpl
@@ -41,3 +41,5 @@ Import is supported using the following syntax:
 
 {{ codefile "shell" (printf "examples/resources/%s/import.sh" .Name)}}
 {{- end }}
+
+Note: terraform plan+apply may be needed after successful import to fill out all the missing fields (like `password`) in state.


### PR DESCRIPTION
Handle user import correctly.

Password is empty after the `snowflake_user` import; we can't read it from the config or from Snowflake.
During the next terraform plan+apply it's updated to the "same" value.
It results in an error on Snowflake side: `New password rejected by current password policy. Reason: 'PRIOR_USE'.`
The error will be ignored on the provider side (after all, it means that the password in state is the same as on Snowflake side). Still, plan+apply is needed after importing user.