### PR TITLE
chore: Add support for usage tracking to data sources

### DIFF
--- a/pkg/datasources/common.go
+++ b/pkg/datasources/common.go
@@ -1,8 +1,13 @@
 package datasources
 
 import (
+	"context"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/tracking"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -146,4 +151,11 @@ func handleExtendedIn(d *schema.ResourceData, setField **sdk.ExtendedIn) error {
 		}
 	}
 	return nil
+}
+
+func TrackingReadWrapper(datasourceName datasources.Datasource, readImplementation schema.ReadContextFunc) schema.ReadContextFunc {
+	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+		ctx = tracking.NewContext(ctx, tracking.NewVersionedDatasourceMetadata(datasourceName))
+		return readImplementation(ctx, d, meta)
+	}
 }

--- a/pkg/datasources/connections.go
+++ b/pkg/datasources/connections.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -34,7 +36,7 @@ var connectionsSchema = map[string]*schema.Schema{
 
 func Connections() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadConnections,
+		ReadContext: TrackingReadWrapper(datasources.Connections, ReadConnections),
 		Schema:      connectionsSchema,
 		Description: "Datasource used to get details of filtered connections. Filtering is aligned with the current possibilities for [SHOW CONNECTIONS](https://docs.snowflake.com/en/sql-reference/sql/show-connections) query. The results of SHOW is encapsulated in one output collection `connections`.",
 	}

