### PR TITLE
fix: Fix tasks tests

### DIFF
--- a/pkg/acceptance/bettertestspoc/assert/objectassert/task_snowflake_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/task_snowflake_ext.go
@@ -54,9 +54,8 @@ func (t *TaskAssert) HasTaskRelations(expected sdk.TaskRelations) *TaskAssert {
 		if !reflect.DeepEqual(expected.FinalizerTask, o.TaskRelations.FinalizerTask) {
 			errs = append(errs, fmt.Errorf("expected finalizer task: %v; got: %v", expected.FinalizerTask, o.TaskRelations.FinalizerTask))
 		}
-		if expected.FinalizedRootTask != nil {
-			// This is not supported because we would have to traverse the task graph to find the root task.
-			errs = append(errs, fmt.Errorf("asserting FinalizedRootTask is not supported"))
+		if !reflect.DeepEqual(expected.FinalizedRootTask, o.TaskRelations.FinalizedRootTask) {
+			errs = append(errs, fmt.Errorf("expected finalized root task: %v; got: %v", expected.FinalizedRootTask, o.TaskRelations.FinalizedRootTask))
 		}
 		return errors.Join(errs...)
 	})


### PR DESCRIPTION
Using the wrong assertion resulted in assertions not being applied at all. 6 tests needed to be fixed:
- change the expected value
- use fetching the object after changes and not reusing the same one
- setup for finalizer tasks reversed