### PR TITLE
docs: Update migration guide

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -24,7 +24,29 @@ for changes required after enabling given [Snowflake BCR Bundle](https://docs.sn
 > [!TIP]
 > If you're still using the `Snowflake-Labs/snowflake` source, see [Upgrading from Snowflake-Labs Provider](./SNOWFLAKEDB_MIGRATION.md) to upgrade to the snowflakedb namespace.
 
-## v2.5.0 ➞ v2.5.1
+## v2.5.0 ➞ v2.6.0
+
+### *(improvement)* Handling conversion-based errors
+
+Previously, when an error occurred during the conversion from Snowflake data to the SDK object, the error would be printed as a debug log.
+We would then proceed with the conversion and later handle the standard operations within the resource or data source with potentially incorrectly converted data.
+
+This could result in errors at the resource or data source level, sometimes causing undefined behavior.
+Ideally, these errors should be detected and addressed at the conversion level.
+
+Let's say we got an error in one of our conversion functions that transfers a text column containing JSON to a Go structure.
+Before the change, on failure, we would print something similar to:
+```text
+[DEBUG] Failed to convert X, err: <error from JSON mapping>
+```
+
+After implementing these improvements, any such failure will be propagated and acknowledged by the resources and data sources.
+This will result in operations reporting failures, as in the following example:
+```text
+conversion from Snowflake failed with error: failed to convert X, err: <error from JSON mapping>
+```
+
+If you encounter any errors of this kind, we encourage you to report them. Your feedback helps us improve the provider stability.
 
 ### *(bugfix)* Fixed handling `IMPORTED PRIVILEGES` grant in the `grant_privileges_to_account_role` resource
 In Snowflake, `WITH GRANT OPTION` is not supported when granting or revoking the `IMPORTED PRIVILEGES` privilege. In previous versions, in handling resource updates, the provider revoked `IMPORTED PRIVILEGES` with `WITH GRANT OPTION`, even for cases when this option was not set in the resource. It resulted in errors like
@@ -58,28 +80,6 @@ Additionally, when `IMPORTED PRIVILEGES` is granted with other privileges in one
 Before, this was not validated, but it failed in Snowflake.
 
 References: https://github.com/snowflakedb/terraform-provider-snowflake/issues/2803#issuecomment-3152992005
-
-### *(improvement)* Handling conversion-based errors
-
-Previously, when an error occurred during the conversion from Snowflake data to the SDK object, the error would be printed as a debug log.
-We would then proceed with the conversion and later handle the standard operations within the resource or data source with potentially incorrectly converted data.
-
-This could result in errors at the resource or data source level, sometimes causing undefined behavior.
-Ideally, these errors should be detected and addressed at the conversion level.
-
-Let's say we got an error in one of our conversion functions that transfers a text column containing JSON to a Go structure.
-Before the change, on failure, we would print something similar to:
-```text
-[DEBUG] Failed to convert X, err: <error from JSON mapping>
-```
-
-After implementing these improvements, any such failure will be propagated and acknowledged by the resources and data sources.
-This will result in operations reporting failures, as in the following example:
-```text
-conversion from Snowflake failed with error: failed to convert X, err: <error from JSON mapping>
-```
-
-If you encounter any errors of this kind, we encourage you to report them. Your feedback helps us improve the provider stability.
 
 ### *(bugfix)* Fixed `snowflake_primary_connection` or `snowflake_secondary_connection` reading and improved creation and deletion operations
 


### PR DESCRIPTION
Update migration guide to point to the 2.6.0 version instead of 2.5.1
Moved the conversion improvement to the top
