### PR TITLE
chore: Add external removal tests to functions and procedures

### DIFF
--- a/pkg/resources/function_java_acceptance_test.go
+++ b/pkg/resources/function_java_acceptance_test.go
@@ -77,6 +77,22 @@ func TestAcc_FunctionJava_InlineBasic(t *testing.T) {
 					assert.Check(resource.TestCheckResourceAttr(functionModel.ResourceReference(), "arguments.0.arg_default_value", "")),
 				),
 			},
+			// REMOVE EXTERNALLY (CHECK RECREATION)
+			{
+				PreConfig: func() {
+					acc.TestClient().Function.DropFunctionFunc(t, id)()
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(functionModel.ResourceReference(), plancheck.ResourceActionCreate),
+					},
+				},
+				Config: config.FromModels(t, functionModel),
+				Check: assert.AssertThat(t,
+					resourceassert.FunctionJavaResource(t, functionModel.ResourceReference()).
+						HasNameString(id.Name()),
+				),
+			},
 			// IMPORT
 			{
 				ResourceName:            functionModel.ResourceReference(),

--- a/pkg/resources/function_java_acceptance_test.go
+++ b/pkg/resources/function_java_acceptance_test.go
@@ -199,6 +199,7 @@ func TestAcc_FunctionJava_InlineBasicDefaultArg(t *testing.T) {
 func TestAcc_FunctionJava_InlineFull(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	acc.TestAccPreCheck(t)
+	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 
 	stage, stageCleanup := acc.TestClient().Stage.CreateStage(t)
 	t.Cleanup(stageCleanup)

--- a/pkg/resources/function_javascript_acceptance_test.go
+++ b/pkg/resources/function_javascript_acceptance_test.go
@@ -64,6 +64,22 @@ func TestAcc_FunctionJavascript_InlineBasic(t *testing.T) {
 					assert.Check(resource.TestCheckResourceAttr(functionModel.ResourceReference(), "arguments.0.arg_default_value", "")),
 				),
 			},
+			// REMOVE EXTERNALLY (CHECK RECREATION)
+			{
+				PreConfig: func() {
+					acc.TestClient().Function.DropFunctionFunc(t, id)()
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(functionModel.ResourceReference(), plancheck.ResourceActionCreate),
+					},
+				},
+				Config: config.FromModels(t, functionModel),
+				Check: assert.AssertThat(t,
+					resourceassert.FunctionJavascriptResource(t, functionModel.ResourceReference()).
+						HasNameString(id.Name()),
+				),
+			},
 			// RENAME
 			{
 				Config: config.FromModels(t, functionModelRenamed),

--- a/pkg/resources/function_python_acceptance_test.go
+++ b/pkg/resources/function_python_acceptance_test.go
@@ -23,6 +23,10 @@ import (
 )
 
 func TestAcc_FunctionPython_InlineBasic(t *testing.T) {
+	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
+	acc.TestAccPreCheck(t)
+	t.Setenv(string(testenvs.ConfigureClientOnce), "")
+
 	funcName := "some_function"
 	argName := "x"
 	dataType := testdatatypes.DataTypeNumber_36_2
@@ -110,6 +114,7 @@ func TestAcc_FunctionPython_InlineBasic(t *testing.T) {
 func TestAcc_FunctionPython_InlineFull(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	acc.TestAccPreCheck(t)
+	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 
 	secretId := acc.TestClient().Ids.RandomSchemaObjectIdentifier()
 	secretId2 := acc.TestClient().Ids.RandomSchemaObjectIdentifier()

--- a/pkg/resources/function_python_acceptance_test.go
+++ b/pkg/resources/function_python_acceptance_test.go
@@ -64,6 +64,22 @@ func TestAcc_FunctionPython_InlineBasic(t *testing.T) {
 					assert.Check(resource.TestCheckResourceAttr(functionModel.ResourceReference(), "arguments.0.arg_default_value", "")),
 				),
 			},
+			// REMOVE EXTERNALLY (CHECK RECREATION)
+			{
+				PreConfig: func() {
+					acc.TestClient().Function.DropFunctionFunc(t, id)()
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(functionModel.ResourceReference(), plancheck.ResourceActionCreate),
+					},
+				},
+				Config: config.FromModels(t, functionModel),
+				Check: assert.AssertThat(t,
+					resourceassert.FunctionPythonResource(t, functionModel.ResourceReference()).
+						HasNameString(id.Name()),
+				),
+			},
 			// IMPORT
 			{
 				ResourceName:            functionModel.ResourceReference(),

--- a/pkg/resources/function_scala_acceptance_test.go
+++ b/pkg/resources/function_scala_acceptance_test.go
@@ -115,6 +115,7 @@ func TestAcc_FunctionScala_InlineBasic(t *testing.T) {
 func TestAcc_FunctionScala_InlineFull(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	acc.TestAccPreCheck(t)
+	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 
 	stage, stageCleanup := acc.TestClient().Stage.CreateStage(t)
 	t.Cleanup(stageCleanup)

--- a/pkg/resources/function_scala_acceptance_test.go
+++ b/pkg/resources/function_scala_acceptance_test.go
@@ -69,6 +69,22 @@ func TestAcc_FunctionScala_InlineBasic(t *testing.T) {
 					assert.Check(resource.TestCheckResourceAttr(functionModel.ResourceReference(), "arguments.0.arg_default_value", "")),
 				),
 			},
+			// REMOVE EXTERNALLY (CHECK RECREATION)
+			{
+				PreConfig: func() {
+					acc.TestClient().Function.DropFunctionFunc(t, id)()
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(functionModel.ResourceReference(), plancheck.ResourceActionCreate),
+					},
+				},
+				Config: config.FromModels(t, functionModel),
+				Check: assert.AssertThat(t,
+					resourceassert.FunctionScalaResource(t, functionModel.ResourceReference()).
+						HasNameString(id.Name()),
+				),
+			},
 			// IMPORT
 			{
 				ResourceName:            functionModel.ResourceReference(),

--- a/pkg/resources/function_sql_acceptance_test.go
+++ b/pkg/resources/function_sql_acceptance_test.go
@@ -82,7 +82,7 @@ func TestAcc_FunctionSql_InlineBasic(t *testing.T) {
 				ResourceName:            functionModel.ResourceReference(),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"is_secure"},
 				ImportStateCheck: assert.AssertThatImport(t,
 					resourceassert.ImportedFunctionSqlResource(t, id.FullyQualifiedName()).
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),

--- a/pkg/resources/function_sql_acceptance_test.go
+++ b/pkg/resources/function_sql_acceptance_test.go
@@ -26,7 +26,7 @@ func TestAcc_FunctionSql_InlineBasic(t *testing.T) {
 	argName := "abc"
 	dataType := testdatatypes.DataTypeFloat
 	id := acc.TestClient().Ids.RandomSchemaObjectIdentifierWithArgumentsNewDataTypes(dataType)
-	idWithChangedNameButTheSameDataType := acc.TestClient().Ids.RandomSchemaObjectIdentifierWithArgumentsNewDataTypes()
+	idWithChangedNameButTheSameDataType := acc.TestClient().Ids.RandomSchemaObjectIdentifierWithArgumentsNewDataTypes(dataType)
 
 	definition := acc.TestClient().Function.SampleSqlDefinitionWithArgument(t, argName)
 

--- a/pkg/resources/function_sql_acceptance_test.go
+++ b/pkg/resources/function_sql_acceptance_test.go
@@ -1,11 +1,9 @@
 package resources_test
 
 import (
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"testing"
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	r "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
@@ -13,12 +11,14 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/importchecks"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testdatatypes"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 

--- a/pkg/resources/procedure_java_acceptance_test.go
+++ b/pkg/resources/procedure_java_acceptance_test.go
@@ -76,6 +76,22 @@ func TestAcc_ProcedureJava_InlineBasic(t *testing.T) {
 					assert.Check(resource.TestCheckResourceAttr(procedureModel.ResourceReference(), "arguments.0.arg_default_value", "")),
 				),
 			},
+			// REMOVE EXTERNALLY (CHECK RECREATION)
+			{
+				PreConfig: func() {
+					acc.TestClient().Procedure.DropProcedureFunc(t, id)()
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(procedureModel.ResourceReference(), plancheck.ResourceActionCreate),
+					},
+				},
+				Config: config.FromModels(t, procedureModel),
+				Check: assert.AssertThat(t,
+					resourceassert.ProcedureJavaResource(t, procedureModel.ResourceReference()).
+						HasNameString(id.Name()),
+				),
+			},
 			// IMPORT
 			{
 				ResourceName:            procedureModel.ResourceReference(),

--- a/pkg/resources/procedure_javascript_acceptance_test.go
+++ b/pkg/resources/procedure_javascript_acceptance_test.go
@@ -62,6 +62,22 @@ func TestAcc_ProcedureJavascript_InlineBasic(t *testing.T) {
 					assert.Check(resource.TestCheckResourceAttr(procedureModel.ResourceReference(), "arguments.0.arg_default_value", "")),
 				),
 			},
+			// REMOVE EXTERNALLY (CHECK RECREATION)
+			{
+				PreConfig: func() {
+					acc.TestClient().Procedure.DropProcedureFunc(t, id)()
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(procedureModel.ResourceReference(), plancheck.ResourceActionCreate),
+					},
+				},
+				Config: config.FromModels(t, procedureModel),
+				Check: assert.AssertThat(t,
+					resourceassert.ProcedureJavascriptResource(t, procedureModel.ResourceReference()).
+						HasNameString(id.Name()),
+				),
+			},
 			// IMPORT
 			{
 				ResourceName:            procedureModel.ResourceReference(),

--- a/pkg/resources/procedure_python_acceptance_test.go
+++ b/pkg/resources/procedure_python_acceptance_test.go
@@ -65,6 +65,22 @@ func TestAcc_ProcedurePython_InlineBasic(t *testing.T) {
 					assert.Check(resource.TestCheckResourceAttr(procedureModel.ResourceReference(), "arguments.0.arg_default_value", "")),
 				),
 			},
+			// REMOVE EXTERNALLY (CHECK RECREATION)
+			{
+				PreConfig: func() {
+					acc.TestClient().Procedure.DropProcedureFunc(t, id)()
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(procedureModel.ResourceReference(), plancheck.ResourceActionCreate),
+					},
+				},
+				Config: config.FromModels(t, procedureModel),
+				Check: assert.AssertThat(t,
+					resourceassert.ProcedurePythonResource(t, procedureModel.ResourceReference()).
+						HasNameString(id.Name()),
+				),
+			},
 			// IMPORT
 			{
 				ResourceName:            procedureModel.ResourceReference(),

--- a/pkg/resources/procedure_scala_acceptance_test.go
+++ b/pkg/resources/procedure_scala_acceptance_test.go
@@ -74,6 +74,22 @@ func TestAcc_ProcedureScala_InlineBasic(t *testing.T) {
 					assert.Check(resource.TestCheckResourceAttr(procedureModel.ResourceReference(), "arguments.0.arg_default_value", "")),
 				),
 			},
+			// REMOVE EXTERNALLY (CHECK RECREATION)
+			{
+				PreConfig: func() {
+					acc.TestClient().Procedure.DropProcedureFunc(t, id)()
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(procedureModel.ResourceReference(), plancheck.ResourceActionCreate),
+					},
+				},
+				Config: config.FromModels(t, procedureModel),
+				Check: assert.AssertThat(t,
+					resourceassert.ProcedureScalaResource(t, procedureModel.ResourceReference()).
+						HasNameString(id.Name()),
+				),
+			},
 			// IMPORT
 			{
 				ResourceName:            procedureModel.ResourceReference(),

--- a/pkg/resources/procedure_sql_acceptance_test.go
+++ b/pkg/resources/procedure_sql_acceptance_test.go
@@ -62,6 +62,22 @@ func TestAcc_ProcedureSql_InlineBasic(t *testing.T) {
 					assert.Check(resource.TestCheckResourceAttr(procedureModel.ResourceReference(), "arguments.0.arg_default_value", "")),
 				),
 			},
+			// REMOVE EXTERNALLY (CHECK RECREATION)
+			{
+				PreConfig: func() {
+					acc.TestClient().Procedure.DropProcedureFunc(t, id)()
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(procedureModel.ResourceReference(), plancheck.ResourceActionCreate),
+					},
+				},
+				Config: config.FromModels(t, procedureModel),
+				Check: assert.AssertThat(t,
+					resourceassert.ProcedureSqlResource(t, procedureModel.ResourceReference()).
+						HasNameString(id.Name()),
+				),
+			},
 			// IMPORT
 			{
 				ResourceName:            procedureModel.ResourceReference(),


### PR DESCRIPTION
- Add external removal tests to functions and procedures (done during old issues closing)
- Fix the following tests:
  - TestAcc_FunctionJava_InlineFull
  - TestAcc_FunctionPython_InlineBasic
  - TestAcc_FunctionPython_InlineFull
  - TestAcc_FunctionScala_InlineFull
  - TestAcc_FunctionSql_InlineBasic

