### PR TITLE
fix: change EnforceNetworkRulesForInternalStages ddl to parameter

### DIFF
--- a/pkg/sdk/parameters.go
+++ b/pkg/sdk/parameters.go
@@ -1186,7 +1186,7 @@ type AccountParameters struct {
 	EnableTriSecretAndRekeyOptOutForImageRepository  *bool   `ddl:"parameter" sql:"ENABLE_TRI_SECRET_AND_REKEY_OPT_OUT_FOR_IMAGE_REPOSITORY"`
 	EnableTriSecretAndRekeyOptOutForSpcsBlockStorage *bool   `ddl:"parameter" sql:"ENABLE_TRI_SECRET_AND_REKEY_OPT_OUT_FOR_SPCS_BLOCK_STORAGE"`
 	EnableUnhandledExceptionsReporting               *bool   `ddl:"parameter" sql:"ENABLE_UNHANDLED_EXCEPTIONS_REPORTING"`
-	EnforceNetworkRulesForInternalStages             *bool   `ddl:"keyword" sql:"ENFORCE_NETWORK_RULES_FOR_INTERNAL_STAGES"`
+	EnforceNetworkRulesForInternalStages             *bool   `ddl:"parameter" sql:"ENFORCE_NETWORK_RULES_FOR_INTERNAL_STAGES"`
 	EventTable                                       *string `ddl:"parameter,single_quotes" sql:"EVENT_TABLE"`
 	ExternalOAuthAddPrivilegedRolesToBlockedList     *bool   `ddl:"parameter" sql:"EXTERNAL_OAUTH_ADD_PRIVILEGED_ROLES_TO_BLOCKED_LIST"`
 	// InitialReplicationSizeLimitInTB is a string because values like 3.0 get rounded to 3, resulting in an error in Snowflake.

--- a/pkg/sdk/parameters_test.go
+++ b/pkg/sdk/parameters_test.go
@@ -54,6 +54,21 @@ func TestUnSetObjectParameterNetworkPolicyOnUser(t *testing.T) {
 	})
 }
 
+func TestSetAccountParameterEnforceNetworkRulesForInternalStages(t *testing.T) {
+	opts := &AlterAccountOptions{
+		Set: &AccountSet{
+			Parameters: &AccountLevelParameters{
+				AccountParameters: &AccountParameters{
+					EnforceNetworkRulesForInternalStages: Bool(true),
+				},
+			},
+		},
+	}
+	t.Run("Set Enforce Network Rules for Internal Stages", func(t *testing.T) {
+		assertOptsValidAndSQLEquals(t, opts, "ALTER ACCOUNT SET ENFORCE_NETWORK_RULES_FOR_INTERNAL_STAGES = true")
+	})
+}
+
 func TestToAccountParameter(t *testing.T) {
 	type test struct {
 		input string


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

`ENFORCE_NETWORK_RULES_FOR_INTERNAL_STAGES` requires boolean parameter so I change the setting from ddl:keyword to ddl:parameter.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->
https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/3344