### PR TITLE
docs: SNOW-1865901 add faq for account is empty

### DIFF
--- a/CREATING_ISSUES.md
+++ b/CREATING_ISSUES.md
@@ -136,7 +136,7 @@ Please refer to [this document](https://github.com/Snowflake-Labs/terraform-prov
 * `account_name` (`accountname` if you're sourcing it from `config` TOML)
 * `organization-name` (`organizationname` if you're sourcing it from `config` TOML)
 
-GitHub issue reference: https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/3198, https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/3308
+GitHub issue reference: [#3198](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/3198), [#3308](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/3308)
 
 ### How to set up the connection with the private key?
 **Problem:** From the version v0.78.0, we introduced a lot of provider configuration changes. One of them was deprecating `private_key_path` in favor of `private_key`.

--- a/CREATING_ISSUES.md
+++ b/CREATING_ISSUES.md
@@ -130,6 +130,14 @@ Please refer to [this document](https://github.com/Snowflake-Labs/terraform-prov
 
 [GitHub issue reference](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2432#issuecomment-1915074774)
 
+**Problem**: getting `Error: 260000: account is empty` error with non-empty `account` configuration after upgrading to v1, with the same provider configuration which worked up to v0.100.0
+
+**Solution**: `account` configuration [has been removed in v1.0.0](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#removed-deprecated-objects). Please specify your organization name and account name separately as mentioned in the [migration guide])(https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#removed-deprecated-objects):
+* `account_name` (`accountname` if you're sourcing it from `config` TOML)
+* `organization-name` (`organizationname` if you're sourcing it from `config` TOML)
+
+GitHub issue reference: https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/3198, https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/3308
+
 ### How to set up the connection with the private key?
 **Problem:** From the version v0.78.0, we introduced a lot of provider configuration changes. One of them was deprecating `private_key_path` in favor of `private_key`.
 

--- a/CREATING_ISSUES.md
+++ b/CREATING_ISSUES.md
@@ -130,11 +130,11 @@ Please refer to [this document](https://github.com/Snowflake-Labs/terraform-prov
 
 [GitHub issue reference](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2432#issuecomment-1915074774)
 
-**Problem**: getting `Error: 260000: account is empty` error with non-empty `account` configuration after upgrading to v1, with the same provider configuration which worked up to v0.100.0
+**Problem**: Getting `Error: 260000: account is empty` error with non-empty `account` configuration after upgrading to v1, with the same provider configuration which worked up to v0.100.0
 
-**Solution**: `account` configuration [has been removed in v1.0.0](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#removed-deprecated-objects). Please specify your organization name and account name separately as mentioned in the [migration guide])(https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#removed-deprecated-objects):
+**Solution**: `account` configuration [has been removed in v1.0.0](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#removed-deprecated-objects). Please specify your organization name and account name separately as mentioned in the [migration guide](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#removed-deprecated-objects):
 * `account_name` (`accountname` if you're sourcing it from `config` TOML)
-* `organization-name` (`organizationname` if you're sourcing it from `config` TOML)
+* `organization_name` (`organizationname` if you're sourcing it from `config` TOML)
 
 GitHub issue reference: [#3198](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/3198), [#3308](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/3308)
 


### PR DESCRIPTION
This is a documentation-only change, no code was changed.
Added FAQ entry for `Error: 260000: account is empty` people seem to be hitting after v1.0.0