### PR TITLE
chore: Adjust saml2_integration documentation

### DIFF
--- a/docs/resources/saml2_integration.md
+++ b/docs/resources/saml2_integration.md
@@ -7,6 +7,8 @@ description: |-
 
 !> **Note** The provider does not detect external changes on security integration type. In this case, remove the integration of wrong type manually with `terraform destroy` and recreate the resource. It will be addressed in the future.
 
+!> **Note** To use `allowed_user_domains` and `allowed_email_patterns` fields, first enable [identifier-first logins](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-security-integration-multiple#enable-identifier-first-login). This can be managed with [account_parameter](./account_parameter).
+
 # snowflake_saml2_integration (Resource)
 
 Resource used to manage SAML2 security integration objects. For more information, check [security integrations documentation](https://docs.snowflake.com/en/sql-reference/sql/create-security-integration-saml2).

--- a/templates/resources/saml2_integration.md.tmpl
+++ b/templates/resources/saml2_integration.md.tmpl
@@ -11,6 +11,8 @@ description: |-
 
 !> **Note** The provider does not detect external changes on security integration type. In this case, remove the integration of wrong type manually with `terraform destroy` and recreate the resource. It will be addressed in the future.
 
+!> **Note** To use `allowed_user_domains` and `allowed_email_patterns` fields, first enable [identifier-first logins](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-security-integration-multiple#enable-identifier-first-login). This can be managed with [account_parameter](./account_parameter).
+
 # {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->
- Add a note that using `allowed_user_domains` and `allowed_email_patterns` fields requires enabled identifier-first logins
<!-- summary of changes -->

## References
<!-- issues documentation links, etc  -->
https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/3358