### PR TITLE
chore: Set a fixed golangci-lint version in GH actions

### DIFF
--- a/.github/workflows/reviewdog-golanglint-ci.yml
+++ b/.github/workflows/reviewdog-golanglint-ci.yml
@@ -26,4 +26,6 @@ jobs:
         uses: reviewdog/action-golangci-lint@dd3fda91790ca90e75049e5c767509dc0ec7d99b # v2
         with:
           golangci_lint_flags: "--config=.golangci.yml"
+          # TODO(SNOW-2002208): Upgrade to the latest version of golangci-lint.
+          golangci_lint_version: "v1.63.4"
           go_version_file: "go.mod"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ export TERRAFORM_PLUGIN_LOCAL_INSTALL=$(TERRAFORM_PLUGINS_DIR)/$(BASE_BINARY_NAM
 default: help
 
 dev-setup: ## setup development dependencies
+# TODO(SNOW-2002208): Upgrade to the latest version of golangci-lint.
 	@which ./bin/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v1.63.4
 	cd tools && mkdir -p bin/
 	cd tools && env GOBIN=$$PWD/bin go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->
- Set a fixed golangci-lint version in GH actions. The action uses the latest release by default. This broke our pipelines because [v2 version](https://github.com/golangci/golangci-lint/releases/tag/v2.0.0) has been released. We can fix this for now by setting the version to `v1.63.4` in the GH actions (we already use this version in `make dev-setup`.
- Link the tickets for upgrading golangci-lint to the newest version.
<!-- summary of changes -->
