### PR TITLE
chore: Use environmental secrets in GitHub Actions

### DIFF
--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -7,15 +7,15 @@ on:
 
 jobs:
   ok-to-test:
-    # TODO(SNOW-1965855): Uncomment after adjusting secrets for ok-to-test `environment: ok-to-test`
+    environment: ok-to-test
     runs-on: ubuntu-latest
     steps:
       - name: Create token
         id: create-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.OK_TO_TEST_APP_ID }}
-          private-key: ${{ secrets.OK_TO_TEST_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4 # v4

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   ok-to-test:
+    # TODO(SNOW-1965855): Uncomment after adjusting secrets for ok-to-test `environment: ok-to-test`
     runs-on: ubuntu-latest
     steps:
       - name: Create token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Release please
-        uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3
+        uses: googleapis/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3
         id: release
         with:
           release-type: simple

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   release-please:
+    # TODO(SNOW-1965855): Uncomment after adjusting secrets for release `environment: release`
     runs-on: macos-latest
     steps:
       - uses: actions/github-script@v6

--- a/.github/workflows/team-jira-issues.yml
+++ b/.github/workflows/team-jira-issues.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   jira-action:
+    environment: jira
     runs-on: ubuntu-latest
     name: Create an issue
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,11 +3,12 @@ name: Tests
 
 on:
   repository_dispatch:
-    types: [ok-to-test-command]
+    types: [ ok-to-test-command ]
   pull_request:
 
 jobs:
   all-tests:
+    environment: test
     env:
       TEST_SF_TF_TEST_OBJECT_SUFFIX: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.pull_request.head.sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) }}
     name: Run All
@@ -19,11 +20,11 @@ jobs:
         run: |
           echo \"${{ github.event.client_payload.pull_request.head.sha }}\"
           echo \"${{ github.event.client_payload.slash_command.args.named.sha }}\"
-          SHAINPUT=$(echo ${{github.event.client_payload.slash_command.args.named.sha}} | cut -c1-7)
+          SHAINPUT=$(echo ${{ github.event.client_payload.slash_command.args.named.sha }} | cut -c1-7)
           if [ ${#SHAINPUT} -le 6 ]; then echo "error::input sha not at least 7 characters long" ; exit 1
           else echo "done"
           fi
-          SHAHEAD=$(echo ${{github.event.client_payload.pull_request.head.sha}} | cut -c1-7)
+          SHAHEAD=$(echo ${{ github.event.client_payload.pull_request.head.sha }} | cut -c1-7)
           echo ${#SHAINPUT}
           echo ${#SHAHEAD}
           if [ "${SHAHEAD}" != "${SHAINPUT}" ]; then echo "sha input from slash command does not equal the head sha" ; exit 1


### PR DESCRIPTION
## Changes
Introduce environmental secrets for GitHub Actions:
- Only set environment for `jira` and `test` environments
- `release` and `ok-to-test` require app id and app private key, which will be retrieved later

## Next steps
Check if all workflows are working properly