### PR TITLE
fix: Skip connection data source acc test

### DIFF
--- a/pkg/datasources/connections_acceptance_test.go
+++ b/pkg/datasources/connections_acceptance_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+	accConfig "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert"
-	accConfig "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
@@ -27,7 +28,7 @@ func connectionsData() string {
 
 func TestAcc_Connections_Minimal(t *testing.T) {
 	// TODO: [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed
-	// _ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
+	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
 
 	accountId := acc.TestClient().Account.GetAccountIdentifier(t)
 	id := acc.TestClient().Ids.RandomAccountObjectIdentifier()

--- a/pkg/resources/custom_diffs_test.go
+++ b/pkg/resources/custom_diffs_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"


### PR DESCRIPTION
Skip the test that was mistakenly unskipped.