--- a/pkg/datasources/cortex_search_services.go
+++ b/pkg/datasources/cortex_search_services.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"log"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -108,13 +111,13 @@ var cortexSearchServicesSchema = map[string]*schema.Schema{
 // CortexSearchServices Snowflake Cortex search services resource.
 func CortexSearchServices() *schema.Resource {
 	return &schema.Resource{
-		Read:   ReadCortexSearchServices,
-		Schema: cortexSearchServicesSchema,
+		ReadContext: TrackingReadWrapper(datasources.CortexSearchServices, ReadCortexSearchServices),
+		Schema:      cortexSearchServicesSchema,
 	}
 }
 
 // ReadCortexSearchServices Reads the cortex search services metadata information.
-func ReadCortexSearchServices(d *schema.ResourceData, meta interface{}) error {
+func ReadCortexSearchServices(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	request := sdk.NewShowCortexSearchServiceRequest()
 
@@ -167,7 +170,7 @@ func ReadCortexSearchServices(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		log.Printf("[DEBUG] snowflake_cortex_search_services.go: %v", err)
 		d.SetId("")
-		return err
+		return diag.FromErr(err)
 	}
 	d.SetId("cortex_search_services")
 	records := make([]map[string]any, 0, len(dts))
@@ -181,7 +184,7 @@ func ReadCortexSearchServices(d *schema.ResourceData, meta interface{}) error {
 		records = append(records, record)
 	}
 	if err := d.Set("cortex_search_services", records); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	return nil
 }

--- a/pkg/datasources/current_account.go
+++ b/pkg/datasources/current_account.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -33,15 +36,14 @@ var currentAccountSchema = map[string]*schema.Schema{
 // CurrentAccount the Snowflake current account resource.
 func CurrentAccount() *schema.Resource {
 	return &schema.Resource{
-		Read:   ReadCurrentAccount,
-		Schema: currentAccountSchema,
+		ReadContext: TrackingReadWrapper(datasources.CurrentAccount, ReadCurrentAccount),
+		Schema:      currentAccountSchema,
 	}
 }
 
 // ReadCurrentAccount read the current snowflake account information.
-func ReadCurrentAccount(d *schema.ResourceData, meta interface{}) error {
+func ReadCurrentAccount(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
-	ctx := context.Background()
 
 	current, err := client.ContextFunctions.CurrentSessionDetails(ctx)
 	if err != nil {
@@ -53,11 +55,11 @@ func ReadCurrentAccount(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(fmt.Sprintf("%s.%s", current.Account, current.Region))
 	accountErr := d.Set("account", current.Account)
 	if accountErr != nil {
-		return accountErr
+		return diag.FromErr(accountErr)
 	}
 	regionErr := d.Set("region", current.Region)
 	if regionErr != nil {
-		return regionErr
+		return diag.FromErr(regionErr)
 	}
 	url, err := current.AccountURL()
 	if err != nil {
@@ -67,7 +69,7 @@ func ReadCurrentAccount(d *schema.ResourceData, meta interface{}) error {
 
 	urlErr := d.Set("url", url)
 	if urlErr != nil {
-		return urlErr
+		return diag.FromErr(urlErr)
 	}
 	return nil
 }

--- a/pkg/datasources/database.go
+++ b/pkg/datasources/database.go
@@ -3,6 +3,9 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
@@ -54,52 +57,51 @@ var databaseSchema = map[string]*schema.Schema{
 // Database the Snowflake Database resource.
 func Database() *schema.Resource {
 	return &schema.Resource{
-		Read:   ReadDatabase,
-		Schema: databaseSchema,
+		ReadContext: TrackingReadWrapper(datasources.Database, ReadDatabase),
+		Schema:      databaseSchema,
 	}
 }
 
 // ReadDatabase read the database meta-data information.
-func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
+func ReadDatabase(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
-	ctx := context.Background()
 	name := d.Get("name").(string)
 	id := sdk.NewAccountObjectIdentifier(name)
 	database, err := client.Databases.ShowByID(ctx, id)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	d.SetId(helpers.EncodeResourceIdentifier(database.ID()))
 	if err := d.Set("name", database.Name); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err := d.Set("comment", database.Comment); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err := d.Set("owner", database.Owner); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err := d.Set("is_default", database.IsDefault); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err := d.Set("is_current", database.IsCurrent); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	var origin string
 	if database.Origin != nil {
 		origin = database.Origin.FullyQualifiedName()
 	}
 	if err := d.Set("origin", origin); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err := d.Set("retention_time", database.RetentionTime); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err := d.Set("created_on", database.CreatedOn.String()); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err := d.Set("options", database.Options); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	return nil
 }

--- a/pkg/datasources/database_role.go
+++ b/pkg/datasources/database_role.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"log"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -36,34 +39,33 @@ var databaseRoleSchema = map[string]*schema.Schema{
 // DatabaseRole Snowflake Database Role resource.
 func DatabaseRole() *schema.Resource {
 	return &schema.Resource{
-		Read:   ReadDatabaseRole,
-		Schema: databaseRoleSchema,
+		ReadContext: TrackingReadWrapper(datasources.DatabaseRole, ReadDatabaseRole),
+		Schema:      databaseRoleSchema,
 	}
 }
 
 // ReadDatabaseRole Reads the database role metadata information.
-func ReadDatabaseRole(d *schema.ResourceData, meta interface{}) error {
+func ReadDatabaseRole(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
 	databaseName := d.Get("database").(string)
 	roleName := d.Get("name").(string)
 
-	ctx := context.Background()
 	dbObjId := sdk.NewDatabaseObjectIdentifier(databaseName, roleName)
 	databaseRole, err := client.DatabaseRoles.ShowByID(ctx, dbObjId)
 	if err != nil {
 		log.Printf("[DEBUG] unable to show database role %s in db (%s)", roleName, databaseName)
 		d.SetId("")
-		return err
+		return diag.FromErr(err)
 	}
 
 	err = d.Set("comment", databaseRole.Comment)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	err = d.Set("owner", databaseRole.Owner)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId("database_role_read")

--- a/pkg/datasources/database_roles.go
+++ b/pkg/datasources/database_roles.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -64,7 +66,7 @@ var databaseRolesSchema = map[string]*schema.Schema{
 
 func DatabaseRoles() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadDatabaseRoles,
+		ReadContext: TrackingReadWrapper(datasources.DatabaseRoles, ReadDatabaseRoles),
 		Schema:      databaseRolesSchema,
 		Description: "Datasource used to get details of filtered database roles. Filtering is aligned with the current possibilities for [SHOW DATABASE ROLES](https://docs.snowflake.com/en/sql-reference/sql/show-database-roles) query (`like` and `limit` are supported). The results of SHOW is encapsulated in show_output collection.",
 	}

--- a/pkg/datasources/databases.go
+++ b/pkg/datasources/databases.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -91,7 +93,7 @@ var databasesSchema = map[string]*schema.Schema{
 
 func Databases() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadDatabases,
+		ReadContext: TrackingReadWrapper(datasources.Databases, ReadDatabases),
 		Schema:      databasesSchema,
 		Description: "Datasource used to get details of filtered databases. Filtering is aligned with the current possibilities for [SHOW DATABASES](https://docs.snowflake.com/en/sql-reference/sql/show-databases) query (`like`, `starts_with`, and `limit` are all supported). The results of SHOW, DESCRIBE, and SHOW PARAMETERS IN are encapsulated in one output collection.",
 	}

--- a/pkg/datasources/external_functions.go
+++ b/pkg/datasources/external_functions.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -59,7 +61,7 @@ var externalFunctionsSchema = map[string]*schema.Schema{
 
 func ExternalFunctions() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadContextExternalFunctions,
+		ReadContext: TrackingReadWrapper(datasources.ExternalFunctions, ReadContextExternalFunctions),
 		Schema:      externalFunctionsSchema,
 	}
 }

--- a/pkg/datasources/external_tables.go
+++ b/pkg/datasources/external_tables.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"log"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
@@ -54,14 +57,13 @@ var externalTablesSchema = map[string]*schema.Schema{
 
 func ExternalTables() *schema.Resource {
 	return &schema.Resource{
-		Read:   ReadExternalTables,
-		Schema: externalTablesSchema,
+		ReadContext: TrackingReadWrapper(datasources.ExternalTables, ReadExternalTables),
+		Schema:      externalTablesSchema,
 	}
 }
 
-func ReadExternalTables(d *schema.ResourceData, meta interface{}) error {
+func ReadExternalTables(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
-	ctx := context.Background()
 	databaseName := d.Get("database").(string)
 	schemaName := d.Get("schema").(string)
 
@@ -86,5 +88,5 @@ func ReadExternalTables(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(helpers.EncodeSnowflakeID(schemaId))
 
-	return d.Set("external_tables", externalTablesObjects)
+	return diag.FromErr(d.Set("external_tables", externalTablesObjects))
 }

--- a/pkg/datasources/functions.go
+++ b/pkg/datasources/functions.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
@@ -64,7 +66,7 @@ var functionsSchema = map[string]*schema.Schema{
 
 func Functions() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadContextFunctions,
+		ReadContext: TrackingReadWrapper(datasources.Functions, ReadContextFunctions),
 		Schema:      functionsSchema,
 	}
 }

--- a/pkg/datasources/grants.go
+++ b/pkg/datasources/grants.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
@@ -320,7 +322,7 @@ var grantsSchema = map[string]*schema.Schema{
 
 func Grants() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadGrants,
+		ReadContext: TrackingReadWrapper(datasources.Grants, ReadGrants),
 		Schema:      grantsSchema,
 	}
 }

--- a/pkg/datasources/masking_policies.go
+++ b/pkg/datasources/masking_policies.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -117,7 +119,7 @@ var maskingPoliciesSchema = map[string]*schema.Schema{
 
 func MaskingPolicies() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadMaskingPolicies,
+		ReadContext: TrackingReadWrapper(datasources.MaskingPolicies, ReadMaskingPolicies),
 		Schema:      maskingPoliciesSchema,
 		Description: "Datasource used to get details of filtered masking policies. Filtering is aligned with the current possibilities for [SHOW MASKING POLICIES](https://docs.snowflake.com/en/sql-reference/sql/show-masking-policies) query. The results of SHOW and DESCRIBE are encapsulated in one output collection `masking_policies`.",
 	}

--- a/pkg/datasources/network_policies.go
+++ b/pkg/datasources/network_policies.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -52,7 +54,7 @@ var networkPoliciesSchema = map[string]*schema.Schema{
 
 func NetworkPolicies() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadNetworkPolicies,
+		ReadContext: TrackingReadWrapper(datasources.NetworkPolicies, ReadNetworkPolicies),
 		Schema:      networkPoliciesSchema,
 		Description: "Datasource used to get details of filtered network policies. Filtering is aligned with the current possibilities for [SHOW NETWORK POLICIES](https://docs.snowflake.com/en/sql-reference/sql/show-network-policies) query (`like` is supported). The results of SHOW and DESCRIBE are encapsulated in one output collection.",
 	}

--- a/pkg/datasources/procedures.go
+++ b/pkg/datasources/procedures.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -65,7 +67,7 @@ var proceduresSchema = map[string]*schema.Schema{
 
 func Procedures() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadContextProcedures,
+		ReadContext: TrackingReadWrapper(datasources.Procedures, ReadContextProcedures),
 		Schema:      proceduresSchema,
 	}
 }

--- a/pkg/datasources/resource_monitors.go
+++ b/pkg/datasources/resource_monitors.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -39,7 +41,7 @@ var resourceMonitorsSchema = map[string]*schema.Schema{
 
 func ResourceMonitors() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadResourceMonitors,
+		ReadContext: TrackingReadWrapper(datasources.ResourceMonitors, ReadResourceMonitors),
 		Schema:      resourceMonitorsSchema,
 		Description: "Datasource used to get details of filtered resource monitors. Filtering is aligned with the current possibilities for [SHOW RESOURCE MONITORS](https://docs.snowflake.com/en/sql-reference/sql/show-resource-monitors) query (`like` is supported). The results of SHOW is encapsulated in show_output collection.",
 	}

--- a/pkg/datasources/roles.go
+++ b/pkg/datasources/roles.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
 
@@ -47,7 +49,7 @@ var rolesSchema = map[string]*schema.Schema{
 
 func Roles() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadRoles,
+		ReadContext: TrackingReadWrapper(datasources.Roles, ReadRoles),
 		Schema:      rolesSchema,
 		Description: "Datasource used to get details of filtered roles. Filtering is aligned with the current possibilities for [SHOW ROLES](https://docs.snowflake.com/en/sql-reference/sql/show-roles) query (`like` and `in_class` are all supported). The results of SHOW are encapsulated in one output collection.",
 	}

--- a/pkg/datasources/row_access_policies.go
+++ b/pkg/datasources/row_access_policies.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -113,7 +115,7 @@ var rowAccessPoliciesSchema = map[string]*schema.Schema{
 
 func RowAccessPolicies() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadRowAccessPolicies,
+		ReadContext: TrackingReadWrapper(datasources.RowAccessPolicies, ReadRowAccessPolicies),
 		Schema:      rowAccessPoliciesSchema,
 		Description: "Datasource used to get details of filtered row access policies. Filtering is aligned with the current possibilities for [SHOW ROW ACCESS POLICIES](https://docs.snowflake.com/en/sql-reference/sql/show-row-access-policies) query. The results of SHOW and DESCRIBE are encapsulated in one output collection `row_access_policies`.",
 	}

--- a/pkg/datasources/schemas.go
+++ b/pkg/datasources/schemas.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -127,7 +129,7 @@ var schemasSchema = map[string]*schema.Schema{
 
 func Schemas() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadSchemas,
+		ReadContext: TrackingReadWrapper(datasources.Schemas, ReadSchemas),
 		Schema:      schemasSchema,
 		Description: "Datasource used to get details of filtered schemas. Filtering is aligned with the current possibilities for [SHOW SCHEMAS](https://docs.snowflake.com/en/sql-reference/sql/show-schemas) query. The results of SHOW, DESCRIBE, and SHOW PARAMETERS IN are encapsulated in one output collection.",
 	}

--- a/pkg/datasources/secrets.go
+++ b/pkg/datasources/secrets.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -96,7 +98,7 @@ var secretsSchema = map[string]*schema.Schema{
 
 func Secrets() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadSecrets,
+		ReadContext: TrackingReadWrapper(datasources.Secrets, ReadSecrets),
 		Schema:      secretsSchema,
 		Description: "Datasource used to get details of filtered secrets. Filtering is aligned with the current possibilities for [SHOW SECRETS](https://docs.snowflake.com/en/sql-reference/sql/show-secrets) query. The results of SHOW and DESCRIBE are encapsulated in one output collection `secrets`.",
 	}

--- a/pkg/datasources/security_integrations.go
+++ b/pkg/datasources/security_integrations.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -52,7 +54,7 @@ var securityIntegrationsSchema = map[string]*schema.Schema{
 
 func SecurityIntegrations() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadSecurityIntegrations,
+		ReadContext: TrackingReadWrapper(datasources.SecurityIntegrations, ReadSecurityIntegrations),
 		Schema:      securityIntegrationsSchema,
 		Description: "Datasource used to get details of filtered security integrations. Filtering is aligned with the current possibilities for [SHOW SECURITY INTEGRATIONS](https://docs.snowflake.com/en/sql-reference/sql/show-integrations) query (only `like` is supported). The results of SHOW and DESCRIBE are encapsulated in one output collection `security_integrations`.",
 	}

--- a/pkg/datasources/stages.go
+++ b/pkg/datasources/stages.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
@@ -58,7 +60,7 @@ var stagesSchema = map[string]*schema.Schema{
 
 func Stages() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadStages,
+		ReadContext: TrackingReadWrapper(datasources.Stages, ReadStages),
 		Schema:      stagesSchema,
 	}
 }

--- a/pkg/datasources/streamlits.go
+++ b/pkg/datasources/streamlits.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -100,7 +102,7 @@ var streamlitsSchema = map[string]*schema.Schema{
 
 func Streamlits() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadStreamlits,
+		ReadContext: TrackingReadWrapper(datasources.Streamlits, ReadStreamlits),
 		Schema:      streamlitsSchema,
 		Description: "Datasource used to get details of filtered streamlits. Filtering is aligned with the current possibilities for [SHOW STREAMLITS](https://docs.snowflake.com/en/sql-reference/sql/show-streamlits) query (only `like` is supported). The results of SHOW and DESCRIBE are encapsulated in one output collection `streamlits`.",
 	}

--- a/pkg/datasources/streams.go
+++ b/pkg/datasources/streams.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -52,7 +54,7 @@ var streamsSchema = map[string]*schema.Schema{
 
 func Streams() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadStreams,
+		ReadContext: TrackingReadWrapper(datasources.Streams, ReadStreams),
 		Schema:      streamsSchema,
 		Description: "Datasource used to get details of filtered streams. Filtering is aligned with the current possibilities for [SHOW STREAMS](https://docs.snowflake.com/en/sql-reference/sql/show-streams) query. The results of SHOW and DESCRIBE are encapsulated in one output collection `streams`.",
 	}

--- a/pkg/datasources/system_generate_scim_access_token.go
+++ b/pkg/datasources/system_generate_scim_access_token.go
@@ -1,9 +1,13 @@
 package datasources
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"log"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 
@@ -28,13 +32,13 @@ var systemGenerateSCIMAccesstokenSchema = map[string]*schema.Schema{
 
 func SystemGenerateSCIMAccessToken() *schema.Resource {
 	return &schema.Resource{
-		Read:   ReadSystemGenerateSCIMAccessToken,
-		Schema: systemGenerateSCIMAccesstokenSchema,
+		ReadContext: TrackingReadWrapper(datasources.SystemGenerateScimAccessToken, ReadSystemGenerateSCIMAccessToken),
+		Schema:      systemGenerateSCIMAccesstokenSchema,
 	}
 }
 
 // ReadSystemGetAWSSNSIAMPolicy implements schema.ReadFunc.
-func ReadSystemGenerateSCIMAccessToken(d *schema.ResourceData, meta interface{}) error {
+func ReadSystemGenerateSCIMAccessToken(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	db := client.GetConn().DB
 
@@ -57,5 +61,5 @@ func ReadSystemGenerateSCIMAccessToken(d *schema.ResourceData, meta interface{})
 	}
 
 	d.SetId(integrationName)
-	return d.Set("access_token", accessToken.Token)
+	return diag.FromErr(d.Set("access_token", accessToken.Token))
 }

--- a/pkg/datasources/system_get_privatelink_config.go
+++ b/pkg/datasources/system_get_privatelink_config.go
@@ -1,9 +1,13 @@
 package datasources
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"log"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 
@@ -69,13 +73,13 @@ var systemGetPrivateLinkConfigSchema = map[string]*schema.Schema{
 
 func SystemGetPrivateLinkConfig() *schema.Resource {
 	return &schema.Resource{
-		Read:   ReadSystemGetPrivateLinkConfig,
-		Schema: systemGetPrivateLinkConfigSchema,
+		ReadContext: TrackingReadWrapper(datasources.SystemGetPrivateLinkConfig, ReadSystemGetPrivateLinkConfig),
+		Schema:      systemGetPrivateLinkConfigSchema,
 	}
 }
 
 // ReadSystemGetPrivateLinkConfig implements schema.ReadFunc.
-func ReadSystemGetPrivateLinkConfig(d *schema.ResourceData, meta interface{}) error {
+func ReadSystemGetPrivateLinkConfig(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	db := client.GetConn().DB
 
@@ -100,56 +104,56 @@ func ReadSystemGetPrivateLinkConfig(d *schema.ResourceData, meta interface{}) er
 	d.SetId(config.AccountName)
 	accNameErr := d.Set("account_name", config.AccountName)
 	if accNameErr != nil {
-		return accNameErr
+		return diag.FromErr(accNameErr)
 	}
 	accURLErr := d.Set("account_url", config.AccountURL)
 	if accURLErr != nil {
-		return accURLErr
+		return diag.FromErr(accURLErr)
 	}
 	ocspURLErr := d.Set("ocsp_url", config.OCSPURL)
 	if ocspURLErr != nil {
-		return ocspURLErr
+		return diag.FromErr(ocspURLErr)
 	}
 
 	if config.AwsVpceID != "" {
 		awsVpceIDErr := d.Set("aws_vpce_id", config.AwsVpceID)
 		if awsVpceIDErr != nil {
-			return awsVpceIDErr
+			return diag.FromErr(awsVpceIDErr)
 		}
 	}
 
 	if config.AzurePrivateLinkServiceID != "" {
 		azurePlsIDErr := d.Set("azure_pls_id", config.AzurePrivateLinkServiceID)
 		if azurePlsIDErr != nil {
-			return azurePlsIDErr
+			return diag.FromErr(azurePlsIDErr)
 		}
 	}
 
 	if config.InternalStage != "" {
 		intStgErr := d.Set("internal_stage", config.InternalStage)
 		if intStgErr != nil {
-			return intStgErr
+			return diag.FromErr(intStgErr)
 		}
 	}
 
 	if config.SnowsightURL != "" {
 		snowSigURLErr := d.Set("snowsight_url", config.SnowsightURL)
 		if snowSigURLErr != nil {
-			return snowSigURLErr
+			return diag.FromErr(snowSigURLErr)
 		}
 	}
 
 	if config.RegionlessSnowsightURL != "" {
 		reglssSnowURLErr := d.Set("regionless_snowsight_url", config.RegionlessSnowsightURL)
 		if reglssSnowURLErr != nil {
-			return reglssSnowURLErr
+			return diag.FromErr(reglssSnowURLErr)
 		}
 	}
 
 	if config.RegionlessAccountURL != "" {
 		reglssAccURLErr := d.Set("regionless_account_url", config.RegionlessAccountURL)
 		if reglssAccURLErr != nil {
-			return reglssAccURLErr
+			return diag.FromErr(reglssAccURLErr)
 		}
 	}
 

--- a/pkg/datasources/tags.go
+++ b/pkg/datasources/tags.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -36,7 +38,7 @@ var tagsSchema = map[string]*schema.Schema{
 
 func Tags() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadTags,
+		ReadContext: TrackingReadWrapper(datasources.Tags, ReadTags),
 		Schema:      tagsSchema,
 		Description: "Datasource used to get details of filtered tags. Filtering is aligned with the current possibilities for [SHOW TAGS](https://docs.snowflake.com/en/sql-reference/sql/show-tags) query. The results of SHOW are encapsulated in one output collection `tags`.",
 	}

--- a/pkg/datasources/tasks.go
+++ b/pkg/datasources/tasks.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -57,14 +60,13 @@ var tasksSchema = map[string]*schema.Schema{
 
 func Tasks() *schema.Resource {
 	return &schema.Resource{
-		Read:   ReadTasks,
-		Schema: tasksSchema,
+		ReadContext: TrackingReadWrapper(datasources.Tasks, ReadTasks),
+		Schema:      tasksSchema,
 	}
 }
 
-func ReadTasks(d *schema.ResourceData, meta interface{}) error {
+func ReadTasks(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
-	ctx := context.Background()
 
 	databaseName := d.Get("database").(string)
 	schemaName := d.Get("schema").(string)
@@ -91,5 +93,5 @@ func ReadTasks(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(fmt.Sprintf(`%v|%v`, databaseName, schemaName))
-	return d.Set("tasks", tasks)
+	return diag.FromErr(d.Set("tasks", tasks))
 }

--- a/pkg/datasources/usage_tracking_acceptance_test.go
+++ b/pkg/datasources/usage_tracking_acceptance_test.go
@@ -1,0 +1,84 @@
+package datasources_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/tracking"
+
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert/resourceassert"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAcc_CompleteUsageTracking(t *testing.T) {
+	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
+	acc.TestAccPreCheck(t)
+
+	id := acc.TestClient().Ids.RandomDatabaseObjectIdentifier()
+	schemaModel := model.Schema("test", id.DatabaseName(), id.Name())
+
+	assertQueryMetadataExists := func(t *testing.T, query string) resource.TestCheckFunc {
+		t.Helper()
+		return func(state *terraform.State) error {
+			queryHistory := acc.TestClient().InformationSchema.GetQueryHistory(t, 100)
+			expectedMetadata := tracking.NewVersionedDatasourceMetadata(datasources.Schemas)
+			if _, err := collections.FindFirst(queryHistory, func(history helpers.QueryHistory) bool {
+				metadata, err := tracking.ParseMetadata(history.QueryText)
+				return err == nil &&
+					expectedMetadata == metadata &&
+					strings.Contains(history.QueryText, query)
+			}); err != nil {
+				return fmt.Errorf("query history does not contain query metadata: %v with query containing: %s", expectedMetadata, query)
+			}
+			return nil
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		PreCheck: func() { acc.TestAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: config.FromModel(t, schemaModel) + schemaDatasourceConfigWithDependency(schemaModel.ResourceReference(), id),
+				Check: assert.AssertThat(t,
+					resourceassert.SchemaResource(t, schemaModel.ResourceReference()).
+						HasNameString(id.Name()),
+					assert.Check(assertQueryMetadataExists(t, fmt.Sprintf(`SHOW SCHEMAS LIKE '%s' IN DATABASE "%s"`, id.Name(), id.DatabaseName()))),
+					// SHOW PARAMETERS IN SCHEMA "acc_test_db_AT_1AB7E1DE_1A10_89C3_C13C_899754A250B6"."FPGDHEAT_1AB7E1DE_1A10_89C3_C13C_899754A250B6" --terraform_provider_usage_tracking {"json_schema_version":"1","version":"v0.99.0","datasource":"snowflake_schemas","operation":"read"}
+					assert.Check(assertQueryMetadataExists(t, fmt.Sprintf(`SHOW PARAMETERS IN SCHEMA %s`, id.FullyQualifiedName()))),
+					assert.Check(assertQueryMetadataExists(t, fmt.Sprintf(`DESCRIBE SCHEMA %s`, id.FullyQualifiedName()))),
+				),
+			},
+		},
+	})
+}
+
+func schemaDatasourceConfigWithDependency(schemaResourceReference string, id sdk.DatabaseObjectIdentifier) string {
+	return fmt.Sprintf(`
+data "snowflake_schemas" "test" {
+	depends_on = [ %[1]s ]
+	in {
+		database = "%[2]s"
+	}
+	like = "%[3]s"
+}
+`, schemaResourceReference, id.DatabaseName(), id.Name())
+}

--- a/pkg/datasources/users.go
+++ b/pkg/datasources/users.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -91,7 +93,7 @@ var usersSchema = map[string]*schema.Schema{
 
 func Users() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadUsers,
+		ReadContext: TrackingReadWrapper(datasources.Users, ReadUsers),
 		Schema:      usersSchema,
 		Description: "Datasource used to get details of filtered users. Filtering is aligned with the current possibilities for [SHOW USERS](https://docs.snowflake.com/en/sql-reference/sql/show-users) query. The results of SHOW, DESCRIBE, and SHOW PARAMETERS IN are encapsulated in one output collection. Important note is that when querying users you don't have permissions to, the querying options are limited. You won't get almost any field in `show_output` (only empty or default values), the DESCRIBE command cannot be called, so you have to set `with_describe = false`. Only `parameters` output is not affected by the lack of privileges.",
 	}

--- a/pkg/datasources/views.go
+++ b/pkg/datasources/views.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -106,7 +108,7 @@ var viewsSchema = map[string]*schema.Schema{
 
 func Views() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadViews,
+		ReadContext: TrackingReadWrapper(datasources.Views, ReadViews),
 		Schema:      viewsSchema,
 		Description: "Datasource used to get details of filtered views. Filtering is aligned with the current possibilities for [SHOW VIEWS](https://docs.snowflake.com/en/sql-reference/sql/show-views) query (only `like` is supported). The results of SHOW and DESCRIBE are encapsulated in one output collection `views`.",
 	}

--- a/pkg/datasources/warehouses.go
+++ b/pkg/datasources/warehouses.go
@@ -3,6 +3,8 @@ package datasources
 import (
 	"context"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -66,7 +68,7 @@ var warehousesSchema = map[string]*schema.Schema{
 
 func Warehouses() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: ReadWarehouses,
+		ReadContext: TrackingReadWrapper(datasources.Warehouses, ReadWarehouses),
 		Schema:      warehousesSchema,
 		Description: "Datasource used to get details of filtered warehouses. Filtering is aligned with the current possibilities for [SHOW WAREHOUSES](https://docs.snowflake.com/en/sql-reference/sql/show-warehouses) query (only `like` is supported). The results of SHOW, DESCRIBE, and SHOW PARAMETERS IN are encapsulated in one output collection.",
 	}

--- a/pkg/internal/tracking/context.go
+++ b/pkg/internal/tracking/context.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 )
 
 const (
-	ProviderVersion string = "v0.99.0" // TODO(SNOW-1814934): Currently hardcoded, make it computed
-	MetadataPrefix  string = "terraform_provider_usage_tracking"
+	CurrentSchemaVersion string = "1"
+	ProviderVersion      string = "v0.99.0" // TODO(SNOW-1814934): Currently hardcoded, make it computed
+	MetadataPrefix       string = "terraform_provider_usage_tracking"
 )
 
 type key struct{}
@@ -28,18 +30,23 @@ const (
 )
 
 type Metadata struct {
-	Version   string    `json:"version,omitempty"`
-	Resource  string    `json:"resource,omitempty"`
-	Operation Operation `json:"operation,omitempty"`
+	SchemaVersion string    `json:"json_schema_version,omitempty"`
+	Version       string    `json:"version,omitempty"`
+	Resource      string    `json:"resource,omitempty"`
+	Datasource    string    `json:"datasource,omitempty"`
+	Operation     Operation `json:"operation,omitempty"`
 }
 
 func (m Metadata) validate() error {
 	errs := make([]error, 0)
-	if m.Version == "" {
-		errs = append(errs, errors.New("version for metadata should not be empty"))
+	if m.SchemaVersion == "" {
+		errs = append(errs, errors.New("schema version for metadata should not be empty"))
 	}
-	if m.Resource == "" {
-		errs = append(errs, errors.New("resource name for metadata should not be empty"))
+	if m.Version == "" {
+		errs = append(errs, errors.New("provider version for metadata should not be empty"))
+	}
+	if m.Resource == "" && m.Datasource == "" {
+		errs = append(errs, errors.New("either resource or data source name for metadata should be specified"))
 	}
 	if m.Operation == "" {
 		errs = append(errs, errors.New("operation for metadata should not be empty"))
@@ -47,19 +54,31 @@ func (m Metadata) validate() error {
 	return errors.Join(errs...)
 }
 
-func NewMetadata(version string, resource resources.Resource, operation Operation) Metadata {
+// NewTestMetadata is a helper constructor that is used only for testing purposes
+func NewTestMetadata(version string, resource resources.Resource, operation Operation) Metadata {
 	return Metadata{
-		Version:   version,
-		Resource:  resource.String(),
-		Operation: operation,
+		SchemaVersion: CurrentSchemaVersion,
+		Version:       version,
+		Resource:      resource.String(),
+		Operation:     operation,
 	}
 }
 
-func NewVersionedMetadata(resource resources.Resource, operation Operation) Metadata {
+func NewVersionedResourceMetadata(resource resources.Resource, operation Operation) Metadata {
 	return Metadata{
-		Version:   ProviderVersion,
-		Resource:  resource.String(),
-		Operation: operation,
+		SchemaVersion: CurrentSchemaVersion,
+		Version:       ProviderVersion,
+		Resource:      resource.String(),
+		Operation:     operation,
+	}
+}
+
+func NewVersionedDatasourceMetadata(datasource datasources.Datasource) Metadata {
+	return Metadata{
+		SchemaVersion: CurrentSchemaVersion,
+		Version:       ProviderVersion,
+		Datasource:    datasource.String(),
+		Operation:     ReadOperation,
 	}
 }
 

--- a/pkg/internal/tracking/context_test.go
+++ b/pkg/internal/tracking/context_test.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/datasources"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_Context(t *testing.T) {
-	metadata := NewMetadata("123", resources.Account, CreateOperation)
-	newMetadata := NewMetadata("321", resources.Database, UpdateOperation)
+	metadata := NewTestMetadata("123", resources.Account, CreateOperation)
+	newMetadata := NewVersionedDatasourceMetadata(datasources.Databases)
 	ctx := context.Background()
 
 	// no metadata in context

--- a/pkg/internal/tracking/query_test.go
+++ b/pkg/internal/tracking/query_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAppendMetadata(t *testing.T) {
-	metadata := NewMetadata("123", resources.Account, CreateOperation)
+	metadata := NewTestMetadata("123", resources.Account, CreateOperation)
 	sql := "SELECT 1"
 
 	bytes, err := json.Marshal(metadata)
@@ -24,7 +24,7 @@ func TestAppendMetadata(t *testing.T) {
 }
 
 func TestParseMetadata(t *testing.T) {
-	metadata := NewMetadata("123", resources.Account, CreateOperation)
+	metadata := NewTestMetadata("123", resources.Account, CreateOperation)
 	bytes, err := json.Marshal(metadata)
 	require.NoError(t, err)
 	sql := fmt.Sprintf("SELECT 1 --%s %s", MetadataPrefix, string(bytes))
@@ -38,8 +38,9 @@ func TestParseInvalidMetadataKeys(t *testing.T) {
 	sql := fmt.Sprintf(`SELECT 1 --%s {"key": "value"}`, MetadataPrefix)
 
 	parsedMetadata, err := ParseMetadata(sql)
-	require.ErrorContains(t, err, "version for metadata should not be empty")
-	require.ErrorContains(t, err, "resource name for metadata should not be empty")
+	require.ErrorContains(t, err, "schema version for metadata should not be empty")
+	require.ErrorContains(t, err, "provider version for metadata should not be empty")
+	require.ErrorContains(t, err, "either resource or data source name for metadata should be specified")
 	require.ErrorContains(t, err, "operation for metadata should not be empty")
 	require.Equal(t, Metadata{}, parsedMetadata)
 }
@@ -53,7 +54,7 @@ func TestParseInvalidMetadataJson(t *testing.T) {
 }
 
 func TestParseMetadataFromInvalidSqlCommentPrefix(t *testing.T) {
-	metadata := NewMetadata("123", resources.Account, CreateOperation)
+	metadata := NewTestMetadata("123", resources.Account, CreateOperation)
 	sql := "SELECT 1"
 
 	bytes, err := json.Marshal(metadata)

--- a/pkg/provider/datasources/datasources.go
+++ b/pkg/provider/datasources/datasources.go
@@ -1,0 +1,63 @@
+package datasources
+
+type datasource string
+
+const (
+	Accounts                       datasource = "snowflake_accounts"
+	Alerts                         datasource = "snowflake_alerts"
+	Connections                    datasource = "snowflake_connections"
+	CortexSearchServices           datasource = "snowflake_cortex_search_services"
+	CurrentAccount                 datasource = "snowflake_current_account"
+	CurrentRole                    datasource = "snowflake_current_role"
+	Database                       datasource = "snowflake_database"
+	DatabaseRole                   datasource = "snowflake_database_role"
+	DatabaseRoles                  datasource = "snowflake_database_roles"
+	Databases                      datasource = "snowflake_databases"
+	DynamicTables                  datasource = "snowflake_dynamic_tables"
+	ExternalFunctions              datasource = "snowflake_external_functions"
+	ExternalTables                 datasource = "snowflake_external_tables"
+	FailoverGroups                 datasource = "snowflake_failover_groups"
+	FileFormats                    datasource = "snowflake_file_formats"
+	Functions                      datasource = "snowflake_functions"
+	Grants                         datasource = "snowflake_grants"
+	MaskingPolicies                datasource = "snowflake_masking_policies"
+	MaterializedViews              datasource = "snowflake_materialized_views"
+	NetworkPolicies                datasource = "snowflake_network_policies"
+	Parameters                     datasource = "snowflake_parameters"
+	Pipes                          datasource = "snowflake_pipes"
+	Procedures                     datasource = "snowflake_procedures"
+	ResourceMonitors               datasource = "snowflake_resource_monitors"
+	Role                           datasource = "snowflake_role"
+	Roles                          datasource = "snowflake_roles"
+	RowAccessPolicies              datasource = "snowflake_row_access_policies"
+	Schemas                        datasource = "snowflake_schemas"
+	Secrets                        datasource = "snowflake_secrets"
+	SecurityIntegrations           datasource = "snowflake_security_integrations"
+	Sequences                      datasource = "snowflake_sequences"
+	Shares                         datasource = "snowflake_shares"
+	Stages                         datasource = "snowflake_stages"
+	StorageIntegrations            datasource = "snowflake_storage_integrations"
+	Streams                        datasource = "snowflake_streams"
+	Streamlits                     datasource = "snowflake_streamlits"
+	SystemGenerateScimAccessToken  datasource = "snowflake_system_generate_scim_access_token"
+	SystemGetAwsSnsIamPolicy       datasource = "snowflake_system_get_aws_sns_iam_policy"
+	SystemGetPrivateLinkConfig     datasource = "snowflake_system_get_privatelink_config"
+	SystemGetSnowflakePlatformInfo datasource = "snowflake_system_get_snowflake_platform_info"
+	Tables                         datasource = "snowflake_tables"
+	Tags                           datasource = "snowflake_tags"
+	Tasks                          datasource = "snowflake_tasks"
+	Users                          datasource = "snowflake_users"
+	Views                          datasource = "snowflake_views"
+	Warehouses                     datasource = "snowflake_warehouses"
+)
+
+type Datasource interface {
+	xxxProtected()
+	String() string
+}
+
+func (r datasource) xxxProtected() {}
+
+func (r datasource) String() string {
+	return string(r)
+}

--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -108,42 +108,42 @@ func ImportName[T sdk.AccountObjectIdentifier | sdk.DatabaseObjectIdentifier | s
 
 func TrackingImportWrapper(resourceName resources.Resource, importImplementation schema.StateContextFunc) schema.StateContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-		ctx = tracking.NewContext(ctx, tracking.NewVersionedMetadata(resourceName, tracking.ImportOperation))
+		ctx = tracking.NewContext(ctx, tracking.NewVersionedResourceMetadata(resourceName, tracking.ImportOperation))
 		return importImplementation(ctx, d, meta)
 	}
 }
 
 func TrackingCreateWrapper(resourceName resources.Resource, createImplementation schema.CreateContextFunc) schema.CreateContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-		ctx = tracking.NewContext(ctx, tracking.NewVersionedMetadata(resourceName, tracking.CreateOperation))
+		ctx = tracking.NewContext(ctx, tracking.NewVersionedResourceMetadata(resourceName, tracking.CreateOperation))
 		return createImplementation(ctx, d, meta)
 	}
 }
 
 func TrackingReadWrapper(resourceName resources.Resource, readImplementation schema.ReadContextFunc) schema.ReadContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-		ctx = tracking.NewContext(ctx, tracking.NewVersionedMetadata(resourceName, tracking.ReadOperation))
+		ctx = tracking.NewContext(ctx, tracking.NewVersionedResourceMetadata(resourceName, tracking.ReadOperation))
 		return readImplementation(ctx, d, meta)
 	}
 }
 
 func TrackingUpdateWrapper(resourceName resources.Resource, updateImplementation schema.UpdateContextFunc) schema.UpdateContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-		ctx = tracking.NewContext(ctx, tracking.NewVersionedMetadata(resourceName, tracking.UpdateOperation))
+		ctx = tracking.NewContext(ctx, tracking.NewVersionedResourceMetadata(resourceName, tracking.UpdateOperation))
 		return updateImplementation(ctx, d, meta)
 	}
 }
 
 func TrackingDeleteWrapper(resourceName resources.Resource, deleteImplementation schema.DeleteContextFunc) schema.DeleteContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-		ctx = tracking.NewContext(ctx, tracking.NewVersionedMetadata(resourceName, tracking.DeleteOperation))
+		ctx = tracking.NewContext(ctx, tracking.NewVersionedResourceMetadata(resourceName, tracking.DeleteOperation))
 		return deleteImplementation(ctx, d, meta)
 	}
 }
 
 func TrackingCustomDiffWrapper(resourceName resources.Resource, customdiffImplementation schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
 	return func(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
-		ctx = tracking.NewContext(ctx, tracking.NewVersionedMetadata(resourceName, tracking.CustomDiffOperation))
+		ctx = tracking.NewContext(ctx, tracking.NewVersionedResourceMetadata(resourceName, tracking.CustomDiffOperation))
 		return customdiffImplementation(ctx, diff, meta)
 	}
 }

--- a/pkg/resources/usage_tracking_acceptance_test.go
+++ b/pkg/resources/usage_tracking_acceptance_test.go
@@ -38,14 +38,12 @@ func TestAcc_CompleteUsageTracking(t *testing.T) {
 		t.Helper()
 		return func(state *terraform.State) error {
 			queryHistory := acc.TestClient().InformationSchema.GetQueryHistory(t, 60)
-			expectedMetadata := tracking.NewVersionedMetadata(resources.Schema, operation)
+			expectedMetadata := tracking.NewVersionedResourceMetadata(resources.Schema, operation)
 			if _, err := collections.FindFirst(queryHistory, func(history helpers.QueryHistory) bool {
-				if metadata, err := tracking.ParseMetadata(history.QueryText); err == nil {
-					if expectedMetadata == metadata && strings.Contains(history.QueryText, query) {
-						return true
-					}
-				}
-				return false
+				metadata, err := tracking.ParseMetadata(history.QueryText)
+				return err == nil &&
+					expectedMetadata == metadata &&
+					strings.Contains(history.QueryText, query)
 			}); err != nil {
 				return fmt.Errorf("query history does not contain query metadata: %v with query containing: %s", expectedMetadata, query)
 			}

--- a/pkg/sdk/testint/client_integration_test.go
+++ b/pkg/sdk/testint/client_integration_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestInt_Client_AdditionalMetadata(t *testing.T) {
 	client := testClient(t)
-	metadata := tracking.NewMetadata("v1.13.1002-rc-test", resources.Database, tracking.CreateOperation)
+	metadata := tracking.NewTestMetadata("v1.13.1002-rc-test", resources.Database, tracking.CreateOperation)
 
 	assertQueryMetadata := func(t *testing.T, queryId string) {
 		t.Helper()


### PR DESCRIPTION
The last part of usage tracking, changes:
- Added support for usage tracking in all data sources (\+ acceptance test)
- Added schema version and datasource field to metadata