### PR TITLE
chore: Replace import paths part 1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/snowflakedb/gosnowflake v1.13.1
+	github.com/snowflakedb/terraform-provider-snowflake/v2 v2.0.0
 	github.com/stretchr/testify v1.10.0
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
 	golang.org/x/crypto v0.37.0
@@ -113,3 +114,5 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/snowflakedb/terraform-provider-snowflake/v2 => ./

--- a/pkg/acceptance/helpers/stage_client.go
+++ b/pkg/acceptance/helpers/stage_client.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
+	"github.com/snowflakedb/terraform-provider-snowflake/v2/pkg/testhelpers"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/acceptance/helpers/tmp_toml_setup_helpers.go
+++ b/pkg/acceptance/helpers/tmp_toml_setup_helpers.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
+	"github.com/snowflakedb/terraform-provider-snowflake/v2/pkg/testhelpers"
 )
 
 // TODO [SNOW-1827324]: add TestClient ref to each specific client, so that we enhance specific client and not the base one

--- a/pkg/internal/oswrapper/os_test.go
+++ b/pkg/internal/oswrapper/os_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/oswrapper"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
+	"github.com/snowflakedb/terraform-provider-snowflake/v2/pkg/testhelpers"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/manual_tests/windows/files_test.go
+++ b/pkg/manual_tests/windows/files_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/oswrapper"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
+	"github.com/snowflakedb/terraform-provider-snowflake/v2/pkg/testhelpers"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/manual_tests/windows/provider_test.go
+++ b/pkg/manual_tests/windows/provider_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/oswrapper"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeenvs"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/snowflakedb/terraform-provider-snowflake/v2/pkg/testhelpers"
 )
 
 func TestAcc_Provider_tomlConfigIsTooPermissive(t *testing.T) {

--- a/pkg/provider/provider_acceptance_test.go
+++ b/pkg/provider/provider_acceptance_test.go
@@ -27,11 +27,11 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeenvs"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/previewfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/snowflakedb/gosnowflake"
+	"github.com/snowflakedb/terraform-provider-snowflake/v2/pkg/testhelpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/sdk/config_test.go
+++ b/pkg/sdk/config_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeenvs"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/snowflakedb/gosnowflake"
+	"github.com/snowflakedb/terraform-provider-snowflake/v2/pkg/testhelpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/sdk/legacy_config_test.go
+++ b/pkg/sdk/legacy_config_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeenvs"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/snowflakedb/gosnowflake"
+	"github.com/snowflakedb/terraform-provider-snowflake/v2/pkg/testhelpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/sdk/testint/tables_integration_test.go
+++ b/pkg/sdk/testint/tables_integration_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeroles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
+	"github.com/snowflakedb/terraform-provider-snowflake/v2/pkg/testhelpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
Replace import paths in the testhelpers package - use `github.com/snowflakedb/terraform-provider-snowflake/v2`.