### PR TITLE
Sdk remove integration tests generation

### DIFF
--- a/pkg/sdk/api_integrations_def.go
+++ b/pkg/sdk/api_integrations_def.go
@@ -151,7 +151,7 @@ var ApiIntegrationsDef = g.NewInterface(
 			SQL("API INTEGRATIONS").
 			OptionalLike(),
 	).
-	ShowByIdOperation().
+	ShowByIdOperationNoFiltering().
 	DescribeOperation(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-integration",

--- a/pkg/sdk/application_packages_def.go
+++ b/pkg/sdk/application_packages_def.go
@@ -163,4 +163,4 @@ var ApplicationPackagesDef = g.NewInterface(
 		OptionalLike().
 		OptionalStartsWith().
 		OptionalLimit(),
-).ShowByIdOperation()
+).ShowByIdOperationNoFiltering()

--- a/pkg/sdk/applications_def.go
+++ b/pkg/sdk/applications_def.go
@@ -132,7 +132,7 @@ var ApplicationsDef = g.NewInterface(
 		OptionalLike().
 		OptionalStartsWith().
 		OptionalLimit(),
-).ShowByIdOperation().DescribeOperation(
+).ShowByIdOperationNoFiltering().DescribeOperation(
 	g.DescriptionMappingKindSlice,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-application",
 	g.DbStruct("applicationPropertyRow").

--- a/pkg/sdk/authentication_policies_def.go
+++ b/pkg/sdk/authentication_policies_def.go
@@ -170,7 +170,7 @@ var AuthenticationPoliciesDef = g.NewInterface(
 			OptionalStartsWith().
 			OptionalLimit(),
 	).
-	ShowByIdOperation().
+	ShowByIdOperationNoFiltering().
 	DescribeOperation(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-authentication-policy",

--- a/pkg/sdk/cortex_search_services_def.go
+++ b/pkg/sdk/cortex_search_services_def.go
@@ -77,7 +77,7 @@ var CortexSearchServiceDef = g.NewInterface(
 		OptionalIn().
 		OptionalStartsWith().
 		OptionalLimitFrom(),
-).ShowByIdOperation().DescribeOperation(
+).ShowByIdOperationNoFiltering().DescribeOperation(
 	g.DescriptionMappingKindSingleValue,
 	"https://docs.snowflake.com/LIMITEDACCESS/cortex-search/sql/desc-cortex-search",
 	g.DbStruct("cortexSearchServiceDetailsRow").

--- a/pkg/sdk/event_tables_def.go
+++ b/pkg/sdk/event_tables_def.go
@@ -102,7 +102,7 @@ var EventTablesDef = g.NewInterface(
 		OptionalIn().
 		OptionalStartsWith().
 		OptionalLimit(),
-).ShowByIdOperation().DescribeOperation(
+).ShowByIdOperationNoFiltering().DescribeOperation(
 	g.DescriptionMappingKindSingleValue,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-event-table",
 	g.DbStruct("eventTableDetailsRow").

--- a/pkg/sdk/external_functions_def.go
+++ b/pkg/sdk/external_functions_def.go
@@ -149,7 +149,7 @@ var ExternalFunctionsDef = g.NewInterface(
 		SQL("EXTERNAL FUNCTIONS").
 		OptionalLike().
 		OptionalIn(),
-).ShowByIdOperation().DescribeOperation(
+).ShowByIdOperationNoFiltering().DescribeOperation(
 	g.DescriptionMappingKindSlice,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-function",
 	g.DbStruct("externalFunctionPropertyRow").

--- a/pkg/sdk/external_volumes_def.go
+++ b/pkg/sdk/external_volumes_def.go
@@ -226,4 +226,4 @@ var ExternalVolumesDef = g.NewInterface(
 			SQL("EXTERNAL VOLUMES").
 			OptionalLike(),
 	).
-	ShowByIdOperation()
+	ShowByIdOperationNoFiltering()

--- a/pkg/sdk/functions_def.go
+++ b/pkg/sdk/functions_def.go
@@ -305,7 +305,7 @@ var FunctionsDef = g.NewInterface(
 		SQL("USER FUNCTIONS").
 		OptionalLike().
 		OptionalIn(),
-).ShowByIdOperation().DescribeOperation(
+).ShowByIdOperationNoFiltering().DescribeOperation(
 	g.DescriptionMappingKindSlice,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-function",
 	g.DbStruct("functionDetailRow").

--- a/pkg/sdk/managed_accounts_def.go
+++ b/pkg/sdk/managed_accounts_def.go
@@ -67,4 +67,4 @@ var ManagedAccountsDef = g.NewInterface(
 			SQL("MANAGED ACCOUNTS").
 			OptionalLike(),
 	).
-	ShowByIdOperation()
+	ShowByIdOperationNoFiltering()

--- a/pkg/sdk/materialized_views_def.go
+++ b/pkg/sdk/materialized_views_def.go
@@ -175,7 +175,7 @@ var MaterializedViewsDef = g.NewInterface(
 			OptionalLike().
 			OptionalIn(),
 	).
-	ShowByIdOperation().
+	ShowByIdOperationNoFiltering().
 	DescribeOperation(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-materialized-view",

--- a/pkg/sdk/network_policies_def.go
+++ b/pkg/sdk/network_policies_def.go
@@ -143,7 +143,7 @@ var (
 				SQL("NETWORK POLICIES").
 				OptionalLike(),
 		).
-		ShowByIdOperation().
+		ShowByIdOperationNoFiltering().
 		DescribeOperation(
 			g.DescriptionMappingKindSlice,
 			"https://docs.snowflake.com/en/sql-reference/sql/desc-network-policy",

--- a/pkg/sdk/network_rule_def.go
+++ b/pkg/sdk/network_rule_def.go
@@ -108,7 +108,7 @@ var NetworkRuleDef = g.NewInterface(
 			OptionalStartsWith().
 			OptionalLimitFrom(),
 	).
-	ShowByIdOperation().
+	ShowByIdOperationNoFiltering().
 	DescribeOperation(
 		g.DescriptionMappingKindSingleValue,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-network-rule",

--- a/pkg/sdk/notification_integrations_def.go
+++ b/pkg/sdk/notification_integrations_def.go
@@ -181,7 +181,7 @@ var NotificationIntegrationsDef = g.NewInterface(
 			SQL("NOTIFICATION INTEGRATIONS").
 			OptionalLike(),
 	).
-	ShowByIdOperation().
+	ShowByIdOperationNoFiltering().
 	DescribeOperation(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-integration",

--- a/pkg/sdk/poc/README.md
+++ b/pkg/sdk/poc/README.md
@@ -13,7 +13,7 @@ There is an example file ready for generation [database_role_def.go](example/dat
 - [database_role_gen_test.go](example/database_role_gen_test.go) - unit tests placeholders with guidance comments (at least for now)
 
 Note:
-- integration tests files are not generated and they have to be created manually in the `pkg/sdk/testint` directory
+- for now integration tests files are not generated and they have to be created manually in the `pkg/sdk/testint` directory
 
 ### How it works
 ##### Creating object generation definition
@@ -51,10 +51,6 @@ also adding small changes is very challenging, e.g. for new validation rule you 
 one new function, revert to old tests (the one with filled tests), copy new test case (of course we could add that one by hand
 but if we add one case, or modify more cases this becomes more challenging)
 - add support for Enums
-- generate `ShowID` function with 3 implementation variations (the last one is the rarest one and can be postponed)
-  - use `Show` function with Like
-  - use Show without any options and filter with Go for + if
-  - in some cases we could need more filters -> see alerts.go (but we can implement it later)
 - handle arrays
 - handle more validation types
 - write new `valueSet` function (see validations.go) that will have better defaults or more parameters that will determine

--- a/pkg/sdk/poc/README.md
+++ b/pkg/sdk/poc/README.md
@@ -11,7 +11,9 @@ There is an example file ready for generation [database_role_def.go](example/dat
 - [database_role_validations_gen.go](example/database_role_validations_gen.go) - options structs validations
 - [database_role_impl_gen.go](example/database_role_impl_gen.go) - SDK interface implementation
 - [database_role_gen_test.go](example/database_role_gen_test.go) - unit tests placeholders with guidance comments (at least for now)
-- [database_role_gen_integration_test.go](example/database_role_gen_integration_test.go) - integration test placeholder file
+
+Note:
+- integration tests files are not generated and they have to be created manually in the `pkg/sdk/testint` directory
 
 ### How it works
 ##### Creating object generation definition
@@ -123,15 +125,6 @@ B := QueryStruct("B")
 ```
 - cannot re-generate when client.go is using generated interface
 - spaces in templates (especially nested validations)
-- request mapping fails (`.toOpts()`) when nested object is not optional (pointer) e.g.
-```go
-type NestedReq struct {
-}
-
-type SomeReq struct {
-    NestedReq NestedReq // Not a pointer and in toOpts right now we're always do a check if req.NestedReq != nil which is not correct for non pointer type
-}
-```
 
 ##### Known limitations
 - automatic array conversion is not recursive, so we're only supporting one level mapping

--- a/pkg/sdk/poc/generator/operation.go
+++ b/pkg/sdk/poc/generator/operation.go
@@ -161,12 +161,14 @@ func (i *Interface) ShowOperation(doc string, dbRepresentation *dbStruct, resour
 	return i
 }
 
-func (i *Interface) ShowByIdOperation() *Interface {
+// ShowByIdOperationNoFiltering adds a ShowByID operation to the interface without any filtering. Should be used for objects that do not implement any filtering options.
+func (i *Interface) ShowByIdOperationNoFiltering() *Interface {
 	op := newNoSqlOperation(string(OperationKindShowByID))
 	i.Operations = append(i.Operations, op)
 	return i
 }
 
+// ShowByIdOperationWithFiltering adds a ShowByID operation to the interface with filtering. Should be used for objects that implement filtering options e.g. Like or In.
 func (i *Interface) ShowByIdOperationWithFiltering(filter ShowByIDFilteringKind, filtering ...ShowByIDFilteringKind) *Interface {
 	op := newNoSqlOperation(string(OperationKindShowByID))
 	op.ObjectInterface = i

--- a/pkg/sdk/poc/generator/show_by_id_filtering.go
+++ b/pkg/sdk/poc/generator/show_by_id_filtering.go
@@ -12,7 +12,6 @@ const (
 	ShowByIDInFiltering
 	ShowByIDExtendedInFiltering
 	ShowByIDApplicationNameFiltering
-	ShowByIDNoFiltering
 )
 
 type idPrefix string
@@ -58,10 +57,6 @@ func newShowByIDFiltering(name, kind, args string) ShowByIDFiltering {
 	}
 }
 
-func newShowByIDNoFiltering() ShowByIDFiltering {
-	return newShowByIDFiltering("NoFiltering", "", "")
-}
-
 func newShowByIDLikeFiltering() ShowByIDFiltering {
 	return newShowByIDFiltering("Like", "Like", "Pattern: String(id.Name())")
 }
@@ -103,8 +98,6 @@ func (s *Operation) withFiltering(filtering ...ShowByIDFilteringKind) *Operation
 			s.ShowByIDFiltering = append(s.ShowByIDFiltering, newShowByIDLikeFiltering())
 		case ShowByIDApplicationNameFiltering:
 			s.ShowByIDFiltering = append(s.ShowByIDFiltering, newShowByIDApplicationFiltering())
-		case ShowByIDNoFiltering:
-			s.ShowByIDFiltering = []ShowByIDFiltering{newShowByIDNoFiltering()}
 		default:
 			log.Println("No showByID filtering found for kind:", filteringKind)
 		}

--- a/pkg/sdk/poc/generator/templates/sub_templates/implementation_functions.tmpl
+++ b/pkg/sdk/poc/generator/templates/sub_templates/implementation_functions.tmpl
@@ -16,10 +16,8 @@
     {{ else if eq .Name "ShowByID" }}
         func (v *{{ $impl }}) ShowByID(ctx context.Context, id {{ .ObjectInterface.IdentifierKind }}) (*{{ .ObjectInterface.NameSingular }}, error) {
             request := NewShow{{ .ObjectInterface.NameSingular }}Request()
-            {{- range .ShowByIDFiltering }}
-                {{- if not (eq .Name "NoFiltering") -}}.
-                    {{ .WithFiltering }}
-                {{- end }}
+            {{- range .ShowByIDFiltering }}.
+                {{ .WithFiltering }}
             {{- end }}
         {{ $impl }}, err := v.Show(ctx, request)
         if err != nil {

--- a/pkg/sdk/poc/main.go
+++ b/pkg/sdk/poc/main.go
@@ -57,6 +57,7 @@ func main() {
 
 	// runAllTemplatesToStdOut(definition)
 	runAllTemplatesAndSave(definition, file)
+	fmt.Println("Integration tests should be added manually to the pkg/sdk/testint/ directory")
 }
 
 func getDefinition(file string) *generator.Interface {
@@ -104,7 +105,6 @@ func runAllTemplatesAndSave(definition *generator.Interface, file string) {
 	runTemplateAndSave(definition, generator.GenerateImplementation, filenameFor(fileWithoutSuffix, "_impl"))
 	runTemplateAndSave(definition, generator.GenerateUnitTests, filename(fileWithoutSuffix, "_gen", "_test.go"))
 	runTemplateAndSave(definition, generator.GenerateValidations, filenameFor(fileWithoutSuffix, "_validations"))
-	runTemplateAndSave(definition, generator.GenerateIntegrationTests, filename(fileWithoutSuffix, "_gen_integration", "_test.go"))
 }
 
 func runTemplateAndSave(def *generator.Interface, genFunc func(io.Writer, *generator.Interface), fileName string) {

--- a/pkg/sdk/procedures_def.go
+++ b/pkg/sdk/procedures_def.go
@@ -321,7 +321,7 @@ var ProceduresDef = g.NewInterface(
 		SQL("PROCEDURES").
 		OptionalLike().
 		OptionalIn(), // TODO: 'In' struct for procedures not support keyword "CLASS" now
-).ShowByIdOperation().DescribeOperation(
+).ShowByIdOperationNoFiltering().DescribeOperation(
 	g.DescriptionMappingKindSlice,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-procedure",
 	g.DbStruct("procedureDetailRow").

--- a/pkg/sdk/row_access_policies_def.go
+++ b/pkg/sdk/row_access_policies_def.go
@@ -90,7 +90,7 @@ var RowAccessPoliciesDef = g.NewInterface(
 			OptionalExtendedIn().
 			OptionalLimitFrom(),
 	).
-	ShowByIdOperation().
+	ShowByIdOperationNoFiltering().
 	DescribeOperation(
 		g.DescriptionMappingKindSingleValue,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-row-access-policy",

--- a/pkg/sdk/security_integrations_def.go
+++ b/pkg/sdk/security_integrations_def.go
@@ -976,4 +976,4 @@ var SecurityIntegrationsDef = g.NewInterface(
 			SQL("SECURITY INTEGRATIONS").
 			OptionalLike(),
 	).
-	ShowByIdOperation()
+	ShowByIdOperationNoFiltering()

--- a/pkg/sdk/sequences_def.go
+++ b/pkg/sdk/sequences_def.go
@@ -78,7 +78,7 @@ var SequencesDef = g.NewInterface(
 		SQL("SEQUENCES").
 		OptionalLike().
 		OptionalIn(),
-).ShowByIdOperation().DescribeOperation(
+).ShowByIdOperationNoFiltering().DescribeOperation(
 	g.DescriptionMappingKindSingleValue,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-sequence",
 	g.DbStruct("sequenceDetailRow").

--- a/pkg/sdk/session_policies_def.go
+++ b/pkg/sdk/session_policies_def.go
@@ -89,9 +89,7 @@ var SessionPoliciesDef = g.NewInterface(
 			Show().
 			SQL("SESSION POLICIES"),
 	).
-	ShowByIdOperationWithFiltering(
-		g.ShowByIDNoFiltering,
-	).
+	ShowByIdOperationNoFiltering().
 	DescribeOperation(
 		g.DescriptionMappingKindSingleValue,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-session-policy",

--- a/pkg/sdk/stages_def.go
+++ b/pkg/sdk/stages_def.go
@@ -398,4 +398,4 @@ var StagesDef = g.NewInterface(
 			OptionalLike().
 			OptionalIn(),
 	).
-	ShowByIdOperation()
+	ShowByIdOperationNoFiltering()

--- a/pkg/sdk/storage_integration_def.go
+++ b/pkg/sdk/storage_integration_def.go
@@ -151,7 +151,7 @@ var StorageIntegrationDef = g.NewInterface(
 			SQL("STORAGE INTEGRATIONS").
 			OptionalLike(),
 	).
-	ShowByIdOperation().
+	ShowByIdOperationNoFiltering().
 	DescribeOperation(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-integration",

--- a/pkg/sdk/streams_def.go
+++ b/pkg/sdk/streams_def.go
@@ -233,7 +233,7 @@ var (
 				OptionalStartsWith().
 				OptionalLimit(),
 		).
-		ShowByIdOperation().
+		ShowByIdOperationNoFiltering().
 		DescribeOperation(
 			g.DescriptionMappingKindSingleValue,
 			"https://docs.snowflake.com/en/sql-reference/sql/desc-stream",

--- a/pkg/sdk/tasks_def.go
+++ b/pkg/sdk/tasks_def.go
@@ -292,7 +292,7 @@ var TasksDef = g.NewInterface(
 			OptionalSQL("ROOT ONLY").
 			OptionalLimit(),
 	).
-	ShowByIdOperation().
+	ShowByIdOperationNoFiltering().
 	DescribeOperation(
 		g.DescriptionMappingKindSingleValue,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-task",

--- a/pkg/sdk/views_def.go
+++ b/pkg/sdk/views_def.go
@@ -336,7 +336,7 @@ var ViewsDef = g.NewInterface(
 			OptionalStartsWith().
 			OptionalLimit(),
 	).
-	ShowByIdOperation().
+	ShowByIdOperationNoFiltering().
 	DescribeOperation(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-view",


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->
## Changes
- removed generation of integration_tests file
- added a print for the user to create the integration tests manually
- changed the `ShowByIdOperation` name to `ShowByIdOperationNoFiltering` for no automatic generation of filtering options
- adjusted the template for ShowByID filtering
- adjusted README of the SDK generator to the current state 

## References
<!-- issues documentation links, etc  -->
* https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/3227
* https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/3240