### PR TITLE
chore: Sweepers and Test workflow changes

### DIFF
--- a/.github/workflows/tests-account-level.yml
+++ b/.github/workflows/tests-account-level.yml
@@ -22,7 +22,7 @@ jobs:
     environment: test
     env:
       ## adding additional suffix to don't have conflict in non-account level tests and their pre-created objects
-      TEST_SF_TF_TEST_OBJECT_SUFFIX: "${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.pull_request.head.sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) }}_${{ github.run_attempt }}AL"
+      TEST_SF_TF_TEST_OBJECT_SUFFIX: ${{ ((github.event_name == 'repository_dispatch' && github.event.client_payload.pull_request.head.sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha)) && 'AL' }}
     name: Run all account-level tests
     runs-on: ubuntu-latest
     if: (github.event_name == 'repository_dispatch') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
   all-tests:
     environment: test
     env:
-      TEST_SF_TF_TEST_OBJECT_SUFFIX: "${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.pull_request.head.sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) }}_${{ github.run_attempt }}"
+      TEST_SF_TF_TEST_OBJECT_SUFFIX: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.pull_request.head.sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) }}
     name: Run All
     runs-on: ubuntu-latest
     if: (github.event_name == 'repository_dispatch') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)


### PR DESCRIPTION
## Changes
- Adjust sweepers to include user sweeping (to avoid policy related issues)
- Change test workflow's test object suffix so that it's unique even if test are re-run
  - This is important in the context of failed cleanup, on test workflow re-run we may encounter "object already exists" errors. By having unique object prefix this could be avoided (and because we have stale object sweepers, leftovers will be cleaned up anyway)