### PR TITLE
chore: Remove hardcoded values from documentation

### DIFF
--- a/docs/guides/authentication_methods.md
+++ b/docs/guides/authentication_methods.md
@@ -49,7 +49,12 @@ provider "snowflake" {
   organization_name = "<organization_name>"
   account_name      = "<account_name>"
   user              = "<user_name>"
-  password          = "<password>"
+  password          = var.password
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }
 ```
 
@@ -61,12 +66,17 @@ provider "snowflake" {
   organization_name = "<organization_name>"
   account_name      = "<account_name>"
   user              = "<user_name>"
-  password          = "<password>"
+  password          = var.password
   authenticator     = "Snowflake"
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }
 ```
 
-### JWT authenticator flow 
+### JWT authenticator flow
 
 To use JWT authentication, you have to firstly generate key-pairs used by Snowflake.
 To correctly generate the necessary keys, follow [this guide](https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-authentication) from the official Snowflake documentation.
@@ -86,20 +96,14 @@ provider "snowflake" {
 To load the private key you can utilize the built-in [file](https://developer.hashicorp.com/terraform/language/functions/file) function.
 If you have any issues with this method, one of the possible root causes could be an additional newline at the end of the file that causes error in the underlying Go Snowflake driver.
 If this doesn't help, you can try other methods of supplying this field:
-- Filling the key directly by using [multi-string notation](https://developer.hashicorp.com/terraform/language/expressions/strings#heredoc-strings)
 - Sourcing it from the environment variable:
 ```shell
-export SNOWFLAKE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----..."
-# Alternatively, source from a file.
 export SNOWFLAKE_PRIVATE_KEY=$(cat ~/.ssh/snowflake_private_key.p8)
-
-export SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="..."
 ```
 - Using TOML configuration file:
 ```toml
 [default]
 private_key = "..."
-private_key_passphrase = "..."
 ```
 
 In case of any other issues, take a look at related topics:
@@ -117,7 +121,12 @@ provider "snowflake" {
   user                   = "<user_name>"
   authenticator          = "JWT"
   private_key            = file("~/.ssh/snowflake_private_key.p8")
-  private_key_passphrase = "<passphrase>"
+  private_key_passphrase = var.private_key_passphrase
+}
+
+variable "private_key_passphrase" {
+  type      = string
+  sensitive = true
 }
 ```
 
@@ -168,9 +177,14 @@ provider "snowflake" {
   organization_name = "<organization_name>"
   account_name      = "<account_name>"
   user              = "<user_name>"
-  password          = "<password>"
+  password          = var.password
   authenticator     = "Okta"
   okta_url          = "https://dev-123456.okta.com"
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }
 ```
 
@@ -196,7 +210,7 @@ The output of this command is your `<account_name>`.
 
 ### Be sure you are passing all the required fields
 
-This point is not only referring to double-checking the fields you are passing, but also to inform you that depending on the account 
+This point is not only referring to double-checking the fields you are passing, but also to inform you that depending on the account
 you want to log into, a different set of parameters may be required.
 
 Whenever you are on a Snowflake deployment that has different url than the default one:

--- a/docs/guides/authentication_methods.md
+++ b/docs/guides/authentication_methods.md
@@ -58,6 +58,14 @@ variable "password" {
 }
 ```
 
+You can then set Terraform variables like:
+- If a variable does not have any value set, you will be prompted by Terraform to provide the value.
+- Use Terraform VAR environment variables: `TF_VAR_password="<key>" terraform plan`
+- Use Terraform flags: `terraform plan -var="private_key=<key>"`
+- Use Snowflake Terraform Provider flags: `SNOWFLAKE_PRIVATE_KEY="<key>" terraform plan`
+
+Remember to load `<key>` from a secure location, instead of hardcoding the value.
+
 Without passing any authenticator, we depend on the underlying Go Snowflake driver and Snowflake itself to fill this field out.
 This means that we do not provision the default, and it may change at some point, so if you want to be explicit, you can define Snowflake authenticator like so:
 
@@ -88,8 +96,15 @@ provider "snowflake" {
   organization_name = "<organization_name>"
   account_name      = "<account_name>"
   user              = "<user_name>"
-  authenticator     = "JWT"
+  authenticator     = "SNOWFLAKE_JWT"
   private_key       = file("~/.ssh/snowflake_private_key.p8")
+  # Optionally, set it with Terraform variable.
+  private_key       = var.private_key
+}
+
+variable "private_key" {
+  type      = string
+  sensitive = true
 }
 ```
 
@@ -119,7 +134,7 @@ provider "snowflake" {
   organization_name      = "<organization_name>"
   account_name           = "<account_name>"
   user                   = "<user_name>"
-  authenticator          = "JWT"
+  authenticator          = "SNOWFLAKE_JWT"
   private_key            = file("~/.ssh/snowflake_private_key.p8")
   private_key_passphrase = var.private_key_passphrase
 }
@@ -143,8 +158,13 @@ provider "snowflake" {
   organization_name = "<organization_name>"
   account_name      = "<account_name>"
   user              = "<user_name>"
-  password          = "<password>"
+  password          = var.password
   authenticator     = "UsernamePasswordMFA"
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }
 ```
 
@@ -155,9 +175,14 @@ provider "snowflake" {
   organization_name = "<organization_name>"
   account_name      = "<account_name>"
   user              = "<user_name>"
-  password          = "<password>"
+  password          = var.password
   authenticator     = "UsernamePasswordMFA"
   passcode          = "000000"
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }
 ```
 

--- a/docs/guides/authentication_methods.md
+++ b/docs/guides/authentication_methods.md
@@ -111,9 +111,12 @@ variable "private_key" {
 To load the private key you can utilize the built-in [file](https://developer.hashicorp.com/terraform/language/functions/file) function.
 If you have any issues with this method, one of the possible root causes could be an additional newline at the end of the file that causes error in the underlying Go Snowflake driver.
 If this doesn't help, you can try other methods of supplying this field:
+- Filling the key directly by using [multi-string notation](https://developer.hashicorp.com/terraform/language/expressions/strings#heredoc-strings) (not recommended).
 - Sourcing it from the environment variable:
 ```shell
 export SNOWFLAKE_PRIVATE_KEY=$(cat ~/.ssh/snowflake_private_key.p8)
+# Or inline the value (not recommended).
+export SNOWFLAKE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----..."
 ```
 - Using TOML configuration file:
 ```toml

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,8 +51,14 @@ provider "snowflake" {
   account_name           = "..." # required if not using profile. Can also be set via SNOWFLAKE_ACCOUNT_NAME env var
   user                   = "..." # required if not using profile or token. Can also be set via SNOWFLAKE_USER env var
   authenticator          = "SNOWFLAKE_JWT"
-  private_key            = "-----BEGIN ENCRYPTED PRIVATE KEY-----..."
-  private_key_passphrase = "passphrase"
+  private_key            = file("~/.ssh/snowflake_key.p8")
+  private_key_passphrase = var.private_key_passphrase
+}
+
+# Remember to provide the passphrase securely.
+variable "private_key_passphrase" {
+  type      = string
+  sensitive = true
 }
 
 # By using the `profile` field, missing fields will be populated from ~/.snowflake/config TOML file
@@ -135,6 +141,8 @@ The Snowflake provider support multiple ways to authenticate:
 
 In all cases `organization_name`, `account_name` and `user` are required.
 
+-> **Note** Storing the credentials and other secret values safely is on the users' side. Read more in [Authentication Methods guide](./guides/authentication_methods).
+
 ### Keypair Authentication Environment Variables
 
 You should generate the public and private keys and set up environment variables.
@@ -150,8 +158,6 @@ To export the variables into your provider:
 
 ```shell
 export SNOWFLAKE_USER="..."
-export SNOWFLAKE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----..."
-# Alternatively, source from a file.
 export SNOWFLAKE_PRIVATE_KEY=$(cat ~/.ssh/snowflake_key.p8)
 ```
 
@@ -233,7 +239,7 @@ provider "snowflake" {
 
 ```bash
 export SNOWFLAKE_USER="..."
-export SNOWFLAKE_PRIVATE_KEY="~/.ssh/snowflake_key"
+export SNOWFLAKE_PRIVATE_KEY=$(cat ~/.ssh/snowflake_key.p8)
 ```
 
 3. In a TOML file (default in ~/.snowflake/config). Notice the use of different profiles. The profile name needs to be specified in the Terraform configuration file in `profile` field. When this is not specified, `default` profile is loaded.

--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -19,9 +19,9 @@ The account resource allows you to create and manage Snowflake accounts. For mor
 ## Minimal
 resource "snowflake_account" "minimal" {
   name                 = "ACCOUNT_NAME"
-  admin_name           = "ADMIN_NAME"
-  admin_password       = "ADMIN_PASSWORD"
-  email                = "admin@email.com"
+  admin_name           = var.admin_name
+  admin_password       = var.admin_password
+  email                = var.email
   edition              = "STANDARD"
   grace_period_in_days = 3
 }
@@ -29,10 +29,10 @@ resource "snowflake_account" "minimal" {
 ## Complete (with SERVICE user type)
 resource "snowflake_account" "complete" {
   name                 = "ACCOUNT_NAME"
-  admin_name           = "ADMIN_NAME"
+  admin_name           = var.admin_name
   admin_rsa_public_key = "<public_key>"
   admin_user_type      = "SERVICE"
-  email                = "admin@email.com"
+  email                = var.email
   edition              = "STANDARD"
   region_group         = "PUBLIC"
   region               = "AWS_US_WEST_2"
@@ -44,12 +44,12 @@ resource "snowflake_account" "complete" {
 ## Complete (with PERSON user type)
 resource "snowflake_account" "complete" {
   name                 = "ACCOUNT_NAME"
-  admin_name           = "ADMIN_NAME"
-  admin_password       = "ADMIN_PASSWORD"
+  admin_name           = var.admin_name
+  admin_password       = var.admin_password
   admin_user_type      = "PERSON"
-  first_name           = "first_name"
-  last_name            = "last_name"
-  email                = "admin@email.com"
+  first_name           = var.first_name
+  last_name            = var.last_name
+  email                = var.email
   must_change_password = "false"
   edition              = "STANDARD"
   region_group         = "PUBLIC"
@@ -57,6 +57,31 @@ resource "snowflake_account" "complete" {
   comment              = "some comment"
   is_org_admin         = "true"
   grace_period_in_days = 3
+}
+
+variable "admin_name" {
+  type      = string
+  sensitive = true
+}
+
+variable "email" {
+  type      = string
+  sensitive = true
+}
+
+variable "admin_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "first_name" {
+  type      = string
+  sensitive = true
+}
+
+variable "last_name" {
+  type      = string
+  sensitive = true
 }
 ```
 -> **Note** Instead of using fully_qualified_name, you can reference objects managed outside Terraform by constructing a correct ID, consult [identifiers guide](../guides/identifiers_rework_design_decisions#new-computed-fully-qualified-name-field-in-resources).

--- a/docs/resources/api_authentication_integration_with_authorization_code_grant.md
+++ b/docs/resources/api_authentication_integration_with_authorization_code_grant.md
@@ -19,7 +19,7 @@ resource "snowflake_api_authentication_integration_with_authorization_code_grant
   enabled             = true
   name                = "test"
   oauth_client_id     = "sn-oauth-134o9erqfedlc"
-  oauth_client_secret = "eb9vaXsrcEvrFdfcvCaoijhilj4fc"
+  oauth_client_secret = var.oauth_client_secret
 }
 # resource with all fields set
 resource "snowflake_api_authentication_integration_with_authorization_code_grant" "test" {
@@ -31,9 +31,14 @@ resource "snowflake_api_authentication_integration_with_authorization_code_grant
   oauth_authorization_endpoint = "https://example.com"
   oauth_client_auth_method     = "CLIENT_SECRET_POST"
   oauth_client_id              = "sn-oauth-134o9erqfedlc"
-  oauth_client_secret          = "eb9vaXsrcEvrFdfcvCaoijhilj4fc"
+  oauth_client_secret          = var.oauth_client_secret
   oauth_refresh_token_validity = 42
   oauth_token_endpoint         = "https://example.com"
+}
+
+variable "oauth_client_secret" {
+  type      = string
+  sensitive = true
 }
 ```
 -> **Note** Instead of using fully_qualified_name, you can reference objects managed outside Terraform by constructing a correct ID, consult [identifiers guide](../guides/identifiers_rework_design_decisions#new-computed-fully-qualified-name-field-in-resources).

--- a/docs/resources/api_authentication_integration_with_authorization_code_grant.md
+++ b/docs/resources/api_authentication_integration_with_authorization_code_grant.md
@@ -18,7 +18,7 @@ Resource used to manage api authentication security integration objects with aut
 resource "snowflake_api_authentication_integration_with_authorization_code_grant" "test" {
   enabled             = true
   name                = "test"
-  oauth_client_id     = "sn-oauth-134o9erqfedlc"
+  oauth_client_id     = var.oauth_client_id
   oauth_client_secret = var.oauth_client_secret
 }
 # resource with all fields set
@@ -30,10 +30,15 @@ resource "snowflake_api_authentication_integration_with_authorization_code_grant
   oauth_allowed_scopes         = ["useraccount"]
   oauth_authorization_endpoint = "https://example.com"
   oauth_client_auth_method     = "CLIENT_SECRET_POST"
-  oauth_client_id              = "sn-oauth-134o9erqfedlc"
+  oauth_client_id              = var.oauth_client_id
   oauth_client_secret          = var.oauth_client_secret
   oauth_refresh_token_validity = 42
   oauth_token_endpoint         = "https://example.com"
+}
+
+variable "oauth_client_id" {
+  type      = string
+  sensitive = true
 }
 
 variable "oauth_client_secret" {

--- a/docs/resources/api_authentication_integration_with_client_credentials.md
+++ b/docs/resources/api_authentication_integration_with_client_credentials.md
@@ -18,7 +18,7 @@ Resource used to manage api authentication security integration objects with cli
 resource "snowflake_api_authentication_integration_with_client_credentials" "test" {
   enabled             = true
   name                = "test"
-  oauth_client_id     = "sn-oauth-134o9erqfedlc"
+  oauth_client_id     = var.oauth_client_id
   oauth_client_secret = var.oauth_client_secret
 }
 # resource with all fields set
@@ -29,9 +29,14 @@ resource "snowflake_api_authentication_integration_with_client_credentials" "tes
   oauth_access_token_validity = 42
   oauth_allowed_scopes        = ["useraccount"]
   oauth_client_auth_method    = "CLIENT_SECRET_POST"
-  oauth_client_id             = "sn-oauth-134o9erqfedlc"
+  oauth_client_id             = var.oauth_client_id
   oauth_client_secret         = var.oauth_client_secret
   oauth_token_endpoint        = "https://example.com"
+}
+
+variable "oauth_client_id" {
+  type      = string
+  sensitive = true
 }
 
 variable "oauth_client_secret" {

--- a/docs/resources/api_authentication_integration_with_client_credentials.md
+++ b/docs/resources/api_authentication_integration_with_client_credentials.md
@@ -19,7 +19,7 @@ resource "snowflake_api_authentication_integration_with_client_credentials" "tes
   enabled             = true
   name                = "test"
   oauth_client_id     = "sn-oauth-134o9erqfedlc"
-  oauth_client_secret = "eb9vaXsrcEvrFdfcvCaoijhilj4fc"
+  oauth_client_secret = var.oauth_client_secret
 }
 # resource with all fields set
 resource "snowflake_api_authentication_integration_with_client_credentials" "test" {
@@ -30,8 +30,13 @@ resource "snowflake_api_authentication_integration_with_client_credentials" "tes
   oauth_allowed_scopes        = ["useraccount"]
   oauth_client_auth_method    = "CLIENT_SECRET_POST"
   oauth_client_id             = "sn-oauth-134o9erqfedlc"
-  oauth_client_secret         = "eb9vaXsrcEvrFdfcvCaoijhilj4fc"
+  oauth_client_secret         = var.oauth_client_secret
   oauth_token_endpoint        = "https://example.com"
+}
+
+variable "oauth_client_secret" {
+  type      = string
+  sensitive = true
 }
 ```
 -> **Note** Instead of using fully_qualified_name, you can reference objects managed outside Terraform by constructing a correct ID, consult [identifiers guide](../guides/identifiers_rework_design_decisions#new-computed-fully-qualified-name-field-in-resources).

--- a/docs/resources/api_authentication_integration_with_jwt_bearer.md
+++ b/docs/resources/api_authentication_integration_with_jwt_bearer.md
@@ -18,7 +18,7 @@ Resource used to manage api authentication security integration objects with jwt
 resource "snowflake_api_authentication_integration_with_jwt_bearer" "test" {
   enabled                = true
   name                   = "test"
-  oauth_client_id        = "sn-oauth-134o9erqfedlc"
+  oauth_client_id        = var.oauth_client_id
   oauth_client_secret    = var.oauth_client_secret
   oauth_assertion_issuer = "issuer"
 }
@@ -30,11 +30,16 @@ resource "snowflake_api_authentication_integration_with_jwt_bearer" "test" {
   oauth_access_token_validity  = 42
   oauth_authorization_endpoint = "https://example.com"
   oauth_client_auth_method     = "CLIENT_SECRET_POST"
-  oauth_client_id              = "sn-oauth-134o9erqfedlc"
+  oauth_client_id              = var.oauth_client_id
   oauth_client_secret          = var.oauth_client_secret
   oauth_refresh_token_validity = 42
   oauth_token_endpoint         = "https://example.com"
   oauth_assertion_issuer       = "issuer"
+}
+
+variable "oauth_client_id" {
+  type      = string
+  sensitive = true
 }
 
 variable "oauth_client_secret" {

--- a/docs/resources/api_authentication_integration_with_jwt_bearer.md
+++ b/docs/resources/api_authentication_integration_with_jwt_bearer.md
@@ -19,7 +19,7 @@ resource "snowflake_api_authentication_integration_with_jwt_bearer" "test" {
   enabled                = true
   name                   = "test"
   oauth_client_id        = "sn-oauth-134o9erqfedlc"
-  oauth_client_secret    = "eb9vaXsrcEvrFdfcvCaoijhilj4fc"
+  oauth_client_secret    = var.oauth_client_secret
   oauth_assertion_issuer = "issuer"
 }
 # resource with all fields set
@@ -31,10 +31,15 @@ resource "snowflake_api_authentication_integration_with_jwt_bearer" "test" {
   oauth_authorization_endpoint = "https://example.com"
   oauth_client_auth_method     = "CLIENT_SECRET_POST"
   oauth_client_id              = "sn-oauth-134o9erqfedlc"
-  oauth_client_secret          = "eb9vaXsrcEvrFdfcvCaoijhilj4fc"
+  oauth_client_secret          = var.oauth_client_secret
   oauth_refresh_token_validity = 42
   oauth_token_endpoint         = "https://example.com"
   oauth_assertion_issuer       = "issuer"
+}
+
+variable "oauth_client_secret" {
+  type      = string
+  sensitive = true
 }
 ```
 -> **Note** Instead of using fully_qualified_name, you can reference objects managed outside Terraform by constructing a correct ID, consult [identifiers guide](../guides/identifiers_rework_design_decisions#new-computed-fully-qualified-name-field-in-resources).

--- a/docs/resources/legacy_service_user.md
+++ b/docs/resources/legacy_service_user.md
@@ -28,12 +28,12 @@ resource "snowflake_legacy_service_user" "minimal" {
 # with all attributes set
 resource "snowflake_legacy_service_user" "user" {
   name         = "Snowflake Legacy Service User"
-  login_name   = "legacy_service_user"
+  login_name   = var.login_name
   comment      = "A legacy service user of snowflake."
-  password     = "secret"
+  password     = var.password
   disabled     = "false"
   display_name = "Snowflake Legacy Service User display name"
-  email        = "legacy.service.user@snowflake.example"
+  email        = var.email
 
   default_warehouse              = "warehouse"
   default_secondary_roles_option = "ALL"
@@ -111,6 +111,21 @@ resource "snowflake_legacy_service_user" "u" {
   use_cached_result                             = false
   week_of_year_policy                           = 1
   week_start                                    = 1
+}
+
+variable "email" {
+  type      = string
+  sensitive = true
+}
+
+variable "login_name" {
+  type      = string
+  sensitive = true
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }
 ```
 -> **Note** Instead of using fully_qualified_name, you can reference objects managed outside Terraform by constructing a correct ID, consult [identifiers guide](../guides/identifiers_rework_design_decisions#new-computed-fully-qualified-name-field-in-resources).

--- a/docs/resources/managed_account.md
+++ b/docs/resources/managed_account.md
@@ -17,12 +17,17 @@ description: |-
 resource "snowflake_managed_account" "account" {
   name           = "managed account"
   admin_name     = "admin"
-  admin_password = "secret"
+  admin_password = var.admin_password
   type           = "READER"
   comment        = "A managed account."
   cloud          = "aws"
   region         = "us-west-2"
   locator        = "managed-account"
+}
+
+variable "admin_password" {
+  type      = string
+  sensitive = true
 }
 ```
 

--- a/docs/resources/secret_with_authorization_code_grant.md
+++ b/docs/resources/secret_with_authorization_code_grant.md
@@ -18,7 +18,7 @@ resource "snowflake_secret_with_authorization_code_grant" "test" {
   database                        = "EXAMPLE_DB"
   schema                          = "EXAMPLE_SCHEMA"
   api_authentication              = snowflake_api_authentication_integration_with_authorization_code_grant.example.fully_qualified_name
-  oauth_refresh_token             = "EXAMPLE_TOKEN"
+  oauth_refresh_token             = var.oauth_refresh_token
   oauth_refresh_token_expiry_time = "2025-01-02 15:04:01"
 }
 
@@ -28,9 +28,14 @@ resource "snowflake_secret_with_authorization_code_grant" "test" {
   database                        = "EXAMPLE_DB"
   schema                          = "EXAMPLE_SCHEMA"
   api_authentication              = snowflake_api_authentication_integration_with_authorization_code_grant.example.fully_qualified_name
-  oauth_refresh_token             = "EXAMPLE_TOKEN"
+  oauth_refresh_token             = var.oauth_refresh_token
   oauth_refresh_token_expiry_time = "2025-01-02 15:04:01"
   comment                         = "EXAMPLE_COMMENT"
+}
+
+variable "oauth_refresh_token" {
+  type      = string
+  sensitive = true
 }
 ```
 -> **Note** Instead of using fully_qualified_name, you can reference objects managed outside Terraform by constructing a correct ID, consult [identifiers guide](../guides/identifiers_rework_design_decisions#new-computed-fully-qualified-name-field-in-resources).

--- a/docs/resources/secret_with_basic_authentication.md
+++ b/docs/resources/secret_with_basic_authentication.md
@@ -17,18 +17,29 @@ resource "snowflake_secret_with_basic_authentication" "test" {
   name     = "EXAMPLE_SECRET"
   database = "EXAMPLE_DB"
   schema   = "EXAMPLE_SCHEMA"
-  username = "EXAMPLE_USERNAME"
-  password = "EXAMPLE_PASSWORD"
+  username = var.username
+  password = var.password
 }
+
 
 # resource with all fields set
 resource "snowflake_secret_with_basic_authentication" "test" {
   name     = "EXAMPLE_SECRET"
   database = "EXAMPLE_DB"
   schema   = "EXAMPLE_SCHEMA"
-  username = "EXAMPLE_USERNAME"
-  password = "EXAMPLE_PASSWORD"
+  username = var.username
+  password = var.password
   comment  = "EXAMPLE_COMMENT"
+}
+
+variable "username" {
+  type      = string
+  sensitive = true
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }
 ```
 -> **Note** Instead of using fully_qualified_name, you can reference objects managed outside Terraform by constructing a correct ID, consult [identifiers guide](../guides/identifiers_rework_design_decisions#new-computed-fully-qualified-name-field-in-resources).

--- a/docs/resources/secret_with_generic_string.md
+++ b/docs/resources/secret_with_generic_string.md
@@ -17,7 +17,7 @@ resource "snowflake_secret_with_generic_string" "test" {
   name          = "EXAMPLE_SECRET"
   database      = "EXAMPLE_DB"
   schema        = "EXAMPLE_SCHEMA"
-  secret_string = "EXAMPLE_SECRET_STRING"
+  secret_string = var.secret_string
 }
 
 # resource with all fields set
@@ -25,8 +25,13 @@ resource "snowflake_secret_with_generic_string" "test" {
   name          = "EXAMPLE_SECRET"
   database      = "EXAMPLE_DB"
   schema        = "EXAMPLE_SCHEMA"
-  secret_string = "EXAMPLE_SECRET_STRING"
+  secret_string = var.secret_string
   comment       = "EXAMPLE_COMMENT"
+}
+
+variable "secret_string" {
+  type      = string
+  sensitive = true
 }
 ```
 -> **Note** Instead of using fully_qualified_name, you can reference objects managed outside Terraform by constructing a correct ID, consult [identifiers guide](../guides/identifiers_rework_design_decisions#new-computed-fully-qualified-name-field-in-resources).

--- a/docs/resources/service_user.md
+++ b/docs/resources/service_user.md
@@ -28,11 +28,11 @@ resource "snowflake_service_user" "minimal" {
 # with all attributes set
 resource "snowflake_service_user" "service_user" {
   name         = "Snowflake Service User"
-  login_name   = "service_user"
+  login_name   = var.login_name
   comment      = "A service user of snowflake."
   disabled     = "false"
   display_name = "Snowflake Service User"
-  email        = "service_user@snowflake.example"
+  email        = var.email
 
   default_warehouse              = "warehouse"
   default_secondary_roles_option = "ALL"
@@ -108,6 +108,16 @@ resource "snowflake_service_user" "u" {
   use_cached_result                             = false
   week_of_year_policy                           = 1
   week_start                                    = 1
+}
+
+variable "email" {
+  type      = string
+  sensitive = true
+}
+
+variable "login_name" {
+  type      = string
+  sensitive = true
 }
 ```
 -> **Note** Instead of using fully_qualified_name, you can reference objects managed outside Terraform by constructing a correct ID, consult [identifiers guide](../guides/identifiers_rework_design_decisions#new-computed-fully-qualified-name-field-in-resources).

--- a/docs/resources/stage.md
+++ b/docs/resources/stage.md
@@ -23,7 +23,7 @@ resource "snowflake_stage" "example_stage" {
 }
 
 # with an existing hardcoded file format
-# please see other examples in the resource documentation
+# please see other examples in the snowflake_file_format resource documentation
 resource "snowflake_stage" "example_stage_with_file_format" {
   name        = "EXAMPLE_STAGE"
   url         = "s3://com.example.bucket/prefix"
@@ -31,6 +31,16 @@ resource "snowflake_stage" "example_stage_with_file_format" {
   schema      = "EXAMPLE_SCHEMA"
   credentials = "AWS_KEY_ID='${var.example_aws_key_id}' AWS_SECRET_KEY='${var.example_aws_secret_key}'"
   file_format = "FORMAT_NAME = DB.SCHEMA.FORMATNAME"
+}
+
+variable "example_aws_key_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "example_aws_secret_key" {
+  type      = string
+  sensitive = true
 }
 ```
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -28,15 +28,15 @@ resource "snowflake_user" "minimal" {
 # with all attributes set
 resource "snowflake_user" "user" {
   name         = "Snowflake User"
-  login_name   = "snowflake_user"
-  first_name   = "Snowflake"
-  middle_name  = "Middle"
-  last_name    = "User"
+  login_name   = var.login_name
+  first_name   = var.first_name
+  middle_name  = var.middle_name
+  last_name    = var.last_name
   comment      = "User of snowflake."
-  password     = "secret"
+  password     = var.password
   disabled     = "false"
   display_name = "Snowflake User display name"
-  email        = "user@snowflake.example"
+  email        = var.email
 
   default_warehouse              = snowflake_warehouse.example.fully_qualified_name
   default_secondary_roles_option = "ALL"
@@ -116,6 +116,36 @@ resource "snowflake_user" "u" {
   use_cached_result                             = false
   week_of_year_policy                           = 1
   week_start                                    = 1
+}
+
+variable "email" {
+  type      = string
+  sensitive = true
+}
+
+variable "login_name" {
+  type      = string
+  sensitive = true
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
+}
+
+variable "first_name" {
+  type      = string
+  sensitive = true
+}
+
+variable "middle_name" {
+  type      = string
+  sensitive = true
+}
+
+variable "last_name" {
+  type      = string
+  sensitive = true
 }
 ```
 -> **Note** Instead of using fully_qualified_name, you can reference objects managed outside Terraform by constructing a correct ID, consult [identifiers guide](../guides/identifiers_rework_design_decisions#new-computed-fully-qualified-name-field-in-resources).

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -29,8 +29,14 @@ provider "snowflake" {
   account_name           = "..." # required if not using profile. Can also be set via SNOWFLAKE_ACCOUNT_NAME env var
   user                   = "..." # required if not using profile or token. Can also be set via SNOWFLAKE_USER env var
   authenticator          = "SNOWFLAKE_JWT"
-  private_key            = "-----BEGIN ENCRYPTED PRIVATE KEY-----..."
-  private_key_passphrase = "passphrase"
+  private_key            = file("~/.ssh/snowflake_key.p8")
+  private_key_passphrase = var.private_key_passphrase
+}
+
+# Remember to provide the passphrase securely.
+variable "private_key_passphrase" {
+  type      = string
+  sensitive = true
 }
 
 # By using the `profile` field, missing fields will be populated from ~/.snowflake/config TOML file

--- a/examples/resources/snowflake_account/resource.tf
+++ b/examples/resources/snowflake_account/resource.tf
@@ -1,9 +1,9 @@
 ## Minimal
 resource "snowflake_account" "minimal" {
   name                 = "ACCOUNT_NAME"
-  admin_name           = "ADMIN_NAME"
-  admin_password       = "ADMIN_PASSWORD"
-  email                = "admin@email.com"
+  admin_name           = var.admin_name
+  admin_password       = var.admin_password
+  email                = var.email
   edition              = "STANDARD"
   grace_period_in_days = 3
 }
@@ -11,10 +11,10 @@ resource "snowflake_account" "minimal" {
 ## Complete (with SERVICE user type)
 resource "snowflake_account" "complete" {
   name                 = "ACCOUNT_NAME"
-  admin_name           = "ADMIN_NAME"
+  admin_name           = var.admin_name
   admin_rsa_public_key = "<public_key>"
   admin_user_type      = "SERVICE"
-  email                = "admin@email.com"
+  email                = var.email
   edition              = "STANDARD"
   region_group         = "PUBLIC"
   region               = "AWS_US_WEST_2"
@@ -26,12 +26,12 @@ resource "snowflake_account" "complete" {
 ## Complete (with PERSON user type)
 resource "snowflake_account" "complete" {
   name                 = "ACCOUNT_NAME"
-  admin_name           = "ADMIN_NAME"
-  admin_password       = "ADMIN_PASSWORD"
+  admin_name           = var.admin_name
+  admin_password       = var.admin_password
   admin_user_type      = "PERSON"
-  first_name           = "first_name"
-  last_name            = "last_name"
-  email                = "admin@email.com"
+  first_name           = var.first_name
+  last_name            = var.last_name
+  email                = var.email
   must_change_password = "false"
   edition              = "STANDARD"
   region_group         = "PUBLIC"
@@ -39,4 +39,29 @@ resource "snowflake_account" "complete" {
   comment              = "some comment"
   is_org_admin         = "true"
   grace_period_in_days = 3
+}
+
+variable "admin_name" {
+  type      = string
+  sensitive = true
+}
+
+variable "email" {
+  type      = string
+  sensitive = true
+}
+
+variable "admin_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "first_name" {
+  type      = string
+  sensitive = true
+}
+
+variable "last_name" {
+  type      = string
+  sensitive = true
 }

--- a/examples/resources/snowflake_api_authentication_integration_with_authorization_code_grant/resource.tf
+++ b/examples/resources/snowflake_api_authentication_integration_with_authorization_code_grant/resource.tf
@@ -2,7 +2,7 @@
 resource "snowflake_api_authentication_integration_with_authorization_code_grant" "test" {
   enabled             = true
   name                = "test"
-  oauth_client_id     = "sn-oauth-134o9erqfedlc"
+  oauth_client_id     = var.oauth_client_id
   oauth_client_secret = var.oauth_client_secret
 }
 # resource with all fields set
@@ -14,10 +14,15 @@ resource "snowflake_api_authentication_integration_with_authorization_code_grant
   oauth_allowed_scopes         = ["useraccount"]
   oauth_authorization_endpoint = "https://example.com"
   oauth_client_auth_method     = "CLIENT_SECRET_POST"
-  oauth_client_id              = "sn-oauth-134o9erqfedlc"
+  oauth_client_id              = var.oauth_client_id
   oauth_client_secret          = var.oauth_client_secret
   oauth_refresh_token_validity = 42
   oauth_token_endpoint         = "https://example.com"
+}
+
+variable "oauth_client_id" {
+  type      = string
+  sensitive = true
 }
 
 variable "oauth_client_secret" {

--- a/examples/resources/snowflake_api_authentication_integration_with_authorization_code_grant/resource.tf
+++ b/examples/resources/snowflake_api_authentication_integration_with_authorization_code_grant/resource.tf
@@ -3,7 +3,7 @@ resource "snowflake_api_authentication_integration_with_authorization_code_grant
   enabled             = true
   name                = "test"
   oauth_client_id     = "sn-oauth-134o9erqfedlc"
-  oauth_client_secret = "eb9vaXsrcEvrFdfcvCaoijhilj4fc"
+  oauth_client_secret = var.oauth_client_secret
 }
 # resource with all fields set
 resource "snowflake_api_authentication_integration_with_authorization_code_grant" "test" {
@@ -15,7 +15,12 @@ resource "snowflake_api_authentication_integration_with_authorization_code_grant
   oauth_authorization_endpoint = "https://example.com"
   oauth_client_auth_method     = "CLIENT_SECRET_POST"
   oauth_client_id              = "sn-oauth-134o9erqfedlc"
-  oauth_client_secret          = "eb9vaXsrcEvrFdfcvCaoijhilj4fc"
+  oauth_client_secret          = var.oauth_client_secret
   oauth_refresh_token_validity = 42
   oauth_token_endpoint         = "https://example.com"
+}
+
+variable "oauth_client_secret" {
+  type      = string
+  sensitive = true
 }

--- a/examples/resources/snowflake_api_authentication_integration_with_client_credentials/resource.tf
+++ b/examples/resources/snowflake_api_authentication_integration_with_client_credentials/resource.tf
@@ -2,7 +2,7 @@
 resource "snowflake_api_authentication_integration_with_client_credentials" "test" {
   enabled             = true
   name                = "test"
-  oauth_client_id     = "sn-oauth-134o9erqfedlc"
+  oauth_client_id     = var.oauth_client_id
   oauth_client_secret = var.oauth_client_secret
 }
 # resource with all fields set
@@ -13,9 +13,14 @@ resource "snowflake_api_authentication_integration_with_client_credentials" "tes
   oauth_access_token_validity = 42
   oauth_allowed_scopes        = ["useraccount"]
   oauth_client_auth_method    = "CLIENT_SECRET_POST"
-  oauth_client_id             = "sn-oauth-134o9erqfedlc"
+  oauth_client_id             = var.oauth_client_id
   oauth_client_secret         = var.oauth_client_secret
   oauth_token_endpoint        = "https://example.com"
+}
+
+variable "oauth_client_id" {
+  type      = string
+  sensitive = true
 }
 
 variable "oauth_client_secret" {

--- a/examples/resources/snowflake_api_authentication_integration_with_client_credentials/resource.tf
+++ b/examples/resources/snowflake_api_authentication_integration_with_client_credentials/resource.tf
@@ -3,7 +3,7 @@ resource "snowflake_api_authentication_integration_with_client_credentials" "tes
   enabled             = true
   name                = "test"
   oauth_client_id     = "sn-oauth-134o9erqfedlc"
-  oauth_client_secret = "eb9vaXsrcEvrFdfcvCaoijhilj4fc"
+  oauth_client_secret = var.oauth_client_secret
 }
 # resource with all fields set
 resource "snowflake_api_authentication_integration_with_client_credentials" "test" {
@@ -14,6 +14,11 @@ resource "snowflake_api_authentication_integration_with_client_credentials" "tes
   oauth_allowed_scopes        = ["useraccount"]
   oauth_client_auth_method    = "CLIENT_SECRET_POST"
   oauth_client_id             = "sn-oauth-134o9erqfedlc"
-  oauth_client_secret         = "eb9vaXsrcEvrFdfcvCaoijhilj4fc"
+  oauth_client_secret         = var.oauth_client_secret
   oauth_token_endpoint        = "https://example.com"
+}
+
+variable "oauth_client_secret" {
+  type      = string
+  sensitive = true
 }

--- a/examples/resources/snowflake_api_authentication_integration_with_jwt_bearer/resource.tf
+++ b/examples/resources/snowflake_api_authentication_integration_with_jwt_bearer/resource.tf
@@ -2,7 +2,7 @@
 resource "snowflake_api_authentication_integration_with_jwt_bearer" "test" {
   enabled                = true
   name                   = "test"
-  oauth_client_id        = "sn-oauth-134o9erqfedlc"
+  oauth_client_id        = var.oauth_client_id
   oauth_client_secret    = var.oauth_client_secret
   oauth_assertion_issuer = "issuer"
 }
@@ -14,11 +14,16 @@ resource "snowflake_api_authentication_integration_with_jwt_bearer" "test" {
   oauth_access_token_validity  = 42
   oauth_authorization_endpoint = "https://example.com"
   oauth_client_auth_method     = "CLIENT_SECRET_POST"
-  oauth_client_id              = "sn-oauth-134o9erqfedlc"
+  oauth_client_id              = var.oauth_client_id
   oauth_client_secret          = var.oauth_client_secret
   oauth_refresh_token_validity = 42
   oauth_token_endpoint         = "https://example.com"
   oauth_assertion_issuer       = "issuer"
+}
+
+variable "oauth_client_id" {
+  type      = string
+  sensitive = true
 }
 
 variable "oauth_client_secret" {

--- a/examples/resources/snowflake_api_authentication_integration_with_jwt_bearer/resource.tf
+++ b/examples/resources/snowflake_api_authentication_integration_with_jwt_bearer/resource.tf
@@ -3,7 +3,7 @@ resource "snowflake_api_authentication_integration_with_jwt_bearer" "test" {
   enabled                = true
   name                   = "test"
   oauth_client_id        = "sn-oauth-134o9erqfedlc"
-  oauth_client_secret    = "eb9vaXsrcEvrFdfcvCaoijhilj4fc"
+  oauth_client_secret    = var.oauth_client_secret
   oauth_assertion_issuer = "issuer"
 }
 # resource with all fields set
@@ -15,8 +15,13 @@ resource "snowflake_api_authentication_integration_with_jwt_bearer" "test" {
   oauth_authorization_endpoint = "https://example.com"
   oauth_client_auth_method     = "CLIENT_SECRET_POST"
   oauth_client_id              = "sn-oauth-134o9erqfedlc"
-  oauth_client_secret          = "eb9vaXsrcEvrFdfcvCaoijhilj4fc"
+  oauth_client_secret          = var.oauth_client_secret
   oauth_refresh_token_validity = 42
   oauth_token_endpoint         = "https://example.com"
   oauth_assertion_issuer       = "issuer"
+}
+
+variable "oauth_client_secret" {
+  type      = string
+  sensitive = true
 }

--- a/examples/resources/snowflake_legacy_service_user/resource.tf
+++ b/examples/resources/snowflake_legacy_service_user/resource.tf
@@ -6,12 +6,12 @@ resource "snowflake_legacy_service_user" "minimal" {
 # with all attributes set
 resource "snowflake_legacy_service_user" "user" {
   name         = "Snowflake Legacy Service User"
-  login_name   = "legacy_service_user"
+  login_name   = var.login_name
   comment      = "A legacy service user of snowflake."
-  password     = "secret"
+  password     = var.password
   disabled     = "false"
   display_name = "Snowflake Legacy Service User display name"
-  email        = "legacy.service.user@snowflake.example"
+  email        = var.email
 
   default_warehouse              = "warehouse"
   default_secondary_roles_option = "ALL"
@@ -89,4 +89,19 @@ resource "snowflake_legacy_service_user" "u" {
   use_cached_result                             = false
   week_of_year_policy                           = 1
   week_start                                    = 1
+}
+
+variable "email" {
+  type      = string
+  sensitive = true
+}
+
+variable "login_name" {
+  type      = string
+  sensitive = true
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }

--- a/examples/resources/snowflake_managed_account/resource.tf
+++ b/examples/resources/snowflake_managed_account/resource.tf
@@ -1,10 +1,15 @@
 resource "snowflake_managed_account" "account" {
   name           = "managed account"
   admin_name     = "admin"
-  admin_password = "secret"
+  admin_password = var.admin_password
   type           = "READER"
   comment        = "A managed account."
   cloud          = "aws"
   region         = "us-west-2"
   locator        = "managed-account"
+}
+
+variable "admin_password" {
+  type      = string
+  sensitive = true
 }

--- a/examples/resources/snowflake_secret_with_authorization_code_grant/resource.tf
+++ b/examples/resources/snowflake_secret_with_authorization_code_grant/resource.tf
@@ -4,7 +4,7 @@ resource "snowflake_secret_with_authorization_code_grant" "test" {
   database                        = "EXAMPLE_DB"
   schema                          = "EXAMPLE_SCHEMA"
   api_authentication              = snowflake_api_authentication_integration_with_authorization_code_grant.example.fully_qualified_name
-  oauth_refresh_token             = "EXAMPLE_TOKEN"
+  oauth_refresh_token             = var.oauth_refresh_token
   oauth_refresh_token_expiry_time = "2025-01-02 15:04:01"
 }
 
@@ -14,7 +14,12 @@ resource "snowflake_secret_with_authorization_code_grant" "test" {
   database                        = "EXAMPLE_DB"
   schema                          = "EXAMPLE_SCHEMA"
   api_authentication              = snowflake_api_authentication_integration_with_authorization_code_grant.example.fully_qualified_name
-  oauth_refresh_token             = "EXAMPLE_TOKEN"
+  oauth_refresh_token             = var.oauth_refresh_token
   oauth_refresh_token_expiry_time = "2025-01-02 15:04:01"
   comment                         = "EXAMPLE_COMMENT"
+}
+
+variable "oauth_refresh_token" {
+  type      = string
+  sensitive = true
 }

--- a/examples/resources/snowflake_secret_with_basic_authentication/resource.tf
+++ b/examples/resources/snowflake_secret_with_basic_authentication/resource.tf
@@ -3,16 +3,27 @@ resource "snowflake_secret_with_basic_authentication" "test" {
   name     = "EXAMPLE_SECRET"
   database = "EXAMPLE_DB"
   schema   = "EXAMPLE_SCHEMA"
-  username = "EXAMPLE_USERNAME"
-  password = "EXAMPLE_PASSWORD"
+  username = var.username
+  password = var.password
 }
+
 
 # resource with all fields set
 resource "snowflake_secret_with_basic_authentication" "test" {
   name     = "EXAMPLE_SECRET"
   database = "EXAMPLE_DB"
   schema   = "EXAMPLE_SCHEMA"
-  username = "EXAMPLE_USERNAME"
-  password = "EXAMPLE_PASSWORD"
+  username = var.username
+  password = var.password
   comment  = "EXAMPLE_COMMENT"
+}
+
+variable "username" {
+  type      = string
+  sensitive = true
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }

--- a/examples/resources/snowflake_secret_with_generic_string/resource.tf
+++ b/examples/resources/snowflake_secret_with_generic_string/resource.tf
@@ -3,7 +3,7 @@ resource "snowflake_secret_with_generic_string" "test" {
   name          = "EXAMPLE_SECRET"
   database      = "EXAMPLE_DB"
   schema        = "EXAMPLE_SCHEMA"
-  secret_string = "EXAMPLE_SECRET_STRING"
+  secret_string = var.secret_string
 }
 
 # resource with all fields set
@@ -11,6 +11,11 @@ resource "snowflake_secret_with_generic_string" "test" {
   name          = "EXAMPLE_SECRET"
   database      = "EXAMPLE_DB"
   schema        = "EXAMPLE_SCHEMA"
-  secret_string = "EXAMPLE_SECRET_STRING"
+  secret_string = var.secret_string
   comment       = "EXAMPLE_COMMENT"
+}
+
+variable "secret_string" {
+  type      = string
+  sensitive = true
 }

--- a/examples/resources/snowflake_service_user/resource.tf
+++ b/examples/resources/snowflake_service_user/resource.tf
@@ -6,11 +6,11 @@ resource "snowflake_service_user" "minimal" {
 # with all attributes set
 resource "snowflake_service_user" "service_user" {
   name         = "Snowflake Service User"
-  login_name   = "service_user"
+  login_name   = var.login_name
   comment      = "A service user of snowflake."
   disabled     = "false"
   display_name = "Snowflake Service User"
-  email        = "service_user@snowflake.example"
+  email        = var.email
 
   default_warehouse              = "warehouse"
   default_secondary_roles_option = "ALL"
@@ -86,4 +86,14 @@ resource "snowflake_service_user" "u" {
   use_cached_result                             = false
   week_of_year_policy                           = 1
   week_start                                    = 1
+}
+
+variable "email" {
+  type      = string
+  sensitive = true
+}
+
+variable "login_name" {
+  type      = string
+  sensitive = true
 }

--- a/examples/resources/snowflake_stage/resource.tf
+++ b/examples/resources/snowflake_stage/resource.tf
@@ -8,7 +8,7 @@ resource "snowflake_stage" "example_stage" {
 }
 
 # with an existing hardcoded file format
-# please see other examples in the resource documentation
+# please see other examples in the snowflake_file_format resource documentation
 resource "snowflake_stage" "example_stage_with_file_format" {
   name        = "EXAMPLE_STAGE"
   url         = "s3://com.example.bucket/prefix"
@@ -16,4 +16,14 @@ resource "snowflake_stage" "example_stage_with_file_format" {
   schema      = "EXAMPLE_SCHEMA"
   credentials = "AWS_KEY_ID='${var.example_aws_key_id}' AWS_SECRET_KEY='${var.example_aws_secret_key}'"
   file_format = "FORMAT_NAME = DB.SCHEMA.FORMATNAME"
+}
+
+variable "example_aws_key_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "example_aws_secret_key" {
+  type      = string
+  sensitive = true
 }

--- a/examples/resources/snowflake_user/resource.tf
+++ b/examples/resources/snowflake_user/resource.tf
@@ -6,15 +6,15 @@ resource "snowflake_user" "minimal" {
 # with all attributes set
 resource "snowflake_user" "user" {
   name         = "Snowflake User"
-  login_name   = "snowflake_user"
-  first_name   = "Snowflake"
-  middle_name  = "Middle"
-  last_name    = "User"
+  login_name   = var.login_name
+  first_name   = var.first_name
+  middle_name  = var.middle_name
+  last_name    = var.last_name
   comment      = "User of snowflake."
-  password     = "secret"
+  password     = var.password
   disabled     = "false"
   display_name = "Snowflake User display name"
-  email        = "user@snowflake.example"
+  email        = var.email
 
   default_warehouse              = snowflake_warehouse.example.fully_qualified_name
   default_secondary_roles_option = "ALL"
@@ -94,4 +94,34 @@ resource "snowflake_user" "u" {
   use_cached_result                             = false
   week_of_year_policy                           = 1
   week_start                                    = 1
+}
+
+variable "email" {
+  type      = string
+  sensitive = true
+}
+
+variable "login_name" {
+  type      = string
+  sensitive = true
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
+}
+
+variable "first_name" {
+  type      = string
+  sensitive = true
+}
+
+variable "middle_name" {
+  type      = string
+  sensitive = true
+}
+
+variable "last_name" {
+  type      = string
+  sensitive = true
 }

--- a/templates/guides/authentication_methods.md.tmpl
+++ b/templates/guides/authentication_methods.md.tmpl
@@ -49,7 +49,12 @@ provider "snowflake" {
   organization_name = "<organization_name>"
   account_name      = "<account_name>"
   user              = "<user_name>"
-  password          = "<password>"
+  password          = var.password
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }
 ```
 
@@ -61,12 +66,17 @@ provider "snowflake" {
   organization_name = "<organization_name>"
   account_name      = "<account_name>"
   user              = "<user_name>"
-  password          = "<password>"
+  password          = var.password
   authenticator     = "Snowflake"
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }
 ```
 
-### JWT authenticator flow 
+### JWT authenticator flow
 
 To use JWT authentication, you have to firstly generate key-pairs used by Snowflake.
 To correctly generate the necessary keys, follow [this guide](https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-authentication) from the official Snowflake documentation.
@@ -86,20 +96,14 @@ provider "snowflake" {
 To load the private key you can utilize the built-in [file](https://developer.hashicorp.com/terraform/language/functions/file) function.
 If you have any issues with this method, one of the possible root causes could be an additional newline at the end of the file that causes error in the underlying Go Snowflake driver.
 If this doesn't help, you can try other methods of supplying this field:
-- Filling the key directly by using [multi-string notation](https://developer.hashicorp.com/terraform/language/expressions/strings#heredoc-strings)
 - Sourcing it from the environment variable:
 ```shell
-export SNOWFLAKE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----..."
-# Alternatively, source from a file.
 export SNOWFLAKE_PRIVATE_KEY=$(cat ~/.ssh/snowflake_private_key.p8)
-
-export SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="..."
 ```
 - Using TOML configuration file:
 ```toml
 [default]
 private_key = "..."
-private_key_passphrase = "..."
 ```
 
 In case of any other issues, take a look at related topics:
@@ -117,7 +121,12 @@ provider "snowflake" {
   user                   = "<user_name>"
   authenticator          = "JWT"
   private_key            = file("~/.ssh/snowflake_private_key.p8")
-  private_key_passphrase = "<passphrase>"
+  private_key_passphrase = var.private_key_passphrase
+}
+
+variable "private_key_passphrase" {
+  type      = string
+  sensitive = true
 }
 ```
 
@@ -168,9 +177,14 @@ provider "snowflake" {
   organization_name = "<organization_name>"
   account_name      = "<account_name>"
   user              = "<user_name>"
-  password          = "<password>"
+  password          = var.password
   authenticator     = "Okta"
   okta_url          = "https://dev-123456.okta.com"
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }
 ```
 
@@ -196,7 +210,7 @@ The output of this command is your `<account_name>`.
 
 ### Be sure you are passing all the required fields
 
-This point is not only referring to double-checking the fields you are passing, but also to inform you that depending on the account 
+This point is not only referring to double-checking the fields you are passing, but also to inform you that depending on the account
 you want to log into, a different set of parameters may be required.
 
 Whenever you are on a Snowflake deployment that has different url than the default one:

--- a/templates/guides/authentication_methods.md.tmpl
+++ b/templates/guides/authentication_methods.md.tmpl
@@ -58,6 +58,14 @@ variable "password" {
 }
 ```
 
+You can then set Terraform variables like:
+- If a variable does not have any value set, you will be prompted by Terraform to provide the value.
+- Use Terraform VAR environment variables: `TF_VAR_password="<key>" terraform plan`
+- Use Terraform flags: `terraform plan -var="private_key=<key>"`
+- Use Snowflake Terraform Provider flags: `SNOWFLAKE_PRIVATE_KEY="<key>" terraform plan`
+
+Remember to load `<key>` from a secure location, instead of hardcoding the value.
+
 Without passing any authenticator, we depend on the underlying Go Snowflake driver and Snowflake itself to fill this field out.
 This means that we do not provision the default, and it may change at some point, so if you want to be explicit, you can define Snowflake authenticator like so:
 
@@ -88,8 +96,15 @@ provider "snowflake" {
   organization_name = "<organization_name>"
   account_name      = "<account_name>"
   user              = "<user_name>"
-  authenticator     = "JWT"
+  authenticator     = "SNOWFLAKE_JWT"
   private_key       = file("~/.ssh/snowflake_private_key.p8")
+  # Optionally, set it with Terraform variable.
+  private_key       = var.private_key
+}
+
+variable "private_key" {
+  type      = string
+  sensitive = true
 }
 ```
 
@@ -119,7 +134,7 @@ provider "snowflake" {
   organization_name      = "<organization_name>"
   account_name           = "<account_name>"
   user                   = "<user_name>"
-  authenticator          = "JWT"
+  authenticator          = "SNOWFLAKE_JWT"
   private_key            = file("~/.ssh/snowflake_private_key.p8")
   private_key_passphrase = var.private_key_passphrase
 }
@@ -143,8 +158,13 @@ provider "snowflake" {
   organization_name = "<organization_name>"
   account_name      = "<account_name>"
   user              = "<user_name>"
-  password          = "<password>"
+  password          = var.password
   authenticator     = "UsernamePasswordMFA"
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }
 ```
 
@@ -155,9 +175,14 @@ provider "snowflake" {
   organization_name = "<organization_name>"
   account_name      = "<account_name>"
   user              = "<user_name>"
-  password          = "<password>"
+  password          = var.password
   authenticator     = "UsernamePasswordMFA"
   passcode          = "000000"
+}
+
+variable "password" {
+  type      = string
+  sensitive = true
 }
 ```
 

--- a/templates/guides/authentication_methods.md.tmpl
+++ b/templates/guides/authentication_methods.md.tmpl
@@ -111,9 +111,12 @@ variable "private_key" {
 To load the private key you can utilize the built-in [file](https://developer.hashicorp.com/terraform/language/functions/file) function.
 If you have any issues with this method, one of the possible root causes could be an additional newline at the end of the file that causes error in the underlying Go Snowflake driver.
 If this doesn't help, you can try other methods of supplying this field:
+- Filling the key directly by using [multi-string notation](https://developer.hashicorp.com/terraform/language/expressions/strings#heredoc-strings) (not recommended).
 - Sourcing it from the environment variable:
 ```shell
 export SNOWFLAKE_PRIVATE_KEY=$(cat ~/.ssh/snowflake_private_key.p8)
+# Or inline the value (not recommended).
+export SNOWFLAKE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----..."
 ```
 - Using TOML configuration file:
 ```toml

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -40,6 +40,8 @@ The Snowflake provider support multiple ways to authenticate:
 
 In all cases `organization_name`, `account_name` and `user` are required.
 
+-> **Note** Storing the credentials and other secret values safely is on the users' side. Read more in [Authentication Methods guide](./guides/authentication_methods).
+
 ### Keypair Authentication Environment Variables
 
 You should generate the public and private keys and set up environment variables.
@@ -55,8 +57,6 @@ To export the variables into your provider:
 
 ```shell
 export SNOWFLAKE_USER="..."
-export SNOWFLAKE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----..."
-# Alternatively, source from a file.
 export SNOWFLAKE_PRIVATE_KEY=$(cat ~/.ssh/snowflake_key.p8)
 ```
 
@@ -138,7 +138,7 @@ provider "snowflake" {
 
 ```bash
 export SNOWFLAKE_USER="..."
-export SNOWFLAKE_PRIVATE_KEY="~/.ssh/snowflake_key"
+export SNOWFLAKE_PRIVATE_KEY=$(cat ~/.ssh/snowflake_key.p8)
 ```
 
 3. In a TOML file (default in ~/.snowflake/config). Notice the use of different profiles. The profile name needs to be specified in the Terraform configuration file in `profile` field. When this is not specified, `default` profile is loaded.


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->
- Discourage using hardcoded values by removing them from the examples in resources and the provider. Use TF variables instead.
<!-- summary of changes -->
