### PR TITLE
feat: Basic functions implementation

### DIFF
--- a/docs/resources/function_java.md
+++ b/docs/resources/function_java.md
@@ -17,7 +17,6 @@ Resource used to manage java function objects. For more information, check [func
 ### Required
 
 - `database` (String) The database in which to create the function. Due to technical limitations (read more [here](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/docs/technical-documentation/identifiers_rework_design_decisions.md#known-limitations-and-identifier-recommendations)), avoid using the following characters: `|`, `.`, `"`.
-- `function_definition` (String) Defines the handler code executed when the UDF is called. Wrapping `$$` signs are added by the provider automatically; do not include them. The `function_definition` value must be Java source code. For more information, see [Introduction to Java UDFs](https://docs.snowflake.com/en/developer-guide/udf/java/udf-java-introduction). To mitigate permadiff on this field, the provider replaces blank characters with a space. This can lead to false positives in cases where a change in case or run of whitespace is semantically significant.
 - `handler` (String) The name of the handler method or class. If the handler is for a scalar UDF, returning a non-tabular value, the HANDLER value should be a method name, as in the following form: `MyClass.myMethod`. If the handler is for a tabular UDF, the HANDLER value should be the name of a handler class.
 - `name` (String) The name of the function; the identifier does not need to be unique for the schema in which the function is created because UDFs are identified and resolved by the combination of the name and argument types. Check the [docs](https://docs.snowflake.com/en/sql-reference/sql/create-function#all-languages). Due to technical limitations (read more [here](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/docs/technical-documentation/identifiers_rework_design_decisions.md#known-limitations-and-identifier-recommendations)), avoid using the following characters: `|`, `.`, `"`.
 - `return_type` (String) Specifies the results returned by the UDF, which determines the UDF type. Use `<result_data_type>` to create a scalar UDF that returns a single value with the specified data type. Use `TABLE (col_name col_data_type, ...)` to creates a table UDF that returns tabular results with the specified table column(s) and column type(s). For the details, consult the [docs](https://docs.snowflake.com/en/sql-reference/sql/create-function#all-languages).
@@ -29,13 +28,14 @@ Resource used to manage java function objects. For more information, check [func
 - `comment` (String) Specifies a comment for the function.
 - `enable_console_output` (Boolean) Enable stdout/stderr fast path logging for anonyous stored procs. This is a public parameter (similar to LOG_LEVEL). For more information, check [ENABLE_CONSOLE_OUTPUT docs](https://docs.snowflake.com/en/sql-reference/parameters#enable-console-output).
 - `external_access_integrations` (Set of String) The names of [external access integrations](https://docs.snowflake.com/en/sql-reference/sql/create-external-access-integration) needed in order for this function’s handler code to access external networks. An external access integration specifies [network rules](https://docs.snowflake.com/en/sql-reference/sql/create-network-rule) and [secrets](https://docs.snowflake.com/en/sql-reference/sql/create-secret) that specify external locations and credentials (if any) allowed for use by handler code when making requests of an external network, such as an external REST API.
-- `imports` (Set of String) The location (stage), path, and name of the file(s) to import. A file can be a JAR file or another type of file. If the file is a JAR file, it can contain one or more .class files and zero or more resource files. JNI (Java Native Interface) is not supported. Snowflake prohibits loading libraries that contain native code (as opposed to Java bytecode). Java UDFs can also read non-JAR files. For an example, see [Reading a file specified statically in IMPORTS](https://docs.snowflake.com/en/developer-guide/udf/java/udf-java-cookbook.html#label-reading-file-from-java-udf-imports). Consult the [docs](https://docs.snowflake.com/en/sql-reference/sql/create-function#java).
+- `function_definition` (String) Defines the handler code executed when the UDF is called. Wrapping `$$` signs are added by the provider automatically; do not include them. The `function_definition` value must be Java source code. For more information, see [Introduction to Java UDFs](https://docs.snowflake.com/en/developer-guide/udf/java/udf-java-introduction). To mitigate permadiff on this field, the provider replaces blank characters with a space. This can lead to false positives in cases where a change in case or run of whitespace is semantically significant.
+- `imports` (Block Set) The location (stage), path, and name of the file(s) to import. A file can be a JAR file or another type of file. If the file is a JAR file, it can contain one or more .class files and zero or more resource files. JNI (Java Native Interface) is not supported. Snowflake prohibits loading libraries that contain native code (as opposed to Java bytecode). Java UDFs can also read non-JAR files. For an example, see [Reading a file specified statically in IMPORTS](https://docs.snowflake.com/en/developer-guide/udf/java/udf-java-cookbook.html#label-reading-file-from-java-udf-imports). Consult the [docs](https://docs.snowflake.com/en/sql-reference/sql/create-function#java). (see [below for nested schema](#nestedblock--imports))
 - `is_secure` (String) Specifies that the function is secure. By design, the Snowflake's `SHOW FUNCTIONS` command does not provide information about secure functions (consult [function docs](https://docs.snowflake.com/en/sql-reference/sql/create-function#id1) and [Protecting Sensitive Information with Secure UDFs and Stored Procedures](https://docs.snowflake.com/en/developer-guide/secure-udf-procedure)) which is essential to manage/import function with Terraform. Use the role owning the function while managing secure functions. Available options are: "true" or "false". When the value is not set in the configuration the provider will put "default" there which means to use the Snowflake default for this value.
 - `log_level` (String) LOG_LEVEL to use when filtering events For more information, check [LOG_LEVEL docs](https://docs.snowflake.com/en/sql-reference/parameters#log-level).
 - `metric_level` (String) METRIC_LEVEL value to control whether to emit metrics to Event Table For more information, check [METRIC_LEVEL docs](https://docs.snowflake.com/en/sql-reference/parameters#metric-level).
 - `null_input_behavior` (String) Specifies the behavior of the function when called with null inputs. Valid values are (case-insensitive): `CALLED ON NULL INPUT` | `RETURNS NULL ON NULL INPUT`.
 - `packages` (Set of String) The name and version number of Snowflake system packages required as dependencies. The value should be of the form `package_name:version_number`, where `package_name` is `snowflake_domain:package`.
-- `return_behavior` (String) Specifies the behavior of the function when returning results. Valid values are (case-insensitive): `VOLATILE` | `IMMUTABLE`.
+- `return_results_behavior` (String) Specifies the behavior of the function when returning results. Valid values are (case-insensitive): `VOLATILE` | `IMMUTABLE`.
 - `runtime_version` (String) Specifies the Java JDK runtime version to use. The supported versions of Java are 11.x and 17.x. If RUNTIME_VERSION is not set, Java JDK 11 is used.
 - `secrets` (Block Set) Assigns the names of [secrets](https://docs.snowflake.com/en/sql-reference/sql/create-secret) to variables so that you can use the variables to reference the secrets when retrieving information from secrets in handler code. Secrets you specify here must be allowed by the [external access integration](https://docs.snowflake.com/en/sql-reference/sql/create-external-access-integration) specified as a value of this CREATE FUNCTION command’s EXTERNAL_ACCESS_INTEGRATIONS parameter. (see [below for nested schema](#nestedblock--secrets))
 - `target_path` (String) The name of the handler method or class. If the handler is for a scalar UDF, returning a non-tabular value, the HANDLER value should be a method name, as in the following form: `MyClass.myMethod`. If the handler is for a tabular UDF, the HANDLER value should be the name of a handler class.
@@ -58,6 +58,15 @@ Required:
 - `arg_name` (String) The argument name.
 
 
+<a id="nestedblock--imports"></a>
+### Nested Schema for `imports`
+
+Required:
+
+- `path_on_stage` (String) Path for import on stage, without the leading `/`.
+- `stage_location` (String) Stage location without leading `@`. To use your user's stage set this to `~`, otherwise pass fully qualified name of the stage (with every part contained in double quotes or use `snowflake_stage.<your stage's resource name>.fully_qualified_name` if you manage this stage through terraform).
+
+
 <a id="nestedblock--secrets"></a>
 ### Nested Schema for `secrets`
 
@@ -72,10 +81,58 @@ Required:
 
 Read-Only:
 
-- `enable_console_output` (Boolean)
-- `log_level` (String)
-- `metric_level` (String)
-- `trace_level` (String)
+- `enable_console_output` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--enable_console_output))
+- `log_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--log_level))
+- `metric_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--metric_level))
+- `trace_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--trace_level))
+
+<a id="nestedobjatt--parameters--enable_console_output"></a>
+### Nested Schema for `parameters.enable_console_output`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--log_level"></a>
+### Nested Schema for `parameters.log_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--metric_level"></a>
+### Nested Schema for `parameters.metric_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--trace_level"></a>
+### Nested Schema for `parameters.trace_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
 
 
 <a id="nestedatt--show_output"></a>

--- a/docs/resources/function_java.md
+++ b/docs/resources/function_java.md
@@ -38,7 +38,7 @@ Resource used to manage java function objects. For more information, check [func
 - `return_results_behavior` (String) Specifies the behavior of the function when returning results. Valid values are (case-insensitive): `VOLATILE` | `IMMUTABLE`.
 - `runtime_version` (String) Specifies the Java JDK runtime version to use. The supported versions of Java are 11.x and 17.x. If RUNTIME_VERSION is not set, Java JDK 11 is used.
 - `secrets` (Block Set) Assigns the names of [secrets](https://docs.snowflake.com/en/sql-reference/sql/create-secret) to variables so that you can use the variables to reference the secrets when retrieving information from secrets in handler code. Secrets you specify here must be allowed by the [external access integration](https://docs.snowflake.com/en/sql-reference/sql/create-external-access-integration) specified as a value of this CREATE FUNCTION command’s EXTERNAL_ACCESS_INTEGRATIONS parameter. (see [below for nested schema](#nestedblock--secrets))
-- `target_path` (String) The name of the handler method or class. If the handler is for a scalar UDF, returning a non-tabular value, the HANDLER value should be a method name, as in the following form: `MyClass.myMethod`. If the handler is for a tabular UDF, the HANDLER value should be the name of a handler class.
+- `target_path` (Block Set, Max: 1) The name of the handler method or class. If the handler is for a scalar UDF, returning a non-tabular value, the HANDLER value should be a method name, as in the following form: `MyClass.myMethod`. If the handler is for a tabular UDF, the HANDLER value should be the name of a handler class. (see [below for nested schema](#nestedblock--target_path))
 - `trace_level` (String) Trace level value to use when generating/filtering trace events For more information, check [TRACE_LEVEL docs](https://docs.snowflake.com/en/sql-reference/parameters#trace-level).
 
 ### Read-Only
@@ -57,6 +57,10 @@ Required:
 - `arg_data_type` (String) The argument type.
 - `arg_name` (String) The argument name.
 
+Optional:
+
+- `arg_default_value` (String) Optional default value for the argument. For text values use single quotes. Numeric values can be unquoted. External changes for this field won't be detected. In case you want to apply external changes, you can re-create the resource manually using "terraform taint".
+
 
 <a id="nestedblock--imports"></a>
 ### Nested Schema for `imports`
@@ -74,6 +78,15 @@ Required:
 
 - `secret_id` (String) Fully qualified name of the allowed [secret](https://docs.snowflake.com/en/sql-reference/sql/create-secret). You will receive an error if you specify a SECRETS value whose secret isn’t also included in an integration specified by the EXTERNAL_ACCESS_INTEGRATIONS parameter.
 - `secret_variable_name` (String) The variable that will be used in handler code when retrieving information from the secret.
+
+
+<a id="nestedblock--target_path"></a>
+### Nested Schema for `target_path`
+
+Required:
+
+- `path_on_stage` (String) Path for import on stage, without the leading `/`.
+- `stage_location` (String) Stage location without leading `@`. To use your user's stage set this to `~`, otherwise pass fully qualified name of the stage (with every part contained in double quotes or use `snowflake_stage.<your stage's resource name>.fully_qualified_name` if you manage this stage through terraform).
 
 
 <a id="nestedatt--parameters"></a>

--- a/docs/resources/function_javascript.md
+++ b/docs/resources/function_javascript.md
@@ -50,6 +50,10 @@ Required:
 - `arg_data_type` (String) The argument type.
 - `arg_name` (String) The argument name.
 
+Optional:
+
+- `arg_default_value` (String) Optional default value for the argument. For text values use single quotes. Numeric values can be unquoted. External changes for this field won't be detected. In case you want to apply external changes, you can re-create the resource manually using "terraform taint".
+
 
 <a id="nestedatt--parameters"></a>
 ### Nested Schema for `parameters`

--- a/docs/resources/function_javascript.md
+++ b/docs/resources/function_javascript.md
@@ -31,7 +31,7 @@ Resource used to manage javascript function objects. For more information, check
 - `log_level` (String) LOG_LEVEL to use when filtering events For more information, check [LOG_LEVEL docs](https://docs.snowflake.com/en/sql-reference/parameters#log-level).
 - `metric_level` (String) METRIC_LEVEL value to control whether to emit metrics to Event Table For more information, check [METRIC_LEVEL docs](https://docs.snowflake.com/en/sql-reference/parameters#metric-level).
 - `null_input_behavior` (String) Specifies the behavior of the function when called with null inputs. Valid values are (case-insensitive): `CALLED ON NULL INPUT` | `RETURNS NULL ON NULL INPUT`.
-- `return_behavior` (String) Specifies the behavior of the function when returning results. Valid values are (case-insensitive): `VOLATILE` | `IMMUTABLE`.
+- `return_results_behavior` (String) Specifies the behavior of the function when returning results. Valid values are (case-insensitive): `VOLATILE` | `IMMUTABLE`.
 - `trace_level` (String) Trace level value to use when generating/filtering trace events For more information, check [TRACE_LEVEL docs](https://docs.snowflake.com/en/sql-reference/parameters#trace-level).
 
 ### Read-Only
@@ -56,10 +56,58 @@ Required:
 
 Read-Only:
 
-- `enable_console_output` (Boolean)
-- `log_level` (String)
-- `metric_level` (String)
-- `trace_level` (String)
+- `enable_console_output` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--enable_console_output))
+- `log_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--log_level))
+- `metric_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--metric_level))
+- `trace_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--trace_level))
+
+<a id="nestedobjatt--parameters--enable_console_output"></a>
+### Nested Schema for `parameters.enable_console_output`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--log_level"></a>
+### Nested Schema for `parameters.log_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--metric_level"></a>
+### Nested Schema for `parameters.metric_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--trace_level"></a>
+### Nested Schema for `parameters.trace_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
 
 
 <a id="nestedatt--show_output"></a>

--- a/docs/resources/function_python.md
+++ b/docs/resources/function_python.md
@@ -17,7 +17,6 @@ Resource used to manage python function objects. For more information, check [fu
 ### Required
 
 - `database` (String) The database in which to create the function. Due to technical limitations (read more [here](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/docs/technical-documentation/identifiers_rework_design_decisions.md#known-limitations-and-identifier-recommendations)), avoid using the following characters: `|`, `.`, `"`.
-- `function_definition` (String) Defines the handler code executed when the UDF is called. Wrapping `$$` signs are added by the provider automatically; do not include them. The `function_definition` value must be Python source code. For more information, see [Introduction to Python UDFs](https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-introduction). To mitigate permadiff on this field, the provider replaces blank characters with a space. This can lead to false positives in cases where a change in case or run of whitespace is semantically significant.
 - `handler` (String) The name of the handler function or class. If the handler is for a scalar UDF, returning a non-tabular value, the HANDLER value should be a function name. If the handler code is in-line with the CREATE FUNCTION statement, you can use the function name alone. When the handler code is referenced at a stage, this value should be qualified with the module name, as in the following form: `my_module.my_function`. If the handler is for a tabular UDF, the HANDLER value should be the name of a handler class.
 - `name` (String) The name of the function; the identifier does not need to be unique for the schema in which the function is created because UDFs are identified and resolved by the combination of the name and argument types. Check the [docs](https://docs.snowflake.com/en/sql-reference/sql/create-function#all-languages). Due to technical limitations (read more [here](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/docs/technical-documentation/identifiers_rework_design_decisions.md#known-limitations-and-identifier-recommendations)), avoid using the following characters: `|`, `.`, `"`.
 - `return_type` (String) Specifies the results returned by the UDF, which determines the UDF type. Use `<result_data_type>` to create a scalar UDF that returns a single value with the specified data type. Use `TABLE (col_name col_data_type, ...)` to creates a table UDF that returns tabular results with the specified table column(s) and column type(s). For the details, consult the [docs](https://docs.snowflake.com/en/sql-reference/sql/create-function#all-languages).
@@ -30,14 +29,15 @@ Resource used to manage python function objects. For more information, check [fu
 - `comment` (String) Specifies a comment for the function.
 - `enable_console_output` (Boolean) Enable stdout/stderr fast path logging for anonyous stored procs. This is a public parameter (similar to LOG_LEVEL). For more information, check [ENABLE_CONSOLE_OUTPUT docs](https://docs.snowflake.com/en/sql-reference/parameters#enable-console-output).
 - `external_access_integrations` (Set of String) The names of [external access integrations](https://docs.snowflake.com/en/sql-reference/sql/create-external-access-integration) needed in order for this function’s handler code to access external networks. An external access integration specifies [network rules](https://docs.snowflake.com/en/sql-reference/sql/create-network-rule) and [secrets](https://docs.snowflake.com/en/sql-reference/sql/create-secret) that specify external locations and credentials (if any) allowed for use by handler code when making requests of an external network, such as an external REST API.
-- `imports` (Set of String) The location (stage), path, and name of the file(s) to import. A file can be a `.py` file or another type of file. Python UDFs can also read non-Python files, such as text files. For an example, see [Reading a file](https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-examples.html#label-udf-python-read-files). Consult the [docs](https://docs.snowflake.com/en/sql-reference/sql/create-function#python).
+- `function_definition` (String) Defines the handler code executed when the UDF is called. Wrapping `$$` signs are added by the provider automatically; do not include them. The `function_definition` value must be Python source code. For more information, see [Introduction to Python UDFs](https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-introduction). To mitigate permadiff on this field, the provider replaces blank characters with a space. This can lead to false positives in cases where a change in case or run of whitespace is semantically significant.
+- `imports` (Block Set) The location (stage), path, and name of the file(s) to import. A file can be a `.py` file or another type of file. Python UDFs can also read non-Python files, such as text files. For an example, see [Reading a file](https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-examples.html#label-udf-python-read-files). Consult the [docs](https://docs.snowflake.com/en/sql-reference/sql/create-function#python). (see [below for nested schema](#nestedblock--imports))
 - `is_aggregate` (String) Specifies that the function is an aggregate function. For more information about user-defined aggregate functions, see [Python user-defined aggregate functions](https://docs.snowflake.com/en/developer-guide/udf/python/udf-python-aggregate-functions). Available options are: "true" or "false". When the value is not set in the configuration the provider will put "default" there which means to use the Snowflake default for this value.
 - `is_secure` (String) Specifies that the function is secure. By design, the Snowflake's `SHOW FUNCTIONS` command does not provide information about secure functions (consult [function docs](https://docs.snowflake.com/en/sql-reference/sql/create-function#id1) and [Protecting Sensitive Information with Secure UDFs and Stored Procedures](https://docs.snowflake.com/en/developer-guide/secure-udf-procedure)) which is essential to manage/import function with Terraform. Use the role owning the function while managing secure functions. Available options are: "true" or "false". When the value is not set in the configuration the provider will put "default" there which means to use the Snowflake default for this value.
 - `log_level` (String) LOG_LEVEL to use when filtering events For more information, check [LOG_LEVEL docs](https://docs.snowflake.com/en/sql-reference/parameters#log-level).
 - `metric_level` (String) METRIC_LEVEL value to control whether to emit metrics to Event Table For more information, check [METRIC_LEVEL docs](https://docs.snowflake.com/en/sql-reference/parameters#metric-level).
 - `null_input_behavior` (String) Specifies the behavior of the function when called with null inputs. Valid values are (case-insensitive): `CALLED ON NULL INPUT` | `RETURNS NULL ON NULL INPUT`.
 - `packages` (Set of String) The name and version number of packages required as dependencies. The value should be of the form `package_name==version_number`.
-- `return_behavior` (String) Specifies the behavior of the function when returning results. Valid values are (case-insensitive): `VOLATILE` | `IMMUTABLE`.
+- `return_results_behavior` (String) Specifies the behavior of the function when returning results. Valid values are (case-insensitive): `VOLATILE` | `IMMUTABLE`.
 - `secrets` (Block Set) Assigns the names of [secrets](https://docs.snowflake.com/en/sql-reference/sql/create-secret) to variables so that you can use the variables to reference the secrets when retrieving information from secrets in handler code. Secrets you specify here must be allowed by the [external access integration](https://docs.snowflake.com/en/sql-reference/sql/create-external-access-integration) specified as a value of this CREATE FUNCTION command’s EXTERNAL_ACCESS_INTEGRATIONS parameter. (see [below for nested schema](#nestedblock--secrets))
 - `trace_level` (String) Trace level value to use when generating/filtering trace events For more information, check [TRACE_LEVEL docs](https://docs.snowflake.com/en/sql-reference/parameters#trace-level).
 
@@ -58,6 +58,15 @@ Required:
 - `arg_name` (String) The argument name.
 
 
+<a id="nestedblock--imports"></a>
+### Nested Schema for `imports`
+
+Required:
+
+- `path_on_stage` (String) Path for import on stage, without the leading `/`.
+- `stage_location` (String) Stage location without leading `@`. To use your user's stage set this to `~`, otherwise pass fully qualified name of the stage (with every part contained in double quotes or use `snowflake_stage.<your stage's resource name>.fully_qualified_name` if you manage this stage through terraform).
+
+
 <a id="nestedblock--secrets"></a>
 ### Nested Schema for `secrets`
 
@@ -72,10 +81,58 @@ Required:
 
 Read-Only:
 
-- `enable_console_output` (Boolean)
-- `log_level` (String)
-- `metric_level` (String)
-- `trace_level` (String)
+- `enable_console_output` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--enable_console_output))
+- `log_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--log_level))
+- `metric_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--metric_level))
+- `trace_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--trace_level))
+
+<a id="nestedobjatt--parameters--enable_console_output"></a>
+### Nested Schema for `parameters.enable_console_output`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--log_level"></a>
+### Nested Schema for `parameters.log_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--metric_level"></a>
+### Nested Schema for `parameters.metric_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--trace_level"></a>
+### Nested Schema for `parameters.trace_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
 
 
 <a id="nestedatt--show_output"></a>

--- a/docs/resources/function_python.md
+++ b/docs/resources/function_python.md
@@ -57,6 +57,10 @@ Required:
 - `arg_data_type` (String) The argument type.
 - `arg_name` (String) The argument name.
 
+Optional:
+
+- `arg_default_value` (String) Optional default value for the argument. For text values use single quotes. Numeric values can be unquoted. External changes for this field won't be detected. In case you want to apply external changes, you can re-create the resource manually using "terraform taint".
+
 
 <a id="nestedblock--imports"></a>
 ### Nested Schema for `imports`

--- a/docs/resources/function_scala.md
+++ b/docs/resources/function_scala.md
@@ -38,7 +38,7 @@ Resource used to manage scala function objects. For more information, check [fun
 - `packages` (Set of String) The name and version number of Snowflake system packages required as dependencies. The value should be of the form `package_name:version_number`, where `package_name` is `snowflake_domain:package`.
 - `return_results_behavior` (String) Specifies the behavior of the function when returning results. Valid values are (case-insensitive): `VOLATILE` | `IMMUTABLE`.
 - `secrets` (Block Set) Assigns the names of [secrets](https://docs.snowflake.com/en/sql-reference/sql/create-secret) to variables so that you can use the variables to reference the secrets when retrieving information from secrets in handler code. Secrets you specify here must be allowed by the [external access integration](https://docs.snowflake.com/en/sql-reference/sql/create-external-access-integration) specified as a value of this CREATE FUNCTION command’s EXTERNAL_ACCESS_INTEGRATIONS parameter. (see [below for nested schema](#nestedblock--secrets))
-- `target_path` (String) The name of the handler method or class. If the handler is for a scalar UDF, returning a non-tabular value, the HANDLER value should be a method name, as in the following form: `MyClass.myMethod`.
+- `target_path` (Block Set, Max: 1) The name of the handler method or class. If the handler is for a scalar UDF, returning a non-tabular value, the HANDLER value should be a method name, as in the following form: `MyClass.myMethod`. (see [below for nested schema](#nestedblock--target_path))
 - `trace_level` (String) Trace level value to use when generating/filtering trace events For more information, check [TRACE_LEVEL docs](https://docs.snowflake.com/en/sql-reference/parameters#trace-level).
 
 ### Read-Only
@@ -57,6 +57,10 @@ Required:
 - `arg_data_type` (String) The argument type.
 - `arg_name` (String) The argument name.
 
+Optional:
+
+- `arg_default_value` (String) Optional default value for the argument. For text values use single quotes. Numeric values can be unquoted. External changes for this field won't be detected. In case you want to apply external changes, you can re-create the resource manually using "terraform taint".
+
 
 <a id="nestedblock--imports"></a>
 ### Nested Schema for `imports`
@@ -74,6 +78,15 @@ Required:
 
 - `secret_id` (String) Fully qualified name of the allowed [secret](https://docs.snowflake.com/en/sql-reference/sql/create-secret). You will receive an error if you specify a SECRETS value whose secret isn’t also included in an integration specified by the EXTERNAL_ACCESS_INTEGRATIONS parameter.
 - `secret_variable_name` (String) The variable that will be used in handler code when retrieving information from the secret.
+
+
+<a id="nestedblock--target_path"></a>
+### Nested Schema for `target_path`
+
+Required:
+
+- `path_on_stage` (String) Path for import on stage, without the leading `/`.
+- `stage_location` (String) Stage location without leading `@`. To use your user's stage set this to `~`, otherwise pass fully qualified name of the stage (with every part contained in double quotes or use `snowflake_stage.<your stage's resource name>.fully_qualified_name` if you manage this stage through terraform).
 
 
 <a id="nestedatt--parameters"></a>

--- a/docs/resources/function_sql.md
+++ b/docs/resources/function_sql.md
@@ -31,7 +31,7 @@ Resource used to manage sql function objects. For more information, check [funct
 - `log_level` (String) LOG_LEVEL to use when filtering events For more information, check [LOG_LEVEL docs](https://docs.snowflake.com/en/sql-reference/parameters#log-level).
 - `metric_level` (String) METRIC_LEVEL value to control whether to emit metrics to Event Table For more information, check [METRIC_LEVEL docs](https://docs.snowflake.com/en/sql-reference/parameters#metric-level).
 - `null_input_behavior` (String) Specifies the behavior of the function when called with null inputs. Valid values are (case-insensitive): `CALLED ON NULL INPUT` | `RETURNS NULL ON NULL INPUT`.
-- `return_behavior` (String) Specifies the behavior of the function when returning results. Valid values are (case-insensitive): `VOLATILE` | `IMMUTABLE`.
+- `return_results_behavior` (String) Specifies the behavior of the function when returning results. Valid values are (case-insensitive): `VOLATILE` | `IMMUTABLE`.
 - `trace_level` (String) Trace level value to use when generating/filtering trace events For more information, check [TRACE_LEVEL docs](https://docs.snowflake.com/en/sql-reference/parameters#trace-level).
 
 ### Read-Only
@@ -56,10 +56,58 @@ Required:
 
 Read-Only:
 
-- `enable_console_output` (Boolean)
-- `log_level` (String)
-- `metric_level` (String)
-- `trace_level` (String)
+- `enable_console_output` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--enable_console_output))
+- `log_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--log_level))
+- `metric_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--metric_level))
+- `trace_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--trace_level))
+
+<a id="nestedobjatt--parameters--enable_console_output"></a>
+### Nested Schema for `parameters.enable_console_output`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--log_level"></a>
+### Nested Schema for `parameters.log_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--metric_level"></a>
+### Nested Schema for `parameters.metric_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--trace_level"></a>
+### Nested Schema for `parameters.trace_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
 
 
 <a id="nestedatt--show_output"></a>

--- a/docs/resources/function_sql.md
+++ b/docs/resources/function_sql.md
@@ -50,6 +50,10 @@ Required:
 - `arg_data_type` (String) The argument type.
 - `arg_name` (String) The argument name.
 
+Optional:
+
+- `arg_default_value` (String) Optional default value for the argument. For text values use single quotes. Numeric values can be unquoted. External changes for this field won't be detected. In case you want to apply external changes, you can re-create the resource manually using "terraform taint".
+
 
 <a id="nestedatt--parameters"></a>
 ### Nested Schema for `parameters`

--- a/docs/resources/procedure_java.md
+++ b/docs/resources/procedure_java.md
@@ -73,10 +73,58 @@ Required:
 
 Read-Only:
 
-- `enable_console_output` (Boolean)
-- `log_level` (String)
-- `metric_level` (String)
-- `trace_level` (String)
+- `enable_console_output` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--enable_console_output))
+- `log_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--log_level))
+- `metric_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--metric_level))
+- `trace_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--trace_level))
+
+<a id="nestedobjatt--parameters--enable_console_output"></a>
+### Nested Schema for `parameters.enable_console_output`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--log_level"></a>
+### Nested Schema for `parameters.log_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--metric_level"></a>
+### Nested Schema for `parameters.metric_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--trace_level"></a>
+### Nested Schema for `parameters.trace_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
 
 
 <a id="nestedatt--show_output"></a>

--- a/docs/resources/procedure_javascript.md
+++ b/docs/resources/procedure_javascript.md
@@ -56,10 +56,58 @@ Required:
 
 Read-Only:
 
-- `enable_console_output` (Boolean)
-- `log_level` (String)
-- `metric_level` (String)
-- `trace_level` (String)
+- `enable_console_output` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--enable_console_output))
+- `log_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--log_level))
+- `metric_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--metric_level))
+- `trace_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--trace_level))
+
+<a id="nestedobjatt--parameters--enable_console_output"></a>
+### Nested Schema for `parameters.enable_console_output`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--log_level"></a>
+### Nested Schema for `parameters.log_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--metric_level"></a>
+### Nested Schema for `parameters.metric_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--trace_level"></a>
+### Nested Schema for `parameters.trace_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
 
 
 <a id="nestedatt--show_output"></a>

--- a/docs/resources/procedure_python.md
+++ b/docs/resources/procedure_python.md
@@ -72,10 +72,58 @@ Required:
 
 Read-Only:
 
-- `enable_console_output` (Boolean)
-- `log_level` (String)
-- `metric_level` (String)
-- `trace_level` (String)
+- `enable_console_output` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--enable_console_output))
+- `log_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--log_level))
+- `metric_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--metric_level))
+- `trace_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--trace_level))
+
+<a id="nestedobjatt--parameters--enable_console_output"></a>
+### Nested Schema for `parameters.enable_console_output`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--log_level"></a>
+### Nested Schema for `parameters.log_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--metric_level"></a>
+### Nested Schema for `parameters.metric_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--trace_level"></a>
+### Nested Schema for `parameters.trace_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
 
 
 <a id="nestedatt--show_output"></a>

--- a/docs/resources/procedure_scala.md
+++ b/docs/resources/procedure_scala.md
@@ -73,10 +73,58 @@ Required:
 
 Read-Only:
 
-- `enable_console_output` (Boolean)
-- `log_level` (String)
-- `metric_level` (String)
-- `trace_level` (String)
+- `enable_console_output` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--enable_console_output))
+- `log_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--log_level))
+- `metric_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--metric_level))
+- `trace_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--trace_level))
+
+<a id="nestedobjatt--parameters--enable_console_output"></a>
+### Nested Schema for `parameters.enable_console_output`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--log_level"></a>
+### Nested Schema for `parameters.log_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--metric_level"></a>
+### Nested Schema for `parameters.metric_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--trace_level"></a>
+### Nested Schema for `parameters.trace_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
 
 
 <a id="nestedatt--show_output"></a>

--- a/docs/resources/procedure_sql.md
+++ b/docs/resources/procedure_sql.md
@@ -56,10 +56,58 @@ Required:
 
 Read-Only:
 
-- `enable_console_output` (Boolean)
-- `log_level` (String)
-- `metric_level` (String)
-- `trace_level` (String)
+- `enable_console_output` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--enable_console_output))
+- `log_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--log_level))
+- `metric_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--metric_level))
+- `trace_level` (List of Object) (see [below for nested schema](#nestedobjatt--parameters--trace_level))
+
+<a id="nestedobjatt--parameters--enable_console_output"></a>
+### Nested Schema for `parameters.enable_console_output`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--log_level"></a>
+### Nested Schema for `parameters.log_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--metric_level"></a>
+### Nested Schema for `parameters.metric_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
+
+<a id="nestedobjatt--parameters--trace_level"></a>
+### Nested Schema for `parameters.trace_level`
+
+Read-Only:
+
+- `default` (String)
+- `description` (String)
+- `key` (String)
+- `level` (String)
+- `value` (String)
+
 
 
 <a id="nestedatt--show_output"></a>

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/function_describe_snowflake_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/function_describe_snowflake_ext.go
@@ -407,7 +407,7 @@ func (f *FunctionDetailsAssert) HasExactlySecrets(expectedSecrets map[string]sdk
 	return f
 }
 
-func (f *FunctionDetailsAssert) HasExactlyImportsNormalizedInAnyOrder(imports ...sdk.FunctionDetailsImport) *FunctionDetailsAssert {
+func (f *FunctionDetailsAssert) HasExactlyImportsNormalizedInAnyOrder(imports ...sdk.NormalizedPath) *FunctionDetailsAssert {
 	f.AddAssertion(func(t *testing.T, o *sdk.FunctionDetails) error {
 		t.Helper()
 		if o.NormalizedImports == nil {

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/function_describe_snowflake_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/function_describe_snowflake_ext.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+	assert2 "github.com/stretchr/testify/assert"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
@@ -400,6 +401,20 @@ func (f *FunctionDetailsAssert) HasExactlySecrets(expectedSecrets map[string]sdk
 		expected := fmt.Sprintf(`{%s}`, strings.Join(parts, ","))
 		if *o.Secrets != expected {
 			return fmt.Errorf("expected secrets: %v; got: %v", expected, *o.Secrets)
+		}
+		return nil
+	})
+	return f
+}
+
+func (f *FunctionDetailsAssert) HasExactlyImportsNormalizedInAnyOrder(imports ...sdk.FunctionDetailsImport) *FunctionDetailsAssert {
+	f.AddAssertion(func(t *testing.T, o *sdk.FunctionDetails) error {
+		t.Helper()
+		if o.NormalizedImports == nil {
+			return fmt.Errorf("expected imports to have value; got: nil")
+		}
+		if !assert2.ElementsMatch(t, imports, o.NormalizedImports) {
+			return fmt.Errorf("expected %v imports in task relations, got %v", imports, o.NormalizedImports)
 		}
 		return nil
 	})

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/function_describe_snowflake_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/function_describe_snowflake_ext.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 )
 
 // TODO [SNOW-1501905]: this file should be fully regenerated when adding and option to assert the results of describe
@@ -415,6 +416,59 @@ func (f *FunctionDetailsAssert) HasExactlyImportsNormalizedInAnyOrder(imports ..
 		}
 		if !assert2.ElementsMatch(t, imports, o.NormalizedImports) {
 			return fmt.Errorf("expected %v imports in task relations, got %v", imports, o.NormalizedImports)
+		}
+		return nil
+	})
+	return f
+}
+
+func (f *FunctionDetailsAssert) HasNormalizedTargetPath(expectedStageLocation string, expectedPathOnStage string) *FunctionDetailsAssert {
+	f.AddAssertion(func(t *testing.T, o *sdk.FunctionDetails) error {
+		t.Helper()
+		if o.NormalizedTargetPath == nil {
+			return fmt.Errorf("expected normalized target path to have value; got: nil")
+		}
+		if o.NormalizedTargetPath.StageLocation != expectedStageLocation {
+			return fmt.Errorf("expected %s stage location for target path, got %v", expectedStageLocation, o.NormalizedTargetPath.StageLocation)
+		}
+		if o.NormalizedTargetPath.PathOnStage != expectedPathOnStage {
+			return fmt.Errorf("expected %s path on stage for target path, got %v", expectedPathOnStage, o.NormalizedTargetPath.PathOnStage)
+		}
+		return nil
+	})
+	return f
+}
+
+func (f *FunctionDetailsAssert) HasNormalizedTargetPathNil() *FunctionDetailsAssert {
+	f.AddAssertion(func(t *testing.T, o *sdk.FunctionDetails) error {
+		t.Helper()
+		if o.NormalizedTargetPath != nil {
+			return fmt.Errorf("expected normalized target path to be nil, got: %s", *o.NormalizedTargetPath)
+		}
+		return nil
+	})
+	return f
+}
+
+func (f *FunctionDetailsAssert) HasReturnDataType(expectedDataType datatypes.DataType) *FunctionDetailsAssert {
+	f.AddAssertion(func(t *testing.T, o *sdk.FunctionDetails) error {
+		t.Helper()
+		if o.ReturnDataType == nil {
+			return fmt.Errorf("expected return data type to have value; got: nil")
+		}
+		if !datatypes.AreTheSame(o.ReturnDataType, expectedDataType) {
+			return fmt.Errorf("expected %s return data type, got %v", expectedDataType, o.ReturnDataType.ToSql())
+		}
+		return nil
+	})
+	return f
+}
+
+func (f *FunctionDetailsAssert) HasReturnNotNull(expected bool) *FunctionDetailsAssert {
+	f.AddAssertion(func(t *testing.T, o *sdk.FunctionDetails) error {
+		t.Helper()
+		if o.ReturnNotNull != expected {
+			return fmt.Errorf("expected return not null %t; got: %t", expected, o.ReturnNotNull)
 		}
 		return nil
 	})

--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/function_java_resource_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/function_java_resource_ext.go
@@ -10,3 +10,8 @@ func (f *FunctionJavaResourceAssert) HasImportsLength(len int) *FunctionJavaReso
 	f.AddAssertion(assert.ValueSet("imports.#", strconv.FormatInt(int64(len), 10)))
 	return f
 }
+
+func (f *FunctionJavaResourceAssert) HasTargetPathEmpty() *FunctionJavaResourceAssert {
+	f.AddAssertion(assert.ValueSet("target_path.#", "0"))
+	return f
+}

--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/function_java_resource_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/function_java_resource_ext.go
@@ -1,0 +1,12 @@
+package resourceassert
+
+import (
+	"strconv"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
+)
+
+func (f *FunctionJavaResourceAssert) HasImportsLength(len int) *FunctionJavaResourceAssert {
+	f.AddAssertion(assert.ValueSet("imports.#", strconv.FormatInt(int64(len), 10)))
+	return f
+}

--- a/pkg/acceptance/bettertestspoc/assert/resourceparametersassert/function_resource_parameters_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceparametersassert/function_resource_parameters_ext.go
@@ -1,0 +1,13 @@
+package resourceparametersassert
+
+import (
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+)
+
+func (f *FunctionResourceParametersAssert) HasAllDefaults() *FunctionResourceParametersAssert {
+	return f.
+		HasEnableConsoleOutput(false).
+		HasLogLevel(sdk.LogLevelOff).
+		HasMetricLevel(sdk.MetricLevelNone).
+		HasTraceLevel(sdk.TraceLevelOff)
+}

--- a/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
@@ -37,10 +37,11 @@ func FunctionJavaBasicStaged(
 	id sdk.SchemaObjectIdentifierWithArguments,
 	returnType datatypes.DataType,
 	handler string,
-	importPath string,
+	stageLocation string,
+	pathOnStage string,
 ) *FunctionJavaModel {
 	return FunctionJavaf(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), id.SchemaName()).
-		WithImport(importPath)
+		WithImport(stageLocation, pathOnStage)
 }
 
 func FunctionJavaf(
@@ -71,8 +72,13 @@ func (f *FunctionJavaModel) WithArgument(argName string, argDataType datatypes.D
 	)
 }
 
-func (f *FunctionJavaModel) WithImport(importPath string) *FunctionJavaModel {
-	return f.WithArgumentsValue(
-		tfconfig.SetVariable(tfconfig.StringVariable(importPath)),
+func (f *FunctionJavaModel) WithImport(stageLocation string, pathOnStage string) *FunctionJavaModel {
+	return f.WithImportsValue(
+		tfconfig.ObjectVariable(
+			map[string]tfconfig.Variable{
+				"stage_location": tfconfig.StringVariable(stageLocation),
+				"path_on_stage":  tfconfig.StringVariable(pathOnStage),
+			},
+		),
 	)
 }

--- a/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
+	"github.com/hashicorp/terraform-plugin-testing/config"
 )
 
 func (f *FunctionJavaModel) MarshalJSON() ([]byte, error) {
@@ -26,4 +27,15 @@ func FunctionJavaWithId(
 	functionDefinition string,
 ) *FunctionJavaModel {
 	return FunctionJava(resourceName, id.DatabaseName(), functionDefinition, handler, id.Name(), returnType.ToSql(), id.SchemaName())
+}
+
+func (f *FunctionJavaModel) WithArgument(argName string, argDataType datatypes.DataType) *FunctionJavaModel {
+	return f.WithArgumentsValue(
+		config.ObjectVariable(
+			map[string]config.Variable{
+				"arg_name":      config.StringVariable(argName),
+				"arg_data_type": config.StringVariable(argDataType.ToSql()),
+			},
+		),
+	)
 }

--- a/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
@@ -72,6 +72,18 @@ func (f *FunctionJavaModel) WithArgument(argName string, argDataType datatypes.D
 	)
 }
 
+func (f *FunctionJavaModel) WithArgumentWithDefaultValue(argName string, argDataType datatypes.DataType, value string) *FunctionJavaModel {
+	return f.WithArgumentsValue(
+		tfconfig.ObjectVariable(
+			map[string]tfconfig.Variable{
+				"arg_name":          tfconfig.StringVariable(argName),
+				"arg_data_type":     tfconfig.StringVariable(argDataType.ToSql()),
+				"arg_default_value": tfconfig.StringVariable(value),
+			},
+		),
+	)
+}
+
 func (f *FunctionJavaModel) WithImport(stageLocation string, pathOnStage string) *FunctionJavaModel {
 	return f.WithImportsValue(
 		tfconfig.ObjectVariable(

--- a/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
@@ -82,3 +82,14 @@ func (f *FunctionJavaModel) WithImport(stageLocation string, pathOnStage string)
 		),
 	)
 }
+
+func (f *FunctionJavaModel) WithTargetPathParts(stageLocation string, pathOnStage string) *FunctionJavaModel {
+	return f.WithTargetPathValue(
+		tfconfig.ObjectVariable(
+			map[string]tfconfig.Variable{
+				"stage_location": tfconfig.StringVariable(stageLocation),
+				"path_on_stage":  tfconfig.StringVariable(pathOnStage),
+			},
+		),
+	)
+}

--- a/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
@@ -5,8 +5,6 @@ import (
 
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 )
@@ -29,7 +27,7 @@ func FunctionJavaBasicInline(
 	handler string,
 	functionDefinition string,
 ) *FunctionJavaModel {
-	return FunctionJavaf(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), id.SchemaName()).WithFunctionDefinition(functionDefinition)
+	return FunctionJava(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), id.SchemaName()).WithFunctionDefinition(functionDefinition)
 }
 
 func FunctionJavaBasicStaged(
@@ -40,25 +38,8 @@ func FunctionJavaBasicStaged(
 	stageLocation string,
 	pathOnStage string,
 ) *FunctionJavaModel {
-	return FunctionJavaf(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), id.SchemaName()).
+	return FunctionJava(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), id.SchemaName()).
 		WithImport(stageLocation, pathOnStage)
-}
-
-func FunctionJavaf(
-	resourceName string,
-	database string,
-	handler string,
-	name string,
-	returnType string,
-	schema string,
-) *FunctionJavaModel {
-	f := &FunctionJavaModel{ResourceModelMeta: config.Meta(resourceName, resources.FunctionJava)}
-	f.WithDatabase(database)
-	f.WithHandler(handler)
-	f.WithName(name)
-	f.WithReturnType(returnType)
-	f.WithSchema(schema)
-	return f
 }
 
 func (f *FunctionJavaModel) WithArgument(argName string, argDataType datatypes.DataType) *FunctionJavaModel {

--- a/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
@@ -3,9 +3,12 @@ package model
 import (
 	"encoding/json"
 
+	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
-	"github.com/hashicorp/terraform-plugin-testing/config"
 )
 
 func (f *FunctionJavaModel) MarshalJSON() ([]byte, error) {
@@ -19,23 +22,57 @@ func (f *FunctionJavaModel) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func FunctionJavaWithId(
+func FunctionJavaBasicInline(
 	resourceName string,
 	id sdk.SchemaObjectIdentifierWithArguments,
 	returnType datatypes.DataType,
 	handler string,
 	functionDefinition string,
 ) *FunctionJavaModel {
-	return FunctionJava(resourceName, id.DatabaseName(), functionDefinition, handler, id.Name(), returnType.ToSql(), id.SchemaName())
+	return FunctionJavaf(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), id.SchemaName()).WithFunctionDefinition(functionDefinition)
+}
+
+func FunctionJavaBasicStaged(
+	resourceName string,
+	id sdk.SchemaObjectIdentifierWithArguments,
+	returnType datatypes.DataType,
+	handler string,
+	importPath string,
+) *FunctionJavaModel {
+	return FunctionJavaf(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), id.SchemaName()).
+		WithImport(importPath)
+}
+
+func FunctionJavaf(
+	resourceName string,
+	database string,
+	handler string,
+	name string,
+	returnType string,
+	schema string,
+) *FunctionJavaModel {
+	f := &FunctionJavaModel{ResourceModelMeta: config.Meta(resourceName, resources.FunctionJava)}
+	f.WithDatabase(database)
+	f.WithHandler(handler)
+	f.WithName(name)
+	f.WithReturnType(returnType)
+	f.WithSchema(schema)
+	return f
 }
 
 func (f *FunctionJavaModel) WithArgument(argName string, argDataType datatypes.DataType) *FunctionJavaModel {
 	return f.WithArgumentsValue(
-		config.ObjectVariable(
-			map[string]config.Variable{
-				"arg_name":      config.StringVariable(argName),
-				"arg_data_type": config.StringVariable(argDataType.ToSql()),
+		tfconfig.ObjectVariable(
+			map[string]tfconfig.Variable{
+				"arg_name":      tfconfig.StringVariable(argName),
+				"arg_data_type": tfconfig.StringVariable(argDataType.ToSql()),
 			},
 		),
+	)
+}
+
+func (f *FunctionJavaModel) WithImport(importPath string) *FunctionJavaModel {
+	return f.WithArgumentsValue(
+		tfconfig.SetVariable(tfconfig.StringVariable(importPath)),
 	)
 }

--- a/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
@@ -2,6 +2,9 @@ package model
 
 import (
 	"encoding/json"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 )
 
 func (f *FunctionJavaModel) MarshalJSON() ([]byte, error) {
@@ -13,4 +16,14 @@ func (f *FunctionJavaModel) MarshalJSON() ([]byte, error) {
 		Alias:     (*Alias)(f),
 		DependsOn: f.DependsOn(),
 	})
+}
+
+func FunctionJavaWithId(
+	resourceName string,
+	id sdk.SchemaObjectIdentifierWithArguments,
+	returnType datatypes.DataType,
+	handler string,
+	functionDefinition string,
+) *FunctionJavaModel {
+	return FunctionJava(resourceName, id.DatabaseName(), functionDefinition, handler, id.Name(), returnType.ToSql(), id.SchemaName())
 }

--- a/pkg/acceptance/bettertestspoc/config/model/function_java_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_java_model_gen.go
@@ -26,7 +26,7 @@ type FunctionJavaModel struct {
 	Name                       tfconfig.Variable `json:"name,omitempty"`
 	NullInputBehavior          tfconfig.Variable `json:"null_input_behavior,omitempty"`
 	Packages                   tfconfig.Variable `json:"packages,omitempty"`
-	ReturnBehavior             tfconfig.Variable `json:"return_behavior,omitempty"`
+	ReturnResultsBehavior      tfconfig.Variable `json:"return_results_behavior,omitempty"`
 	ReturnType                 tfconfig.Variable `json:"return_type,omitempty"`
 	RuntimeVersion             tfconfig.Variable `json:"runtime_version,omitempty"`
 	Schema                     tfconfig.Variable `json:"schema,omitempty"`
@@ -44,7 +44,6 @@ type FunctionJavaModel struct {
 func FunctionJava(
 	resourceName string,
 	database string,
-	functionDefinition string,
 	handler string,
 	name string,
 	returnType string,
@@ -52,7 +51,6 @@ func FunctionJava(
 ) *FunctionJavaModel {
 	f := &FunctionJavaModel{ResourceModelMeta: config.Meta(resourceName, resources.FunctionJava)}
 	f.WithDatabase(database)
-	f.WithFunctionDefinition(functionDefinition)
 	f.WithHandler(handler)
 	f.WithName(name)
 	f.WithReturnType(returnType)
@@ -62,7 +60,6 @@ func FunctionJava(
 
 func FunctionJavaWithDefaultMeta(
 	database string,
-	functionDefinition string,
 	handler string,
 	name string,
 	returnType string,
@@ -70,7 +67,6 @@ func FunctionJavaWithDefaultMeta(
 ) *FunctionJavaModel {
 	f := &FunctionJavaModel{ResourceModelMeta: config.DefaultMeta(resources.FunctionJava)}
 	f.WithDatabase(database)
-	f.WithFunctionDefinition(functionDefinition)
 	f.WithHandler(handler)
 	f.WithName(name)
 	f.WithReturnType(returnType)
@@ -150,8 +146,8 @@ func (f *FunctionJavaModel) WithNullInputBehavior(nullInputBehavior string) *Fun
 
 // packages attribute type is not yet supported, so WithPackages can't be generated
 
-func (f *FunctionJavaModel) WithReturnBehavior(returnBehavior string) *FunctionJavaModel {
-	f.ReturnBehavior = tfconfig.StringVariable(returnBehavior)
+func (f *FunctionJavaModel) WithReturnResultsBehavior(returnResultsBehavior string) *FunctionJavaModel {
+	f.ReturnResultsBehavior = tfconfig.StringVariable(returnResultsBehavior)
 	return f
 }
 
@@ -172,10 +168,7 @@ func (f *FunctionJavaModel) WithSchema(schema string) *FunctionJavaModel {
 
 // secrets attribute type is not yet supported, so WithSecrets can't be generated
 
-func (f *FunctionJavaModel) WithTargetPath(targetPath string) *FunctionJavaModel {
-	f.TargetPath = tfconfig.StringVariable(targetPath)
-	return f
-}
+// target_path attribute type is not yet supported, so WithTargetPath can't be generated
 
 func (f *FunctionJavaModel) WithTraceLevel(traceLevel string) *FunctionJavaModel {
 	f.TraceLevel = tfconfig.StringVariable(traceLevel)
@@ -266,8 +259,8 @@ func (f *FunctionJavaModel) WithPackagesValue(value tfconfig.Variable) *Function
 	return f
 }
 
-func (f *FunctionJavaModel) WithReturnBehaviorValue(value tfconfig.Variable) *FunctionJavaModel {
-	f.ReturnBehavior = value
+func (f *FunctionJavaModel) WithReturnResultsBehaviorValue(value tfconfig.Variable) *FunctionJavaModel {
+	f.ReturnResultsBehavior = value
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/function_javascript_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_javascript_model_gen.go
@@ -10,22 +10,22 @@ import (
 )
 
 type FunctionJavascriptModel struct {
-	Arguments           tfconfig.Variable `json:"arguments,omitempty"`
-	Comment             tfconfig.Variable `json:"comment,omitempty"`
-	Database            tfconfig.Variable `json:"database,omitempty"`
-	EnableConsoleOutput tfconfig.Variable `json:"enable_console_output,omitempty"`
-	FullyQualifiedName  tfconfig.Variable `json:"fully_qualified_name,omitempty"`
-	FunctionDefinition  tfconfig.Variable `json:"function_definition,omitempty"`
-	FunctionLanguage    tfconfig.Variable `json:"function_language,omitempty"`
-	IsSecure            tfconfig.Variable `json:"is_secure,omitempty"`
-	LogLevel            tfconfig.Variable `json:"log_level,omitempty"`
-	MetricLevel         tfconfig.Variable `json:"metric_level,omitempty"`
-	Name                tfconfig.Variable `json:"name,omitempty"`
-	NullInputBehavior   tfconfig.Variable `json:"null_input_behavior,omitempty"`
-	ReturnBehavior      tfconfig.Variable `json:"return_behavior,omitempty"`
-	ReturnType          tfconfig.Variable `json:"return_type,omitempty"`
-	Schema              tfconfig.Variable `json:"schema,omitempty"`
-	TraceLevel          tfconfig.Variable `json:"trace_level,omitempty"`
+	Arguments             tfconfig.Variable `json:"arguments,omitempty"`
+	Comment               tfconfig.Variable `json:"comment,omitempty"`
+	Database              tfconfig.Variable `json:"database,omitempty"`
+	EnableConsoleOutput   tfconfig.Variable `json:"enable_console_output,omitempty"`
+	FullyQualifiedName    tfconfig.Variable `json:"fully_qualified_name,omitempty"`
+	FunctionDefinition    tfconfig.Variable `json:"function_definition,omitempty"`
+	FunctionLanguage      tfconfig.Variable `json:"function_language,omitempty"`
+	IsSecure              tfconfig.Variable `json:"is_secure,omitempty"`
+	LogLevel              tfconfig.Variable `json:"log_level,omitempty"`
+	MetricLevel           tfconfig.Variable `json:"metric_level,omitempty"`
+	Name                  tfconfig.Variable `json:"name,omitempty"`
+	NullInputBehavior     tfconfig.Variable `json:"null_input_behavior,omitempty"`
+	ReturnResultsBehavior tfconfig.Variable `json:"return_results_behavior,omitempty"`
+	ReturnType            tfconfig.Variable `json:"return_type,omitempty"`
+	Schema                tfconfig.Variable `json:"schema,omitempty"`
+	TraceLevel            tfconfig.Variable `json:"trace_level,omitempty"`
 
 	*config.ResourceModelMeta
 }
@@ -128,8 +128,8 @@ func (f *FunctionJavascriptModel) WithNullInputBehavior(nullInputBehavior string
 	return f
 }
 
-func (f *FunctionJavascriptModel) WithReturnBehavior(returnBehavior string) *FunctionJavascriptModel {
-	f.ReturnBehavior = tfconfig.StringVariable(returnBehavior)
+func (f *FunctionJavascriptModel) WithReturnResultsBehavior(returnResultsBehavior string) *FunctionJavascriptModel {
+	f.ReturnResultsBehavior = tfconfig.StringVariable(returnResultsBehavior)
 	return f
 }
 
@@ -212,8 +212,8 @@ func (f *FunctionJavascriptModel) WithNullInputBehaviorValue(value tfconfig.Vari
 	return f
 }
 
-func (f *FunctionJavascriptModel) WithReturnBehaviorValue(value tfconfig.Variable) *FunctionJavascriptModel {
-	f.ReturnBehavior = value
+func (f *FunctionJavascriptModel) WithReturnResultsBehaviorValue(value tfconfig.Variable) *FunctionJavascriptModel {
+	f.ReturnResultsBehavior = value
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/function_python_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_python_model_gen.go
@@ -27,7 +27,7 @@ type FunctionPythonModel struct {
 	Name                       tfconfig.Variable `json:"name,omitempty"`
 	NullInputBehavior          tfconfig.Variable `json:"null_input_behavior,omitempty"`
 	Packages                   tfconfig.Variable `json:"packages,omitempty"`
-	ReturnBehavior             tfconfig.Variable `json:"return_behavior,omitempty"`
+	ReturnResultsBehavior      tfconfig.Variable `json:"return_results_behavior,omitempty"`
 	ReturnType                 tfconfig.Variable `json:"return_type,omitempty"`
 	RuntimeVersion             tfconfig.Variable `json:"runtime_version,omitempty"`
 	Schema                     tfconfig.Variable `json:"schema,omitempty"`
@@ -44,7 +44,6 @@ type FunctionPythonModel struct {
 func FunctionPython(
 	resourceName string,
 	database string,
-	functionDefinition string,
 	handler string,
 	name string,
 	returnType string,
@@ -53,7 +52,6 @@ func FunctionPython(
 ) *FunctionPythonModel {
 	f := &FunctionPythonModel{ResourceModelMeta: config.Meta(resourceName, resources.FunctionPython)}
 	f.WithDatabase(database)
-	f.WithFunctionDefinition(functionDefinition)
 	f.WithHandler(handler)
 	f.WithName(name)
 	f.WithReturnType(returnType)
@@ -64,7 +62,6 @@ func FunctionPython(
 
 func FunctionPythonWithDefaultMeta(
 	database string,
-	functionDefinition string,
 	handler string,
 	name string,
 	returnType string,
@@ -73,7 +70,6 @@ func FunctionPythonWithDefaultMeta(
 ) *FunctionPythonModel {
 	f := &FunctionPythonModel{ResourceModelMeta: config.DefaultMeta(resources.FunctionPython)}
 	f.WithDatabase(database)
-	f.WithFunctionDefinition(functionDefinition)
 	f.WithHandler(handler)
 	f.WithName(name)
 	f.WithReturnType(returnType)
@@ -159,8 +155,8 @@ func (f *FunctionPythonModel) WithNullInputBehavior(nullInputBehavior string) *F
 
 // packages attribute type is not yet supported, so WithPackages can't be generated
 
-func (f *FunctionPythonModel) WithReturnBehavior(returnBehavior string) *FunctionPythonModel {
-	f.ReturnBehavior = tfconfig.StringVariable(returnBehavior)
+func (f *FunctionPythonModel) WithReturnResultsBehavior(returnResultsBehavior string) *FunctionPythonModel {
+	f.ReturnResultsBehavior = tfconfig.StringVariable(returnResultsBehavior)
 	return f
 }
 
@@ -275,8 +271,8 @@ func (f *FunctionPythonModel) WithPackagesValue(value tfconfig.Variable) *Functi
 	return f
 }
 
-func (f *FunctionPythonModel) WithReturnBehaviorValue(value tfconfig.Variable) *FunctionPythonModel {
-	f.ReturnBehavior = value
+func (f *FunctionPythonModel) WithReturnResultsBehaviorValue(value tfconfig.Variable) *FunctionPythonModel {
+	f.ReturnResultsBehavior = value
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/function_scala_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_scala_model_gen.go
@@ -26,7 +26,7 @@ type FunctionScalaModel struct {
 	Name                       tfconfig.Variable `json:"name,omitempty"`
 	NullInputBehavior          tfconfig.Variable `json:"null_input_behavior,omitempty"`
 	Packages                   tfconfig.Variable `json:"packages,omitempty"`
-	ReturnBehavior             tfconfig.Variable `json:"return_behavior,omitempty"`
+	ReturnResultsBehavior      tfconfig.Variable `json:"return_results_behavior,omitempty"`
 	ReturnType                 tfconfig.Variable `json:"return_type,omitempty"`
 	RuntimeVersion             tfconfig.Variable `json:"runtime_version,omitempty"`
 	Schema                     tfconfig.Variable `json:"schema,omitempty"`
@@ -44,7 +44,6 @@ type FunctionScalaModel struct {
 func FunctionScala(
 	resourceName string,
 	database string,
-	functionDefinition string,
 	handler string,
 	name string,
 	returnType string,
@@ -53,7 +52,6 @@ func FunctionScala(
 ) *FunctionScalaModel {
 	f := &FunctionScalaModel{ResourceModelMeta: config.Meta(resourceName, resources.FunctionScala)}
 	f.WithDatabase(database)
-	f.WithFunctionDefinition(functionDefinition)
 	f.WithHandler(handler)
 	f.WithName(name)
 	f.WithReturnType(returnType)
@@ -64,7 +62,6 @@ func FunctionScala(
 
 func FunctionScalaWithDefaultMeta(
 	database string,
-	functionDefinition string,
 	handler string,
 	name string,
 	returnType string,
@@ -73,7 +70,6 @@ func FunctionScalaWithDefaultMeta(
 ) *FunctionScalaModel {
 	f := &FunctionScalaModel{ResourceModelMeta: config.DefaultMeta(resources.FunctionScala)}
 	f.WithDatabase(database)
-	f.WithFunctionDefinition(functionDefinition)
 	f.WithHandler(handler)
 	f.WithName(name)
 	f.WithReturnType(returnType)
@@ -154,8 +150,8 @@ func (f *FunctionScalaModel) WithNullInputBehavior(nullInputBehavior string) *Fu
 
 // packages attribute type is not yet supported, so WithPackages can't be generated
 
-func (f *FunctionScalaModel) WithReturnBehavior(returnBehavior string) *FunctionScalaModel {
-	f.ReturnBehavior = tfconfig.StringVariable(returnBehavior)
+func (f *FunctionScalaModel) WithReturnResultsBehavior(returnResultsBehavior string) *FunctionScalaModel {
+	f.ReturnResultsBehavior = tfconfig.StringVariable(returnResultsBehavior)
 	return f
 }
 
@@ -176,10 +172,7 @@ func (f *FunctionScalaModel) WithSchema(schema string) *FunctionScalaModel {
 
 // secrets attribute type is not yet supported, so WithSecrets can't be generated
 
-func (f *FunctionScalaModel) WithTargetPath(targetPath string) *FunctionScalaModel {
-	f.TargetPath = tfconfig.StringVariable(targetPath)
-	return f
-}
+// target_path attribute type is not yet supported, so WithTargetPath can't be generated
 
 func (f *FunctionScalaModel) WithTraceLevel(traceLevel string) *FunctionScalaModel {
 	f.TraceLevel = tfconfig.StringVariable(traceLevel)
@@ -270,8 +263,8 @@ func (f *FunctionScalaModel) WithPackagesValue(value tfconfig.Variable) *Functio
 	return f
 }
 
-func (f *FunctionScalaModel) WithReturnBehaviorValue(value tfconfig.Variable) *FunctionScalaModel {
-	f.ReturnBehavior = value
+func (f *FunctionScalaModel) WithReturnResultsBehaviorValue(value tfconfig.Variable) *FunctionScalaModel {
+	f.ReturnResultsBehavior = value
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/function_sql_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_sql_model_gen.go
@@ -10,22 +10,22 @@ import (
 )
 
 type FunctionSqlModel struct {
-	Arguments           tfconfig.Variable `json:"arguments,omitempty"`
-	Comment             tfconfig.Variable `json:"comment,omitempty"`
-	Database            tfconfig.Variable `json:"database,omitempty"`
-	EnableConsoleOutput tfconfig.Variable `json:"enable_console_output,omitempty"`
-	FullyQualifiedName  tfconfig.Variable `json:"fully_qualified_name,omitempty"`
-	FunctionDefinition  tfconfig.Variable `json:"function_definition,omitempty"`
-	FunctionLanguage    tfconfig.Variable `json:"function_language,omitempty"`
-	IsSecure            tfconfig.Variable `json:"is_secure,omitempty"`
-	LogLevel            tfconfig.Variable `json:"log_level,omitempty"`
-	MetricLevel         tfconfig.Variable `json:"metric_level,omitempty"`
-	Name                tfconfig.Variable `json:"name,omitempty"`
-	NullInputBehavior   tfconfig.Variable `json:"null_input_behavior,omitempty"`
-	ReturnBehavior      tfconfig.Variable `json:"return_behavior,omitempty"`
-	ReturnType          tfconfig.Variable `json:"return_type,omitempty"`
-	Schema              tfconfig.Variable `json:"schema,omitempty"`
-	TraceLevel          tfconfig.Variable `json:"trace_level,omitempty"`
+	Arguments             tfconfig.Variable `json:"arguments,omitempty"`
+	Comment               tfconfig.Variable `json:"comment,omitempty"`
+	Database              tfconfig.Variable `json:"database,omitempty"`
+	EnableConsoleOutput   tfconfig.Variable `json:"enable_console_output,omitempty"`
+	FullyQualifiedName    tfconfig.Variable `json:"fully_qualified_name,omitempty"`
+	FunctionDefinition    tfconfig.Variable `json:"function_definition,omitempty"`
+	FunctionLanguage      tfconfig.Variable `json:"function_language,omitempty"`
+	IsSecure              tfconfig.Variable `json:"is_secure,omitempty"`
+	LogLevel              tfconfig.Variable `json:"log_level,omitempty"`
+	MetricLevel           tfconfig.Variable `json:"metric_level,omitempty"`
+	Name                  tfconfig.Variable `json:"name,omitempty"`
+	NullInputBehavior     tfconfig.Variable `json:"null_input_behavior,omitempty"`
+	ReturnResultsBehavior tfconfig.Variable `json:"return_results_behavior,omitempty"`
+	ReturnType            tfconfig.Variable `json:"return_type,omitempty"`
+	Schema                tfconfig.Variable `json:"schema,omitempty"`
+	TraceLevel            tfconfig.Variable `json:"trace_level,omitempty"`
 
 	*config.ResourceModelMeta
 }
@@ -128,8 +128,8 @@ func (f *FunctionSqlModel) WithNullInputBehavior(nullInputBehavior string) *Func
 	return f
 }
 
-func (f *FunctionSqlModel) WithReturnBehavior(returnBehavior string) *FunctionSqlModel {
-	f.ReturnBehavior = tfconfig.StringVariable(returnBehavior)
+func (f *FunctionSqlModel) WithReturnResultsBehavior(returnResultsBehavior string) *FunctionSqlModel {
+	f.ReturnResultsBehavior = tfconfig.StringVariable(returnResultsBehavior)
 	return f
 }
 
@@ -212,8 +212,8 @@ func (f *FunctionSqlModel) WithNullInputBehaviorValue(value tfconfig.Variable) *
 	return f
 }
 
-func (f *FunctionSqlModel) WithReturnBehaviorValue(value tfconfig.Variable) *FunctionSqlModel {
-	f.ReturnBehavior = value
+func (f *FunctionSqlModel) WithReturnResultsBehaviorValue(value tfconfig.Variable) *FunctionSqlModel {
+	f.ReturnResultsBehavior = value
 	return f
 }
 

--- a/pkg/acceptance/check_destroy.go
+++ b/pkg/acceptance/check_destroy.go
@@ -155,6 +155,21 @@ var showByIdFunctions = map[resources.Resource]showByIdFunc{
 	resources.Function: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
 		return runShowById(ctx, id, client.Functions.ShowByID)
 	},
+	resources.FunctionJava: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
+		return runShowById(ctx, id, client.Functions.ShowByID)
+	},
+	resources.FunctionJavascript: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
+		return runShowById(ctx, id, client.Functions.ShowByID)
+	},
+	resources.FunctionPython: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
+		return runShowById(ctx, id, client.Functions.ShowByID)
+	},
+	resources.FunctionScala: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
+		return runShowById(ctx, id, client.Functions.ShowByID)
+	},
+	resources.FunctionSql: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
+		return runShowById(ctx, id, client.Functions.ShowByID)
+	},
 	resources.LegacyServiceUser: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
 		return runShowById(ctx, id, client.Users.ShowByID)
 	},
@@ -189,6 +204,21 @@ var showByIdFunctions = map[resources.Resource]showByIdFunc{
 		return runShowById(ctx, id, client.Pipes.ShowByID)
 	},
 	resources.Procedure: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
+		return runShowById(ctx, id, client.Procedures.ShowByID)
+	},
+	resources.ProcedureJava: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
+		return runShowById(ctx, id, client.Procedures.ShowByID)
+	},
+	resources.ProcedureJavascript: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
+		return runShowById(ctx, id, client.Procedures.ShowByID)
+	},
+	resources.ProcedurePython: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
+		return runShowById(ctx, id, client.Procedures.ShowByID)
+	},
+	resources.ProcedureScala: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
+		return runShowById(ctx, id, client.Procedures.ShowByID)
+	},
+	resources.ProcedureSql: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
 		return runShowById(ctx, id, client.Procedures.ShowByID)
 	},
 	resources.ResourceMonitor: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {

--- a/pkg/acceptance/check_destroy.go
+++ b/pkg/acceptance/check_destroy.go
@@ -67,9 +67,19 @@ func decodeSnowflakeId(rs *terraform.ResourceState, resource resources.Resource)
 	switch resource {
 	case resources.ExternalFunction:
 		return sdk.NewSchemaObjectIdentifierFromFullyQualifiedName(rs.Primary.ID), nil
-	case resources.Function:
+	case resources.Function,
+		resources.FunctionJava,
+		resources.FunctionJavascript,
+		resources.FunctionPython,
+		resources.FunctionScala,
+		resources.FunctionSql:
 		return sdk.ParseSchemaObjectIdentifierWithArguments(rs.Primary.ID)
-	case resources.Procedure:
+	case resources.Procedure,
+		resources.ProcedureJava,
+		resources.ProcedureJavascript,
+		resources.ProcedurePython,
+		resources.ProcedureScala,
+		resources.ProcedureSql:
 		return sdk.NewSchemaObjectIdentifierFromFullyQualifiedName(rs.Primary.ID), nil
 	default:
 		return helpers.DecodeSnowflakeID(rs.Primary.ID), nil

--- a/pkg/acceptance/helpers/function_client.go
+++ b/pkg/acceptance/helpers/function_client.go
@@ -138,6 +138,26 @@ func (c *FunctionClient) CreateJava(t *testing.T) (*sdk.Function, func()) {
 	return function, c.DropFunctionFunc(t, id)
 }
 
+func (c *FunctionClient) CreateScalaStaged(t *testing.T, id sdk.SchemaObjectIdentifierWithArguments, dataType datatypes.DataType, importPath string, handler string) (*sdk.Function, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	argName := "x"
+	argument := sdk.NewFunctionArgumentRequest(argName, dataType)
+
+	request := sdk.NewCreateForScalaFunctionRequest(id.SchemaObjectId(), dataType, handler, "2.12").
+		WithArguments([]sdk.FunctionArgumentRequest{*argument}).
+		WithImports([]sdk.FunctionImportRequest{*sdk.NewFunctionImportRequest().WithImport(importPath)})
+
+	err := c.client().CreateForScala(ctx, request)
+	require.NoError(t, err)
+
+	function, err := c.client().ShowByID(ctx, id)
+	require.NoError(t, err)
+
+	return function, c.DropFunctionFunc(t, id)
+}
+
 func (c *FunctionClient) CreateWithRequest(t *testing.T, id sdk.SchemaObjectIdentifierWithArguments, req *sdk.CreateForSQLFunctionRequest) *sdk.Function {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/acceptance/helpers/function_client.go
+++ b/pkg/acceptance/helpers/function_client.go
@@ -212,6 +212,18 @@ func (c *FunctionClient) SampleJavaDefinition(t *testing.T, className string, fu
 `, className, funcName, argName)
 }
 
+func (c *FunctionClient) SampleJavaDefinitionNoArgs(t *testing.T, className string, funcName string) string {
+	t.Helper()
+
+	return fmt.Sprintf(`
+	class %[1]s {
+		public static String %[2]s() {
+			return "hello";
+		}
+	}
+`, className, funcName)
+}
+
 func (c *FunctionClient) SampleJavascriptDefinition(t *testing.T, argName string) string {
 	t.Helper()
 

--- a/pkg/acceptance/helpers/function_setup_helpers.go
+++ b/pkg/acceptance/helpers/function_setup_helpers.go
@@ -67,7 +67,7 @@ func (c *TestClient) CreateSampleJavaFunctionAndJarInLocation(t *testing.T, stag
 	}
 }
 
-// TODO [this PR]: adjust to switching location too
+// TODO [SNOW-1348106]: adjust to switching location too
 func (c *TestClient) CreateSampleJavaProcedureAndJar(t *testing.T) *TmpFunction {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/acceptance/helpers/function_setup_helpers.go
+++ b/pkg/acceptance/helpers/function_setup_helpers.go
@@ -67,8 +67,19 @@ func (c *TestClient) CreateSampleJavaFunctionAndJarInLocation(t *testing.T, stag
 	}
 }
 
-// TODO [SNOW-1348106]: adjust to switching location too
-func (c *TestClient) CreateSampleJavaProcedureAndJar(t *testing.T) *TmpFunction {
+func (c *TestClient) CreateSampleJavaProcedureAndJarOnUserStage(t *testing.T) *TmpFunction {
+	t.Helper()
+
+	return c.CreateSampleJavaProcedureAndJarInLocation(t, "@~")
+}
+
+func (c *TestClient) CreateSampleJavaProcedureAndJarOnStage(t *testing.T, stage *sdk.Stage) *TmpFunction {
+	t.Helper()
+
+	return c.CreateSampleJavaProcedureAndJarInLocation(t, stage.Location())
+}
+
+func (c *TestClient) CreateSampleJavaProcedureAndJarInLocation(t *testing.T, stageLocation string) *TmpFunction {
 	t.Helper()
 	ctx := context.Background()
 
@@ -84,7 +95,7 @@ func (c *TestClient) CreateSampleJavaProcedureAndJar(t *testing.T) *TmpFunction 
 	handler := fmt.Sprintf("%s.%s", className, funcName)
 	definition := c.Procedure.SampleJavaDefinition(t, className, funcName, argName)
 	jarName := fmt.Sprintf("tf-%d-%s.jar", time.Now().Unix(), random.AlphaN(5))
-	targetPath := fmt.Sprintf("@~/%s", jarName)
+	targetPath := fmt.Sprintf("%s/%s", stageLocation, jarName)
 	packages := []sdk.ProcedurePackageRequest{*sdk.NewProcedurePackageRequest("com.snowflake:snowpark:1.14.0")}
 
 	request := sdk.NewCreateForJavaProcedureRequest(id.SchemaObjectId(), *returns, "11", packages, handler).
@@ -95,15 +106,16 @@ func (c *TestClient) CreateSampleJavaProcedureAndJar(t *testing.T) *TmpFunction 
 	err := c.context.client.Procedures.CreateForJava(ctx, request)
 	require.NoError(t, err)
 	t.Cleanup(c.Procedure.DropProcedureFunc(t, id))
-	t.Cleanup(c.Stage.RemoveFromUserStageFunc(t, jarName))
+	t.Cleanup(c.Stage.RemoveFromStageFunc(t, stageLocation, jarName))
 
 	return &TmpFunction{
-		FunctionId: id,
-		ClassName:  className,
-		FuncName:   funcName,
-		ArgName:    argName,
-		ArgType:    dataType,
-		JarName:    jarName,
+		FunctionId:    id,
+		ClassName:     className,
+		FuncName:      funcName,
+		ArgName:       argName,
+		ArgType:       dataType,
+		JarName:       jarName,
+		StageLocation: stageLocation,
 	}
 }
 

--- a/pkg/acceptance/helpers/ids_generator.go
+++ b/pkg/acceptance/helpers/ids_generator.go
@@ -4,7 +4,9 @@ import (
 	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 )
 
 type IdsGenerator struct {
@@ -97,12 +99,22 @@ func (c *IdsGenerator) NewSchemaObjectIdentifierWithArguments(name string, argum
 	return sdk.NewSchemaObjectIdentifierWithArguments(c.SchemaId().DatabaseName(), c.SchemaId().Name(), name, arguments...)
 }
 
+func (c *IdsGenerator) NewSchemaObjectIdentifierWithArgumentsNewDataTypes(name string, arguments ...datatypes.DataType) sdk.SchemaObjectIdentifierWithArguments {
+	legacyDataTypes := collections.Map(arguments, func(dt datatypes.DataType) sdk.DataType { return sdk.LegacyDataTypeFrom(dt) })
+	return sdk.NewSchemaObjectIdentifierWithArguments(c.SchemaId().DatabaseName(), c.SchemaId().Name(), name, legacyDataTypes...)
+}
+
 func (c *IdsGenerator) NewSchemaObjectIdentifierWithArgumentsInSchema(name string, schemaId sdk.DatabaseObjectIdentifier, argumentDataTypes ...sdk.DataType) sdk.SchemaObjectIdentifierWithArguments {
 	return sdk.NewSchemaObjectIdentifierWithArgumentsInSchema(schemaId, name, argumentDataTypes...)
 }
 
 func (c *IdsGenerator) RandomSchemaObjectIdentifierWithArguments(arguments ...sdk.DataType) sdk.SchemaObjectIdentifierWithArguments {
 	return sdk.NewSchemaObjectIdentifierWithArguments(c.SchemaId().DatabaseName(), c.SchemaId().Name(), c.Alpha(), arguments...)
+}
+
+func (c *IdsGenerator) RandomSchemaObjectIdentifierWithArgumentsNewDataTypes(arguments ...datatypes.DataType) sdk.SchemaObjectIdentifierWithArguments {
+	legacyDataTypes := collections.Map(arguments, func(dt datatypes.DataType) sdk.DataType { return sdk.LegacyDataTypeFrom(dt) })
+	return sdk.NewSchemaObjectIdentifierWithArguments(c.SchemaId().DatabaseName(), c.SchemaId().Name(), c.Alpha(), legacyDataTypes...)
 }
 
 func (c *IdsGenerator) Alpha() string {

--- a/pkg/acceptance/helpers/ids_generator.go
+++ b/pkg/acceptance/helpers/ids_generator.go
@@ -100,7 +100,7 @@ func (c *IdsGenerator) NewSchemaObjectIdentifierWithArguments(name string, argum
 }
 
 func (c *IdsGenerator) NewSchemaObjectIdentifierWithArgumentsNewDataTypes(name string, arguments ...datatypes.DataType) sdk.SchemaObjectIdentifierWithArguments {
-	legacyDataTypes := collections.Map(arguments, func(dt datatypes.DataType) sdk.DataType { return sdk.LegacyDataTypeFrom(dt) })
+	legacyDataTypes := collections.Map(arguments, sdk.LegacyDataTypeFrom)
 	return sdk.NewSchemaObjectIdentifierWithArguments(c.SchemaId().DatabaseName(), c.SchemaId().Name(), name, legacyDataTypes...)
 }
 
@@ -113,7 +113,7 @@ func (c *IdsGenerator) RandomSchemaObjectIdentifierWithArguments(arguments ...sd
 }
 
 func (c *IdsGenerator) RandomSchemaObjectIdentifierWithArgumentsNewDataTypes(arguments ...datatypes.DataType) sdk.SchemaObjectIdentifierWithArguments {
-	legacyDataTypes := collections.Map(arguments, func(dt datatypes.DataType) sdk.DataType { return sdk.LegacyDataTypeFrom(dt) })
+	legacyDataTypes := collections.Map(arguments, sdk.LegacyDataTypeFrom)
 	return sdk.NewSchemaObjectIdentifierWithArguments(c.SchemaId().DatabaseName(), c.SchemaId().Name(), c.Alpha(), legacyDataTypes...)
 }
 

--- a/pkg/acceptance/helpers/stage_client.go
+++ b/pkg/acceptance/helpers/stage_client.go
@@ -126,6 +126,21 @@ func (c *StageClient) RemoveFromUserStageFunc(t *testing.T, pathOnStage string) 
 	}
 }
 
+func (c *StageClient) RemoveFromStage(t *testing.T, stageLocation string, pathOnStage string) {
+	t.Helper()
+	ctx := context.Background()
+
+	_, err := c.context.client.ExecForTests(ctx, fmt.Sprintf(`REMOVE %s/%s`, stageLocation, pathOnStage))
+	require.NoError(t, err)
+}
+
+func (c *StageClient) RemoveFromStageFunc(t *testing.T, stageLocation string, pathOnStage string) func() {
+	t.Helper()
+	return func() {
+		c.RemoveFromStage(t, stageLocation, pathOnStage)
+	}
+}
+
 func (c *StageClient) PutOnStageWithContent(t *testing.T, id sdk.SchemaObjectIdentifier, filename string, content string) {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/resources/custom_diffs.go
+++ b/pkg/resources/custom_diffs.go
@@ -285,16 +285,13 @@ func RecreateWhenResourceBoolFieldChangedExternally(boolField string, wantValue 
 	}
 }
 
-// RecreateWhenResourceFieldChangedExternally recreates a resource when wantValue is different from value in field.
-// TODO [this PR]: replace above func and test
-func RecreateWhenResourceFieldChangedExternally[T bool | string](field string, wantValue T) schema.CustomizeDiffFunc {
+// RecreateWhenResourceStringFieldChangedExternally recreates a resource when wantValue is different from value in field.
+// TODO [next PR]: merge with above? test.
+func RecreateWhenResourceStringFieldChangedExternally(field string, wantValue string) schema.CustomizeDiffFunc {
 	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
-		if n := diff.Get(field); n != nil {
-			logging.DebugLogger.Printf("[DEBUG] new external value for %v: %v, recreating the resource...\n", field, n.(T))
-
-			if n.(T) != wantValue {
-				return errors.Join(diff.SetNew(field, wantValue), diff.ForceNew(field))
-			}
+		if o, n := diff.GetChange(field); n != nil && o != nil && o != "" && n.(string) != wantValue {
+			log.Printf("[DEBUG] new external value for %s: %s (want: %s), recreating the resource...\n", field, n.(string), wantValue)
+			return errors.Join(diff.SetNew(field, wantValue), diff.ForceNew(field))
 		}
 		return nil
 	}

--- a/pkg/resources/custom_diffs.go
+++ b/pkg/resources/custom_diffs.go
@@ -284,3 +284,18 @@ func RecreateWhenResourceBoolFieldChangedExternally(boolField string, wantValue 
 		return nil
 	}
 }
+
+// RecreateWhenResourceFieldChangedExternally recreates a resource when wantValue is different from value in field.
+// TODO [this PR]: replace above func and test
+func RecreateWhenResourceFieldChangedExternally[T bool | string](field string, wantValue T) schema.CustomizeDiffFunc {
+	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+		if n := diff.Get(field); n != nil {
+			logging.DebugLogger.Printf("[DEBUG] new external value for %v: %v, recreating the resource...\n", field, n.(T))
+
+			if n.(T) != wantValue {
+				return errors.Join(diff.SetNew(field, wantValue), diff.ForceNew(field))
+			}
+		}
+		return nil
+	}
+}

--- a/pkg/resources/custom_diffs.go
+++ b/pkg/resources/custom_diffs.go
@@ -286,7 +286,7 @@ func RecreateWhenResourceBoolFieldChangedExternally(boolField string, wantValue 
 }
 
 // RecreateWhenResourceStringFieldChangedExternally recreates a resource when wantValue is different from value in field.
-// TODO [next PR]: merge with above? test.
+// TODO [SNOW-1850370]: merge with above? test.
 func RecreateWhenResourceStringFieldChangedExternally(field string, wantValue string) schema.CustomizeDiffFunc {
 	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 		if o, n := diff.GetChange(field); n != nil && o != nil && o != "" && n.(string) != wantValue {

--- a/pkg/resources/doc_helpers.go
+++ b/pkg/resources/doc_helpers.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider/docs"
 	providerresources "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider/docs"
 )
 
 func possibleValuesListed[T ~string | ~int](values []T) string {

--- a/pkg/resources/function.go
+++ b/pkg/resources/function.go
@@ -171,7 +171,7 @@ func Function() *schema.Resource {
 		CreateContext: TrackingCreateWrapper(resources.Function, CreateContextFunction),
 		ReadContext:   TrackingReadWrapper(resources.Function, ReadContextFunction),
 		UpdateContext: TrackingUpdateWrapper(resources.Function, UpdateContextFunction),
-		DeleteContext: TrackingDeleteWrapper(resources.Function, DeleteContextFunction),
+		DeleteContext: TrackingDeleteWrapper(resources.Function, DeleteFunction),
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.Function, customdiff.All(
 			// TODO(SNOW-1348103): add `arguments` to ComputedIfAnyAttributeChanged. This can't be done now because this function compares values without diff suppress.
@@ -720,20 +720,6 @@ func UpdateContextFunction(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	return ReadContextFunction(ctx, d, meta)
-}
-
-func DeleteContextFunction(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.Context).Client
-
-	id, err := sdk.ParseSchemaObjectIdentifierWithArguments(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if err := client.Functions.Drop(ctx, sdk.NewDropFunctionRequest(id).WithIfExists(true)); err != nil {
-		return diag.FromErr(err)
-	}
-	d.SetId("")
-	return nil
 }
 
 func parseFunctionArguments(d *schema.ResourceData) ([]sdk.FunctionArgumentRequest, diag.Diagnostics) {

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -435,9 +435,9 @@ func parseFunctionImportsCommon(d *schema.ResourceData) ([]sdk.FunctionImportReq
 func parseFunctionTargetPathCommon(d *schema.ResourceData) (string, error) {
 	var tp string
 	if v, ok := d.GetOk("target_path"); ok {
-		for _, tp := range v.(*schema.Set).List() {
-			stageLocation := tp.(map[string]any)["stage_location"].(string)
-			pathOnStage := tp.(map[string]any)["path_on_stage"].(string)
+		for _, p := range v.(*schema.Set).List() {
+			stageLocation := p.(map[string]any)["stage_location"].(string)
+			pathOnStage := p.(map[string]any)["path_on_stage"].(string)
 			tp = fmt.Sprintf("@%s/%s", stageLocation, pathOnStage)
 		}
 	}

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -26,6 +26,7 @@ func init() {
 type functionSchemaDef struct {
 	additionalArguments           []string
 	functionDefinitionDescription string
+	functionDefinitionRequired    bool
 	runtimeVersionRequired        bool
 	runtimeVersionDescription     string
 	importsDescription            string
@@ -44,6 +45,11 @@ func setUpFunctionSchema(definition functionSchemaDef) map[string]*schema.Schema
 	}
 	if v, ok := currentSchema["function_definition"]; ok && v != nil {
 		v.Description = diffSuppressStatementFieldDescription(definition.functionDefinitionDescription)
+		if definition.functionDefinitionRequired {
+			v.Required = true
+		} else {
+			v.Optional = true
+		}
 	}
 	if v, ok := currentSchema["runtime_version"]; ok && v != nil {
 		if definition.runtimeVersionRequired {
@@ -110,6 +116,7 @@ var (
 	javascriptFunctionSchemaDefinition = functionSchemaDef{
 		additionalArguments:           []string{},
 		functionDefinitionDescription: functionDefinitionTemplate("JavaScript", "https://docs.snowflake.com/en/developer-guide/udf/javascript/udf-javascript-introduction"),
+		functionDefinitionRequired:    true,
 	}
 	pythonFunctionSchemaDefinition = functionSchemaDef{
 		additionalArguments: []string{
@@ -149,6 +156,7 @@ var (
 	sqlFunctionSchemaDefinition = functionSchemaDef{
 		additionalArguments:           []string{},
 		functionDefinitionDescription: functionDefinitionTemplate("SQL", "https://docs.snowflake.com/en/developer-guide/udf/sql/udf-sql-introduction"),
+		functionDefinitionRequired:    true,
 	}
 )
 
@@ -334,10 +342,8 @@ func functionBaseSchema() map[string]schema.Schema {
 			Optional: true,
 			ForceNew: true,
 		},
-		// TODO [this PR]: required only for javascript and sql
 		"function_definition": {
 			Type:             schema.TypeString,
-			Required:         true,
 			ForceNew:         true,
 			DiffSuppressFunc: DiffSuppressStatement,
 		},

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -530,6 +530,22 @@ type allFunctionDetailsCommon struct {
 	functionParameters []*sdk.Parameter
 }
 
+func readFunctionArgumentsCommon(d *schema.ResourceData, args []sdk.NormalizedArgument) error {
+	if len(args) == 0 {
+		// TODO [next PR]: handle empty list
+		return nil
+	}
+	if currentArgs, ok := d.Get("arguments").([]map[string]any); !ok {
+		return fmt.Errorf("arguments must be a list")
+	} else {
+		for i, arg := range args {
+			currentArgs[i]["arg_name"] = arg.Name
+			currentArgs[i]["arg_data_type"] = arg.DataType.ToSql()
+		}
+		return d.Set("arguments", currentArgs)
+	}
+}
+
 func readFunctionImportsCommon(d *schema.ResourceData, imports []sdk.NormalizedPath) error {
 	if len(imports) == 0 {
 		// don't do anything if imports not present

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -249,7 +249,7 @@ func functionBaseSchema() map[string]schema.Schema {
 			Optional:         true,
 			ForceNew:         true,
 			ValidateDiagFunc: sdkValidation(sdk.ToNullInputBehavior),
-			DiffSuppressFunc: SuppressIfAny(NormalizeAndCompare(sdk.ToNullInputBehavior)), // TODO [this PR]: IgnoreChangeToCurrentSnowflakeValueInShow("null_input_behavior") but not in show
+			DiffSuppressFunc: SuppressIfAny(NormalizeAndCompare(sdk.ToNullInputBehavior)), // TODO [SNOW-1348103]: IgnoreChangeToCurrentSnowflakeValueInShow("null_input_behavior") but not in show
 			Description:      fmt.Sprintf("Specifies the behavior of the function when called with null inputs. Valid values are (case-insensitive): %s.", possibleValuesListed(sdk.AllAllowedNullInputBehaviors)),
 		},
 		"return_results_behavior": {
@@ -257,7 +257,7 @@ func functionBaseSchema() map[string]schema.Schema {
 			Optional:         true,
 			ForceNew:         true,
 			ValidateDiagFunc: sdkValidation(sdk.ToReturnResultsBehavior),
-			DiffSuppressFunc: SuppressIfAny(NormalizeAndCompare(sdk.ToReturnResultsBehavior)), // TODO [this PR]: IgnoreChangeToCurrentSnowflakeValueInShow("return_results_behavior") but not in show
+			DiffSuppressFunc: SuppressIfAny(NormalizeAndCompare(sdk.ToReturnResultsBehavior)), // TODO [SNOW-1348103]: IgnoreChangeToCurrentSnowflakeValueInShow("return_results_behavior") but not in show
 			Description:      fmt.Sprintf("Specifies the behavior of the function when returning results. Valid values are (case-insensitive): %s.", possibleValuesListed(sdk.AllAllowedReturnResultsBehaviors)),
 		},
 		"runtime_version": {

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -272,7 +272,7 @@ func functionBaseSchema() map[string]schema.Schema {
 			Description: "Specifies a comment for the function.",
 		},
 		// split into two because of https://docs.snowflake.com/en/sql-reference/sql/create-function#id6
-		// TODO [next PR]: add validations preventing setting improper stage and path
+		// TODO [SNOW-1348103]: add validations preventing setting improper stage and path
 		"imports": {
 			Type:     schema.TypeSet,
 			Optional: true,
@@ -532,7 +532,7 @@ type allFunctionDetailsCommon struct {
 
 func readFunctionArgumentsCommon(d *schema.ResourceData, args []sdk.NormalizedArgument) error {
 	if len(args) == 0 {
-		// TODO [next PR]: handle empty list
+		// TODO [SNOW-1348103]: handle empty list
 		return nil
 	}
 	if currentArgs, ok := d.Get("arguments").([]map[string]any); !ok {

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -1,11 +1,14 @@
 package resources
 
 import (
+	"context"
 	"fmt"
 	"slices"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -343,4 +346,21 @@ func functionBaseSchema() map[string]schema.Schema {
 		},
 		FullyQualifiedNameAttributeName: *schemas.FullyQualifiedNameSchema,
 	}
+}
+
+func DeleteFunction(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	client := meta.(*provider.Context).Client
+
+	id, err := sdk.ParseSchemaObjectIdentifierWithArguments(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = client.Functions.Drop(ctx, sdk.NewDropFunctionRequest(id).WithIfExists(true))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	return nil
 }

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"slices"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -545,6 +546,8 @@ func readFunctionArgumentsCommon(d *schema.ResourceData, args []sdk.NormalizedAr
 		// TODO [SNOW-1348103]: handle empty list
 		return nil
 	}
+	// We do it the unusual way because the default values are not returned by SF.
+	// We update what we have - leaving the defaults unchanged.
 	if currentArgs, ok := d.Get("arguments").([]map[string]any); !ok {
 		return fmt.Errorf("arguments must be a list")
 	} else {
@@ -561,13 +564,12 @@ func readFunctionImportsCommon(d *schema.ResourceData, imports []sdk.NormalizedP
 		// don't do anything if imports not present
 		return nil
 	}
-	imps := make([]map[string]any, len(imports))
-	for i, imp := range imports {
-		imps[i] = map[string]any{
+	imps := collections.Map(imports, func(imp sdk.NormalizedPath) map[string]any {
+		return map[string]any{
 			"stage_location": imp.StageLocation,
 			"path_on_stage":  imp.PathOnStage,
 		}
-	}
+	})
 	return d.Set("imports", imps)
 }
 

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -409,7 +409,7 @@ func parseFunctionArgumentsCommon(d *schema.ResourceData) ([]sdk.FunctionArgumen
 func parseFunctionImportsCommon(d *schema.ResourceData) ([]sdk.FunctionImportRequest, error) {
 	imports := make([]sdk.FunctionImportRequest, 0)
 	if v, ok := d.GetOk("imports"); ok {
-		for _, imp := range v.([]any) {
+		for _, imp := range v.(*schema.Set).List() {
 			stageLocation := imp.(map[string]any)["stage_location"].(string)
 			pathOnStage := imp.(map[string]any)["path_on_stage"].(string)
 			imports = append(imports, *sdk.NewFunctionImportRequest().WithImport(fmt.Sprintf("@%s/%s", stageLocation, pathOnStage)))

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -478,7 +478,9 @@ func setFunctionTargetPathInBuilder[T any](d *schema.ResourceData, setTargetPath
 	if err != nil {
 		return err
 	}
-	setTargetPath(tp)
+	if tp != "" {
+		setTargetPath(tp)
+	}
 	return nil
 }
 

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -106,12 +106,13 @@ var (
 			"target_path",
 		},
 		functionDefinitionDescription: functionDefinitionTemplate("Java", "https://docs.snowflake.com/en/developer-guide/udf/java/udf-java-introduction"),
-		runtimeVersionRequired:        false,
-		runtimeVersionDescription:     "Specifies the Java JDK runtime version to use. The supported versions of Java are 11.x and 17.x. If RUNTIME_VERSION is not set, Java JDK 11 is used.",
-		importsDescription:            "The location (stage), path, and name of the file(s) to import. A file can be a JAR file or another type of file. If the file is a JAR file, it can contain one or more .class files and zero or more resource files. JNI (Java Native Interface) is not supported. Snowflake prohibits loading libraries that contain native code (as opposed to Java bytecode). Java UDFs can also read non-JAR files. For an example, see [Reading a file specified statically in IMPORTS](https://docs.snowflake.com/en/developer-guide/udf/java/udf-java-cookbook.html#label-reading-file-from-java-udf-imports). Consult the [docs](https://docs.snowflake.com/en/sql-reference/sql/create-function#java).",
-		packagesDescription:           "The name and version number of Snowflake system packages required as dependencies. The value should be of the form `package_name:version_number`, where `package_name` is `snowflake_domain:package`.",
-		handlerDescription:            "The name of the handler method or class. If the handler is for a scalar UDF, returning a non-tabular value, the HANDLER value should be a method name, as in the following form: `MyClass.myMethod`. If the handler is for a tabular UDF, the HANDLER value should be the name of a handler class.",
-		targetPathDescription:         "The TARGET_PATH clause specifies the location to which Snowflake should write the compiled code (JAR file) after compiling the source code specified in the `function_definition`. If this clause is included, the user should manually remove the JAR file when it is no longer needed (typically when the Java UDF is dropped). If this clause is omitted, Snowflake re-compiles the source code each time the code is needed. The JAR file is not stored permanently, and the user does not need to clean up the JAR file. Snowflake returns an error if the TARGET_PATH matches an existing file; you cannot use TARGET_PATH to overwrite an existing file.",
+		// May be optional for java because if it is not set, describe return empty version.
+		runtimeVersionRequired:    false,
+		runtimeVersionDescription: "Specifies the Java JDK runtime version to use. The supported versions of Java are 11.x and 17.x. If RUNTIME_VERSION is not set, Java JDK 11 is used.",
+		importsDescription:        "The location (stage), path, and name of the file(s) to import. A file can be a JAR file or another type of file. If the file is a JAR file, it can contain one or more .class files and zero or more resource files. JNI (Java Native Interface) is not supported. Snowflake prohibits loading libraries that contain native code (as opposed to Java bytecode). Java UDFs can also read non-JAR files. For an example, see [Reading a file specified statically in IMPORTS](https://docs.snowflake.com/en/developer-guide/udf/java/udf-java-cookbook.html#label-reading-file-from-java-udf-imports). Consult the [docs](https://docs.snowflake.com/en/sql-reference/sql/create-function#java).",
+		packagesDescription:       "The name and version number of Snowflake system packages required as dependencies. The value should be of the form `package_name:version_number`, where `package_name` is `snowflake_domain:package`.",
+		handlerDescription:        "The name of the handler method or class. If the handler is for a scalar UDF, returning a non-tabular value, the HANDLER value should be a method name, as in the following form: `MyClass.myMethod`. If the handler is for a tabular UDF, the HANDLER value should be the name of a handler class.",
+		targetPathDescription:     "The TARGET_PATH clause specifies the location to which Snowflake should write the compiled code (JAR file) after compiling the source code specified in the `function_definition`. If this clause is included, the user should manually remove the JAR file when it is no longer needed (typically when the Java UDF is dropped). If this clause is omitted, Snowflake re-compiles the source code each time the code is needed. The JAR file is not stored permanently, and the user does not need to clean up the JAR file. Snowflake returns an error if the TARGET_PATH matches an existing file; you cannot use TARGET_PATH to overwrite an existing file.",
 	}
 	javascriptFunctionSchemaDefinition = functionSchemaDef{
 		additionalArguments:           []string{},
@@ -242,7 +243,6 @@ func functionBaseSchema() map[string]schema.Schema {
 			ValidateDiagFunc: IsDataTypeValid,
 			DiffSuppressFunc: DiffSuppressDataTypes,
 			Description:      "Specifies the results returned by the UDF, which determines the UDF type. Use `<result_data_type>` to create a scalar UDF that returns a single value with the specified data type. Use `TABLE (col_name col_data_type, ...)` to creates a table UDF that returns tabular results with the specified table column(s) and column type(s). For the details, consult the [docs](https://docs.snowflake.com/en/sql-reference/sql/create-function#all-languages).",
-			// TODO [SNOW-1348103]: adjust DiffSuppressFunc
 		},
 		"null_input_behavior": {
 			Type:             schema.TypeString,
@@ -263,7 +263,6 @@ func functionBaseSchema() map[string]schema.Schema {
 		"runtime_version": {
 			Type:     schema.TypeString,
 			ForceNew: true,
-			// TODO [SNOW-1348103]: may be optional for java without consequence because if it is not set, the describe is not returning any version.
 		},
 		"comment": {
 			Type:     schema.TypeString,

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -264,12 +264,26 @@ func functionBaseSchema() map[string]schema.Schema {
 			Default:     "user-defined function",
 			Description: "Specifies a comment for the function.",
 		},
-		// TODO [SNOW-1348103]: because of https://docs.snowflake.com/en/sql-reference/sql/create-function#id6, maybe it will be better to split into stage_name + target_path
+		// split into two because of https://docs.snowflake.com/en/sql-reference/sql/create-function#id6
+		// TODO [next PR]: add validations preventing setting improper stage and path
 		"imports": {
 			Type:     schema.TypeSet,
-			Elem:     &schema.Schema{Type: schema.TypeString},
 			Optional: true,
 			ForceNew: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"stage_location": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Stage location without leading `@`. To use your user's stage set this to `~`, otherwise pass fully qualified name of the stage (with every part contained in double quotes or use `snowflake_stage.<your stage's resource name>.fully_qualified_name` if you manage this stage through terraform).",
+					},
+					"path_on_stage": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Path for import on stage, without the leading `/`.",
+					},
+				},
+			},
 		},
 		// TODO [SNOW-1348103]: what do we do with the version "latest".
 		"packages": {

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -320,6 +320,7 @@ func functionBaseSchema() map[string]schema.Schema {
 			Optional: true,
 			ForceNew: true,
 		},
+		// TODO [this PR]: required only for javascript and sql
 		"function_definition": {
 			Type:             schema.TypeString,
 			Required:         true,

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -81,7 +81,7 @@ var (
 		"arguments",
 		"return_type",
 		"null_input_behavior",
-		"return_behavior",
+		"return_results_behavior",
 		"comment",
 		"function_definition",
 		"function_language",
@@ -241,15 +241,15 @@ func functionBaseSchema() map[string]schema.Schema {
 			Optional:         true,
 			ForceNew:         true,
 			ValidateDiagFunc: sdkValidation(sdk.ToNullInputBehavior),
-			DiffSuppressFunc: SuppressIfAny(NormalizeAndCompare(sdk.ToNullInputBehavior), IgnoreChangeToCurrentSnowflakeValueInShow("null_input_behavior")),
+			DiffSuppressFunc: SuppressIfAny(NormalizeAndCompare(sdk.ToNullInputBehavior)), // TODO [this PR]: IgnoreChangeToCurrentSnowflakeValueInShow("null_input_behavior") but not in show
 			Description:      fmt.Sprintf("Specifies the behavior of the function when called with null inputs. Valid values are (case-insensitive): %s.", possibleValuesListed(sdk.AllAllowedNullInputBehaviors)),
 		},
-		"return_behavior": {
+		"return_results_behavior": {
 			Type:             schema.TypeString,
 			Optional:         true,
 			ForceNew:         true,
 			ValidateDiagFunc: sdkValidation(sdk.ToReturnResultsBehavior),
-			DiffSuppressFunc: SuppressIfAny(NormalizeAndCompare(sdk.ToReturnResultsBehavior), IgnoreChangeToCurrentSnowflakeValueInShow("return_behavior")),
+			DiffSuppressFunc: SuppressIfAny(NormalizeAndCompare(sdk.ToReturnResultsBehavior)), // TODO [this PR]: IgnoreChangeToCurrentSnowflakeValueInShow("return_results_behavior") but not in show
 			Description:      fmt.Sprintf("Specifies the behavior of the function when returning results. Valid values are (case-insensitive): %s.", possibleValuesListed(sdk.AllAllowedReturnResultsBehaviors)),
 		},
 		"runtime_version": {

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -344,7 +344,7 @@ func functionBaseSchema() map[string]schema.Schema {
 			Computed:    true,
 			Description: "Outputs the result of `SHOW PARAMETERS IN FUNCTION` for the given function.",
 			Elem: &schema.Resource{
-				Schema: functionParametersSchema,
+				Schema: schemas.ShowFunctionParametersSchema,
 			},
 		},
 		FullyQualifiedNameAttributeName: *schemas.FullyQualifiedNameSchema,

--- a/pkg/resources/function_commons.go
+++ b/pkg/resources/function_commons.go
@@ -494,7 +494,7 @@ type allFunctionDetailsCommon struct {
 	functionParameters []*sdk.Parameter
 }
 
-func readFunctionImportsCommon(d *schema.ResourceData, imports []sdk.FunctionDetailsImport) error {
+func readFunctionImportsCommon(d *schema.ResourceData, imports []sdk.NormalizedPath) error {
 	if len(imports) == 0 {
 		// don't do anything if imports not present
 		return nil

--- a/pkg/resources/function_java.go
+++ b/pkg/resources/function_java.go
@@ -141,7 +141,7 @@ func ReadContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta a
 		// TODO [this PR]: set all proper fields
 		// not reading is_secure on purpose (handled as external change to show output)
 		// arguments
-		// return_type
+		// return_type -> parse Returns from allFunctionDetails.functionDetails (NOT NULL can be added)
 		// not reading null_input_behavior on purpose (handled as external change to show output)
 		// not reading return_results_behavior on purpose (handled as external change to show output)
 		setOptionalFromStringPtr(d, "runtime_version", allFunctionDetails.functionDetails.RuntimeVersion),

--- a/pkg/resources/function_java.go
+++ b/pkg/resources/function_java.go
@@ -103,17 +103,6 @@ func CreateContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	return ReadContextFunctionJava(ctx, d, meta)
-
-	//if v, ok := d.GetOk("comment"); ok {
-	//	request.WithComment(v.(string))
-	//}
-	//if _, ok := d.GetOk("packages"); ok {
-	//	var packages []sdk.FunctionPackageRequest
-	//	for _, item := range d.Get("packages").([]interface{}) {
-	//		packages = append(packages, *sdk.NewFunctionPackageRequest().WithPackage(item.(string)))
-	//	}
-	//	request.WithPackages(packages)
-	//}
 }
 
 func ReadContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/pkg/resources/function_java.go
+++ b/pkg/resources/function_java.go
@@ -134,7 +134,7 @@ func ReadContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta a
 	errs := errors.Join(
 		// TODO [this PR]: set all proper fields
 		// not reading is_secure on purpose (handled as external change to show output)
-		// arguments
+		readFunctionArgumentsCommon(d, allFunctionDetails.functionDetails.NormalizedArguments),
 		d.Set("return_type", allFunctionDetails.functionDetails.ReturnDataType.ToSql()),
 		// not reading null_input_behavior on purpose (handled as external change to show output)
 		// not reading return_results_behavior on purpose (handled as external change to show output)

--- a/pkg/resources/function_java.go
+++ b/pkg/resources/function_java.go
@@ -78,7 +78,7 @@ func CreateContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta
 		// packages
 		// external_access_integrations
 		// secrets
-		// target_path
+		setFunctionTargetPathInBuilder(d, request.WithTargetPath),
 		stringAttributeCreateBuilder(d, "function_definition", request.WithFunctionDefinitionWrapped),
 	)
 	if errs != nil {
@@ -155,7 +155,7 @@ func ReadContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta a
 		setRequiredFromStringPtr(d, "handler", allFunctionDetails.functionDetails.Handler),
 		// external_access_integrations
 		// secrets
-		// target_path
+		readFunctionTargetPathCommon(d, allFunctionDetails.functionDetails.NormalizedTargetPath),
 		setOptionalFromStringPtr(d, "function_definition", allFunctionDetails.functionDetails.Body),
 		d.Set("function_language", allFunctionDetails.functionDetails.Language),
 

--- a/pkg/resources/function_java.go
+++ b/pkg/resources/function_java.go
@@ -185,6 +185,10 @@ func UpdateContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta
 	unsetRequest := sdk.NewFunctionUnsetRequest()
 
 	// TODO [this PR]: handle all updates
+	// secure
+	// external access integration
+	// secrets
+	// comment
 
 	if updateParamDiags := handleFunctionParametersUpdate(d, setRequest, unsetRequest); len(updateParamDiags) > 0 {
 		return updateParamDiags

--- a/pkg/resources/function_java.go
+++ b/pkg/resources/function_java.go
@@ -62,7 +62,7 @@ func CreateContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta
 	request := sdk.NewCreateForJavaFunctionRequest(id.SchemaObjectId(), *returns, handler).
 		WithArguments(argumentRequests)
 
-	if v, ok := d.GetOk("statement"); ok {
+	if v, ok := d.GetOk("function_definition"); ok {
 		request.WithFunctionDefinitionWrapped(v.(string))
 	}
 
@@ -128,12 +128,12 @@ func ReadContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta a
 	errs := errors.Join(
 		// TODO [this PR]: set all proper fields
 
-		d.Set("function_type", allFunctionDetails.functionDetails.Language),
+		d.Set("function_language", allFunctionDetails.functionDetails.Language),
 
 		d.Set(FullyQualifiedNameAttributeName, id.FullyQualifiedName()),
 		handleFunctionParameterRead(d, allFunctionDetails.functionParameters),
 		d.Set(ShowOutputAttributeName, []map[string]any{schemas.FunctionToSchema(allFunctionDetails.function)}),
-		d.Set(ParametersAttributeName, []map[string]any{schemas.UserParametersToSchema(allFunctionDetails.functionParameters)}),
+		d.Set(ParametersAttributeName, []map[string]any{schemas.FunctionParametersToSchema(allFunctionDetails.functionParameters)}),
 	)
 	if errs != nil {
 		return diag.FromErr(err)

--- a/pkg/resources/function_java.go
+++ b/pkg/resources/function_java.go
@@ -17,7 +17,7 @@ func FunctionJava() *schema.Resource {
 		CreateContext: TrackingCreateWrapper(resources.FunctionJava, CreateContextFunctionJava),
 		ReadContext:   TrackingReadWrapper(resources.FunctionJava, ReadContextFunctionJava),
 		UpdateContext: TrackingUpdateWrapper(resources.FunctionJava, UpdateContextFunctionJava),
-		DeleteContext: TrackingDeleteWrapper(resources.FunctionJava, DeleteContextFunctionJava),
+		DeleteContext: TrackingDeleteWrapper(resources.FunctionJava, DeleteFunction),
 		Description:   "Resource used to manage java function objects. For more information, check [function documentation](https://docs.snowflake.com/en/sql-reference/sql/create-function).",
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.FunctionJava, customdiff.All(
@@ -44,9 +44,5 @@ func ReadContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta a
 }
 
 func UpdateContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	return nil
-}
-
-func DeleteContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	return nil
 }

--- a/pkg/resources/function_java.go
+++ b/pkg/resources/function_java.go
@@ -28,11 +28,11 @@ func FunctionJava() *schema.Resource {
 		Description:   "Resource used to manage java function objects. For more information, check [function documentation](https://docs.snowflake.com/en/sql-reference/sql/create-function).",
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.FunctionJava, customdiff.All(
-			// TODO[SNOW-1348103]: ComputedIfAnyAttributeChanged(javaFunctionSchema, ShowOutputAttributeName, ...),
+			// TODO [SNOW-1348103]: ComputedIfAnyAttributeChanged(javaFunctionSchema, ShowOutputAttributeName, ...),
 			ComputedIfAnyAttributeChanged(javaFunctionSchema, FullyQualifiedNameAttributeName, "name"),
 			ComputedIfAnyAttributeChanged(functionParametersSchema, ParametersAttributeName, collections.Map(sdk.AsStringList(sdk.AllFunctionParameters), strings.ToLower)...),
 			functionParametersCustomDiff,
-			// TODO[SNOW-1348103]: recreate when type changed externally
+			RecreateWhenResourceFieldChangedExternally("function_language", "JAVA"),
 		)),
 
 		Schema: collections.MergeMaps(javaFunctionSchema, functionParametersSchema),
@@ -148,7 +148,7 @@ func ReadContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta a
 		// comment
 		// imports
 		// packages
-		// handler
+		setRequiredFromStringPtr(d, "handler", allFunctionDetails.functionDetails.Handler),
 		// external_access_integrations
 		// secrets
 		// target_path

--- a/pkg/resources/function_java.go
+++ b/pkg/resources/function_java.go
@@ -36,7 +36,7 @@ func FunctionJava() *schema.Resource {
 			// Currently, almost all attributes are marked as forceNew.
 			// When language changes, these attributes also change, causing the object to recreate either way.
 			// The only potential option is java staged -> scala staged (however scala need runtime_version which may interfere).
-			RecreateWhenResourceFieldChangedExternally("function_language", "JAVA"),
+			RecreateWhenResourceStringFieldChangedExternally("function_language", "JAVA"),
 		)),
 
 		Schema: collections.MergeMaps(javaFunctionSchema, functionParametersSchema),

--- a/pkg/resources/function_java.go
+++ b/pkg/resources/function_java.go
@@ -107,22 +107,12 @@ func CreateContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta
 	//if v, ok := d.GetOk("comment"); ok {
 	//	request.WithComment(v.(string))
 	//}
-	//if _, ok := d.GetOk("imports"); ok {
-	//	var imports []sdk.FunctionImportRequest
-	//	for _, item := range d.Get("imports").([]interface{}) {
-	//		imports = append(imports, *sdk.NewFunctionImportRequest().WithImport(item.(string)))
-	//	}
-	//	request.WithImports(imports)
-	//}
 	//if _, ok := d.GetOk("packages"); ok {
 	//	var packages []sdk.FunctionPackageRequest
 	//	for _, item := range d.Get("packages").([]interface{}) {
 	//		packages = append(packages, *sdk.NewFunctionPackageRequest().WithPackage(item.(string)))
 	//	}
 	//	request.WithPackages(packages)
-	//}
-	//if v, ok := d.GetOk("target_path"); ok {
-	//	request.WithTargetPath(v.(string))
 	//}
 }
 
@@ -138,14 +128,14 @@ func ReadContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta a
 		return diags
 	}
 
-	// TODO [this PR]: handle external changes marking
-	// TODO [this PR]: handle setting state to value from config
+	// TODO [next PR]: handle external changes marking
+	// TODO [next PR]: handle setting state to value from config
 
 	errs := errors.Join(
 		// TODO [this PR]: set all proper fields
 		// not reading is_secure on purpose (handled as external change to show output)
 		// arguments
-		// return_type -> parse Returns from allFunctionDetails.functionDetails (NOT NULL can be added)
+		d.Set("return_type", allFunctionDetails.functionDetails.ReturnDataType.ToSql()),
 		// not reading null_input_behavior on purpose (handled as external change to show output)
 		// not reading return_results_behavior on purpose (handled as external change to show output)
 		setOptionalFromStringPtr(d, "runtime_version", allFunctionDetails.functionDetails.RuntimeVersion),

--- a/pkg/resources/function_java.go
+++ b/pkg/resources/function_java.go
@@ -128,8 +128,8 @@ func ReadContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta a
 		return diags
 	}
 
-	// TODO [next PR]: handle external changes marking
-	// TODO [next PR]: handle setting state to value from config
+	// TODO [SNOW-1348103]: handle external changes marking
+	// TODO [SNOW-1348103]: handle setting state to value from config
 
 	errs := errors.Join(
 		// TODO [this PR]: set all proper fields

--- a/pkg/resources/function_java.go
+++ b/pkg/resources/function_java.go
@@ -72,7 +72,7 @@ func CreateContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta
 		attributeMappedValueCreateBuilder[string](d, "null_input_behavior", request.WithNullInputBehavior, sdk.ToNullInputBehavior),
 		attributeMappedValueCreateBuilder[string](d, "return_results_behavior", request.WithReturnResultsBehavior, sdk.ToReturnResultsBehavior),
 		stringAttributeCreateBuilder(d, "runtime_version", request.WithRuntimeVersion),
-		// TODO [this PR]: handle all attributes
+		// TODO [SNOW-1348103]: handle the rest of the attributes
 		// comment
 		setFunctionImportsInBuilder(d, request.WithImports),
 		// packages
@@ -132,7 +132,7 @@ func ReadContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta a
 	// TODO [SNOW-1348103]: handle setting state to value from config
 
 	errs := errors.Join(
-		// TODO [this PR]: set all proper fields
+		// TODO [SNOW-1348103]: set the rest of the fields
 		// not reading is_secure on purpose (handled as external change to show output)
 		readFunctionArgumentsCommon(d, allFunctionDetails.functionDetails.NormalizedArguments),
 		d.Set("return_type", allFunctionDetails.functionDetails.ReturnDataType.ToSql()),
@@ -184,7 +184,7 @@ func UpdateContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta
 	setRequest := sdk.NewFunctionSetRequest()
 	unsetRequest := sdk.NewFunctionUnsetRequest()
 
-	// TODO [this PR]: handle all updates
+	// TODO [SNOW-1348103]: handle all updates
 	// secure
 	// external access integration
 	// secrets

--- a/pkg/resources/function_java.go
+++ b/pkg/resources/function_java.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -36,7 +38,72 @@ func FunctionJava() *schema.Resource {
 }
 
 func CreateContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	return nil
+	client := meta.(*provider.Context).Client
+	database := d.Get("database").(string)
+	sc := d.Get("schema").(string)
+	name := d.Get("name").(string)
+
+	argumentRequests, diags := parseFunctionArgumentsCommon(d)
+	if diags != nil {
+		return diags
+	}
+	returns, diags := parseFunctionReturnsCommon(d)
+	if diags != nil {
+		return diags
+	}
+	handler := d.Get("handler").(string)
+
+	argumentDataTypes := collections.Map(argumentRequests, func(r sdk.FunctionArgumentRequest) datatypes.DataType { return r.ArgDataType })
+	id := sdk.NewSchemaObjectIdentifierWithArgumentsNormalized(database, sc, name, argumentDataTypes...)
+	request := sdk.NewCreateForJavaFunctionRequest(id.SchemaObjectId(), *returns, handler).
+		WithArguments(argumentRequests)
+
+	if v, ok := d.GetOk("statement"); ok {
+		request.WithFunctionDefinitionWrapped(v.(string))
+	}
+
+	if err := client.Functions.CreateForJava(ctx, request); err != nil {
+		return diag.FromErr(err)
+	}
+
+	// TODO [this PR]: handle parameters
+
+	d.SetId(id.FullyQualifiedName())
+	return ReadContextFunctionJava(ctx, d, meta)
+
+	// Set optionals
+	//if v, ok := d.GetOk("is_secure"); ok {
+	//	request.WithSecure(v.(bool))
+	//}
+	//if v, ok := d.GetOk("null_input_behavior"); ok {
+	//	request.WithNullInputBehavior(sdk.NullInputBehavior(v.(string)))
+	//}
+	//if v, ok := d.GetOk("return_behavior"); ok {
+	//	request.WithReturnResultsBehavior(sdk.ReturnResultsBehavior(v.(string)))
+	//}
+	//if v, ok := d.GetOk("runtime_version"); ok {
+	//	request.WithRuntimeVersion(v.(string))
+	//}
+	//if v, ok := d.GetOk("comment"); ok {
+	//	request.WithComment(v.(string))
+	//}
+	//if _, ok := d.GetOk("imports"); ok {
+	//	var imports []sdk.FunctionImportRequest
+	//	for _, item := range d.Get("imports").([]interface{}) {
+	//		imports = append(imports, *sdk.NewFunctionImportRequest().WithImport(item.(string)))
+	//	}
+	//	request.WithImports(imports)
+	//}
+	//if _, ok := d.GetOk("packages"); ok {
+	//	var packages []sdk.FunctionPackageRequest
+	//	for _, item := range d.Get("packages").([]interface{}) {
+	//		packages = append(packages, *sdk.NewFunctionPackageRequest().WithPackage(item.(string)))
+	//	}
+	//	request.WithPackages(packages)
+	//}
+	//if v, ok := d.GetOk("target_path"); ok {
+	//	request.WithTargetPath(v.(string))
+	//}
 }
 
 func ReadContextFunctionJava(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/pkg/resources/function_java_acceptance_test.go
+++ b/pkg/resources/function_java_acceptance_test.go
@@ -323,7 +323,6 @@ func TestAcc_FunctionJava_AllParameters(t *testing.T) {
 	})
 }
 
-// TODO [this PR]: Test with Java versus Scala staged (probably the only way to set up functions to have exactly the same config in both languages)
 func TestAcc_FunctionJava_handleExternalLanguageChange(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	acc.TestAccPreCheck(t)
@@ -335,9 +334,8 @@ func TestAcc_FunctionJava_handleExternalLanguageChange(t *testing.T) {
 
 	argName := "x"
 	handler := tmpJavaFunction.JavaHandler()
-	importPath := tmpJavaFunction.JarLocation()
 
-	functionModel := model.FunctionJavaBasicStaged("w", id, dataType, handler, importPath).
+	functionModel := model.FunctionJavaBasicStaged("w", id, dataType, handler, "~", tmpJavaFunction.JarName).
 		WithArgument(argName, dataType)
 
 	resource.Test(t, resource.TestCase{
@@ -360,8 +358,7 @@ func TestAcc_FunctionJava_handleExternalLanguageChange(t *testing.T) {
 			{
 				PreConfig: func() {
 					acc.TestClient().Function.DropFunctionFunc(t, id)()
-					// TODO [this PR]: create scala staged (id, args, return, import, handler)
-					acc.TestClient().Function.CreateSqlWithIdentifierAndArgument(t, id.SchemaObjectId(), dataType)
+					acc.TestClient().Function.CreateScalaStaged(t, id, dataType, tmpJavaFunction.JarLocation(), handler)
 					objectassert.Function(t, id).HasLanguage("SCALA")
 				},
 				Config: config.FromModel(t, functionModel),

--- a/pkg/resources/function_java_acceptance_test.go
+++ b/pkg/resources/function_java_acceptance_test.go
@@ -27,26 +27,25 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
-// TODO [this PR]: test empty args
-// TODO [this PR]: test default args no change
+// TODO [SNOW-1348103]: test import
+// TODO [SNOW-1348103]: test external changes
+// TODO [SNOW-1348103]: test changes of attributes separately
 
 func TestAcc_FunctionJava_InlineBasic(t *testing.T) {
 	className := "TestFunc"
 	funcName := "echoVarchar"
 	argName := "x"
 	dataType := testdatatypes.DataTypeVarchar_100
-	// differentDataType := testdatatypes.DataTypeNumber_36_2
 
 	id := acc.TestClient().Ids.RandomSchemaObjectIdentifierWithArgumentsNewDataTypes(dataType)
 	idWithChangedNameButTheSameDataType := acc.TestClient().Ids.RandomSchemaObjectIdentifierWithArgumentsNewDataTypes(dataType)
-	// idWithSameNameButDifferentDataType := acc.TestClient().Ids.NewSchemaObjectIdentifierWithArgumentsNewDataTypes(idWithChangedNameButTheSameDataType.Name(), differentDataType)
 
 	handler := fmt.Sprintf("%s.%s", className, funcName)
 	definition := acc.TestClient().Function.SampleJavaDefinition(t, className, funcName, argName)
 
-	functionModelNoAttributes := model.FunctionJavaBasicInline("w", id, dataType, handler, definition).
+	functionModel := model.FunctionJavaBasicInline("w", id, dataType, handler, definition).
 		WithArgument(argName, dataType)
-	functionModelNoAttributesRenamed := model.FunctionJavaBasicInline("w", idWithChangedNameButTheSameDataType, dataType, handler, definition).
+	functionModelRenamed := model.FunctionJavaBasicInline("w", idWithChangedNameButTheSameDataType, dataType, handler, definition).
 		WithArgument(argName, dataType)
 
 	resource.Test(t, resource.TestCase{
@@ -59,9 +58,9 @@ func TestAcc_FunctionJava_InlineBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// CREATE BASIC
 			{
-				Config: config.FromModels(t, functionModelNoAttributes),
+				Config: config.FromModels(t, functionModel),
 				Check: assert.AssertThat(t,
-					resourceassert.FunctionJavaResource(t, functionModelNoAttributes.ResourceReference()).
+					resourceassert.FunctionJavaResource(t, functionModel.ResourceReference()).
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanDefault).
 						HasCommentString(sdk.DefaultFunctionComment).
@@ -71,152 +70,98 @@ func TestAcc_FunctionJava_InlineBasic(t *testing.T) {
 						HasFunctionDefinitionString(definition).
 						HasFunctionLanguageString("JAVA").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),
-					resourceshowoutputassert.FunctionShowOutput(t, functionModelNoAttributes.ResourceReference()).
+					resourceshowoutputassert.FunctionShowOutput(t, functionModel.ResourceReference()).
 						HasIsSecure(false),
+					assert.Check(resource.TestCheckResourceAttr(functionModel.ResourceReference(), "arguments.0.arg_name", argName)),
+					assert.Check(resource.TestCheckResourceAttr(functionModel.ResourceReference(), "arguments.0.arg_data_type", dataType.ToSql())),
+					assert.Check(resource.TestCheckResourceAttr(functionModel.ResourceReference(), "arguments.0.arg_default_value", "")),
 				),
 			},
 			// RENAME
 			{
-				Config: config.FromModels(t, functionModelNoAttributesRenamed),
+				Config: config.FromModels(t, functionModelRenamed),
 				Check: assert.AssertThat(t,
-					resourceassert.FunctionJavaResource(t, functionModelNoAttributesRenamed.ResourceReference()).
+					resourceassert.FunctionJavaResource(t, functionModelRenamed.ResourceReference()).
 						HasNameString(idWithChangedNameButTheSameDataType.Name()).
 						HasFullyQualifiedNameString(idWithChangedNameButTheSameDataType.FullyQualifiedName()),
 				),
 			},
-			//// IMPORT
-			//{
-			//	ResourceName:            userModelNoAttributesRenamed.ResourceReference(),
-			//	ImportState:             true,
-			//	ImportStateVerify:       true,
-			//	ImportStateVerifyIgnore: []string{"password", "disable_mfa", "days_to_expiry", "mins_to_unlock", "mins_to_bypass_mfa", "login_name", "display_name", "disabled", "must_change_password"},
-			//	ImportStateCheck: assert.AssertThatImport(t,
-			//		resourceassert.ImportedUserResource(t, id2.Name()).
-			//			HasLoginNameString(strings.ToUpper(id.Name())).
-			//			HasDisplayNameString(id.Name()).
-			//			HasDisabled(false).
-			//			HasMustChangePassword(false),
-			//	),
-			//},
-			//// DESTROY
-			//{
-			//	Config:  config.FromModel(t, userModelNoAttributes),
-			//	Destroy: true,
-			//},
-			//// CREATE WITH ALL ATTRIBUTES
-			//{
-			//	Config: config.FromModel(t, userModelAllAttributes),
-			//	Check: assert.AssertThat(t,
-			//		resourceassert.UserResource(t, userModelAllAttributes.ResourceReference()).
-			//			HasNameString(id.Name()).
-			//			HasPasswordString(pass).
-			//			HasLoginNameString(fmt.Sprintf("%s_login", id.Name())).
-			//			HasDisplayNameString("Display Name").
-			//			HasFirstNameString("Jan").
-			//			HasMiddleNameString("Jakub").
-			//			HasLastNameString("Testowski").
-			//			HasEmailString("fake@email.com").
-			//			HasMustChangePassword(true).
-			//			HasDisabled(false).
-			//			HasDaysToExpiryString("8").
-			//			HasMinsToUnlockString("9").
-			//			HasDefaultWarehouseString("some_warehouse").
-			//			HasDefaultNamespaceString("some.namespace").
-			//			HasDefaultRoleString("some_role").
-			//			HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionAll).
-			//			HasMinsToBypassMfaString("10").
-			//			HasRsaPublicKeyString(key1).
-			//			HasRsaPublicKey2String(key2).
-			//			HasCommentString(comment).
-			//			HasDisableMfaString(r.BooleanTrue).
-			//			HasFullyQualifiedNameString(id.FullyQualifiedName()),
-			//	),
-			//},
-			//// CHANGE PROPERTIES
-			//{
-			//	Config: config.FromModel(t, userModelAllAttributesChanged(id.Name()+"_other_login")),
-			//	Check: assert.AssertThat(t,
-			//		resourceassert.UserResource(t, userModelAllAttributesChanged(id.Name()+"_other_login").ResourceReference()).
-			//			HasNameString(id.Name()).
-			//			HasPasswordString(newPass).
-			//			HasLoginNameString(fmt.Sprintf("%s_other_login", id.Name())).
-			//			HasDisplayNameString("New Display Name").
-			//			HasFirstNameString("Janek").
-			//			HasMiddleNameString("Kuba").
-			//			HasLastNameString("Terraformowski").
-			//			HasEmailString("fake@email.net").
-			//			HasMustChangePassword(false).
-			//			HasDisabled(true).
-			//			HasDaysToExpiryString("12").
-			//			HasMinsToUnlockString("13").
-			//			HasDefaultWarehouseString("other_warehouse").
-			//			HasDefaultNamespaceString("one_part_namespace").
-			//			HasDefaultRoleString("other_role").
-			//			HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionAll).
-			//			HasMinsToBypassMfaString("14").
-			//			HasRsaPublicKeyString(key2).
-			//			HasRsaPublicKey2String(key1).
-			//			HasCommentString(newComment).
-			//			HasDisableMfaString(r.BooleanFalse).
-			//			HasFullyQualifiedNameString(id.FullyQualifiedName()),
-			//	),
-			//},
-			//// IMPORT
-			//{
-			//	ResourceName:            userModelAllAttributesChanged(id.Name() + "_other_login").ResourceReference(),
-			//	ImportState:             true,
-			//	ImportStateVerify:       true,
-			//	ImportStateVerifyIgnore: []string{"password", "disable_mfa", "days_to_expiry", "mins_to_unlock", "mins_to_bypass_mfa", "default_namespace", "login_name", "show_output.0.days_to_expiry"},
-			//	ImportStateCheck: assert.AssertThatImport(t,
-			//		resourceassert.ImportedUserResource(t, id.Name()).
-			//			HasDefaultNamespaceString("ONE_PART_NAMESPACE").
-			//			HasLoginNameString(fmt.Sprintf("%s_OTHER_LOGIN", id.Name())),
-			//	),
-			//},
-			//// CHANGE PROP TO THE CURRENT SNOWFLAKE VALUE
-			//{
-			//	PreConfig: func() {
-			//		acc.TestClient().User.SetLoginName(t, id, id.Name()+"_different_login")
-			//	},
-			//	Config: config.FromModel(t, userModelAllAttributesChanged(id.Name()+"_different_login")),
-			//	ConfigPlanChecks: resource.ConfigPlanChecks{
-			//		PostApplyPostRefresh: []plancheck.PlanCheck{
-			//			plancheck.ExpectEmptyPlan(),
-			//		},
-			//	},
-			//},
-			//// UNSET ALL
-			//{
-			//	Config: config.FromModel(t, userModelNoAttributes),
-			//	Check: assert.AssertThat(t,
-			//		resourceassert.UserResource(t, userModelNoAttributes.ResourceReference()).
-			//			HasNameString(id.Name()).
-			//			HasPasswordString("").
-			//			HasLoginNameString("").
-			//			HasDisplayNameString("").
-			//			HasFirstNameString("").
-			//			HasMiddleNameString("").
-			//			HasLastNameString("").
-			//			HasEmailString("").
-			//			HasMustChangePasswordString(r.BooleanDefault).
-			//			HasDisabledString(r.BooleanDefault).
-			//			HasDaysToExpiryString("0").
-			//			HasMinsToUnlockString(r.IntDefaultString).
-			//			HasDefaultWarehouseString("").
-			//			HasDefaultNamespaceString("").
-			//			HasDefaultRoleString("").
-			//			HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionDefault).
-			//			HasMinsToBypassMfaString(r.IntDefaultString).
-			//			HasRsaPublicKeyString("").
-			//			HasRsaPublicKey2String("").
-			//			HasCommentString("").
-			//			HasDisableMfaString(r.BooleanDefault).
-			//			HasFullyQualifiedNameString(id.FullyQualifiedName()),
-			//		resourceshowoutputassert.UserShowOutput(t, userModelNoAttributes.ResourceReference()).
-			//			HasLoginName(strings.ToUpper(id.Name())).
-			//			HasDisplayName(""),
-			//	),
-			//},
+		},
+	})
+}
+
+func TestAcc_FunctionJava_InlineEmptyArgs(t *testing.T) {
+	className := "TestFunc"
+	funcName := "echoVarchar"
+	returnDataType := testdatatypes.DataTypeVarchar_100
+
+	id := acc.TestClient().Ids.RandomSchemaObjectIdentifierWithArgumentsNewDataTypes()
+
+	handler := fmt.Sprintf("%s.%s", className, funcName)
+	definition := acc.TestClient().Function.SampleJavaDefinitionNoArgs(t, className, funcName)
+
+	functionModel := model.FunctionJavaBasicInline("w", id, returnDataType, handler, definition)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		CheckDestroy: acc.CheckDestroy(t, resources.FunctionJava),
+		Steps: []resource.TestStep{
+			// CREATE BASIC
+			{
+				Config: config.FromModels(t, functionModel),
+				Check: assert.AssertThat(t,
+					resourceassert.FunctionJavaResource(t, functionModel.ResourceReference()).
+						HasNameString(id.Name()).
+						HasFunctionDefinitionString(definition).
+						HasFunctionLanguageString("JAVA").
+						HasFullyQualifiedNameString(id.FullyQualifiedName()),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_FunctionJava_InlineBasicDefaultArg(t *testing.T) {
+	className := "TestFunc"
+	funcName := "echoVarchar"
+	argName := "x"
+	dataType := testdatatypes.DataTypeVarchar_100
+	defaultValue := "'hello'"
+
+	id := acc.TestClient().Ids.RandomSchemaObjectIdentifierWithArgumentsNewDataTypes(dataType)
+
+	handler := fmt.Sprintf("%s.%s", className, funcName)
+	definition := acc.TestClient().Function.SampleJavaDefinition(t, className, funcName, argName)
+
+	functionModel := model.FunctionJavaBasicInline("w", id, dataType, handler, definition).
+		WithArgumentWithDefaultValue(argName, dataType, defaultValue)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		CheckDestroy: acc.CheckDestroy(t, resources.FunctionJava),
+		Steps: []resource.TestStep{
+			// CREATE BASIC
+			{
+				Config: config.FromModels(t, functionModel),
+				Check: assert.AssertThat(t,
+					resourceassert.FunctionJavaResource(t, functionModel.ResourceReference()).
+						HasNameString(id.Name()).
+						HasFunctionDefinitionString(definition).
+						HasFunctionLanguageString("JAVA").
+						HasFullyQualifiedNameString(id.FullyQualifiedName()),
+					assert.Check(resource.TestCheckResourceAttr(functionModel.ResourceReference(), "arguments.0.arg_name", argName)),
+					assert.Check(resource.TestCheckResourceAttr(functionModel.ResourceReference(), "arguments.0.arg_data_type", dataType.ToSql())),
+					assert.Check(resource.TestCheckResourceAttr(functionModel.ResourceReference(), "arguments.0.arg_default_value", defaultValue)),
+				),
+			},
 		},
 	})
 }

--- a/pkg/resources/function_java_acceptance_test.go
+++ b/pkg/resources/function_java_acceptance_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testdatatypes"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -251,13 +252,13 @@ func TestAcc_FunctionJava_AllParameters(t *testing.T) {
 				ResourceName: functionModel.ResourceReference(),
 				ImportState:  true,
 				ImportStateCheck: assert.AssertThatImport(t,
-					resourceparametersassert.ImportedFunctionResourceParameters(t, id.Name()).
+					resourceparametersassert.ImportedFunctionResourceParameters(t, helpers.EncodeResourceIdentifier(id)).
 						HasAllDefaults(),
 				),
 			},
 			// set all parameters
 			{
-				Config: config.FromModel(t, functionModelWithAllParametersSet),
+				Config: config.ResourceFromModel(t, functionModelWithAllParametersSet),
 				Check: assert.AssertThat(t,
 					objectparametersassert.FunctionParameters(t, id).
 						HasEnableConsoleOutput(true).
@@ -276,7 +277,7 @@ func TestAcc_FunctionJava_AllParameters(t *testing.T) {
 				ResourceName: functionModelWithAllParametersSet.ResourceReference(),
 				ImportState:  true,
 				ImportStateCheck: assert.AssertThatImport(t,
-					resourceparametersassert.ImportedFunctionResourceParameters(t, id.Name()).
+					resourceparametersassert.ImportedFunctionResourceParameters(t, helpers.EncodeResourceIdentifier(id)).
 						HasEnableConsoleOutput(true).
 						HasLogLevel(sdk.LogLevelWarn).
 						HasMetricLevel(sdk.MetricLevelAll).
@@ -285,13 +286,34 @@ func TestAcc_FunctionJava_AllParameters(t *testing.T) {
 			},
 			// unset all the parameters
 			{
-				Config: config.FromModel(t, functionModel),
+				Config: config.ResourceFromModel(t, functionModel),
 				Check: assert.AssertThat(t,
 					objectparametersassert.FunctionParameters(t, id).
 						HasAllDefaults().
 						HasAllDefaultsExplicit(),
-					resourceparametersassert.UserResourceParameters(t, functionModel.ResourceReference()).
+					resourceparametersassert.FunctionResourceParameters(t, functionModel.ResourceReference()).
 						HasAllDefaults(),
+				),
+			},
+			// destroy
+			{
+				Config:  config.ResourceFromModel(t, functionModel),
+				Destroy: true,
+			},
+			// create with all parameters set
+			{
+				Config: config.ResourceFromModel(t, functionModelWithAllParametersSet),
+				Check: assert.AssertThat(t,
+					objectparametersassert.FunctionParameters(t, id).
+						HasEnableConsoleOutput(true).
+						HasLogLevel(sdk.LogLevelWarn).
+						HasMetricLevel(sdk.MetricLevelAll).
+						HasTraceLevel(sdk.TraceLevelAlways),
+					resourceparametersassert.FunctionResourceParameters(t, functionModelWithAllParametersSet.ResourceReference()).
+						HasEnableConsoleOutput(true).
+						HasLogLevel(sdk.LogLevelWarn).
+						HasMetricLevel(sdk.MetricLevelAll).
+						HasTraceLevel(sdk.TraceLevelAlways),
 				),
 			},
 		},

--- a/pkg/resources/function_java_acceptance_test.go
+++ b/pkg/resources/function_java_acceptance_test.go
@@ -27,6 +27,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
+// TODO [this PR]: test empty args
+// TODO [this PR]: test default args no change
+
 func TestAcc_FunctionJava_InlineBasic(t *testing.T) {
 	className := "TestFunc"
 	funcName := "echoVarchar"

--- a/pkg/resources/function_java_acceptance_test.go
+++ b/pkg/resources/function_java_acceptance_test.go
@@ -328,7 +328,7 @@ func TestAcc_FunctionJava_handleExternalLanguageChange(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	acc.TestAccPreCheck(t)
 
-	tmpJavaFunction := acc.TestClient().CreateSampleJavaFunctionAndJar(t)
+	tmpJavaFunction := acc.TestClient().CreateSampleJavaFunctionAndJarOnUserStage(t)
 
 	dataType := tmpJavaFunction.ArgType
 	id := acc.TestClient().Ids.RandomSchemaObjectIdentifierWithArgumentsNewDataTypes(dataType)

--- a/pkg/resources/function_java_acceptance_test.go
+++ b/pkg/resources/function_java_acceptance_test.go
@@ -2,9 +2,11 @@ package resources_test
 
 import (
 	"fmt"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"testing"
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+	r "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert/resourceassert"
@@ -12,7 +14,6 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testdatatypes"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -32,8 +33,10 @@ func TestAcc_FunctionJava_BasicFlows(t *testing.T) {
 	handler := fmt.Sprintf("%s.%s", className, funcName)
 	definition := acc.TestClient().Function.SampleJavaDefinition(t, className, funcName, argName)
 
-	functionModelNoAttributes := model.FunctionJavaWithId("w", id, dataType, handler, definition)
-	functionModelNoAttributesRenamed := model.FunctionJavaWithId("w", idWithChangedNameButTheSameDataType, dataType, handler, definition)
+	functionModelNoAttributes := model.FunctionJavaWithId("w", id, dataType, handler, definition).
+		WithArgument(argName, dataType)
+	functionModelNoAttributesRenamed := model.FunctionJavaWithId("w", idWithChangedNameButTheSameDataType, dataType, handler, definition).
+		WithArgument(argName, dataType)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
@@ -41,7 +44,7 @@ func TestAcc_FunctionJava_BasicFlows(t *testing.T) {
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
-		CheckDestroy: acc.CheckDestroy(t, resources.User),
+		CheckDestroy: acc.CheckDestroy(t, resources.Function),
 		Steps: []resource.TestStep{
 			// CREATE BASIC
 			{
@@ -50,6 +53,8 @@ func TestAcc_FunctionJava_BasicFlows(t *testing.T) {
 					resourceassert.FunctionJavaResource(t, functionModelNoAttributes.ResourceReference()).
 						HasNameString(id.Name()).
 						HasCommentString(sdk.DefaultFunctionComment).
+						HasFunctionLanguageString("JAVA").
+						HasIsSecureString(r.BooleanDefault).
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),
 					resourceshowoutputassert.FunctionShowOutput(t, functionModelNoAttributes.ResourceReference()).
 						HasIsSecure(false),

--- a/pkg/resources/function_java_acceptance_test.go
+++ b/pkg/resources/function_java_acceptance_test.go
@@ -361,7 +361,7 @@ func TestAcc_FunctionJava_handleExternalLanguageChange(t *testing.T) {
 					acc.TestClient().Function.CreateScalaStaged(t, id, dataType, tmpJavaFunction.JarLocation(), handler)
 					objectassert.Function(t, id).HasLanguage("SCALA")
 				},
-				Config: config.FromModel(t, functionModel),
+				Config: config.FromModels(t, functionModel),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(functionModel.ResourceReference(), plancheck.ResourceActionDestroyBeforeCreate),

--- a/pkg/resources/function_java_acceptance_test.go
+++ b/pkg/resources/function_java_acceptance_test.go
@@ -63,6 +63,8 @@ func TestAcc_FunctionJava_InlineBasic(t *testing.T) {
 						HasIsSecureString(r.BooleanDefault).
 						HasCommentString(sdk.DefaultFunctionComment).
 						HasImportsLength(0).
+						HasTargetPathEmpty().
+						HasNoRuntimeVersion().
 						HasFunctionDefinitionString(definition).
 						HasFunctionLanguageString("JAVA").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),
@@ -237,7 +239,8 @@ func TestAcc_FunctionJava_InlineFull(t *testing.T) {
 
 	functionModel := model.FunctionJavaBasicInline("w", id, dataType, handler, definition).
 		WithArgument(argName, dataType).
-		WithTargetPathParts(stage.ID().FullyQualifiedName(), jarName)
+		WithTargetPathParts(stage.ID().FullyQualifiedName(), jarName).
+		WithRuntimeVersion("11")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
@@ -256,6 +259,7 @@ func TestAcc_FunctionJava_InlineFull(t *testing.T) {
 						HasIsSecureString(r.BooleanDefault).
 						HasCommentString(sdk.DefaultFunctionComment).
 						HasImportsLength(0).
+						HasRuntimeVersionString("11").
 						HasFunctionDefinitionString(definition).
 						HasFunctionLanguageString("JAVA").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),

--- a/pkg/resources/function_java_acceptance_test.go
+++ b/pkg/resources/function_java_acceptance_test.go
@@ -237,7 +237,7 @@ func TestAcc_FunctionJava_InlineFull(t *testing.T) {
 
 	handler := fmt.Sprintf("%s.%s", className, funcName)
 	definition := acc.TestClient().Function.SampleJavaDefinition(t, className, funcName, argName)
-	// TODO [next PR]: extract to helper
+	// TODO [SNOW-1850370]: extract to helper
 	jarName := fmt.Sprintf("tf-%d-%s.jar", time.Now().Unix(), random.AlphaN(5))
 
 	functionModel := model.FunctionJavaBasicInline("w", id, dataType, handler, definition).

--- a/pkg/resources/function_java_acceptance_test.go
+++ b/pkg/resources/function_java_acceptance_test.go
@@ -1,0 +1,202 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert/resourceassert"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testdatatypes"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+func TestAcc_FunctionJava_BasicFlows(t *testing.T) {
+	className := "TestFunc"
+	funcName := "echoVarchar"
+	argName := "x"
+	dataType := testdatatypes.DataTypeVarchar_100
+	// differentDataType := testdatatypes.DataTypeNumber_36_2
+
+	id := acc.TestClient().Ids.RandomSchemaObjectIdentifierWithArgumentsNewDataTypes(dataType)
+	idWithChangedNameButTheSameDataType := acc.TestClient().Ids.RandomSchemaObjectIdentifierWithArgumentsNewDataTypes(dataType)
+	// idWithSameNameButDifferentDataType := acc.TestClient().Ids.NewSchemaObjectIdentifierWithArgumentsNewDataTypes(idWithChangedNameButTheSameDataType.Name(), differentDataType)
+
+	handler := fmt.Sprintf("%s.%s", className, funcName)
+	definition := acc.TestClient().Function.SampleJavaDefinition(t, className, funcName, argName)
+
+	functionModelNoAttributes := model.FunctionJavaWithId("w", id, dataType, handler, definition)
+	functionModelNoAttributesRenamed := model.FunctionJavaWithId("w", idWithChangedNameButTheSameDataType, dataType, handler, definition)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		CheckDestroy: acc.CheckDestroy(t, resources.User),
+		Steps: []resource.TestStep{
+			// CREATE BASIC
+			{
+				Config: config.ResourceFromModel(t, functionModelNoAttributes),
+				Check: assert.AssertThat(t,
+					resourceassert.FunctionJavaResource(t, functionModelNoAttributes.ResourceReference()).
+						HasNameString(id.Name()).
+						HasCommentString(sdk.DefaultFunctionComment).
+						HasFullyQualifiedNameString(id.FullyQualifiedName()),
+					resourceshowoutputassert.FunctionShowOutput(t, functionModelNoAttributes.ResourceReference()).
+						HasIsSecure(false),
+				),
+			},
+			// RENAME
+			{
+				Config: config.ResourceFromModel(t, functionModelNoAttributesRenamed),
+				Check: assert.AssertThat(t,
+					resourceassert.FunctionJavaResource(t, functionModelNoAttributesRenamed.ResourceReference()).
+						HasNameString(idWithChangedNameButTheSameDataType.Name()).
+						HasFullyQualifiedNameString(idWithChangedNameButTheSameDataType.FullyQualifiedName()),
+				),
+			},
+			//// IMPORT
+			//{
+			//	ResourceName:            userModelNoAttributesRenamed.ResourceReference(),
+			//	ImportState:             true,
+			//	ImportStateVerify:       true,
+			//	ImportStateVerifyIgnore: []string{"password", "disable_mfa", "days_to_expiry", "mins_to_unlock", "mins_to_bypass_mfa", "login_name", "display_name", "disabled", "must_change_password"},
+			//	ImportStateCheck: assert.AssertThatImport(t,
+			//		resourceassert.ImportedUserResource(t, id2.Name()).
+			//			HasLoginNameString(strings.ToUpper(id.Name())).
+			//			HasDisplayNameString(id.Name()).
+			//			HasDisabled(false).
+			//			HasMustChangePassword(false),
+			//	),
+			//},
+			//// DESTROY
+			//{
+			//	Config:  config.FromModel(t, userModelNoAttributes),
+			//	Destroy: true,
+			//},
+			//// CREATE WITH ALL ATTRIBUTES
+			//{
+			//	Config: config.FromModel(t, userModelAllAttributes),
+			//	Check: assert.AssertThat(t,
+			//		resourceassert.UserResource(t, userModelAllAttributes.ResourceReference()).
+			//			HasNameString(id.Name()).
+			//			HasPasswordString(pass).
+			//			HasLoginNameString(fmt.Sprintf("%s_login", id.Name())).
+			//			HasDisplayNameString("Display Name").
+			//			HasFirstNameString("Jan").
+			//			HasMiddleNameString("Jakub").
+			//			HasLastNameString("Testowski").
+			//			HasEmailString("fake@email.com").
+			//			HasMustChangePassword(true).
+			//			HasDisabled(false).
+			//			HasDaysToExpiryString("8").
+			//			HasMinsToUnlockString("9").
+			//			HasDefaultWarehouseString("some_warehouse").
+			//			HasDefaultNamespaceString("some.namespace").
+			//			HasDefaultRoleString("some_role").
+			//			HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionAll).
+			//			HasMinsToBypassMfaString("10").
+			//			HasRsaPublicKeyString(key1).
+			//			HasRsaPublicKey2String(key2).
+			//			HasCommentString(comment).
+			//			HasDisableMfaString(r.BooleanTrue).
+			//			HasFullyQualifiedNameString(id.FullyQualifiedName()),
+			//	),
+			//},
+			//// CHANGE PROPERTIES
+			//{
+			//	Config: config.FromModel(t, userModelAllAttributesChanged(id.Name()+"_other_login")),
+			//	Check: assert.AssertThat(t,
+			//		resourceassert.UserResource(t, userModelAllAttributesChanged(id.Name()+"_other_login").ResourceReference()).
+			//			HasNameString(id.Name()).
+			//			HasPasswordString(newPass).
+			//			HasLoginNameString(fmt.Sprintf("%s_other_login", id.Name())).
+			//			HasDisplayNameString("New Display Name").
+			//			HasFirstNameString("Janek").
+			//			HasMiddleNameString("Kuba").
+			//			HasLastNameString("Terraformowski").
+			//			HasEmailString("fake@email.net").
+			//			HasMustChangePassword(false).
+			//			HasDisabled(true).
+			//			HasDaysToExpiryString("12").
+			//			HasMinsToUnlockString("13").
+			//			HasDefaultWarehouseString("other_warehouse").
+			//			HasDefaultNamespaceString("one_part_namespace").
+			//			HasDefaultRoleString("other_role").
+			//			HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionAll).
+			//			HasMinsToBypassMfaString("14").
+			//			HasRsaPublicKeyString(key2).
+			//			HasRsaPublicKey2String(key1).
+			//			HasCommentString(newComment).
+			//			HasDisableMfaString(r.BooleanFalse).
+			//			HasFullyQualifiedNameString(id.FullyQualifiedName()),
+			//	),
+			//},
+			//// IMPORT
+			//{
+			//	ResourceName:            userModelAllAttributesChanged(id.Name() + "_other_login").ResourceReference(),
+			//	ImportState:             true,
+			//	ImportStateVerify:       true,
+			//	ImportStateVerifyIgnore: []string{"password", "disable_mfa", "days_to_expiry", "mins_to_unlock", "mins_to_bypass_mfa", "default_namespace", "login_name", "show_output.0.days_to_expiry"},
+			//	ImportStateCheck: assert.AssertThatImport(t,
+			//		resourceassert.ImportedUserResource(t, id.Name()).
+			//			HasDefaultNamespaceString("ONE_PART_NAMESPACE").
+			//			HasLoginNameString(fmt.Sprintf("%s_OTHER_LOGIN", id.Name())),
+			//	),
+			//},
+			//// CHANGE PROP TO THE CURRENT SNOWFLAKE VALUE
+			//{
+			//	PreConfig: func() {
+			//		acc.TestClient().User.SetLoginName(t, id, id.Name()+"_different_login")
+			//	},
+			//	Config: config.FromModel(t, userModelAllAttributesChanged(id.Name()+"_different_login")),
+			//	ConfigPlanChecks: resource.ConfigPlanChecks{
+			//		PostApplyPostRefresh: []plancheck.PlanCheck{
+			//			plancheck.ExpectEmptyPlan(),
+			//		},
+			//	},
+			//},
+			//// UNSET ALL
+			//{
+			//	Config: config.FromModel(t, userModelNoAttributes),
+			//	Check: assert.AssertThat(t,
+			//		resourceassert.UserResource(t, userModelNoAttributes.ResourceReference()).
+			//			HasNameString(id.Name()).
+			//			HasPasswordString("").
+			//			HasLoginNameString("").
+			//			HasDisplayNameString("").
+			//			HasFirstNameString("").
+			//			HasMiddleNameString("").
+			//			HasLastNameString("").
+			//			HasEmailString("").
+			//			HasMustChangePasswordString(r.BooleanDefault).
+			//			HasDisabledString(r.BooleanDefault).
+			//			HasDaysToExpiryString("0").
+			//			HasMinsToUnlockString(r.IntDefaultString).
+			//			HasDefaultWarehouseString("").
+			//			HasDefaultNamespaceString("").
+			//			HasDefaultRoleString("").
+			//			HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionDefault).
+			//			HasMinsToBypassMfaString(r.IntDefaultString).
+			//			HasRsaPublicKeyString("").
+			//			HasRsaPublicKey2String("").
+			//			HasCommentString("").
+			//			HasDisableMfaString(r.BooleanDefault).
+			//			HasFullyQualifiedNameString(id.FullyQualifiedName()),
+			//		resourceshowoutputassert.UserShowOutput(t, userModelNoAttributes.ResourceReference()).
+			//			HasLoginName(strings.ToUpper(id.Name())).
+			//			HasDisplayName(""),
+			//	),
+			//},
+		},
+	})
+}

--- a/pkg/resources/function_javascript.go
+++ b/pkg/resources/function_javascript.go
@@ -17,7 +17,7 @@ func FunctionJavascript() *schema.Resource {
 		CreateContext: TrackingCreateWrapper(resources.FunctionJavascript, CreateContextFunctionJavascript),
 		ReadContext:   TrackingReadWrapper(resources.FunctionJavascript, ReadContextFunctionJavascript),
 		UpdateContext: TrackingUpdateWrapper(resources.FunctionJavascript, UpdateContextFunctionJavascript),
-		DeleteContext: TrackingDeleteWrapper(resources.FunctionJavascript, DeleteContextFunctionJavascript),
+		DeleteContext: TrackingDeleteWrapper(resources.FunctionJavascript, DeleteFunction),
 		Description:   "Resource used to manage javascript function objects. For more information, check [function documentation](https://docs.snowflake.com/en/sql-reference/sql/create-function).",
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.FunctionJavascript, customdiff.All(

--- a/pkg/resources/function_parameters.go
+++ b/pkg/resources/function_parameters.go
@@ -80,16 +80,16 @@ func handleFunctionParameterRead(d *schema.ResourceData, functionParameters []*s
 }
 
 // They do not work in create, that's why are set in alter
-func handleFunctionParametersCreate(d *schema.ResourceData, alterOpts *sdk.FunctionSet) diag.Diagnostics {
+func handleFunctionParametersCreate(d *schema.ResourceData, set *sdk.FunctionSetRequest) diag.Diagnostics {
 	return JoinDiags(
-		handleParameterCreate(d, sdk.FunctionParameterEnableConsoleOutput, &alterOpts.EnableConsoleOutput),
-		handleParameterCreateWithMapping(d, sdk.FunctionParameterLogLevel, &alterOpts.LogLevel, stringToStringEnumProvider(sdk.ToLogLevel)),
-		handleParameterCreateWithMapping(d, sdk.FunctionParameterMetricLevel, &alterOpts.MetricLevel, stringToStringEnumProvider(sdk.ToMetricLevel)),
-		handleParameterCreateWithMapping(d, sdk.FunctionParameterTraceLevel, &alterOpts.TraceLevel, stringToStringEnumProvider(sdk.ToTraceLevel)),
+		handleParameterCreate(d, sdk.FunctionParameterEnableConsoleOutput, &set.EnableConsoleOutput),
+		handleParameterCreateWithMapping(d, sdk.FunctionParameterLogLevel, &set.LogLevel, stringToStringEnumProvider(sdk.ToLogLevel)),
+		handleParameterCreateWithMapping(d, sdk.FunctionParameterMetricLevel, &set.MetricLevel, stringToStringEnumProvider(sdk.ToMetricLevel)),
+		handleParameterCreateWithMapping(d, sdk.FunctionParameterTraceLevel, &set.TraceLevel, stringToStringEnumProvider(sdk.ToTraceLevel)),
 	)
 }
 
-func handleFunctionParametersUpdate(d *schema.ResourceData, set *sdk.FunctionSet, unset *sdk.FunctionUnset) diag.Diagnostics {
+func handleFunctionParametersUpdate(d *schema.ResourceData, set *sdk.FunctionSetRequest, unset *sdk.FunctionUnsetRequest) diag.Diagnostics {
 	return JoinDiags(
 		handleParameterUpdate(d, sdk.FunctionParameterEnableConsoleOutput, &set.EnableConsoleOutput, &unset.EnableConsoleOutput),
 		handleParameterUpdateWithMapping(d, sdk.FunctionParameterLogLevel, &set.LogLevel, &unset.LogLevel, stringToStringEnumProvider(sdk.ToLogLevel)),

--- a/pkg/resources/function_python.go
+++ b/pkg/resources/function_python.go
@@ -17,7 +17,7 @@ func FunctionPython() *schema.Resource {
 		CreateContext: TrackingCreateWrapper(resources.FunctionPython, CreateContextFunctionPython),
 		ReadContext:   TrackingReadWrapper(resources.FunctionPython, ReadContextFunctionPython),
 		UpdateContext: TrackingUpdateWrapper(resources.FunctionPython, UpdateContextFunctionPython),
-		DeleteContext: TrackingDeleteWrapper(resources.FunctionPython, DeleteContextFunctionPython),
+		DeleteContext: TrackingDeleteWrapper(resources.FunctionPython, DeleteFunction),
 		Description:   "Resource used to manage python function objects. For more information, check [function documentation](https://docs.snowflake.com/en/sql-reference/sql/create-function).",
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.FunctionPython, customdiff.All(

--- a/pkg/resources/function_scala.go
+++ b/pkg/resources/function_scala.go
@@ -17,7 +17,7 @@ func FunctionScala() *schema.Resource {
 		CreateContext: TrackingCreateWrapper(resources.FunctionScala, CreateContextFunctionScala),
 		ReadContext:   TrackingReadWrapper(resources.FunctionScala, ReadContextFunctionScala),
 		UpdateContext: TrackingUpdateWrapper(resources.FunctionScala, UpdateContextFunctionScala),
-		DeleteContext: TrackingDeleteWrapper(resources.FunctionScala, DeleteContextFunctionScala),
+		DeleteContext: TrackingDeleteWrapper(resources.FunctionScala, DeleteFunction),
 		Description:   "Resource used to manage scala function objects. For more information, check [function documentation](https://docs.snowflake.com/en/sql-reference/sql/create-function).",
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.FunctionScala, customdiff.All(

--- a/pkg/resources/function_sql.go
+++ b/pkg/resources/function_sql.go
@@ -17,7 +17,7 @@ func FunctionSql() *schema.Resource {
 		CreateContext: TrackingCreateWrapper(resources.FunctionSql, CreateContextFunctionSql),
 		ReadContext:   TrackingReadWrapper(resources.FunctionSql, ReadContextFunctionSql),
 		UpdateContext: TrackingUpdateWrapper(resources.FunctionSql, UpdateContextFunctionSql),
-		DeleteContext: TrackingDeleteWrapper(resources.FunctionSql, DeleteContextFunctionSql),
+		DeleteContext: TrackingDeleteWrapper(resources.FunctionSql, DeleteFunction),
 		Description:   "Resource used to manage sql function objects. For more information, check [function documentation](https://docs.snowflake.com/en/sql-reference/sql/create-function).",
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.FunctionSql, customdiff.All(

--- a/pkg/resources/procedure.go
+++ b/pkg/resources/procedure.go
@@ -186,7 +186,7 @@ func Procedure() *schema.Resource {
 		CreateContext: TrackingCreateWrapper(resources.Procedure, CreateContextProcedure),
 		ReadContext:   TrackingReadWrapper(resources.Procedure, ReadContextProcedure),
 		UpdateContext: TrackingUpdateWrapper(resources.Procedure, UpdateContextProcedure),
-		DeleteContext: TrackingDeleteWrapper(resources.Procedure, DeleteContextProcedure),
+		DeleteContext: TrackingDeleteWrapper(resources.Procedure, DeleteProcedure),
 
 		// TODO(SNOW-1348106): add `arguments` to ComputedIfAnyAttributeChanged for FullyQualifiedNameAttributeName.
 		// This can't be done now because this function compares values without diff suppress.
@@ -712,20 +712,6 @@ func UpdateContextProcedure(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	return ReadContextProcedure(ctx, d, meta)
-}
-
-func DeleteContextProcedure(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.Context).Client
-
-	id, err := sdk.ParseSchemaObjectIdentifierWithArguments(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if err := client.Procedures.Drop(ctx, sdk.NewDropProcedureRequest(id).WithIfExists(true)); err != nil {
-		return diag.FromErr(err)
-	}
-	d.SetId("")
-	return nil
 }
 
 func getProcedureArguments(d *schema.ResourceData) ([]sdk.ProcedureArgumentRequest, diag.Diagnostics) {

--- a/pkg/resources/procedure_commons.go
+++ b/pkg/resources/procedure_commons.go
@@ -1,11 +1,14 @@
 package resources
 
 import (
+	"context"
 	"fmt"
 	"slices"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -340,4 +343,20 @@ func procedureBaseSchema() map[string]schema.Schema {
 		},
 		FullyQualifiedNameAttributeName: *schemas.FullyQualifiedNameSchema,
 	}
+}
+
+func DeleteProcedure(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	client := meta.(*provider.Context).Client
+
+	id, err := sdk.ParseSchemaObjectIdentifierWithArguments(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := client.Procedures.Drop(ctx, sdk.NewDropProcedureRequest(id).WithIfExists(true)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	return nil
 }

--- a/pkg/resources/procedure_commons.go
+++ b/pkg/resources/procedure_commons.go
@@ -338,7 +338,7 @@ func procedureBaseSchema() map[string]schema.Schema {
 			Computed:    true,
 			Description: "Outputs the result of `SHOW PARAMETERS IN PROCEDURE` for the given procedure.",
 			Elem: &schema.Resource{
-				Schema: procedureParametersSchema,
+				Schema: schemas.ShowProcedureParametersSchema,
 			},
 		},
 		FullyQualifiedNameAttributeName: *schemas.FullyQualifiedNameSchema,

--- a/pkg/resources/procedure_java.go
+++ b/pkg/resources/procedure_java.go
@@ -17,7 +17,7 @@ func ProcedureJava() *schema.Resource {
 		CreateContext: TrackingCreateWrapper(resources.ProcedureJava, CreateContextProcedureJava),
 		ReadContext:   TrackingReadWrapper(resources.ProcedureJava, ReadContextProcedureJava),
 		UpdateContext: TrackingUpdateWrapper(resources.ProcedureJava, UpdateContextProcedureJava),
-		DeleteContext: TrackingDeleteWrapper(resources.ProcedureJava, DeleteContextProcedureJava),
+		DeleteContext: TrackingDeleteWrapper(resources.ProcedureJava, DeleteProcedure),
 		Description:   "Resource used to manage java procedure objects. For more information, check [procedure documentation](https://docs.snowflake.com/en/sql-reference/sql/create-procedure).",
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.ProcedureJava, customdiff.All(
@@ -44,9 +44,5 @@ func ReadContextProcedureJava(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func UpdateContextProcedureJava(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	return nil
-}
-
-func DeleteContextProcedureJava(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	return nil
 }

--- a/pkg/resources/procedure_javascript.go
+++ b/pkg/resources/procedure_javascript.go
@@ -17,7 +17,7 @@ func ProcedureJavascript() *schema.Resource {
 		CreateContext: TrackingCreateWrapper(resources.ProcedureJavascript, CreateContextProcedureJavascript),
 		ReadContext:   TrackingReadWrapper(resources.ProcedureJavascript, ReadContextProcedureJavascript),
 		UpdateContext: TrackingUpdateWrapper(resources.ProcedureJavascript, UpdateContextProcedureJavascript),
-		DeleteContext: TrackingDeleteWrapper(resources.ProcedureJavascript, DeleteContextProcedureJavascript),
+		DeleteContext: TrackingDeleteWrapper(resources.ProcedureJavascript, DeleteProcedure),
 		Description:   "Resource used to manage javascript procedure objects. For more information, check [procedure documentation](https://docs.snowflake.com/en/sql-reference/sql/create-procedure).",
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.ProcedureJavascript, customdiff.All(
@@ -44,9 +44,5 @@ func ReadContextProcedureJavascript(ctx context.Context, d *schema.ResourceData,
 }
 
 func UpdateContextProcedureJavascript(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	return nil
-}
-
-func DeleteContextProcedureJavascript(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	return nil
 }

--- a/pkg/resources/procedure_python.go
+++ b/pkg/resources/procedure_python.go
@@ -17,7 +17,7 @@ func ProcedurePython() *schema.Resource {
 		CreateContext: TrackingCreateWrapper(resources.ProcedurePython, CreateContextProcedurePython),
 		ReadContext:   TrackingReadWrapper(resources.ProcedurePython, ReadContextProcedurePython),
 		UpdateContext: TrackingUpdateWrapper(resources.ProcedurePython, UpdateContextProcedurePython),
-		DeleteContext: TrackingDeleteWrapper(resources.ProcedurePython, DeleteContextProcedurePython),
+		DeleteContext: TrackingDeleteWrapper(resources.ProcedurePython, DeleteProcedure),
 		Description:   "Resource used to manage python procedure objects. For more information, check [procedure documentation](https://docs.snowflake.com/en/sql-reference/sql/create-procedure).",
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.ProcedurePython, customdiff.All(
@@ -44,9 +44,5 @@ func ReadContextProcedurePython(ctx context.Context, d *schema.ResourceData, met
 }
 
 func UpdateContextProcedurePython(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	return nil
-}
-
-func DeleteContextProcedurePython(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	return nil
 }

--- a/pkg/resources/procedure_scala.go
+++ b/pkg/resources/procedure_scala.go
@@ -17,7 +17,7 @@ func ProcedureScala() *schema.Resource {
 		CreateContext: TrackingCreateWrapper(resources.ProcedureScala, CreateContextProcedureScala),
 		ReadContext:   TrackingReadWrapper(resources.ProcedureScala, ReadContextProcedureScala),
 		UpdateContext: TrackingUpdateWrapper(resources.ProcedureScala, UpdateContextProcedureScala),
-		DeleteContext: TrackingDeleteWrapper(resources.ProcedureScala, DeleteContextProcedureScala),
+		DeleteContext: TrackingDeleteWrapper(resources.ProcedureScala, DeleteProcedure),
 		Description:   "Resource used to manage scala procedure objects. For more information, check [procedure documentation](https://docs.snowflake.com/en/sql-reference/sql/create-procedure).",
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.ProcedureScala, customdiff.All(
@@ -44,9 +44,5 @@ func ReadContextProcedureScala(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func UpdateContextProcedureScala(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	return nil
-}
-
-func DeleteContextProcedureScala(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	return nil
 }

--- a/pkg/resources/procedure_sql.go
+++ b/pkg/resources/procedure_sql.go
@@ -17,7 +17,7 @@ func ProcedureSql() *schema.Resource {
 		CreateContext: TrackingCreateWrapper(resources.ProcedureSql, CreateContextProcedureSql),
 		ReadContext:   TrackingReadWrapper(resources.ProcedureSql, ReadContextProcedureSql),
 		UpdateContext: TrackingUpdateWrapper(resources.ProcedureSql, UpdateContextProcedureSql),
-		DeleteContext: TrackingDeleteWrapper(resources.ProcedureSql, DeleteContextProcedureSql),
+		DeleteContext: TrackingDeleteWrapper(resources.ProcedureSql, DeleteProcedure),
 		Description:   "Resource used to manage sql procedure objects. For more information, check [procedure documentation](https://docs.snowflake.com/en/sql-reference/sql/create-procedure).",
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.ProcedureSql, customdiff.All(
@@ -44,9 +44,5 @@ func ReadContextProcedureSql(ctx context.Context, d *schema.ResourceData, meta a
 }
 
 func UpdateContextProcedureSql(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	return nil
-}
-
-func DeleteContextProcedureSql(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	return nil
 }

--- a/pkg/resources/resource_helpers_create.go
+++ b/pkg/resources/resource_helpers_create.go
@@ -12,6 +12,13 @@ func stringAttributeCreate(d *schema.ResourceData, key string, createField **str
 	return nil
 }
 
+func stringAttributeCreateBuilder[T any](d *schema.ResourceData, key string, setValue func(string) T) error {
+	if v, ok := d.GetOk(key); ok {
+		setValue(v.(string))
+	}
+	return nil
+}
+
 func intAttributeCreate(d *schema.ResourceData, key string, createField **int) error {
 	if v, ok := d.GetOk(key); ok {
 		*createField = sdk.Int(v.(int))
@@ -33,6 +40,17 @@ func booleanStringAttributeCreate(d *schema.ResourceData, key string, createFiel
 			return err
 		}
 		*createField = sdk.Bool(parsed)
+	}
+	return nil
+}
+
+func booleanStringAttributeCreateBuilder[T any](d *schema.ResourceData, key string, setValue func(bool) T) error {
+	if v := d.Get(key).(string); v != BooleanDefault {
+		parsed, err := booleanStringToBool(v)
+		if err != nil {
+			return err
+		}
+		setValue(parsed)
 	}
 	return nil
 }
@@ -69,6 +87,17 @@ func attributeMappedValueCreate[T any](d *schema.ResourceData, key string, creat
 			return err
 		}
 		*createField = value
+	}
+	return nil
+}
+
+func attributeMappedValueCreateBuilder[InputType any, MappedType any, RequestBuilder any](d *schema.ResourceData, key string, setValue func(MappedType) RequestBuilder, mapper func(value InputType) (MappedType, error)) error {
+	if v, ok := d.GetOk(key); ok {
+		value, err := mapper(v.(InputType))
+		if err != nil {
+			return err
+		}
+		setValue(value)
 	}
 	return nil
 }

--- a/pkg/resources/resource_helpers_read.go
+++ b/pkg/resources/resource_helpers_read.go
@@ -63,3 +63,12 @@ func attributeMappedValueReadOrDefault[T, R any](d *schema.ResourceData, key str
 	}
 	return d.Set(key, nil)
 }
+
+func setOptionalFromStringPtr(d *schema.ResourceData, key string, ptr *string) error {
+	if ptr != nil {
+		if err := d.Set(key, *ptr); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/resources/resource_helpers_read.go
+++ b/pkg/resources/resource_helpers_read.go
@@ -72,3 +72,13 @@ func setOptionalFromStringPtr(d *schema.ResourceData, key string, ptr *string) e
 	}
 	return nil
 }
+
+// TODO [this PR]: return error if nil
+func setRequiredFromStringPtr(d *schema.ResourceData, key string, ptr *string) error {
+	if ptr != nil {
+		if err := d.Set(key, *ptr); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/resources/resource_helpers_read.go
+++ b/pkg/resources/resource_helpers_read.go
@@ -73,7 +73,7 @@ func setOptionalFromStringPtr(d *schema.ResourceData, key string, ptr *string) e
 	return nil
 }
 
-// TODO [this PR]: return error if nil
+// TODO [SNOW-1348103]: return error if nil
 func setRequiredFromStringPtr(d *schema.ResourceData, key string, ptr *string) error {
 	if ptr != nil {
 		if err := d.Set(key, *ptr); err != nil {

--- a/pkg/resources/user.go
+++ b/pkg/resources/user.go
@@ -199,7 +199,6 @@ func User() *schema.Resource {
 		},
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.User, customdiff.All(
-			// TODO [SNOW-1629468 - next pr]: test "default_role", "default_secondary_roles"
 			ComputedIfAnyAttributeChanged(userSchema, ShowOutputAttributeName, userExternalChangesAttributes...),
 			ComputedIfAnyAttributeChanged(userParametersSchema, ParametersAttributeName, collections.Map(sdk.AsStringList(sdk.AllUserParameters), strings.ToLower)...),
 			ComputedIfAnyAttributeChanged(userSchema, FullyQualifiedNameAttributeName, "name"),

--- a/pkg/schemas/function_parameters.go
+++ b/pkg/schemas/function_parameters.go
@@ -1,0 +1,35 @@
+package schemas
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var (
+	ShowFunctionParametersSchema = make(map[string]*schema.Schema)
+	functionParameters           = []sdk.FunctionParameter{
+		sdk.FunctionParameterEnableConsoleOutput,
+		sdk.FunctionParameterLogLevel,
+		sdk.FunctionParameterMetricLevel,
+		sdk.FunctionParameterTraceLevel,
+	}
+)
+
+func init() {
+	for _, param := range functionParameters {
+		ShowFunctionParametersSchema[strings.ToLower(string(param))] = ParameterListSchema
+	}
+}
+
+func FunctionParametersToSchema(parameters []*sdk.Parameter) map[string]any {
+	functionParametersValue := make(map[string]any)
+	for _, param := range parameters {
+		if slices.Contains(functionParameters, sdk.FunctionParameter(param.Key)) {
+			functionParametersValue[strings.ToLower(param.Key)] = []map[string]any{ParameterToSchema(param)}
+		}
+	}
+	return functionParametersValue
+}

--- a/pkg/schemas/procedure_parameters.go
+++ b/pkg/schemas/procedure_parameters.go
@@ -1,0 +1,35 @@
+package schemas
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var (
+	ShowProcedureParametersSchema = make(map[string]*schema.Schema)
+	ProcedureParameters           = []sdk.ProcedureParameter{
+		sdk.ProcedureParameterEnableConsoleOutput,
+		sdk.ProcedureParameterLogLevel,
+		sdk.ProcedureParameterMetricLevel,
+		sdk.ProcedureParameterTraceLevel,
+	}
+)
+
+func init() {
+	for _, param := range ProcedureParameters {
+		ShowProcedureParametersSchema[strings.ToLower(string(param))] = ParameterListSchema
+	}
+}
+
+func ProcedureParametersToSchema(parameters []*sdk.Parameter) map[string]any {
+	ProcedureParametersValue := make(map[string]any)
+	for _, param := range parameters {
+		if slices.Contains(ProcedureParameters, sdk.ProcedureParameter(param.Key)) {
+			ProcedureParametersValue[strings.ToLower(param.Key)] = []map[string]any{ParameterToSchema(param)}
+		}
+	}
+	return ProcedureParametersValue
+}

--- a/pkg/sdk/data_types_deprecated.go
+++ b/pkg/sdk/data_types_deprecated.go
@@ -47,5 +47,9 @@ func IsStringType(_type string) bool {
 }
 
 func LegacyDataTypeFrom(newDataType datatypes.DataType) DataType {
+	// TODO [this PR]: remove this check?
+	if newDataType == nil {
+		return ""
+	}
 	return DataType(newDataType.ToLegacyDataTypeSql())
 }

--- a/pkg/sdk/data_types_deprecated.go
+++ b/pkg/sdk/data_types_deprecated.go
@@ -47,7 +47,7 @@ func IsStringType(_type string) bool {
 }
 
 func LegacyDataTypeFrom(newDataType datatypes.DataType) DataType {
-	// TODO [this PR]: remove this check?
+	// TODO [SNOW-1850370]: remove this check?
 	if newDataType == nil {
 		return ""
 	}

--- a/pkg/sdk/datatypes/legacy.go
+++ b/pkg/sdk/datatypes/legacy.go
@@ -16,4 +16,7 @@ const (
 	TimestampNtzLegacyDataType = "TIMESTAMP_NTZ"
 	TimestampTzLegacyDataType  = "TIMESTAMP_TZ"
 	VariantLegacyDataType      = "VARIANT"
+
+	// TableLegacyDataType was not a value of legacy data type in the old implementation. Left for now for an easier implementation.
+	TableLegacyDataType = "TABLE"
 )

--- a/pkg/sdk/datatypes/table.go
+++ b/pkg/sdk/datatypes/table.go
@@ -1,9 +1,9 @@
 package datatypes
 
-// TableDataType is based on TODO [this PR]
+// TableDataType is based on TODO [SNOW-1348103]
 // It does not have synonyms.
 // It consists of a list of column name + column type; may be empty.
-// TODO [this PR]: test and improve
+// TODO [SNOW-1348103]: test and improve
 type TableDataType struct {
 	columns        []TableDataTypeColumn
 	underlyingType string

--- a/pkg/sdk/datatypes/table.go
+++ b/pkg/sdk/datatypes/table.go
@@ -1,0 +1,39 @@
+package datatypes
+
+// TableDataType is based on TODO [this PR]
+// It does not have synonyms.
+// It consists of a list of column name + column type; may be empty.
+// TODO [this PR]: test and improve
+type TableDataType struct {
+	columns        []TableDataTypeColumn
+	underlyingType string
+}
+
+type TableDataTypeColumn struct {
+	name     string
+	dataType DataType
+}
+
+func (c *TableDataTypeColumn) ColumnName() string {
+	return c.name
+}
+
+func (c *TableDataTypeColumn) ColumnType() DataType {
+	return c.dataType
+}
+
+func (t *TableDataType) ToSql() string {
+	return t.underlyingType
+}
+
+func (t *TableDataType) ToLegacyDataTypeSql() string {
+	return TableLegacyDataType
+}
+
+func (t *TableDataType) Canonical() string {
+	return TableLegacyDataType
+}
+
+func (t *TableDataType) Columns() []TableDataTypeColumn {
+	return t.columns
+}

--- a/pkg/sdk/functions_ext.go
+++ b/pkg/sdk/functions_ext.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 )
@@ -103,6 +104,7 @@ func parseFunctionDetailsImport(details FunctionDetails) ([]FunctionDetailsImpor
 	raw := (*details.Imports)[1 : len(*details.Imports)-1]
 	imports := strings.Split(raw, ",")
 	for _, imp := range imports {
+		log.Printf("[DEBUG] parsing imports part: %s", imp)
 		idx := strings.Index(imp, "/")
 		if idx < 0 {
 			return functionDetailsImports, fmt.Errorf("could not parse imports from Snowflake: %s, part %s cannot be split into stage and path", *details.Imports, imp)

--- a/pkg/sdk/functions_ext.go
+++ b/pkg/sdk/functions_ext.go
@@ -38,6 +38,7 @@ type FunctionDetails struct {
 	NormalizedImports    []NormalizedPath
 	NormalizedTargetPath *NormalizedPath
 	ReturnDataType       datatypes.DataType
+	ReturnNotNull        bool
 	NormalizedArguments  []NormalizedArgument
 }
 
@@ -113,7 +114,7 @@ func functionDetailsFromRows(rows []FunctionDetail) (*FunctionDetails, error) {
 		errs = append(errs, err)
 	} else {
 		v.ReturnDataType = dt
-		_ = returnNotNull // TODO [next PR]: used when adding return nullability to the resource
+		v.ReturnNotNull = returnNotNull
 	}
 
 	if args, err := parseFunctionOrProcedureSignature(v.Signature); err != nil {

--- a/pkg/sdk/functions_ext.go
+++ b/pkg/sdk/functions_ext.go
@@ -126,6 +126,7 @@ func functionDetailsFromRows(rows []FunctionDetail) (*FunctionDetails, error) {
 	return v, errors.Join(errs...)
 }
 
+// TODO [SNOW-1850370]: use ParseCommaSeparatedStringArray + collections.MapErr combo here and in other methods?
 func parseFunctionDetailsImport(details FunctionDetails) ([]NormalizedPath, error) {
 	functionDetailsImports := make([]NormalizedPath, 0)
 	if details.Imports == nil || *details.Imports == "" || *details.Imports == "[]" {

--- a/pkg/sdk/functions_ext.go
+++ b/pkg/sdk/functions_ext.go
@@ -109,14 +109,14 @@ func functionDetailsFromRows(rows []FunctionDetail) (*FunctionDetails, error) {
 		}
 	}
 
-	if dt, returnNotNull, err := parseFunctionAndProcedureReturns(v.Returns); err != nil {
+	if dt, returnNotNull, err := parseFunctionOrProcedureReturns(v.Returns); err != nil {
 		errs = append(errs, err)
 	} else {
 		v.ReturnDataType = dt
 		_ = returnNotNull // TODO [next PR]: used when adding return nullability to the resource
 	}
 
-	if args, err := parseFunctionAndProcedureSignature(v.Signature); err != nil {
+	if args, err := parseFunctionOrProcedureSignature(v.Signature); err != nil {
 		errs = append(errs, err)
 	} else {
 		v.NormalizedArguments = args
@@ -166,7 +166,7 @@ func parseStageLocationPath(location string) (*NormalizedPath, error) {
 	return &NormalizedPath{stageRaw, pathRaw}, nil
 }
 
-func parseFunctionAndProcedureReturns(returns string) (datatypes.DataType, bool, error) {
+func parseFunctionOrProcedureReturns(returns string) (datatypes.DataType, bool, error) {
 	var returnNotNull bool
 	trimmed := strings.TrimSpace(returns)
 	if strings.HasSuffix(trimmed, " NOT NULL") {
@@ -178,7 +178,7 @@ func parseFunctionAndProcedureReturns(returns string) (datatypes.DataType, bool,
 }
 
 // Format in Snowflake DB is: (argName argType, argName argType, ...).
-func parseFunctionAndProcedureSignature(signature string) ([]NormalizedArgument, error) {
+func parseFunctionOrProcedureSignature(signature string) ([]NormalizedArgument, error) {
 	normalizedArguments := make([]NormalizedArgument, 0)
 	trimmed := strings.TrimSpace(signature)
 	if trimmed == "" {

--- a/pkg/sdk/functions_ext.go
+++ b/pkg/sdk/functions_ext.go
@@ -204,7 +204,7 @@ func parseFunctionOrProcedureSignature(signature string) ([]NormalizedArgument, 
 	return normalizedArguments, nil
 }
 
-// TODO [next PR]: test with strange arg names (first integration test)
+// TODO [SNOW-1850370]: test with strange arg names (first integration test)
 func parseFunctionOrProcedureArgument(arg string) (*NormalizedArgument, error) {
 	log.Printf("[DEBUG] parsing argument: %s", arg)
 	trimmed := strings.TrimSpace(arg)

--- a/pkg/sdk/functions_ext.go
+++ b/pkg/sdk/functions_ext.go
@@ -29,7 +29,7 @@ type FunctionDetails struct {
 	Handler                    *string // present for python, java, and scala (hidden when SECURE)
 	RuntimeVersion             *string // present for python, java, and scala (hidden when SECURE)
 	Packages                   *string // list // present for python, java, and scala
-	TargetPath                 *string // list present for scala and java (hidden when SECURE)
+	TargetPath                 *string // present for scala and java (hidden when SECURE)
 	InstalledPackages          *string // list present for python (hidden when SECURE)
 	IsAggregate                *bool   // present for python
 
@@ -91,10 +91,12 @@ func functionDetailsFromRows(rows []FunctionDetail) (*FunctionDetails, error) {
 		v.NormalizedImports = functionDetailsImports
 	}
 
-	if p, err := parseStageLocationPath(*v.TargetPath); err != nil {
-		errs = append(errs, err)
-	} else {
-		v.NormalizedTargetPath = p
+	if v.TargetPath != nil {
+		if p, err := parseStageLocationPath(*v.TargetPath); err != nil {
+			errs = append(errs, err)
+		} else {
+			v.NormalizedTargetPath = p
+		}
 	}
 
 	return v, errors.Join(errs...)

--- a/pkg/sdk/functions_ext_test.go
+++ b/pkg/sdk/functions_ext_test.go
@@ -10,17 +10,17 @@ import (
 func Test_parseFunctionDetailsImport(t *testing.T) {
 	inputs := []struct {
 		rawInput string
-		expected []FunctionDetailsImport
+		expected []NormalizedPath
 	}{
-		{"", []FunctionDetailsImport{}},
-		{`[]`, []FunctionDetailsImport{}},
-		{`[@~/abc]`, []FunctionDetailsImport{{"~", "abc"}}},
-		{`[@~/abc/def]`, []FunctionDetailsImport{{"~", "abc/def"}}},
-		{`[@"db"."sc"."st"/abc/def]`, []FunctionDetailsImport{{`"db"."sc"."st"`, "abc/def"}}},
-		{`[@db.sc.st/abc/def]`, []FunctionDetailsImport{{`"db"."sc"."st"`, "abc/def"}}},
-		{`[db.sc.st/abc/def]`, []FunctionDetailsImport{{`"db"."sc"."st"`, "abc/def"}}},
-		{`[@"db"."sc".st/abc/def]`, []FunctionDetailsImport{{`"db"."sc"."st"`, "abc/def"}}},
-		{`[@"db"."sc".st/abc/def, db."sc".st/abc]`, []FunctionDetailsImport{{`"db"."sc"."st"`, "abc/def"}, {`"db"."sc"."st"`, "abc"}}},
+		{"", []NormalizedPath{}},
+		{`[]`, []NormalizedPath{}},
+		{`[@~/abc]`, []NormalizedPath{{"~", "abc"}}},
+		{`[@~/abc/def]`, []NormalizedPath{{"~", "abc/def"}}},
+		{`[@"db"."sc"."st"/abc/def]`, []NormalizedPath{{`"db"."sc"."st"`, "abc/def"}}},
+		{`[@db.sc.st/abc/def]`, []NormalizedPath{{`"db"."sc"."st"`, "abc/def"}}},
+		{`[db.sc.st/abc/def]`, []NormalizedPath{{`"db"."sc"."st"`, "abc/def"}}},
+		{`[@"db"."sc".st/abc/def]`, []NormalizedPath{{`"db"."sc"."st"`, "abc/def"}}},
+		{`[@"db"."sc".st/abc/def, db."sc".st/abc]`, []NormalizedPath{{`"db"."sc"."st"`, "abc/def"}, {`"db"."sc"."st"`, "abc"}}},
 	}
 
 	badInputs := []struct {

--- a/pkg/sdk/functions_ext_test.go
+++ b/pkg/sdk/functions_ext_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func Test_parseFunctionDetailsImport(t *testing.T) {
-
 	inputs := []struct {
 		rawInput string
 		expected []FunctionDetailsImport

--- a/pkg/sdk/functions_ext_test.go
+++ b/pkg/sdk/functions_ext_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TODO [next PR]: test parsing single
+// TODO [SNOW-1850370]: test parsing single
 func Test_parseFunctionDetailsImport(t *testing.T) {
 	inputs := []struct {
 		rawInput string

--- a/pkg/sdk/functions_ext_test.go
+++ b/pkg/sdk/functions_ext_test.go
@@ -1,0 +1,64 @@
+package sdk
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parseFunctionDetailsImport(t *testing.T) {
+
+	inputs := []struct {
+		rawInput string
+		expected []FunctionDetailsImport
+	}{
+		{"", []FunctionDetailsImport{}},
+		{`[]`, []FunctionDetailsImport{}},
+		{`[@~/abc]`, []FunctionDetailsImport{{"~", "abc"}}},
+		{`[@~/abc/def]`, []FunctionDetailsImport{{"~", "abc/def"}}},
+		{`[@"db"."sc"."st"/abc/def]`, []FunctionDetailsImport{{`"db"."sc"."st"`, "abc/def"}}},
+		{`[@db.sc.st/abc/def]`, []FunctionDetailsImport{{`"db"."sc"."st"`, "abc/def"}}},
+		{`[db.sc.st/abc/def]`, []FunctionDetailsImport{{`"db"."sc"."st"`, "abc/def"}}},
+		{`[@"db"."sc".st/abc/def]`, []FunctionDetailsImport{{`"db"."sc"."st"`, "abc/def"}}},
+		{`[@"db"."sc".st/abc/def, db."sc".st/abc]`, []FunctionDetailsImport{{`"db"."sc"."st"`, "abc/def"}, {`"db"."sc"."st"`, "abc"}}},
+	}
+
+	badInputs := []struct {
+		rawInput          string
+		expectedErrorPart string
+	}{
+		{"[", "brackets not find"},
+		{"]", "brackets not find"},
+		{`[@~/]`, "contains empty path"},
+		{`[@~]`, "cannot be split into stage and path"},
+		{`[@"db"."sc"/abc]`, "contains incorrect stage location"},
+		{`[@"db"/abc]`, "contains incorrect stage location"},
+		{`[@"db"."sc"."st"."smth"/abc]`, "contains incorrect stage location"},
+		{`[@"db/a"."sc"."st"/abc]`, "contains incorrect stage location"},
+		{`[@"db"."sc"."st"/abc], @"db"."sc"/abc]`, "contains incorrect stage location"},
+	}
+
+	for _, tc := range inputs {
+		tc := tc
+		t.Run(fmt.Sprintf("Snowflake raw imports: %s", tc.rawInput), func(t *testing.T) {
+			details := FunctionDetails{Imports: &tc.rawInput}
+
+			results, err := parseFunctionDetailsImport(details)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, results)
+		})
+	}
+
+	for _, tc := range badInputs {
+		tc := tc
+		t.Run(fmt.Sprintf("incorrect Snowflake input: %s, expecting error with: %s", tc.rawInput, tc.expectedErrorPart), func(t *testing.T) {
+			details := FunctionDetails{Imports: &tc.rawInput}
+
+			_, err := parseFunctionDetailsImport(details)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "could not parse imports from Snowflake")
+			require.ErrorContains(t, err, tc.expectedErrorPart)
+		})
+	}
+}

--- a/pkg/sdk/functions_ext_test.go
+++ b/pkg/sdk/functions_ext_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO [next PR]: test nil, test parsing single
 func Test_parseFunctionDetailsImport(t *testing.T) {
 	inputs := []struct {
 		rawInput string

--- a/pkg/sdk/identifier_helpers.go
+++ b/pkg/sdk/identifier_helpers.go
@@ -212,7 +212,7 @@ type SchemaObjectIdentifier struct {
 	databaseName string
 	schemaName   string
 	name         string
-	// TODO(next prs): left right now for backward compatibility for procedures and externalFunctions
+	// TODO [SNOW-1850370]: left right now for backward compatibility for procedures and externalFunctions
 	arguments []DataType
 }
 

--- a/pkg/sdk/identifier_helpers.go
+++ b/pkg/sdk/identifier_helpers.go
@@ -349,7 +349,7 @@ func NewSchemaObjectIdentifierWithArgumentsNormalized(databaseName, schemaName, 
 		databaseName:      strings.Trim(databaseName, `"`),
 		schemaName:        strings.Trim(schemaName, `"`),
 		name:              strings.Trim(name, `"`),
-		argumentDataTypes: collections.Map(argumentDataTypes, func(dt datatypes.DataType) DataType { return LegacyDataTypeFrom(dt) }),
+		argumentDataTypes: collections.Map(argumentDataTypes, LegacyDataTypeFrom),
 	}
 }
 

--- a/pkg/sdk/identifier_helpers.go
+++ b/pkg/sdk/identifier_helpers.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 )
 
@@ -340,6 +341,15 @@ func NewSchemaObjectIdentifierWithArguments(databaseName, schemaName, name strin
 		schemaName:        strings.Trim(schemaName, `"`),
 		name:              strings.Trim(name, `"`),
 		argumentDataTypes: normalizedArguments,
+	}
+}
+
+func NewSchemaObjectIdentifierWithArgumentsNormalized(databaseName, schemaName, name string, argumentDataTypes ...datatypes.DataType) SchemaObjectIdentifierWithArguments {
+	return SchemaObjectIdentifierWithArguments{
+		databaseName:      strings.Trim(databaseName, `"`),
+		schemaName:        strings.Trim(schemaName, `"`),
+		name:              strings.Trim(name, `"`),
+		argumentDataTypes: collections.Map(argumentDataTypes, func(dt datatypes.DataType) DataType { return LegacyDataTypeFrom(dt) }),
 	}
 }
 

--- a/pkg/sdk/random_test.go
+++ b/pkg/sdk/random_test.go
@@ -17,10 +17,14 @@ var (
 	emptySchemaObjectIdentifierWithArguments = NewSchemaObjectIdentifierWithArguments("", "", "")
 
 	// TODO [SNOW-1843440]: create using constructors (when we add them)?
-	dataTypeNumber, _  = datatypes.ParseDataType("NUMBER(36, 2)")
-	dataTypeVarchar, _ = datatypes.ParseDataType("VARCHAR(100)")
-	dataTypeFloat, _   = datatypes.ParseDataType("FLOAT")
-	dataTypeVariant, _ = datatypes.ParseDataType("VARIANT")
+	dataTypeNumber, _                     = datatypes.ParseDataType("NUMBER(36, 2)")
+	dataTypeVarchar, _                    = datatypes.ParseDataType("VARCHAR(100)")
+	dataTypeFloat, _                      = datatypes.ParseDataType("FLOAT")
+	dataTypeVariant, _                    = datatypes.ParseDataType("VARIANT")
+	dataTypeChar, _                       = datatypes.ParseDataType("CHAR")
+	dataTypeChar_100, _                   = datatypes.ParseDataType("CHAR(100)")
+	dataTypeDoublePrecision, _            = datatypes.ParseDataType("DOUBLE PRECISION")
+	dataTypeTimestampWithoutTimeZone_5, _ = datatypes.ParseDataType("TIMESTAMP WITHOUT TIME ZONE(5)")
 )
 
 func randomSchemaObjectIdentifierWithArguments(argumentDataTypes ...DataType) SchemaObjectIdentifierWithArguments {

--- a/pkg/sdk/testint/functions_integration_test.go
+++ b/pkg/sdk/testint/functions_integration_test.go
@@ -220,7 +220,7 @@ func TestInt_Functions(t *testing.T) {
 			// TODO [SNOW-1348103]: check multiple secrets (to know how to parse)
 			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}).
 			HasImports(fmt.Sprintf(`[%s]`, tmpJavaFunction.JarLocation())).
-			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+			HasExactlyImportsNormalizedInAnyOrder(sdk.NormalizedPath{
 				StageLocation: "~", PathOnStage: tmpJavaFunction.JarName,
 			}).
 			HasHandler(handler).
@@ -293,7 +293,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImports(fmt.Sprintf(`[%s]`, importPath)).
-			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+			HasExactlyImportsNormalizedInAnyOrder(sdk.NormalizedPath{
 				StageLocation: "~", PathOnStage: tmpJavaFunction.JarName,
 			}).
 			HasHandler(handler).
@@ -378,7 +378,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
 			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}).
 			HasImports(fmt.Sprintf(`[%s]`, tmpJavaFunction.JarLocation())).
-			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+			HasExactlyImportsNormalizedInAnyOrder(sdk.NormalizedPath{
 				StageLocation: "~", PathOnStage: tmpJavaFunction.JarName,
 			}).
 			HasHandler(handler).
@@ -451,7 +451,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImports(fmt.Sprintf(`[@"%s"."%s".%s/%s]`, stage.ID().DatabaseName(), stage.ID().SchemaName(), stage.ID().Name(), tmpJavaFunctionDifferentStage.JarName)).
-			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+			HasExactlyImportsNormalizedInAnyOrder(sdk.NormalizedPath{
 				StageLocation: stage.ID().FullyQualifiedName(), PathOnStage: tmpJavaFunctionDifferentStage.JarName,
 			}).
 			HasHandler(handler).
@@ -749,7 +749,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
 			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}).
 			HasImports(fmt.Sprintf(`[%s]`, tmpPythonFunction.PythonModuleLocation())).
-			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+			HasExactlyImportsNormalizedInAnyOrder(sdk.NormalizedPath{
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(funcName).
@@ -819,7 +819,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImports(fmt.Sprintf(`[%s]`, tmpPythonFunction.PythonModuleLocation())).
-			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+			HasExactlyImportsNormalizedInAnyOrder(sdk.NormalizedPath{
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
@@ -901,7 +901,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
 			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}).
 			HasImports(fmt.Sprintf(`[%s]`, tmpPythonFunction.PythonModuleLocation())).
-			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+			HasExactlyImportsNormalizedInAnyOrder(sdk.NormalizedPath{
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
@@ -1066,7 +1066,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
 			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}).
 			HasImports(fmt.Sprintf(`[%s]`, tmpJavaFunction.JarLocation())).
-			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+			HasExactlyImportsNormalizedInAnyOrder(sdk.NormalizedPath{
 				StageLocation: "~", PathOnStage: tmpJavaFunction.JarName,
 			}).
 			HasHandler(handler).
@@ -1137,7 +1137,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImports(fmt.Sprintf(`[%s]`, importPath)).
-			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+			HasExactlyImportsNormalizedInAnyOrder(sdk.NormalizedPath{
 				StageLocation: "~", PathOnStage: tmpJavaFunction.JarName,
 			}).
 			HasHandler(handler).
@@ -1219,7 +1219,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
 			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}).
 			HasImports(fmt.Sprintf(`[%s]`, tmpJavaFunction.JarLocation())).
-			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+			HasExactlyImportsNormalizedInAnyOrder(sdk.NormalizedPath{
 				StageLocation: "~", PathOnStage: tmpJavaFunction.JarName,
 			}).
 			HasHandler(handler).

--- a/pkg/sdk/testint/functions_integration_test.go
+++ b/pkg/sdk/testint/functions_integration_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TODO [SNOW-1348103]: schemaName and catalog name are quoted (because we use lowercase)
 // TODO [SNOW-1850370]: HasArgumentsRawFrom(functionId, arguments, return)
 // TODO [SNOW-1850370]: extract show assertions with commons fields
 // TODO [SNOW-1850370]: test confirming that runtime version is required for Scala function
@@ -34,6 +33,7 @@ import (
 // TODO [SNOW-1348103]: add a test documenting that we can't set parameters in create (and revert adding these parameters directly in object...)
 // TODO [SNOW-1850370]: active warehouse vs validations
 // TODO [SNOW-1348103]: add a test documenting STRICT behavior
+// TODO [next PR]: add test with multiple imports
 func TestInt_Functions(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
@@ -441,6 +441,9 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImports(fmt.Sprintf(`[@"%s"."%s".%s/%s]`, stage.ID().DatabaseName(), stage.ID().SchemaName(), stage.ID().Name(), tmpJavaFunctionDifferentStage.JarName)).
+			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+				StageLocation: stage.ID().FullyQualifiedName(), PathOnStage: tmpJavaFunctionDifferentStage.JarName,
+			}).
 			HasHandler(handler).
 			HasRuntimeVersionNil().
 			HasPackages(`[]`).

--- a/pkg/sdk/testint/functions_integration_test.go
+++ b/pkg/sdk/testint/functions_integration_test.go
@@ -123,6 +123,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImports(`[]`).
+			HasExactlyImportsNormalizedInAnyOrder().
 			HasHandler(handler).
 			HasRuntimeVersionNil().
 			HasPackages(`[]`).
@@ -219,6 +220,9 @@ func TestInt_Functions(t *testing.T) {
 			// TODO [SNOW-1348103]: check multiple secrets (to know how to parse)
 			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}).
 			HasImports(fmt.Sprintf(`[%s]`, tmpJavaFunction.JarLocation())).
+			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+				StageLocation: "~", PathOnStage: tmpJavaFunction.JarName,
+			}).
 			HasHandler(handler).
 			HasRuntimeVersion("11").
 			HasPackages(`[com.snowflake:snowpark:1.14.0,com.snowflake:telemetry:0.1.0]`).
@@ -289,6 +293,9 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImports(fmt.Sprintf(`[%s]`, importPath)).
+			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+				StageLocation: "~", PathOnStage: tmpJavaFunction.JarName,
+			}).
 			HasHandler(handler).
 			HasRuntimeVersionNil().
 			HasPackages(`[]`).
@@ -371,6 +378,9 @@ func TestInt_Functions(t *testing.T) {
 			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
 			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}).
 			HasImports(fmt.Sprintf(`[%s]`, tmpJavaFunction.JarLocation())).
+			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+				StageLocation: "~", PathOnStage: tmpJavaFunction.JarName,
+			}).
 			HasHandler(handler).
 			HasRuntimeVersion("11").
 			HasPackages(`[com.snowflake:snowpark:1.14.0,com.snowflake:telemetry:0.1.0]`).
@@ -512,6 +522,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImportsNil().
+			HasExactlyImportsNormalizedInAnyOrder().
 			HasHandlerNil().
 			HasRuntimeVersionNil().
 			HasPackagesNil().
@@ -585,6 +596,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImportsNil().
+			HasExactlyImportsNormalizedInAnyOrder().
 			HasHandlerNil().
 			HasRuntimeVersionNil().
 			HasPackagesNil().
@@ -654,6 +666,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImports(`[]`).
+			HasExactlyImportsNormalizedInAnyOrder().
 			HasHandler(funcName).
 			HasRuntimeVersion("3.8").
 			HasPackages(`[]`).
@@ -736,6 +749,9 @@ func TestInt_Functions(t *testing.T) {
 			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
 			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}).
 			HasImports(fmt.Sprintf(`[%s]`, tmpPythonFunction.PythonModuleLocation())).
+			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
+			}).
 			HasHandler(funcName).
 			HasRuntimeVersion("3.8").
 			HasPackages(`['absl-py==0.10.0','about-time==4.2.1']`).
@@ -803,6 +819,9 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImports(fmt.Sprintf(`[%s]`, tmpPythonFunction.PythonModuleLocation())).
+			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
+			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
 			HasRuntimeVersion("3.8").
 			HasPackages(`[]`).
@@ -882,6 +901,9 @@ func TestInt_Functions(t *testing.T) {
 			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
 			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}).
 			HasImports(fmt.Sprintf(`[%s]`, tmpPythonFunction.PythonModuleLocation())).
+			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
+			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
 			HasRuntimeVersion("3.8").
 			HasPackages(`['absl-py==0.10.0','about-time==4.2.1']`).
@@ -952,6 +974,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImports(`[]`).
+			HasExactlyImportsNormalizedInAnyOrder().
 			HasHandler(handler).
 			HasRuntimeVersion("2.12").
 			HasPackages(`[]`).
@@ -1043,6 +1066,9 @@ func TestInt_Functions(t *testing.T) {
 			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
 			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}).
 			HasImports(fmt.Sprintf(`[%s]`, tmpJavaFunction.JarLocation())).
+			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+				StageLocation: "~", PathOnStage: tmpJavaFunction.JarName,
+			}).
 			HasHandler(handler).
 			HasRuntimeVersion("2.12").
 			HasPackages(`[com.snowflake:snowpark:1.14.0,com.snowflake:telemetry:0.1.0]`).
@@ -1111,6 +1137,9 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImports(fmt.Sprintf(`[%s]`, importPath)).
+			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+				StageLocation: "~", PathOnStage: tmpJavaFunction.JarName,
+			}).
 			HasHandler(handler).
 			HasRuntimeVersion("2.12").
 			HasPackages(`[]`).
@@ -1190,6 +1219,9 @@ func TestInt_Functions(t *testing.T) {
 			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
 			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}).
 			HasImports(fmt.Sprintf(`[%s]`, tmpJavaFunction.JarLocation())).
+			HasExactlyImportsNormalizedInAnyOrder(sdk.FunctionDetailsImport{
+				StageLocation: "~", PathOnStage: tmpJavaFunction.JarName,
+			}).
 			HasHandler(handler).
 			HasRuntimeVersion("2.12").
 			HasPackages(`[com.snowflake:snowpark:1.14.0,com.snowflake:telemetry:0.1.0]`).
@@ -1257,6 +1289,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImportsNil().
+			HasExactlyImportsNormalizedInAnyOrder().
 			HasHandlerNil().
 			HasRuntimeVersionNil().
 			HasPackagesNil().
@@ -1332,6 +1365,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImportsNil().
+			HasExactlyImportsNormalizedInAnyOrder().
 			HasHandlerNil().
 			HasRuntimeVersionNil().
 			HasPackagesNil().
@@ -1396,6 +1430,7 @@ func TestInt_Functions(t *testing.T) {
 			HasExternalAccessIntegrationsNil().
 			HasSecretsNil().
 			HasImportsNil().
+			HasExactlyImportsNormalizedInAnyOrder().
 			HasHandlerNil().
 			HasRuntimeVersionNil().
 			HasPackagesNil().

--- a/pkg/sdk/testint/functions_integration_test.go
+++ b/pkg/sdk/testint/functions_integration_test.go
@@ -33,7 +33,7 @@ import (
 // TODO [SNOW-1348103]: test weird names for arg name - lower/upper if used with double quotes, to upper without quotes, dots, spaces, and both quotes not permitted
 // TODO [SNOW-1348103]: test secure
 // TODO [SNOW-1348103]: python aggregate func (100357 (P0000): Could not find accumulate method in function CVVEMHIT_06547800_08D6_DBCA_1AC7_5E422AFF8B39 with handler dump)
-// TODO [next PR]: add test with multiple imports
+// TODO [SNOW-1348103]: add test with multiple imports
 func TestInt_Functions(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()

--- a/pkg/sdk/testint/functions_integration_test.go
+++ b/pkg/sdk/testint/functions_integration_test.go
@@ -34,6 +34,7 @@ import (
 // TODO [SNOW-1850370]: active warehouse vs validations
 // TODO [SNOW-1348103]: add a test documenting STRICT behavior
 // TODO [next PR]: add test with multiple imports
+// TODO [this PR]: add assertion to each test for the normalized target path, returned data type, and return not null
 func TestInt_Functions(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()

--- a/pkg/sdk/testint/functions_integration_test.go
+++ b/pkg/sdk/testint/functions_integration_test.go
@@ -23,18 +23,17 @@ import (
 // TODO [SNOW-1850370]: HasArgumentsRawFrom(functionId, arguments, return)
 // TODO [SNOW-1850370]: extract show assertions with commons fields
 // TODO [SNOW-1850370]: test confirming that runtime version is required for Scala function
-// TODO [SNOW-1348103 or SNOW-1850370]: test create or replace with name change, args change
-// TODO [SNOW-1348103]: test rename more (arg stays, can't change arg, rename to different schema)
-// TODO [SNOW-1348103]: test weird names for arg name - lower/upper if used with double quotes, to upper without quotes, dots, spaces, and both quotes not permitted
+// TODO [SNOW-1850370]: test create or replace with name change, args change
+// TODO [SNOW-1850370]: test rename more (arg stays, can't change arg, rename to different schema)
 // TODO [SNOW-1850370]: add test documenting that UNSET SECRETS does not work
 // TODO [SNOW-1850370]: add test documenting [JAVA]: 391516 (42601): SQL compilation error: Cannot specify TARGET_PATH without a function BODY.
-// TODO [SNOW-1348103 or SNOW-1850370]: test secure
-// TODO [SNOW-1348103]: python aggregate func (100357 (P0000): Could not find accumulate method in function CVVEMHIT_06547800_08D6_DBCA_1AC7_5E422AFF8B39 with handler dump)
-// TODO [SNOW-1348103]: add a test documenting that we can't set parameters in create (and revert adding these parameters directly in object...)
+// TODO [SNOW-1850370]: add a test documenting that we can't set parameters in create (and revert adding these parameters directly in object...)
 // TODO [SNOW-1850370]: active warehouse vs validations
-// TODO [SNOW-1348103]: add a test documenting STRICT behavior
+// TODO [SNOW-1850370]: add a test documenting STRICT behavior
+// TODO [SNOW-1348103]: test weird names for arg name - lower/upper if used with double quotes, to upper without quotes, dots, spaces, and both quotes not permitted
+// TODO [SNOW-1348103]: test secure
+// TODO [SNOW-1348103]: python aggregate func (100357 (P0000): Could not find accumulate method in function CVVEMHIT_06547800_08D6_DBCA_1AC7_5E422AFF8B39 with handler dump)
 // TODO [next PR]: add test with multiple imports
-// TODO [this PR]: add assertion to each test for the normalized target path, returned data type, and return not null
 func TestInt_Functions(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
@@ -117,6 +116,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(dataType.ToSql()).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(false).
 			HasLanguage("JAVA").
 			HasBody(definition).
 			HasNullHandling(string(sdk.NullInputBehaviorCalledOnNullInput)).
@@ -129,6 +130,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersionNil().
 			HasPackages(`[]`).
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)
@@ -212,6 +214,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(fmt.Sprintf(`%s NOT NULL`, dataType.ToSql())).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(true).
 			HasLanguage("JAVA").
 			HasBody(definition).
 			HasNullHandling(string(sdk.NullInputBehaviorReturnsNullInput)).
@@ -228,6 +232,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersion("11").
 			HasPackages(`[com.snowflake:snowpark:1.14.0,com.snowflake:telemetry:0.1.0]`).
 			HasTargetPath(targetPath).
+			HasNormalizedTargetPath("~", jarName).
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)
@@ -287,6 +292,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(dataType.ToSql()).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(false).
 			HasLanguage("JAVA").
 			HasBodyNil().
 			HasNullHandling(string(sdk.NullInputBehaviorCalledOnNullInput)).
@@ -301,6 +308,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersionNil().
 			HasPackages(`[]`).
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)
@@ -372,6 +380,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(fmt.Sprintf(`%s NOT NULL`, dataType.ToSql())).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(true).
 			HasLanguage("JAVA").
 			HasBodyNil().
 			HasNullHandling(string(sdk.NullInputBehaviorReturnsNullInput)).
@@ -386,6 +396,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersion("11").
 			HasPackages(`[com.snowflake:snowpark:1.14.0,com.snowflake:telemetry:0.1.0]`).
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)
@@ -445,6 +456,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(dataType.ToSql()).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(false).
 			HasLanguage("JAVA").
 			HasBodyNil().
 			HasNullHandling(string(sdk.NullInputBehaviorCalledOnNullInput)).
@@ -459,6 +472,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersionNil().
 			HasPackages(`[]`).
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)
@@ -550,6 +564,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(dataType.ToSql()).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(false).
 			HasLanguage("JAVASCRIPT").
 			HasBody(definition).
 			HasNullHandling(string(sdk.NullInputBehaviorCalledOnNullInput)).
@@ -562,6 +578,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersionNil().
 			HasPackagesNil().
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)
@@ -624,6 +641,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(fmt.Sprintf(`%s NOT NULL`, dataType.ToSql())).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(true).
 			HasLanguage("JAVASCRIPT").
 			HasBody(definition).
 			HasNullHandling(string(sdk.NullInputBehaviorReturnsNullInput)).
@@ -636,6 +655,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersionNil().
 			HasPackagesNil().
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)
@@ -693,7 +713,9 @@ func TestInt_Functions(t *testing.T) {
 
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
-			HasReturns(strings.ReplaceAll(dataType.ToSql(), " ", "")). // TODO [SNOW-1348103]: do we care about this whitespace?
+			HasReturns(strings.ReplaceAll(dataType.ToSql(), " ", "")).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(false).
 			HasLanguage("PYTHON").
 			HasBody(definition).
 			HasNullHandling(string(sdk.NullInputBehaviorCalledOnNullInput)).
@@ -706,6 +728,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersion("3.8").
 			HasPackages(`[]`).
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNotEmpty().
 			HasIsAggregate(false),
 		)
@@ -776,7 +799,9 @@ func TestInt_Functions(t *testing.T) {
 
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
-			HasReturns(strings.ReplaceAll(dataType.ToSql(), " ", "")+" NOT NULL"). // TODO [SNOW-1348103]: do we care about this whitespace?
+			HasReturns(strings.ReplaceAll(dataType.ToSql(), " ", "")+" NOT NULL").
+			HasReturnDataType(dataType).
+			HasReturnNotNull(true).
 			HasLanguage("PYTHON").
 			HasBody(definition).
 			HasNullHandling(string(sdk.NullInputBehaviorReturnsNullInput)).
@@ -791,6 +816,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersion("3.8").
 			HasPackages(`['absl-py==0.10.0','about-time==4.2.1']`).
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNotEmpty().
 			HasIsAggregate(false),
 		)
@@ -847,6 +873,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(strings.ReplaceAll(dataType.ToSql(), " ", "")).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(false).
 			HasLanguage("PYTHON").
 			HasBodyNil().
 			HasNullHandling(string(sdk.NullInputBehaviorCalledOnNullInput)).
@@ -861,6 +889,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersion("3.8").
 			HasPackages(`[]`).
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNotEmpty().
 			HasIsAggregate(false),
 		)
@@ -929,6 +958,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(strings.ReplaceAll(dataType.ToSql(), " ", "")+" NOT NULL").
+			HasReturnDataType(dataType).
+			HasReturnNotNull(true).
 			HasLanguage("PYTHON").
 			HasBodyNil().
 			HasNullHandling(string(sdk.NullInputBehaviorReturnsNullInput)).
@@ -943,6 +974,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersion("3.8").
 			HasPackages(`['absl-py==0.10.0','about-time==4.2.1']`).
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNotEmpty().
 			HasIsAggregate(false),
 		)
@@ -1002,6 +1034,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(dataType.ToSql()).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(false).
 			HasLanguage("SCALA").
 			HasBody(definition).
 			HasNullHandling(string(sdk.NullInputBehaviorCalledOnNullInput)).
@@ -1014,6 +1048,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersion("2.12").
 			HasPackages(`[]`).
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)
@@ -1094,6 +1129,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(fmt.Sprintf(`%s NOT NULL`, dataType.ToSql())).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(true).
 			HasLanguage("SCALA").
 			HasBody(definition).
 			HasNullHandling(string(sdk.NullInputBehaviorReturnsNullInput)).
@@ -1108,6 +1145,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersion("2.12").
 			HasPackages(`[com.snowflake:snowpark:1.14.0,com.snowflake:telemetry:0.1.0]`).
 			HasTargetPath(targetPath).
+			HasNormalizedTargetPath("~", jarName).
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)
@@ -1165,6 +1203,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(dataType.ToSql()).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(false).
 			HasLanguage("SCALA").
 			HasBodyNil().
 			HasNullHandling(string(sdk.NullInputBehaviorCalledOnNullInput)).
@@ -1179,6 +1219,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersion("2.12").
 			HasPackages(`[]`).
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)
@@ -1247,6 +1288,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(fmt.Sprintf(`%s NOT NULL`, dataType.ToSql())).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(true).
 			HasLanguage("SCALA").
 			HasBodyNil().
 			HasNullHandling(string(sdk.NullInputBehaviorReturnsNullInput)).
@@ -1261,6 +1304,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersion("2.12").
 			HasPackages(`[com.snowflake:snowpark:1.14.0,com.snowflake:telemetry:0.1.0]`).
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)
@@ -1317,6 +1361,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(dataType.ToSql()).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(false).
 			HasLanguage("SQL").
 			HasBody(definition).
 			HasNullHandlingNil().
@@ -1329,6 +1375,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersionNil().
 			HasPackagesNil().
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)
@@ -1420,6 +1467,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(fmt.Sprintf(`%s NOT NULL`, dataType.ToSql())).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(true).
 			HasLanguage("SQL").
 			HasBody(definition).
 			HasNullHandlingNil().
@@ -1434,6 +1483,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersionNil().
 			HasPackagesNil().
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)
@@ -1487,6 +1537,8 @@ func TestInt_Functions(t *testing.T) {
 		assertions.AssertThatObject(t, objectassert.FunctionDetails(t, function.ID()).
 			HasSignature("()").
 			HasReturns(dataType.ToSql()).
+			HasReturnDataType(dataType).
+			HasReturnNotNull(false).
 			HasLanguage("SQL").
 			HasBody(definition).
 			HasNullHandlingNil().
@@ -1499,6 +1551,7 @@ func TestInt_Functions(t *testing.T) {
 			HasRuntimeVersionNil().
 			HasPackagesNil().
 			HasTargetPathNil().
+			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNil().
 			HasIsAggregateNil(),
 		)


### PR DESCRIPTION
Prepare most of the java resource implementation:
- add common drop method (also to procedures)
- fix parameters schema and add mapping (also for procedures)
- fix parameter handling
- handle parameters and test
- handle arguments, return type, runtime version, imports, target path, language
- add default values to arguments
- improve function details with mapping logic (for easier use in resource)
- add a bunch of common functions to handle this family of resources
- handle basic rename
- add TABLE data type (needs logic and tests)
- handle external language change
- test no arguments
- regenerate model builders and the docs
- rename a few attributes
- change requirements for some fields

Next PRs:
- TABLE function improvements and tests
- handle secrets, external access integrations, packages, return not null, and comments
- Add a similar PR for java procedure (reuse what we can)
- Add PR with all other function types
- datasources