### PR TITLE
chore: Add more mappings for the grant migration script part1

### DIFF
--- a/pkg/scripts/migration_script/converter_grants.go
+++ b/pkg/scripts/migration_script/converter_grants.go
@@ -14,7 +14,6 @@ type GrantCsvRow struct {
 	GrantedOn   string `csv:"granted_on"`
 	GrantOn     string `csv:"grant_on"`
 	Name        string `csv:"name"`
-	Role        string `csv:"role"`
 	GrantedTo   string `csv:"granted_to"`
 	GrantTo     string `csv:"grant_to"`
 	GranteeName string `csv:"grantee_name"`
@@ -63,15 +62,6 @@ func (row GrantCsvRow) convert() (*sdk.Grant, error) {
 		name = sdk.NewObjectIdentifierFromFullyQualifiedName(row.Name)
 	}
 
-	var role sdk.ObjectIdentifier
-	if row.Role != "" {
-		role, err = sdk.ParseDatabaseObjectIdentifier(row.Role)
-		if err != nil {
-			log.Printf("[DEBUG] Failed to parse identifier [%s], err = \"%s\"; falling back to fully qualified name conversion", row.Role, err)
-			role = sdk.NewObjectIdentifierFromFullyQualifiedName(row.Role)
-		}
-	}
-
 	return &sdk.Grant{
 		Privilege:   row.Privilege,
 		GrantedOn:   grantedOn,
@@ -79,7 +69,6 @@ func (row GrantCsvRow) convert() (*sdk.Grant, error) {
 		GrantedTo:   grantedTo,
 		GrantTo:     grantTo,
 		Name:        name,
-		Role:        role,
 		GranteeName: sdk.NewAccountObjectIdentifier(row.GranteeName),
 		GrantOption: row.GrantOption,
 		GrantedBy:   sdk.NewAccountObjectIdentifier(row.GrantedBy),

--- a/pkg/scripts/migration_script/mappings_grants_test.go
+++ b/pkg/scripts/migration_script/mappings_grants_test.go
@@ -310,20 +310,6 @@ resource "snowflake_grant_account_role" "snowflake_generated_grant_TEST_ROLE_to_
 # terraform import snowflake_grant_account_role.snowflake_generated_grant_TEST_ROLE_to_user_TEST_USER '"TEST_ROLE"|USER|"TEST_USER"'
 `,
 		},
-		{
-			name: "grant role to role (SHOW GRANTS OF ROLE output)",
-			inputRows: [][]string{
-				{"role", "granted_to", "grantee_name"},
-				{"TEST_ROLE", "ROLE", "PARENT_TEST_ROLE"},
-			},
-			expectedOutput: `
-resource "snowflake_grant_account_role" "snowflake_generated_grant_TEST_ROLE_to_role_PARENT_TEST_ROLE" {
-  parent_role_name = "PARENT_TEST_ROLE"
-  role_name = "TEST_ROLE"
-}
-# terraform import snowflake_grant_account_role.snowflake_generated_grant_TEST_ROLE_to_role_PARENT_TEST_ROLE '"TEST_ROLE"|ROLE|"PARENT_TEST_ROLE"'
-`,
-		},
 	}
 
 	for _, tc := range testCases {
@@ -371,48 +357,6 @@ resource "snowflake_grant_database_role" "snowflake_generated_grant_TEST_DATABAS
   parent_database_role_name = "\"TEST_DATABASE\".\"PARENT_TEST_ROLE\""
 }
 # terraform import snowflake_grant_database_role.snowflake_generated_grant_TEST_DATABASE_TEST_ROLE_to_database_role_TEST_DATABASE_PARENT_TEST_ROLE '"TEST_DATABASE"."TEST_ROLE"|DATABASE ROLE|"TEST_DATABASE"."PARENT_TEST_ROLE"'
-`,
-		},
-		{
-			name: "grant database role to database role (SHOW GRANTS OF DATABASE ROLE output)",
-			inputRows: [][]string{
-				{"role", "granted_to", "grantee_name"},
-				{"TEST_DATABASE.TEST_ROLE", "DATABASE_ROLE", "PARENT_TEST_ROLE"},
-			},
-			expectedOutput: `
-resource "snowflake_grant_database_role" "snowflake_generated_grant_TEST_DATABASE_TEST_ROLE_to_database_role_TEST_DATABASE_PARENT_TEST_ROLE" {
-  database_role_name = "\"TEST_DATABASE\".\"TEST_ROLE\""
-  parent_database_role_name = "\"TEST_DATABASE\".\"PARENT_TEST_ROLE\""
-}
-# terraform import snowflake_grant_database_role.snowflake_generated_grant_TEST_DATABASE_TEST_ROLE_to_database_role_TEST_DATABASE_PARENT_TEST_ROLE '"TEST_DATABASE"."TEST_ROLE"|DATABASE ROLE|"TEST_DATABASE"."PARENT_TEST_ROLE"'
-`,
-		},
-		{
-			name: "grant database role to database role (SHOW GRANTS OF ROLE output)",
-			inputRows: [][]string{
-				{"role", "granted_to", "grantee_name"},
-				{"TEST_DATABASE.TEST_ROLE", "DATABASE_ROLE", "TEST_DATABASE.PARENT_TEST_ROLE"},
-			},
-			expectedOutput: `
-resource "snowflake_grant_database_role" "snowflake_generated_grant_TEST_DATABASE_TEST_ROLE_to_database_role_TEST_DATABASE_PARENT_TEST_ROLE" {
-  database_role_name = "\"TEST_DATABASE\".\"TEST_ROLE\""
-  parent_database_role_name = "\"TEST_DATABASE\".\"PARENT_TEST_ROLE\""
-}
-# terraform import snowflake_grant_database_role.snowflake_generated_grant_TEST_DATABASE_TEST_ROLE_to_database_role_TEST_DATABASE_PARENT_TEST_ROLE '"TEST_DATABASE"."TEST_ROLE"|DATABASE ROLE|"TEST_DATABASE"."PARENT_TEST_ROLE"'
-`,
-		},
-		{
-			name: "grant database role to role (SHOW GRANTS OF ROLE output)",
-			inputRows: [][]string{
-				{"role", "granted_to", "grantee_name"},
-				{"TEST_DATABASE.TEST_ROLE", "ROLE", "PARENT_TEST_ROLE"},
-			},
-			expectedOutput: `
-resource "snowflake_grant_database_role" "snowflake_generated_grant_TEST_DATABASE_TEST_ROLE_to_role_PARENT_TEST_ROLE" {
-  database_role_name = "\"TEST_DATABASE\".\"TEST_ROLE\""
-  parent_role_name = "PARENT_TEST_ROLE"
-}
-# terraform import snowflake_grant_database_role.snowflake_generated_grant_TEST_DATABASE_TEST_ROLE_to_role_PARENT_TEST_ROLE '"TEST_DATABASE"."TEST_ROLE"|ROLE|"PARENT_TEST_ROLE"'
 `,
 		},
 	}

--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -213,7 +213,6 @@ type Grant struct {
 	GrantedOn   ObjectType
 	GrantOn     ObjectType
 	Name        ObjectIdentifier
-	Role        ObjectIdentifier
 	GrantedTo   ObjectType
 	GrantTo     ObjectType
 	GranteeName ObjectIdentifier


### PR DESCRIPTION
## Changes
- Add support for:
  - `grant_privileges_to_database_role`
  - `grant_account_role`
  - `grant_database_role`
- Add missing Role column in the sdk.Grant (only touched the script part, but I'm guessing the Role mapping should be available in the SDK too)

## Next steps
- Create a ticket for Role mapping in the SDK (SHOW GRANTS refactor issue)
- Add other missing mappings