### PR TITLE
chore: Protect pentesting user and role from sweepers

### DIFF
--- a/pkg/internal/snowflakeroles/snowflake_predefined_roles.go
+++ b/pkg/internal/snowflakeroles/snowflake_predefined_roles.go
@@ -3,9 +3,10 @@ package snowflakeroles
 import "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 
 var (
-	Orgadmin      = sdk.NewAccountObjectIdentifier("ORGADMIN")
-	Accountadmin  = sdk.NewAccountObjectIdentifier("ACCOUNTADMIN")
-	SecurityAdmin = sdk.NewAccountObjectIdentifier("SECURITYADMIN")
+	Orgadmin       = sdk.NewAccountObjectIdentifier("ORGADMIN")
+	Accountadmin   = sdk.NewAccountObjectIdentifier("ACCOUNTADMIN")
+	SecurityAdmin  = sdk.NewAccountObjectIdentifier("SECURITYADMIN")
+	PentestingRole = sdk.NewAccountObjectIdentifier("PENTESTING_ROLE")
 
 	OktaProvisioner        = sdk.NewAccountObjectIdentifier("OKTA_PROVISIONER")
 	AadProvisioner         = sdk.NewAccountObjectIdentifier("AAD_PROVISIONER")

--- a/pkg/sdk/sweepers.go
+++ b/pkg/sdk/sweepers.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"slices"
 	"strings"
-
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeroles"
 )
 
 func SweepAfterIntegrationTests(client *Client, suffix string) error {
@@ -203,7 +201,7 @@ func getRoleSweeper(client *Client, suffix string) func() error {
 			return fmt.Errorf("sweeping roles ended with error, err = %w", err)
 		}
 		for _, role := range roles {
-			if strings.HasSuffix(role.Name, suffix) && !slices.Contains([]string{"ACCOUNTADMIN", "SECURITYADMIN", "SYSADMIN", "ORGADMIN", "USERADMIN", "PUBLIC", snowflakeroles.PentestingRole.Name()}, role.Name) {
+			if strings.HasSuffix(role.Name, suffix) && !slices.Contains([]string{"ACCOUNTADMIN", "SECURITYADMIN", "SYSADMIN", "ORGADMIN", "USERADMIN", "PUBLIC", "PENTESTING_ROLE"}, role.Name) {
 				log.Printf("[DEBUG] Dropping role %s", role.ID().FullyQualifiedName())
 				if err := client.Roles.Drop(ctx, NewDropRoleRequest(role.ID())); err != nil {
 					return fmt.Errorf("sweeping role %s ended with error, err = %w", role.ID().FullyQualifiedName(), err)

--- a/pkg/sdk/sweepers.go
+++ b/pkg/sdk/sweepers.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"slices"
 	"strings"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeroles"
 )
 
 func SweepAfterIntegrationTests(client *Client, suffix string) error {
@@ -201,7 +203,7 @@ func getRoleSweeper(client *Client, suffix string) func() error {
 			return fmt.Errorf("sweeping roles ended with error, err = %w", err)
 		}
 		for _, role := range roles {
-			if strings.HasSuffix(role.Name, suffix) && !slices.Contains([]string{"ACCOUNTADMIN", "SECURITYADMIN", "SYSADMIN", "ORGADMIN", "USERADMIN", "PUBLIC"}, role.Name) {
+			if strings.HasSuffix(role.Name, suffix) && !slices.Contains([]string{"ACCOUNTADMIN", "SECURITYADMIN", "SYSADMIN", "ORGADMIN", "USERADMIN", "PUBLIC", snowflakeroles.PentestingRole.Name()}, role.Name) {
 				log.Printf("[DEBUG] Dropping role %s", role.ID().FullyQualifiedName())
 				if err := client.Roles.Drop(ctx, NewDropRoleRequest(role.ID())); err != nil {
 					return fmt.Errorf("sweeping role %s ended with error, err = %w", role.ID().FullyQualifiedName(), err)

--- a/pkg/sdk/sweepers_test.go
+++ b/pkg/sdk/sweepers_test.go
@@ -233,6 +233,8 @@ func nukeUsers(client *Client) func() error {
 		"JAN_CIESLAK_LEGACY",
 		"TERRAFORM_SVC_ACCOUNT",
 		"TEST_CI_SERVICE_USER",
+		"PENTESTING_USER_1",
+		"PENTESTING_USER_2",
 	}
 
 	return func() error {


### PR DESCRIPTION
## Changes
- Adjust sweepers to ignore users and roles used for testing.