### PR TITLE
chore: Add new database to the protected databases in sweepers

### DIFF
--- a/pkg/sdk/sweepers_test.go
+++ b/pkg/sdk/sweepers_test.go
@@ -211,6 +211,7 @@ func nukeDatabases(client *Client, prefix string) func() error {
 	protectedDatabases := []string{
 		"SNOWFLAKE",
 		"MFA_ENFORCEMENT_POLICY",
+		"TERRAFORM_TEST_SETUP_OBJECTS",
 	}
 
 	return func() error {


### PR DESCRIPTION
## Changes
- Add a new protected database to the sweepers
- This database will be a central database for all objects required for our test setup (policies, network rules, and other objects)