### PR TITLE
chore: Generate multiline by default

### DIFF
--- a/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_java_model_ext.go
@@ -5,7 +5,6 @@ import (
 
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
@@ -18,7 +17,7 @@ func FunctionJavaBasicInline(
 	handler string,
 	functionDefinition string,
 ) *FunctionJavaModel {
-	return FunctionJava(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), id.SchemaName()).WithFunctionDefinitionValue(config.MultilineWrapperVariable(functionDefinition))
+	return FunctionJava(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), id.SchemaName()).WithFunctionDefinition(functionDefinition)
 }
 
 func FunctionJavaBasicStaged(

--- a/pkg/acceptance/bettertestspoc/config/model/function_java_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_java_model_gen.go
@@ -125,7 +125,7 @@ func (f *FunctionJavaModel) WithFullyQualifiedName(fullyQualifiedName string) *F
 }
 
 func (f *FunctionJavaModel) WithFunctionDefinition(functionDefinition string) *FunctionJavaModel {
-	f.FunctionDefinition = tfconfig.StringVariable(functionDefinition)
+	f.FunctionDefinition = config.MultilineWrapperVariable(functionDefinition)
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/function_javascript_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_javascript_model_ext.go
@@ -3,14 +3,12 @@ package model
 import (
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 )
 
 func FunctionJavascriptInline(resourceName string, id sdk.SchemaObjectIdentifierWithArguments, functionDefinition string, returnType string) *FunctionJavascriptModel {
-	return FunctionJavascript(resourceName, id.DatabaseName(), functionDefinition, id.Name(), returnType, id.SchemaName()).
-		WithFunctionDefinitionValue(config.MultilineWrapperVariable(functionDefinition))
+	return FunctionJavascript(resourceName, id.DatabaseName(), functionDefinition, id.Name(), returnType, id.SchemaName())
 }
 
 func (f *FunctionJavascriptModel) WithArgument(argName string, argDataType datatypes.DataType) *FunctionJavascriptModel {

--- a/pkg/acceptance/bettertestspoc/config/model/function_javascript_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_javascript_model_gen.go
@@ -116,7 +116,7 @@ func (f *FunctionJavascriptModel) WithFullyQualifiedName(fullyQualifiedName stri
 }
 
 func (f *FunctionJavascriptModel) WithFunctionDefinition(functionDefinition string) *FunctionJavascriptModel {
-	f.FunctionDefinition = tfconfig.StringVariable(functionDefinition)
+	f.FunctionDefinition = config.MultilineWrapperVariable(functionDefinition)
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/function_python_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_python_model_ext.go
@@ -3,14 +3,13 @@ package model
 import (
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 )
 
 func FunctionPythonBasicInline(resourceName string, id sdk.SchemaObjectIdentifierWithArguments, runtimeVersion string, returnType datatypes.DataType, handler string, functionDefinition string) *FunctionPythonModel {
-	return FunctionPython(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), runtimeVersion, id.SchemaName()).WithFunctionDefinitionValue(config.MultilineWrapperVariable(functionDefinition))
+	return FunctionPython(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), runtimeVersion, id.SchemaName()).WithFunctionDefinition(functionDefinition)
 }
 
 func (f *FunctionPythonModel) WithArgument(argName string, argDataType datatypes.DataType) *FunctionPythonModel {

--- a/pkg/acceptance/bettertestspoc/config/model/function_python_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_python_model_gen.go
@@ -129,7 +129,7 @@ func (f *FunctionPythonModel) WithFullyQualifiedName(fullyQualifiedName string) 
 }
 
 func (f *FunctionPythonModel) WithFunctionDefinition(functionDefinition string) *FunctionPythonModel {
-	f.FunctionDefinition = tfconfig.StringVariable(functionDefinition)
+	f.FunctionDefinition = config.MultilineWrapperVariable(functionDefinition)
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/function_scala_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_scala_model_ext.go
@@ -5,7 +5,6 @@ import (
 
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
@@ -19,7 +18,7 @@ func FunctionScalaBasicInline(
 	handler string,
 	functionDefinition string,
 ) *FunctionScalaModel {
-	return FunctionScala(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), runtimeVersion, id.SchemaName()).WithFunctionDefinitionValue(config.MultilineWrapperVariable(functionDefinition))
+	return FunctionScala(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), runtimeVersion, id.SchemaName()).WithFunctionDefinition(functionDefinition)
 }
 
 func (f *FunctionScalaModel) WithArgument(argName string, argDataType datatypes.DataType) *FunctionScalaModel {

--- a/pkg/acceptance/bettertestspoc/config/model/function_scala_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_scala_model_gen.go
@@ -129,7 +129,7 @@ func (f *FunctionScalaModel) WithFullyQualifiedName(fullyQualifiedName string) *
 }
 
 func (f *FunctionScalaModel) WithFunctionDefinition(functionDefinition string) *FunctionScalaModel {
-	f.FunctionDefinition = tfconfig.StringVariable(functionDefinition)
+	f.FunctionDefinition = config.MultilineWrapperVariable(functionDefinition)
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/function_sql_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_sql_model_ext.go
@@ -3,14 +3,12 @@ package model
 import (
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 )
 
 func FunctionSqlBasicInline(resourceName string, id sdk.SchemaObjectIdentifierWithArguments, functionDefinition string, returnType string) *FunctionSqlModel {
-	return FunctionSql(resourceName, id.DatabaseName(), functionDefinition, id.Name(), returnType, id.SchemaName()).
-		WithFunctionDefinitionValue(config.MultilineWrapperVariable(functionDefinition))
+	return FunctionSql(resourceName, id.DatabaseName(), functionDefinition, id.Name(), returnType, id.SchemaName())
 }
 
 func (f *FunctionSqlModel) WithArgument(argName string, argDataType datatypes.DataType) *FunctionSqlModel {

--- a/pkg/acceptance/bettertestspoc/config/model/function_sql_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_sql_model_gen.go
@@ -115,7 +115,7 @@ func (f *FunctionSqlModel) WithFullyQualifiedName(fullyQualifiedName string) *Fu
 }
 
 func (f *FunctionSqlModel) WithFunctionDefinition(functionDefinition string) *FunctionSqlModel {
-	f.FunctionDefinition = tfconfig.StringVariable(functionDefinition)
+	f.FunctionDefinition = config.MultilineWrapperVariable(functionDefinition)
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/gen/model.go
+++ b/pkg/acceptance/bettertestspoc/config/model/gen/model.go
@@ -29,12 +29,24 @@ type ResourceConfigBuilderAttributeModel struct {
 	AttributeType  string
 	Required       bool
 	VariableMethod string
+	MethodImport   string
 }
 
 func ModelFromResourceSchemaDetails(resourceSchemaDetails genhelpers.ResourceSchemaDetails) ResourceConfigBuilderModel {
 	attributes := make([]ResourceConfigBuilderAttributeModel, 0)
 	for _, attr := range resourceSchemaDetails.Attributes {
 		if slices.Contains([]string{resources.ShowOutputAttributeName, resources.ParametersAttributeName, resources.DescribeOutputAttributeName}, attr.Name) {
+			continue
+		}
+
+		if v, ok := multilineAttributesOverrides[resourceSchemaDetails.Name]; ok && slices.Contains(v, attr.Name) && attr.AttributeType == schema.TypeString {
+			attributes = append(attributes, ResourceConfigBuilderAttributeModel{
+				Name:           attr.Name,
+				AttributeType:  "string",
+				Required:       attr.Required,
+				VariableMethod: "MultilineWrapperVariable",
+				MethodImport:   "config",
+			})
 			continue
 		}
 
@@ -61,6 +73,7 @@ func ModelFromResourceSchemaDetails(resourceSchemaDetails genhelpers.ResourceSch
 			AttributeType:  attributeType,
 			Required:       attr.Required,
 			VariableMethod: variableMethod,
+			MethodImport:   "tfconfig",
 		})
 	}
 

--- a/pkg/acceptance/bettertestspoc/config/model/gen/multiline_attributes_overrides.go
+++ b/pkg/acceptance/bettertestspoc/config/model/gen/multiline_attributes_overrides.go
@@ -1,0 +1,17 @@
+package gen
+
+var multilineAttributesOverrides = map[string][]string{
+	"User":                {"rsa_public_key", "rsa_public_key_2"},
+	"ServiceUser":         {"rsa_public_key", "rsa_public_key_2"},
+	"LegacyServiceUser":   {"rsa_public_key", "rsa_public_key_2"},
+	"FunctionJava":        {"function_definition"},
+	"FunctionJavascript":  {"function_definition"},
+	"FunctionPython":      {"function_definition"},
+	"FunctionScala":       {"function_definition"},
+	"FunctionSql":         {"function_definition"},
+	"ProcedureJava":       {"procedure_definition"},
+	"ProcedureJavascript": {"procedure_definition"},
+	"ProcedurePython":     {"procedure_definition"},
+	"ProcedureScala":      {"procedure_definition"},
+	"ProcedureSql":        {"procedure_definition"},
+}

--- a/pkg/acceptance/bettertestspoc/config/model/gen/templates/builders.tmpl
+++ b/pkg/acceptance/bettertestspoc/config/model/gen/templates/builders.tmpl
@@ -11,7 +11,7 @@
     {{- $attributeNameCamel := SnakeCaseToCamel .Name -}}
     {{ if .AttributeType }}
         func ({{ $modelVar }} *{{ $modelName }}) With{{ $attributeNameCamel }}({{ FirstLetterLowercase $attributeNameCamel }} {{ .AttributeType }}) *{{ $modelName }} {
-            {{ $modelVar }}.{{ $attributeNameCamel }} = tfconfig.{{ .VariableMethod }}({{ FirstLetterLowercase $attributeNameCamel }})
+            {{ $modelVar }}.{{ $attributeNameCamel }} = {{ .MethodImport }}.{{ .VariableMethod }}({{ FirstLetterLowercase $attributeNameCamel }})
             return {{ $modelVar }}
         }
     {{ else }}

--- a/pkg/acceptance/bettertestspoc/config/model/legacy_service_user_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/legacy_service_user_model_gen.go
@@ -383,12 +383,12 @@ func (l *LegacyServiceUserModel) WithRowsPerResultset(rowsPerResultset int) *Leg
 }
 
 func (l *LegacyServiceUserModel) WithRsaPublicKey(rsaPublicKey string) *LegacyServiceUserModel {
-	l.RsaPublicKey = tfconfig.StringVariable(rsaPublicKey)
+	l.RsaPublicKey = config.MultilineWrapperVariable(rsaPublicKey)
 	return l
 }
 
 func (l *LegacyServiceUserModel) WithRsaPublicKey2(rsaPublicKey2 string) *LegacyServiceUserModel {
-	l.RsaPublicKey2 = tfconfig.StringVariable(rsaPublicKey2)
+	l.RsaPublicKey2 = config.MultilineWrapperVariable(rsaPublicKey2)
 	return l
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_java_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_java_model_ext.go
@@ -3,7 +3,6 @@ package model
 import (
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
@@ -17,7 +16,7 @@ func ProcedureJavaBasicInline(
 	procedureDefinition string,
 ) *ProcedureJavaModel {
 	return ProcedureJava(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), "11", id.SchemaName(), "1.14.0").
-		WithProcedureDefinitionValue(config.MultilineWrapperVariable(procedureDefinition))
+		WithProcedureDefinition(procedureDefinition)
 }
 
 func ProcedureJavaBasicStaged(

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_java_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_java_model_gen.go
@@ -173,7 +173,7 @@ func (p *ProcedureJavaModel) WithNullInputBehavior(nullInputBehavior string) *Pr
 // packages attribute type is not yet supported, so WithPackages can't be generated
 
 func (p *ProcedureJavaModel) WithProcedureDefinition(procedureDefinition string) *ProcedureJavaModel {
-	p.ProcedureDefinition = tfconfig.StringVariable(procedureDefinition)
+	p.ProcedureDefinition = config.MultilineWrapperVariable(procedureDefinition)
 	return p
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_javascript_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_javascript_model_ext.go
@@ -3,7 +3,6 @@ package model
 import (
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 )
@@ -14,8 +13,7 @@ func ProcedureJavascriptBasicInline(
 	returnType datatypes.DataType,
 	procedureDefinition string,
 ) *ProcedureJavascriptModel {
-	return ProcedureJavascript(resourceName, id.DatabaseName(), id.Name(), procedureDefinition, returnType.ToSql(), id.SchemaName()).
-		WithProcedureDefinitionValue(config.MultilineWrapperVariable(procedureDefinition))
+	return ProcedureJavascript(resourceName, id.DatabaseName(), id.Name(), procedureDefinition, returnType.ToSql(), id.SchemaName())
 }
 
 func (f *ProcedureJavascriptModel) WithArgument(argName string, argDataType datatypes.DataType) *ProcedureJavascriptModel {

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_javascript_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_javascript_model_gen.go
@@ -146,7 +146,7 @@ func (p *ProcedureJavascriptModel) WithNullInputBehavior(nullInputBehavior strin
 }
 
 func (p *ProcedureJavascriptModel) WithProcedureDefinition(procedureDefinition string) *ProcedureJavascriptModel {
-	p.ProcedureDefinition = tfconfig.StringVariable(procedureDefinition)
+	p.ProcedureDefinition = config.MultilineWrapperVariable(procedureDefinition)
 	return p
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_python_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_python_model_ext.go
@@ -3,7 +3,6 @@ package model
 import (
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
@@ -17,7 +16,7 @@ func ProcedurePythonBasicInline(
 	procedureDefinition string,
 ) *ProcedurePythonModel {
 	return ProcedurePython(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), "3.8", id.SchemaName(), "1.14.0").
-		WithProcedureDefinitionValue(config.MultilineWrapperVariable(procedureDefinition))
+		WithProcedureDefinition(procedureDefinition)
 }
 
 func (f *ProcedurePythonModel) WithArgument(argName string, argDataType datatypes.DataType) *ProcedurePythonModel {

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_python_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_python_model_gen.go
@@ -172,7 +172,7 @@ func (p *ProcedurePythonModel) WithNullInputBehavior(nullInputBehavior string) *
 // packages attribute type is not yet supported, so WithPackages can't be generated
 
 func (p *ProcedurePythonModel) WithProcedureDefinition(procedureDefinition string) *ProcedurePythonModel {
-	p.ProcedureDefinition = tfconfig.StringVariable(procedureDefinition)
+	p.ProcedureDefinition = config.MultilineWrapperVariable(procedureDefinition)
 	return p
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_scala_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_scala_model_ext.go
@@ -3,7 +3,6 @@ package model
 import (
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
@@ -17,7 +16,7 @@ func ProcedureScalaBasicInline(
 	procedureDefinition string,
 ) *ProcedureScalaModel {
 	return ProcedureScala(resourceName, id.DatabaseName(), handler, id.Name(), returnType.ToSql(), "2.12", id.SchemaName(), "1.14.0").
-		WithProcedureDefinitionValue(config.MultilineWrapperVariable(procedureDefinition))
+		WithProcedureDefinition(procedureDefinition)
 }
 
 func ProcedureScalaBasicStaged(

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_scala_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_scala_model_gen.go
@@ -173,7 +173,7 @@ func (p *ProcedureScalaModel) WithNullInputBehavior(nullInputBehavior string) *P
 // packages attribute type is not yet supported, so WithPackages can't be generated
 
 func (p *ProcedureScalaModel) WithProcedureDefinition(procedureDefinition string) *ProcedureScalaModel {
-	p.ProcedureDefinition = tfconfig.StringVariable(procedureDefinition)
+	p.ProcedureDefinition = config.MultilineWrapperVariable(procedureDefinition)
 	return p
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_sql_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_sql_model_ext.go
@@ -3,7 +3,6 @@ package model
 import (
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 )
@@ -14,8 +13,7 @@ func ProcedureSqlBasicInline(
 	returnType datatypes.DataType,
 	procedureDefinition string,
 ) *ProcedureSqlModel {
-	return ProcedureSql(resourceName, id.DatabaseName(), id.Name(), procedureDefinition, returnType.ToSql(), id.SchemaName()).
-		WithProcedureDefinitionValue(config.MultilineWrapperVariable(procedureDefinition))
+	return ProcedureSql(resourceName, id.DatabaseName(), id.Name(), procedureDefinition, returnType.ToSql(), id.SchemaName())
 }
 
 func (f *ProcedureSqlModel) WithArgument(argName string, argDataType datatypes.DataType) *ProcedureSqlModel {

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_sql_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_sql_model_gen.go
@@ -146,7 +146,7 @@ func (p *ProcedureSqlModel) WithNullInputBehavior(nullInputBehavior string) *Pro
 }
 
 func (p *ProcedureSqlModel) WithProcedureDefinition(procedureDefinition string) *ProcedureSqlModel {
-	p.ProcedureDefinition = tfconfig.StringVariable(procedureDefinition)
+	p.ProcedureDefinition = config.MultilineWrapperVariable(procedureDefinition)
 	return p
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/service_user_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/service_user_model_gen.go
@@ -371,12 +371,12 @@ func (s *ServiceUserModel) WithRowsPerResultset(rowsPerResultset int) *ServiceUs
 }
 
 func (s *ServiceUserModel) WithRsaPublicKey(rsaPublicKey string) *ServiceUserModel {
-	s.RsaPublicKey = tfconfig.StringVariable(rsaPublicKey)
+	s.RsaPublicKey = config.MultilineWrapperVariable(rsaPublicKey)
 	return s
 }
 
 func (s *ServiceUserModel) WithRsaPublicKey2(rsaPublicKey2 string) *ServiceUserModel {
-	s.RsaPublicKey2 = tfconfig.StringVariable(rsaPublicKey2)
+	s.RsaPublicKey2 = config.MultilineWrapperVariable(rsaPublicKey2)
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/user_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/user_model_gen.go
@@ -413,12 +413,12 @@ func (u *UserModel) WithRowsPerResultset(rowsPerResultset int) *UserModel {
 }
 
 func (u *UserModel) WithRsaPublicKey(rsaPublicKey string) *UserModel {
-	u.RsaPublicKey = tfconfig.StringVariable(rsaPublicKey)
+	u.RsaPublicKey = config.MultilineWrapperVariable(rsaPublicKey)
 	return u
 }
 
 func (u *UserModel) WithRsaPublicKey2(rsaPublicKey2 string) *UserModel {
-	u.RsaPublicKey2 = tfconfig.StringVariable(rsaPublicKey2)
+	u.RsaPublicKey2 = config.MultilineWrapperVariable(rsaPublicKey2)
 	return u
 }
 

--- a/pkg/datasources/users_acceptance_test.go
+++ b/pkg/datasources/users_acceptance_test.go
@@ -46,8 +46,8 @@ func TestAcc_Users_PersonUser(t *testing.T) {
 		WithDefaultRole("some_role").
 		WithDefaultSecondaryRolesOptionEnum(sdk.SecondaryRolesOptionAll).
 		WithMinsToBypassMfa(10).
-		WithRsaPublicKeyValue(config.MultilineWrapperVariable(key1)).
-		WithRsaPublicKey2Value(config.MultilineWrapperVariable(key2)).
+		WithRsaPublicKey(key1).
+		WithRsaPublicKey2(key2).
 		WithComment(comment).
 		WithDisableMfa("true")
 
@@ -204,8 +204,8 @@ func TestAcc_Users_ServiceUser(t *testing.T) {
 		WithDefaultNamespace("some.namespace").
 		WithDefaultRole("some_role").
 		WithDefaultSecondaryRolesOptionEnum(sdk.SecondaryRolesOptionAll).
-		WithRsaPublicKeyValue(config.MultilineWrapperVariable(key1)).
-		WithRsaPublicKey2Value(config.MultilineWrapperVariable(key2)).
+		WithRsaPublicKey(key1).
+		WithRsaPublicKey2(key2).
 		WithComment(comment)
 
 	resource.Test(t, resource.TestCase{
@@ -364,8 +364,8 @@ func TestAcc_Users_LegacyServiceUser(t *testing.T) {
 		WithDefaultNamespace("some.namespace").
 		WithDefaultRole("some_role").
 		WithDefaultSecondaryRolesOptionEnum(sdk.SecondaryRolesOptionAll).
-		WithRsaPublicKeyValue(config.MultilineWrapperVariable(key1)).
-		WithRsaPublicKey2Value(config.MultilineWrapperVariable(key2)).
+		WithRsaPublicKey(key1).
+		WithRsaPublicKey2(key2).
 		WithComment(comment)
 
 	resource.Test(t, resource.TestCase{

--- a/pkg/resources/legacy_service_user_acceptance_test.go
+++ b/pkg/resources/legacy_service_user_acceptance_test.go
@@ -56,8 +56,8 @@ func TestAcc_LegacyServiceUser_BasicFlows(t *testing.T) {
 		WithDefaultNamespace("some.namespace").
 		WithDefaultRole("some_role").
 		WithDefaultSecondaryRolesOptionEnum(sdk.SecondaryRolesOptionAll).
-		WithRsaPublicKeyValue(config.MultilineWrapperVariable(key1)).
-		WithRsaPublicKey2Value(config.MultilineWrapperVariable(key2)).
+		WithRsaPublicKey(key1).
+		WithRsaPublicKey2(key2).
 		WithComment(comment)
 
 	userModelAllAttributesChanged := func(loginName string) *model.LegacyServiceUserModel {
@@ -74,8 +74,8 @@ func TestAcc_LegacyServiceUser_BasicFlows(t *testing.T) {
 			WithDefaultNamespace("one_part_namespace").
 			WithDefaultRole("other_role").
 			WithDefaultSecondaryRolesOptionEnum(sdk.SecondaryRolesOptionAll).
-			WithRsaPublicKeyValue(config.MultilineWrapperVariable(key2)).
-			WithRsaPublicKey2Value(config.MultilineWrapperVariable(key1)).
+			WithRsaPublicKey(key2).
+			WithRsaPublicKey2(key1).
 			WithComment(newComment)
 	}
 

--- a/pkg/resources/service_user_acceptance_test.go
+++ b/pkg/resources/service_user_acceptance_test.go
@@ -51,8 +51,8 @@ func TestAcc_ServiceUser_BasicFlows(t *testing.T) {
 		WithDefaultNamespace("some.namespace").
 		WithDefaultRole("some_role").
 		WithDefaultSecondaryRolesOptionEnum(sdk.SecondaryRolesOptionAll).
-		WithRsaPublicKeyValue(config.MultilineWrapperVariable(key1)).
-		WithRsaPublicKey2Value(config.MultilineWrapperVariable(key2)).
+		WithRsaPublicKey(key1).
+		WithRsaPublicKey2(key2).
 		WithComment(comment)
 
 	userModelAllAttributesChanged := func(loginName string) *model.ServiceUserModel {
@@ -67,8 +67,8 @@ func TestAcc_ServiceUser_BasicFlows(t *testing.T) {
 			WithDefaultNamespace("one_part_namespace").
 			WithDefaultRole("other_role").
 			WithDefaultSecondaryRolesOptionEnum(sdk.SecondaryRolesOptionAll).
-			WithRsaPublicKeyValue(config.MultilineWrapperVariable(key2)).
-			WithRsaPublicKey2Value(config.MultilineWrapperVariable(key1)).
+			WithRsaPublicKey(key2).
+			WithRsaPublicKey2(key1).
 			WithComment(newComment)
 	}
 

--- a/pkg/resources/user_acceptance_test.go
+++ b/pkg/resources/user_acceptance_test.go
@@ -64,8 +64,8 @@ func TestAcc_User_BasicFlows(t *testing.T) {
 		WithDefaultRole("some_role").
 		WithDefaultSecondaryRolesOptionEnum(sdk.SecondaryRolesOptionAll).
 		WithMinsToBypassMfa(10).
-		WithRsaPublicKeyValue(config.MultilineWrapperVariable(key1)).
-		WithRsaPublicKey2Value(config.MultilineWrapperVariable(key2)).
+		WithRsaPublicKey(key1).
+		WithRsaPublicKey2(key2).
 		WithComment(comment).
 		WithDisableMfa("true")
 
@@ -87,8 +87,8 @@ func TestAcc_User_BasicFlows(t *testing.T) {
 			WithDefaultRole("other_role").
 			WithDefaultSecondaryRolesOptionEnum(sdk.SecondaryRolesOptionAll).
 			WithMinsToBypassMfa(14).
-			WithRsaPublicKeyValue(config.MultilineWrapperVariable(key2)).
-			WithRsaPublicKey2Value(config.MultilineWrapperVariable(key1)).
+			WithRsaPublicKey(key2).
+			WithRsaPublicKey2(key1).
 			WithComment(newComment).
 			WithDisableMfa("false")
 	}
@@ -696,15 +696,15 @@ func TestAcc_User_issue2970(t *testing.T) {
 
 	userModel := model.User(resourceName, userId.Name()).
 		WithPassword(pass).
-		WithRsaPublicKeyValue(config.MultilineWrapperVariable(key))
+		WithRsaPublicKey(key)
 
 	newUserModelIncorrectNewKey := model.User(resourceName, userId.Name()).
 		WithPassword(newPass).
-		WithRsaPublicKeyValue(config.MultilineWrapperVariable(incorrectlyFormattedNewKey))
+		WithRsaPublicKey(incorrectlyFormattedNewKey)
 
 	newUserModel := model.User(resourceName, userId.Name()).
 		WithPassword(newPass).
-		WithRsaPublicKeyValue(config.MultilineWrapperVariable(newKey))
+		WithRsaPublicKey(newKey)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,


### PR DESCRIPTION
Enable generating multiline config building:
- use overrides to decide what type of method should be generated
- add it to the known cases (all user types, all function types, and all procedure types)
- apply change only to resource models; it is still an extension method for the provider config model
- adjusted existing models and acceptance tests