### PR TITLE
chore: Introduce a new build tag for tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ To run the tests we have the following commands:
 
 The tests distinction between account-level and non-account-level tests is currently achieved by go build directive:
 - `//go:build account_level_tests` for account-level tests;
-- `//go:build !account_level_tests` for non-account-level tests.
+- `//go:build non_account_level_tests` for non-account-level tests.
 Make sure you specify the correct directive when adding new integration or acceptance test file.
 
 You can run the particular tests from inside your chosen IDE but remember that you have to set `TF_ACC=1` environment variable to run any acceptance tests (the above commands set it for you). There are more environment variables set in the above Makefile rules, so familiarize with them before using them. It is also worth setting up more verbose logging (check [this section](FAQ.md#how-can-i-turn-on-logs) for more details).

--- a/Makefile
+++ b/Makefile
@@ -71,13 +71,13 @@ test-unit: ## run unit tests
 	go test -v -cover $$(go list ./... | grep -v -E "$(UNIT_TESTS_EXCLUDE_PATTERN)")
 
 test-acceptance: ## run acceptance tests
-	TF_ACC=1 SF_TF_ACC_TEST_CONFIGURE_CLIENT_ONCE=true TEST_SF_TF_REQUIRE_TEST_OBJECT_SUFFIX=1 TEST_SF_TF_REQUIRE_GENERATED_RANDOM_VALUE=1 SF_TF_ACC_TEST_ENABLE_ALL_PREVIEW_FEATURES=true go test -run "^TestAcc_" -v -cover -timeout=150m ./pkg/testacc
+	TF_ACC=1 SF_TF_ACC_TEST_CONFIGURE_CLIENT_ONCE=true TEST_SF_TF_REQUIRE_TEST_OBJECT_SUFFIX=1 TEST_SF_TF_REQUIRE_GENERATED_RANDOM_VALUE=1 SF_TF_ACC_TEST_ENABLE_ALL_PREVIEW_FEATURES=true go test --tags=non_account_level_tests -run "^TestAcc_" -v -cover -timeout=150m ./pkg/testacc
 
 test-account-level-features: ## run integration and acceptance test modifying account
 	TF_ACC=1 SF_TF_ACC_TEST_CONFIGURE_CLIENT_ONCE=true TEST_SF_TF_REQUIRE_TEST_OBJECT_SUFFIX=1 TEST_SF_TF_REQUIRE_GENERATED_RANDOM_VALUE=1 SF_TF_ACC_TEST_ENABLE_ALL_PREVIEW_FEATURES=true go test --tags=account_level_tests -run "^(TestAcc_|TestInt_)" -v -cover -timeout=45m ./pkg/testacc ./pkg/sdk/testint
 
 test-integration: ## run SDK integration tests
-	TEST_SF_TF_REQUIRE_TEST_OBJECT_SUFFIX=1 TEST_SF_TF_REQUIRE_GENERATED_RANDOM_VALUE=1 go test -run "^TestInt_" -v -cover -timeout=60m ./pkg/sdk/testint
+	TEST_SF_TF_REQUIRE_TEST_OBJECT_SUFFIX=1 TEST_SF_TF_REQUIRE_GENERATED_RANDOM_VALUE=1 go test --tags=non_account_level_tests -run "^TestInt_" -v -cover -timeout=60m ./pkg/sdk/testint
 
 test-functional: ## run functional tests of the underlying terraform libraries (currently SDKv2)
 	TF_ACC=1 TEST_SF_TF_ENABLE_OBJECT_RENAMING=1 go test -v -cover -timeout=10m ./pkg/testfunctional
@@ -85,8 +85,8 @@ test-functional: ## run functional tests of the underlying terraform libraries (
 test-architecture: ## check architecture constraints between packages
 	go test ./pkg/architests/... -v
 
-test-acceptance-%: ## run acceptance tests for the given resource only, e.g. test-acceptance-Warehouse
-	TF_ACC=1 TF_LOG=DEBUG SNOWFLAKE_DRIVER_TRACING=debug SF_TF_ACC_TEST_CONFIGURE_CLIENT_ONCE=true SF_TF_ACC_TEST_ENABLE_ALL_PREVIEW_FEATURES=true go test -run ^TestAcc_$*_ -v -timeout=20m ./pkg/testacc
+test-acceptance-%: ## run acceptance tests (both non-account and account level ones) for the given resource only, e.g. test-acceptance-Warehouse
+	TF_ACC=1 TF_LOG=DEBUG SNOWFLAKE_DRIVER_TRACING=debug SF_TF_ACC_TEST_CONFIGURE_CLIENT_ONCE=true SF_TF_ACC_TEST_ENABLE_ALL_PREVIEW_FEATURES=true go test --tags='non_account_level_tests,account_level_tests' -run ^TestAcc_$*_ -v -timeout=20m ./pkg/testacc
 
 build-local: ## build the binary locally
 	go build -o $(BASE_BINARY_NAME) .

--- a/pkg/architest/assertions.go
+++ b/pkg/architest/assertions.go
@@ -37,4 +37,4 @@ func (method *Method) AssertNameDoesNotMatch(t *testing.T, regex *regexp.Regexp)
 	assert.Falsef(t, regex.MatchString(method.Name()), "file %s contains exported method %s which matches %s", method.FileName(), method.Name(), regex.String())
 }
 
-// TODO [SNOW-2036808]: add build directive assertion on file (to check the presence of //go:build !account_level_tests and //go:build account_level_tests directives)
+// TODO [SNOW-2036808]: add build directive assertion on file (to check the presence of //go:build non_account_level_tests and //go:build account_level_tests directives)

--- a/pkg/resources/custom_diffs_test.go
+++ b/pkg/resources/custom_diffs_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package resources_test
 

--- a/pkg/resources/diff_suppressions_test.go
+++ b/pkg/resources/diff_suppressions_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package resources_test
 

--- a/pkg/resources/helpers_test.go
+++ b/pkg/resources/helpers_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package resources_test
 

--- a/pkg/resources/tag_association_test.go
+++ b/pkg/resources/tag_association_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package resources_test
 

--- a/pkg/sdk/testint/alerts_integration_test.go
+++ b/pkg/sdk/testint/alerts_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/api_integrations_gen_integration_test.go
+++ b/pkg/sdk/testint/api_integrations_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/application_packages_integration_test.go
+++ b/pkg/sdk/testint/application_packages_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/application_roles_gen_integration_test.go
+++ b/pkg/sdk/testint/application_roles_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/authentication_policies_gen_integration_test.go
+++ b/pkg/sdk/testint/authentication_policies_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/basic_object_tracking_integration_test.go
+++ b/pkg/sdk/testint/basic_object_tracking_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/client_integration_test.go
+++ b/pkg/sdk/testint/client_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/client_unsafe_extensions_integration_test.go
+++ b/pkg/sdk/testint/client_unsafe_extensions_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/comments_integration_test.go
+++ b/pkg/sdk/testint/comments_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/compute_pools_integration_test.go
+++ b/pkg/sdk/testint/compute_pools_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/connections_gen_integration_test.go
+++ b/pkg/sdk/testint/connections_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/context_functions_integration_test.go
+++ b/pkg/sdk/testint/context_functions_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/cortex_search_services_integration_test.go
+++ b/pkg/sdk/testint/cortex_search_services_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/data_metric_function_references_gen_integration_test.go
+++ b/pkg/sdk/testint/data_metric_function_references_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/data_types_integration_test.go
+++ b/pkg/sdk/testint/data_types_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/database_role_integration_test.go
+++ b/pkg/sdk/testint/database_role_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/drop_integration_test.go
+++ b/pkg/sdk/testint/drop_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/dynamic_table_integration_test.go
+++ b/pkg/sdk/testint/dynamic_table_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/errors_integration_test.go
+++ b/pkg/sdk/testint/errors_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/event_tables_integration_test.go
+++ b/pkg/sdk/testint/event_tables_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/external_functions_integration_test.go
+++ b/pkg/sdk/testint/external_functions_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/external_tables_integration_test.go
+++ b/pkg/sdk/testint/external_tables_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/external_volumes_gen_integration_test.go
+++ b/pkg/sdk/testint/external_volumes_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/failover_groups_integration_test.go
+++ b/pkg/sdk/testint/failover_groups_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/file_format_integration_test.go
+++ b/pkg/sdk/testint/file_format_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/functions_integration_test.go
+++ b/pkg/sdk/testint/functions_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/git_repositories_integration_test.go
+++ b/pkg/sdk/testint/git_repositories_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/grants_integration_test.go
+++ b/pkg/sdk/testint/grants_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/identifier_integration_test.go
+++ b/pkg/sdk/testint/identifier_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/image_repositories_integration_test.go
+++ b/pkg/sdk/testint/image_repositories_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/listings_integration_test.go
+++ b/pkg/sdk/testint/listings_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/managed_accounts_gen_integration_test.go
+++ b/pkg/sdk/testint/managed_accounts_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/masking_policy_integration_test.go
+++ b/pkg/sdk/testint/masking_policy_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/materialized_views_gen_integration_test.go
+++ b/pkg/sdk/testint/materialized_views_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/network_policies_gen_integration_test.go
+++ b/pkg/sdk/testint/network_policies_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/network_rule_gen_integration_test.go
+++ b/pkg/sdk/testint/network_rule_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/notification_integrations_gen_integration_test.go
+++ b/pkg/sdk/testint/notification_integrations_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/password_policy_integration_test.go
+++ b/pkg/sdk/testint/password_policy_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/pipes_integration_test.go
+++ b/pkg/sdk/testint/pipes_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/policy_references_integration_test.go
+++ b/pkg/sdk/testint/policy_references_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/procedures_integration_test.go
+++ b/pkg/sdk/testint/procedures_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/replication_functions_integration_test.go
+++ b/pkg/sdk/testint/replication_functions_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/resource_monitors_integration_test.go
+++ b/pkg/sdk/testint/resource_monitors_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/roles_integration_test.go
+++ b/pkg/sdk/testint/roles_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/row_access_policies_gen_integration_test.go
+++ b/pkg/sdk/testint/row_access_policies_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/schemas_integration_test.go
+++ b/pkg/sdk/testint/schemas_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/secrets_gen_integration_test.go
+++ b/pkg/sdk/testint/secrets_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/semantic_view_integration_test.go
+++ b/pkg/sdk/testint/semantic_view_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/sequences_integration_test.go
+++ b/pkg/sdk/testint/sequences_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/session_policies_gen_integration_test.go
+++ b/pkg/sdk/testint/session_policies_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/sessions_integration_test.go
+++ b/pkg/sdk/testint/sessions_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/shares_integration_test.go
+++ b/pkg/sdk/testint/shares_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/show_by_id_integration_test.go
+++ b/pkg/sdk/testint/show_by_id_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/stages_gen_integration_test.go
+++ b/pkg/sdk/testint/stages_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/storage_integration_gen_integration_test.go
+++ b/pkg/sdk/testint/storage_integration_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/streamlits_integration_test.go
+++ b/pkg/sdk/testint/streamlits_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/streams_gen_integration_test.go
+++ b/pkg/sdk/testint/streams_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/system_functions_integration_test.go
+++ b/pkg/sdk/testint/system_functions_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/tables_integration_test.go
+++ b/pkg/sdk/testint/tables_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/tags_integration_test.go
+++ b/pkg/sdk/testint/tags_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/user_programmatic_access_token_integration_test.go
+++ b/pkg/sdk/testint/user_programmatic_access_token_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/views_gen_integration_test.go
+++ b/pkg/sdk/testint/views_gen_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testint
 

--- a/pkg/testacc/data_source_account_roles_acceptance_test.go
+++ b/pkg/testacc/data_source_account_roles_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_accounts_acceptance_test.go
+++ b/pkg/testacc/data_source_accounts_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_alerts_acceptance_test.go
+++ b/pkg/testacc/data_source_alerts_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_compute_pools_acceptance_test.go
+++ b/pkg/testacc/data_source_compute_pools_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_connections_acceptance_test.go
+++ b/pkg/testacc/data_source_connections_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_cortex_search_services_acceptance_test.go
+++ b/pkg/testacc/data_source_cortex_search_services_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_current_account_acceptance_test.go
+++ b/pkg/testacc/data_source_current_account_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_current_role_acceptance_test.go
+++ b/pkg/testacc/data_source_current_role_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_database_acceptance_test.go
+++ b/pkg/testacc/data_source_database_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_database_role_acceptance_test.go
+++ b/pkg/testacc/data_source_database_role_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_database_roles_acceptance_test.go
+++ b/pkg/testacc/data_source_database_roles_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_databases_acceptance_test.go
+++ b/pkg/testacc/data_source_databases_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_dynamic_tables_acceptance_test.go
+++ b/pkg/testacc/data_source_dynamic_tables_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_external_functions_acceptance_test.go
+++ b/pkg/testacc/data_source_external_functions_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_external_tables_acceptance_test.go
+++ b/pkg/testacc/data_source_external_tables_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_failover_groups_acceptance_test.go
+++ b/pkg/testacc/data_source_failover_groups_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_file_formats_acceptance_test.go
+++ b/pkg/testacc/data_source_file_formats_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_functions_acceptance_test.go
+++ b/pkg/testacc/data_source_functions_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_git_repositories_acceptance_test.go
+++ b/pkg/testacc/data_source_git_repositories_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_grants_acceptance_test.go
+++ b/pkg/testacc/data_source_grants_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_image_repositories_acceptance_test.go
+++ b/pkg/testacc/data_source_image_repositories_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_masking_policies_acceptance_test.go
+++ b/pkg/testacc/data_source_masking_policies_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_materialized_views_acceptance_test.go
+++ b/pkg/testacc/data_source_materialized_views_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_network_policies_acceptance_test.go
+++ b/pkg/testacc/data_source_network_policies_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_parameters_acceptance_test.go
+++ b/pkg/testacc/data_source_parameters_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_pipes_acceptance_test.go
+++ b/pkg/testacc/data_source_pipes_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_procedures_acceptance_test.go
+++ b/pkg/testacc/data_source_procedures_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_resource_monitors_acceptance_test.go
+++ b/pkg/testacc/data_source_resource_monitors_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_row_access_policies_acceptance_test.go
+++ b/pkg/testacc/data_source_row_access_policies_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_schemas_acceptance_test.go
+++ b/pkg/testacc/data_source_schemas_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_secrets_acceptance_test.go
+++ b/pkg/testacc/data_source_secrets_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_security_integrations_acceptance_test.go
+++ b/pkg/testacc/data_source_security_integrations_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_sequences_acceptance_test.go
+++ b/pkg/testacc/data_source_sequences_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_services_acceptance_test.go
+++ b/pkg/testacc/data_source_services_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_shares_acceptance_test.go
+++ b/pkg/testacc/data_source_shares_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_stages_acceptance_test.go
+++ b/pkg/testacc/data_source_stages_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_storage_integrations_acceptance_test.go
+++ b/pkg/testacc/data_source_storage_integrations_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_streamlits_acceptance_test.go
+++ b/pkg/testacc/data_source_streamlits_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_streams_acceptance_test.go
+++ b/pkg/testacc/data_source_streams_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_system_generate_scim_access_token_acceptance_test.go
+++ b/pkg/testacc/data_source_system_generate_scim_access_token_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_system_get_aws_sns_iam_policy_acceptance_test.go
+++ b/pkg/testacc/data_source_system_get_aws_sns_iam_policy_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_system_get_privatelink_config_acceptance_test.go
+++ b/pkg/testacc/data_source_system_get_privatelink_config_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_system_get_snowflake_platform_info_acceptance_test.go
+++ b/pkg/testacc/data_source_system_get_snowflake_platform_info_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_tables_acceptance_test.go
+++ b/pkg/testacc/data_source_tables_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_tags_acceptance_test.go
+++ b/pkg/testacc/data_source_tags_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_usage_tracking_acceptance_test.go
+++ b/pkg/testacc/data_source_usage_tracking_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_user_programmatic_access_tokens_acceptance_test.go
+++ b/pkg/testacc/data_source_user_programmatic_access_tokens_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/data_source_views_acceptance_test.go
+++ b/pkg/testacc/data_source_views_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/provider_acceptance_test.go
+++ b/pkg/testacc/provider_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_account_acceptance_test.go
+++ b/pkg/testacc/resource_account_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_account_authentication_policy_attachment_acceptance_test.go
+++ b/pkg/testacc/resource_account_authentication_policy_attachment_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_account_password_policy_attachment_acceptance_test.go
+++ b/pkg/testacc/resource_account_password_policy_attachment_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_account_role_acceptance_test.go
+++ b/pkg/testacc/resource_account_role_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_alert_acceptance_test.go
+++ b/pkg/testacc/resource_alert_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_api_authentication_integration_with_authorization_code_grant_acceptance_test.go
+++ b/pkg/testacc/resource_api_authentication_integration_with_authorization_code_grant_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_api_authentication_integration_with_client_credentials_acceptance_test.go
+++ b/pkg/testacc/resource_api_authentication_integration_with_client_credentials_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_api_authentication_integration_with_jwt_bearer_acceptance_test.go
+++ b/pkg/testacc/resource_api_authentication_integration_with_jwt_bearer_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_api_integration_acceptance_test.go
+++ b/pkg/testacc/resource_api_integration_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_authentication_policy_acceptance_test.go
+++ b/pkg/testacc/resource_authentication_policy_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_compute_pool_acceptance_test.go
+++ b/pkg/testacc/resource_compute_pool_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_cortex_search_service_acceptance_test.go
+++ b/pkg/testacc/resource_cortex_search_service_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_database_role_acceptance_test.go
+++ b/pkg/testacc/resource_database_role_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_dynamic_table_acceptance_test.go
+++ b/pkg/testacc/resource_dynamic_table_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_email_notification_integration_acceptance_test.go
+++ b/pkg/testacc/resource_email_notification_integration_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_execute_acceptance_test.go
+++ b/pkg/testacc/resource_execute_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_external_function_acceptance_test.go
+++ b/pkg/testacc/resource_external_function_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_external_oauth_integration_acceptance_test.go
+++ b/pkg/testacc/resource_external_oauth_integration_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_external_stage_acceptance_test.go
+++ b/pkg/testacc/resource_external_stage_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_external_table_acceptance_test.go
+++ b/pkg/testacc/resource_external_table_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_external_volume_acceptance_test.go
+++ b/pkg/testacc/resource_external_volume_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_failover_group_acceptance_test.go
+++ b/pkg/testacc/resource_failover_group_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_file_format_acceptance_test.go
+++ b/pkg/testacc/resource_file_format_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_function_java_acceptance_test.go
+++ b/pkg/testacc/resource_function_java_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_function_javascript_acceptance_test.go
+++ b/pkg/testacc/resource_function_javascript_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_function_python_acceptance_test.go
+++ b/pkg/testacc/resource_function_python_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_function_scala_acceptance_test.go
+++ b/pkg/testacc/resource_function_scala_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_function_sql_acceptance_test.go
+++ b/pkg/testacc/resource_function_sql_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_git_repository_acceptance_test.go
+++ b/pkg/testacc/resource_git_repository_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_grant_account_role_acceptance_test.go
+++ b/pkg/testacc/resource_grant_account_role_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_grant_application_role_acceptance_test.go
+++ b/pkg/testacc/resource_grant_application_role_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_grant_database_role_acceptance_test.go
+++ b/pkg/testacc/resource_grant_database_role_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_grant_ownership_acceptance_test.go
+++ b/pkg/testacc/resource_grant_ownership_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_grant_privileges_to_account_role_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_account_role_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_grant_privileges_to_database_role_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_database_role_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_grant_privileges_to_share_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_share_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_image_repository_acceptance_test.go
+++ b/pkg/testacc/resource_image_repository_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_internal_stage_acceptance_test.go
+++ b/pkg/testacc/resource_internal_stage_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_job_service_acceptance_test.go
+++ b/pkg/testacc/resource_job_service_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_listing_acceptance_test.go
+++ b/pkg/testacc/resource_listing_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_managed_account_acceptance_test.go
+++ b/pkg/testacc/resource_managed_account_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_masking_policy_acceptance_test.go
+++ b/pkg/testacc/resource_masking_policy_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_materialized_view_acceptance_test.go
+++ b/pkg/testacc/resource_materialized_view_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_network_policy_acceptance_test.go
+++ b/pkg/testacc/resource_network_policy_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_network_policy_attachment_acceptance_test.go
+++ b/pkg/testacc/resource_network_policy_attachment_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_network_rule_acceptance_test.go
+++ b/pkg/testacc/resource_network_rule_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_notification_integration_acceptance_test.go
+++ b/pkg/testacc/resource_notification_integration_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_oauth_integration_for_custom_clients_acceptance_test.go
+++ b/pkg/testacc/resource_oauth_integration_for_custom_clients_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_object_parameter_acceptance_test.go
+++ b/pkg/testacc/resource_object_parameter_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_password_policy_acceptance_test.go
+++ b/pkg/testacc/resource_password_policy_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_pipe_acceptance_test.go
+++ b/pkg/testacc/resource_pipe_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_primary_connection_acceptance_test.go
+++ b/pkg/testacc/resource_primary_connection_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_procedure_java_acceptance_test.go
+++ b/pkg/testacc/resource_procedure_java_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_procedure_javascript_acceptance_test.go
+++ b/pkg/testacc/resource_procedure_javascript_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_procedure_python_acceptance_test.go
+++ b/pkg/testacc/resource_procedure_python_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_procedure_scala_acceptance_test.go
+++ b/pkg/testacc/resource_procedure_scala_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_procedure_sql_acceptance_test.go
+++ b/pkg/testacc/resource_procedure_sql_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_resource_monitor_acceptance_test.go
+++ b/pkg/testacc/resource_resource_monitor_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_row_access_policy_acceptance_test.go
+++ b/pkg/testacc/resource_row_access_policy_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_saml2_integration_acceptance_test.go
+++ b/pkg/testacc/resource_saml2_integration_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_schema_acceptance_test.go
+++ b/pkg/testacc/resource_schema_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_scim_integration_acceptance_test.go
+++ b/pkg/testacc/resource_scim_integration_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_secondary_connection_acceptance_test.go
+++ b/pkg/testacc/resource_secondary_connection_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_secret_with_basic_authentication_acceptance_test.go
+++ b/pkg/testacc/resource_secret_with_basic_authentication_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_secret_with_generic_string_acceptance_test.go
+++ b/pkg/testacc/resource_secret_with_generic_string_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_secret_with_oauth_authorization_code_grant_acceptance_test.go
+++ b/pkg/testacc/resource_secret_with_oauth_authorization_code_grant_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_secret_with_oauth_client_credentials_acceptance_test.go
+++ b/pkg/testacc/resource_secret_with_oauth_client_credentials_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_sequence_acceptance_test.go
+++ b/pkg/testacc/resource_sequence_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_service_acceptance_test.go
+++ b/pkg/testacc/resource_service_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_share_acceptance_test.go
+++ b/pkg/testacc/resource_share_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_stage_acceptance_test.go
+++ b/pkg/testacc/resource_stage_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_storage_integration_acceptance_test.go
+++ b/pkg/testacc/resource_storage_integration_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_stream_on_directory_table_acceptance_test.go
+++ b/pkg/testacc/resource_stream_on_directory_table_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_stream_on_external_table_acceptance_test.go
+++ b/pkg/testacc/resource_stream_on_external_table_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_stream_on_table_acceptance_test.go
+++ b/pkg/testacc/resource_stream_on_table_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_stream_on_view_acceptance_test.go
+++ b/pkg/testacc/resource_stream_on_view_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_streamlit_acceptance_test.go
+++ b/pkg/testacc/resource_streamlit_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_table_acceptance_test.go
+++ b/pkg/testacc/resource_table_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_table_column_masking_policy_application_acceptance_test.go
+++ b/pkg/testacc/resource_table_column_masking_policy_application_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_table_constraint_acceptance_test.go
+++ b/pkg/testacc/resource_table_constraint_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_tag_acceptance_test.go
+++ b/pkg/testacc/resource_tag_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_tag_association_acceptance_test.go
+++ b/pkg/testacc/resource_tag_association_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_usage_tracking_acceptance_test.go
+++ b/pkg/testacc/resource_usage_tracking_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_user_authentication_policy_attachment_acceptance_test.go
+++ b/pkg/testacc/resource_user_authentication_policy_attachment_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_user_password_policy_attachment_acceptance_test.go
+++ b/pkg/testacc/resource_user_password_policy_attachment_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_user_programmatic_access_token_acceptance_test.go
+++ b/pkg/testacc/resource_user_programmatic_access_token_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_user_public_keys_acceptance_test.go
+++ b/pkg/testacc/resource_user_public_keys_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/resource_view_acceptance_test.go
+++ b/pkg/testacc/resource_view_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 

--- a/pkg/testacc/snowflake_behavior_object_renaming_acceptance_test.go
+++ b/pkg/testacc/snowflake_behavior_object_renaming_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 


### PR DESCRIPTION
## Changes
Add a new build tag for non-account-level tests (instead of relying on one build tag). Because of this, we can unlock possibilities to call both account and non-account level tests at once (which will be used in the following pr).