### PR TITLE
chore: Add basic cursor rules

### DIFF
--- a/.cursor/rules/cursor-rules.mdc
+++ b/.cursor/rules/cursor-rules.mdc
@@ -1,0 +1,56 @@
+---
+description: How to add or edit Cursor rules in our project
+globs:
+  - ".cursor/rules/*.mdc"
+alwaysApply: false
+---
+# Cursor Rules Location
+
+How to add new cursor rules to the project
+
+1. **ALWAYS** place rule files in PROJECT_ROOT/.cursor/rules/*:
+    ```
+    .cursor/rules/
+    ├── your-rule-name.mdc
+    └── another-rule.mdc
+    ```
+
+2. Follow the conventions:
+    - Use kebab-case for filenames
+    - Always use .mdc extension
+    - Make names descriptive of the rule's purpose
+    - Small, never bigger than 500 lines
+    - Concise and easy to understand
+    - Rules should be written like technical documentation explaining everything step by step with similar content being groupped
+    - Rules should be composable, meaning, if a given topic is mentioned in more than one rule, the common topic should be extracted into its own rule
+
+3. Cursor rules have the following structure:
+
+---
+description: Short description of the rule's purpose
+globs: optional/path/pattern/**/*
+alwaysApply: false
+---
+# Rule Title
+
+Main content explaining the rule with markdown formatting.
+
+1. Step-by-step instructions
+2. Code examples
+3. Guidelines
+
+Example:
+
+When you see a similar pattern:
+```go
+func Example() string {
+  return "1" + "-" + "2"
+}
+```
+
+Apply the following change:
+```go
+func Example() string {
+  return fmt.Sprintf("%[1]s-%[2]s", "1", "2")
+}
+```

--- a/.cursor/rules/sdk-development.mdc
+++ b/.cursor/rules/sdk-development.mdc
@@ -141,7 +141,7 @@ For new Snowflake objects, prefer the code generation approach over manual imple
 **Test File Organization:**
 - **Unit Tests**: Generated in `*_gen_test.go` files, completed manually
 - **Integration Tests**: Manual implementation in `testint/` directory
-- **Build Constraints**: Use `//go:build !account_level_tests` by default
+- **Build Constraints**: Use `//go:build !account_level_tests` in integration tests by default
 
 ## Unit Testing Requirements
 
@@ -197,7 +197,7 @@ Beyond generated tests, add manual tests for:
 
 **Integration Test Structure:**
 ```go
-//go:build !account_level_tests  // or account_level_tests for account operations
+//go:build !account_level_tests
 
 func TestInt_Objects(t *testing.T) {
     client := testClient(t)

--- a/.cursor/rules/sdk-development.mdc
+++ b/.cursor/rules/sdk-development.mdc
@@ -9,6 +9,10 @@ alwaysApply: false
 
 You are working on the Snowflake SDK that provides Go types and methods for interacting with Snowflake APIs.
 
+**Scope**: This document covers SDK architecture, development patterns, data conventions, testing strategy, and Snowflake-specific patterns.
+
+**Related**: For SDK object implementation using the generator, see [SDK Generator Rules](sdk-generator.mdc).
+
 ## SDK Architecture
 
 The Snowflake SDK is organized around a centralized Client structure that provides access to all Snowflake object operations through typed interfaces. The SDK uses a hybrid approach combining code generation for newer objects and manual implementation for legacy objects.
@@ -87,13 +91,10 @@ The Snowflake SDK is organized around a centralized Client structure that provid
 
 For new Snowflake objects, prefer the code generation approach over manual implementation:
 
-- **Primary Reference**: Follow [SDK Generator Rules](sdk-generator.mdc) for complete implementation workflow
-- Create `*_def.go` file with DSL definition using the generator package
-- Thoroughly analyze Snowflake documentation before implementing (see [Documentation Analysis](sdk-generator.mdc#2-documentation-analysis))
+**Implementation Workflow:**
+- **Primary Reference**: Follow [SDK Generator Rules](./sdk-generator.mdc) for complete implementation workflow
 - Add object to Client struct and initialize it in `initialize()` method
-- Run generation to create all required files
-- Complete generated unit test TODOs with realistic SQL expectations (see [Unit Testing Requirements](sdk-generator.mdc#unit-testing-requirements))
-- Implement comprehensive integration tests (see [Integration Testing Patterns](sdk-generator.mdc#integration-testing-patterns))
+- Update `object_types.go` registry with new object type if needed
 - Add manual extensions in `*_ext.go` files only when necessary
 
 ## Data Type Conventions
@@ -132,30 +133,139 @@ For new Snowflake objects, prefer the code generation approach over manual imple
 
 ## Testing Strategy
 
-**Unit Tests**:
-- Generated unit tests provide basic coverage for option structs and validations
-- Add manual unit tests for:
-  - Complex validation logic not covered by generated tests
-  - Enum conversion methods and error cases
-  - Custom helper functions and utilities
-  - SQL generation edge cases
+**Testing Approach:**
+- **Generated Tests**: SDK generator creates basic unit test structure
+- **Manual Completion**: Developers complete generated TODOs and add comprehensive coverage
+- **Integration Tests**: Manual implementation against real Snowflake instances
 
-**Integration Tests**:
-- Located in `testint/` subdirectory, always manually written
-- Use request builders: `NewCreate<Resource>Request()`, `NewAlter<Resource>Request()`
-- Test against real Snowflake connections with proper setup/teardown
-- Validate all CRUD operations with comprehensive option coverage
-- Use generated assertions from `pkg/acceptance/bettertestspoc/assert/objectassert/`
-- Create helper functions for groupping similar assertions
-- Use test client for creating objects that are needed to test particular object
-- Clean up test resources properly to avoid test pollution
-- Test error scenarios and edge cases
+**Test File Organization:**
+- **Unit Tests**: Generated in `*_gen_test.go` files, completed manually
+- **Integration Tests**: Manual implementation in `testint/` directory
+- **Build Constraints**: Use `//go:build !account_level_tests` by default
 
-**Test Organization**:
-- Group tests by operation type (Create, Alter, Drop, Show)
-- Use table-driven tests for multiple configuration scenarios
-- Include both positive and negative test cases
-- Document any special test requirements or setup needs
+## Unit Testing Requirements
+
+**Generated Test Structure:**
+The SDK generator creates unit test templates that must be completed manually:
+
+```go
+func TestObjects_Create(t *testing.T) {
+    id := randomSchemaObjectIdentifier()
+
+    // Minimal valid options - MUST BE COMPLETED
+    defaultOpts := func() *CreateObjectOptions {
+        return &CreateObjectOptions{
+            name: id,
+            // Add other required fields based on Snowflake documentation
+        }
+    }
+
+    t.Run("validation: nil options", func(t *testing.T) {
+        // Auto-generated validation test
+    })
+
+    t.Run("basic", func(t *testing.T) {
+        opts := defaultOpts()
+        // TODO: fill me - MUST be replaced with expected SQL
+        assertOptsValidAndSQLEquals(t, opts, "CREATE OBJECT %s", id.FullyQualifiedName())
+    })
+
+    t.Run("all options", func(t *testing.T) {
+        opts := defaultOpts()
+        // TODO: fill me - MUST test comprehensive option combinations
+        assertOptsValidAndSQLEquals(t, opts, "CREATE OBJECT %s COMMENT = 'test'", id.FullyQualifiedName())
+    })
+}
+```
+
+**Manual Completion Requirements:**
+- **Replace ALL TODO comments** with actual expected SQL
+- **Test basic case** with minimal required parameters
+- **Test comprehensive case** with all optional parameters set
+- **Verify SQL syntax** matches official Snowflake documentation exactly
+- **Test validation cases** for conflicting options and required fields
+- **Use realistic values** not placeholder text
+
+**Additional Manual Unit Tests:**
+Beyond generated tests, add manual tests for:
+- Enum conversion methods and error cases
+- Custom helper functions and utilities
+- SQL generation edge cases
+- Complex validation logic not covered by generated tests
+
+## Integration Testing Requirements
+
+**Integration Test Structure:**
+```go
+//go:build !account_level_tests  // or account_level_tests for account operations
+
+func TestInt_Objects(t *testing.T) {
+    client := testClient(t)
+    ctx := testContext(t)
+
+    // Helper functions for test resource management
+    createObject := func(t *testing.T) (*sdk.Object, func()) {
+        t.Helper()
+        id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
+        req := sdk.NewCreateObjectRequest(id)
+        err := client.Objects.Create(ctx, req)
+        require.NoError(t, err)
+
+        object, err := client.Objects.ShowByID(ctx, id)
+        require.NoError(t, err)
+
+        cleanup := func() {
+            err := testClientHelper().Object.DropObjectFunc(t, id)()
+            require.NoError(t, err)
+        }
+
+        return object, cleanup
+    }
+
+    t.Run("create and show", func(t *testing.T) {
+        object, cleanup := createObject(t)
+        t.Cleanup(cleanup)
+
+        // Test object was created correctly
+        assert.Equal(t, expectedValue, object.Field)
+    })
+
+    // Test privilege requirements and edge cases
+    t.Run("privilege requirements", func(t *testing.T) {
+        // Document and test required privileges
+        // Test with insufficient privileges where applicable
+    })
+}
+```
+
+**Integration Test Implementation:**
+- **Use `testClient()` and `testContext()`** for setup
+- **Implement proper cleanup** with `t.Cleanup()`
+- **Test all CRUD operations** comprehensively
+- **Test privilege requirements** and edge cases
+- **Use helper functions** from `testClientHelper()` for common operations
+- **Test error scenarios** and insufficient privilege cases
+
+**Test Resource Management:**
+- **Create helper functions** for test resource creation and cleanup
+- **Use test client** for creating prerequisite objects
+- **Clean up test resources** properly to avoid test pollution
+- **Group similar assertions** using helper functions
+- **Use generated assertions** from `pkg/acceptance/bettertestspoc/assert/objectassert/`
+
+**Test Organization Standards:**
+- **Group tests by operation type** (Create, Alter, Drop, Show)
+- **Use table-driven tests** for multiple configuration scenarios
+- **Include both positive and negative test cases**
+- **Document special test requirements** and setup needs
+- **Test comprehensive option coverage** for all operations
+
+**Privilege and Edge Case Testing:**
+- **Document privilege requirements** in test comments
+- **Test with different role configurations** where applicable
+- **Verify error handling** for insufficient privileges
+- **Test ownership transfer scenarios** when relevant
+- **Cover account vs object-level privilege differences**
 
 ## Snowflake-Specific Patterns
 
@@ -167,10 +277,8 @@ For new Snowflake objects, prefer the code generation approach over manual imple
 - Schema-level: `SchemaObjectIdentifier` (tables, views)
 - Schema-level with data types as arguments: `SchemaObjectIdentifierWithArguments` (functions, procedures)
 
-**SQL Generation**:
-- Leverage DDL tag system for automatic SQL generation from Go structs
-- Core tags: `ddl:"static"`, `ddl:"keyword"`, `ddl:"identifier"`, `ddl:"parameter"`, `ddl:"list"`
-- SQL modifiers: `single_quotes`, `double_quotes`, `no_quotes`, `parentheses`, `no_equals`, `comma`
-- Support complex SQL patterns with parentheses, quotes, and custom separators
-- **Reference**: See [DSL Patterns and DDL Tag System](sdk-generator.mdc#dsl-patterns-and-ddl-tag-system) for comprehensive tag usage
-- Test generated SQL against actual Snowflake syntax requirements based on official documentation
+**SQL Generation System**:
+- Automatic SQL generation from Go structs using DDL tag system
+- Core philosophy: Map Snowflake SQL syntax directly to Go struct tags
+- **Implementation Details**: See [DDL Tag System](sdk-generator.mdc#dsl-patterns-and-ddl-tag-system) for comprehensive usage
+- Validation: Generated SQL must match official Snowflake documentation exactly

--- a/.cursor/rules/sdk-development.mdc
+++ b/.cursor/rules/sdk-development.mdc
@@ -1,0 +1,176 @@
+---
+description: Rules for SDK development and maintenance in the pkg/sdk directory
+globs:
+  - "pkg/sdk/**/*.go"
+alwaysApply: false
+---
+
+# SDK Development Rules
+
+You are working on the Snowflake SDK that provides Go types and methods for interacting with Snowflake APIs.
+
+## SDK Architecture
+
+The Snowflake SDK is organized around a centralized Client structure that provides access to all Snowflake object operations through typed interfaces. The SDK uses a hybrid approach combining code generation for newer objects and manual implementation for legacy objects.
+
+### Core Components
+
+**Client Structure** (`client.go`):
+- Central hub providing access to all Snowflake object types
+- Organizes operations into logical groups (DDL Commands, System Functions)
+- Each object type exposed as a field (e.g., `client.Databases`, `client.Users`)
+- Initialized with all object implementations in `initialize()` method
+
+**Object Types** (`object_types.go`):
+- Centralized registry of all supported Snowflake object types
+- Maps singular to plural forms for SQL generation
+- Provides identifier type resolution for different object hierarchies
+- Currently supports 50+ object types from Account to Services
+
+### File Organization Patterns
+
+**Generated Objects** (New objects using SDK generator):
+- `*_def.go` - Object definition using generator DSL (e.g., `applications_def.go`)
+- `*_gen.go` - Generated interfaces and option structs
+- `*_dto_gen.go` - Generated request DTOs
+- `*_dto_builders_gen.go` - Generated DTO constructors and builders
+- `*_impl_gen.go` - Generated interface implementations
+- `*_validations_gen.go` - Generated validation logic
+- `*_gen_test.go` - Generated unit test placeholders
+- `*_ext.go` - Manual extensions to generated code (when needed)
+
+**Manual Objects** (Legacy objects written by hand):
+- `*.go` - Combined interface, implementation, and types (e.g., `databases.go`)
+- No `_def.go` file
+- Manual DTO definitions with `//go:generate` for builders
+- Manual validation and test implementations
+
+**Integration Tests**:
+- Located in `testint/` subdirectory
+- Always manually written (never generated)
+- Follow pattern `*_integration_test.go`
+
+### Code Generation System
+
+**SDK Generator** (`pkg/sdk/poc/`):
+- Template-based code generation from DSL definitions
+- Generates 5 main file types per object definition
+- Uses Go generate directives: `//go:generate go run ./poc/main.go`
+- Supports complex validation, SQL generation, and type mapping
+- Still considered PoC but widely used for new objects
+
+**DTO Builder Generator** (`pkg/sdk/dto-builder-generator/`):
+- Generates constructor and builder methods for DTO structs
+- Uses Go generate directive: `//go:generate go run ./dto-builder-generator/main.go`
+- Identifies required fields via `// required` comments
+- Separate from main SDK generator
+
+### Object Implementation Patterns
+
+**Interface Design**:
+- Each object type implements a standard interface (Create, Alter, Drop, Show, etc.)
+- Common methods: `ShowByID()`, `ShowByIDSafely()`, `DropSafely()`
+- Context-aware operations with `context.Context` parameter
+
+**Identifier System**:
+- Typed identifiers based on Snowflake hierarchy
+- `AccountObjectIdentifier` - Account-level objects (databases, warehouses, users)
+- `DatabaseObjectIdentifier` - Database-level objects (schemas)
+- `SchemaObjectIdentifier` - Schema-level objects (tables, views, functions)
+
+**SQL Generation**:
+- DDL tag system for struct-to-SQL conversion
+- Tags: `ddl:"static"`, `ddl:"keyword"`, `ddl:"identifier"`, `ddl:"parameter"`, `ddl:"list"`
+- Supports complex SQL generation with parentheses, quotes, and separators
+
+## Adding New SDK Objects
+
+For new Snowflake objects, prefer the code generation approach over manual implementation:
+
+- **Primary Reference**: Follow [SDK Generator Rules](sdk-generator.mdc) for complete implementation workflow
+- Create `*_def.go` file with DSL definition using the generator package
+- Thoroughly analyze Snowflake documentation before implementing (see [Documentation Analysis](sdk-generator.mdc#2-documentation-analysis))
+- Add object to Client struct and initialize it in `initialize()` method
+- Run generation to create all required files
+- Complete generated unit test TODOs with realistic SQL expectations (see [Unit Testing Requirements](sdk-generator.mdc#unit-testing-requirements))
+- Implement comprehensive integration tests (see [Integration Testing Patterns](sdk-generator.mdc#integration-testing-patterns))
+- Add manual extensions in `*_ext.go` files only when necessary
+
+## Data Type Conventions
+
+**Nullable Fields**:
+- Use pointer types (`*string`, `*int`, `*bool`) for optional/nullable fields
+- Use `sdk.String()`, `sdk.Int()`, `sdk.Bool()`, `sdk.Pointer()` helpers for pointer creation
+- Handle nil values appropriately in conversion methods
+
+**Enums and Constants**:
+- Define enum types as custom string types (e.g., `type TaskState string`)
+- Use const blocks for enum values with clear naming patterns
+- Define a slice of all enum values under (e.g., `var AllTaskStates = []TaskState { ... }`) as it's used in places like conversion method or documentation generation
+- Implement `To<EnumType>(string)` conversion methods with validation
+- Test conversion methods thoroughly, including error cases
+- Use `ListingState` enum and `ToListingState` method as implementation example
+
+**Identifier Conventions**:
+- Use typed identifiers based on Snowflake object hierarchy
+- Validation is auto-generated by the SDK generator
+- Use `FullyQualifiedName()` method for SQL representation
+- Implement `ID()` method returning appropriate identifier type
+
+## Error Handling
+
+**SDK Error Types**:
+- Define custom error types for different error categories
+- Wrap Snowflake API errors with additional context using error wrapping
+- Use error constants for common error patterns to enable error checking
+- Provide meaningful error messages that help with debugging
+
+**Error Patterns**:
+- Check for specific Snowflake error codes when handling API responses
+- Return structured errors that can be programmatically handled
+- Include object identifiers and operation context in error messages
+
+## Testing Strategy
+
+**Unit Tests**:
+- Generated unit tests provide basic coverage for option structs and validations
+- Add manual unit tests for:
+  - Complex validation logic not covered by generated tests
+  - Enum conversion methods and error cases
+  - Custom helper functions and utilities
+  - SQL generation edge cases
+
+**Integration Tests**:
+- Located in `testint/` subdirectory, always manually written
+- Use request builders: `NewCreate<Resource>Request()`, `NewAlter<Resource>Request()`
+- Test against real Snowflake connections with proper setup/teardown
+- Validate all CRUD operations with comprehensive option coverage
+- Use generated assertions from `pkg/acceptance/bettertestspoc/assert/objectassert/`
+- Create helper functions for groupping similar assertions
+- Use test client for creating objects that are needed to test particular object
+- Clean up test resources properly to avoid test pollution
+- Test error scenarios and edge cases
+
+**Test Organization**:
+- Group tests by operation type (Create, Alter, Drop, Show)
+- Use table-driven tests for multiple configuration scenarios
+- Include both positive and negative test cases
+- Document any special test requirements or setup needs
+
+## Snowflake-Specific Patterns
+
+**Object Hierarchies**:
+- Respect Snowflake's three-tier hierarchy: Account > Database > Schema > Object
+- Use appropriate identifier types for each hierarchy level
+- Account-level: `AccountObjectIdentifier` (databases, warehouses, users)
+- Database-level: `DatabaseObjectIdentifier` (schemas)
+- Schema-level: `SchemaObjectIdentifier` (tables, views)
+- Schema-level with data types as arguments: `SchemaObjectIdentifierWithArguments` (functions, procedures)
+
+**SQL Generation**:
+- Leverage DDL tag system for automatic SQL generation from Go structs
+- Core tags: `ddl:"static"`, `ddl:"keyword"`, `ddl:"identifier"`, `ddl:"parameter"`, `ddl:"list"`
+- SQL modifiers: `single_quotes`, `double_quotes`, `no_quotes`, `parentheses`, `no_equals`, `comma`
+- Support complex SQL patterns with parentheses, quotes, and custom separators
+- **Reference**: See [DSL Patterns and DDL Tag System](sdk-generator.mdc#dsl-patterns-and-ddl-tag-system) for comprehensive tag usage
+- Test generated SQL against actual Snowflake syntax requirements based on official documentation

--- a/.cursor/rules/sdk-generator.mdc
+++ b/.cursor/rules/sdk-generator.mdc
@@ -52,35 +52,68 @@ var ObjectsDef = g.NewInterface(
     "Object",           // Struct name (singular)
     g.KindOfT[SchemaObjectIdentifier](), // Identifier type
 ).
-CreateOperation("https://docs.snowflake.com/...",
-    g.NewQueryStruct("CreateObject").
-        Create().
-        SQL("OBJECT").
-        Name().
-        OptionalComment(),
-).
-ShowOperation("https://docs.snowflake.com/...",
-    objectDbRow, object,
-    g.NewQueryStruct("ShowObjects").
-        Show().
-        SQL("OBJECTS").
-        OptionalLike().
-        OptionalExtendedIn(),
-).
-ShowByIdOperationWithFiltering(
-    g.ShowByIDLikeFiltering,
-    g.ShowByIDExtendedInFiltering,
-).
-DescribeOperation(
-    g.DescriptionMappingKindSingleValue,
-    "https://docs.snowflake.com/...",
-    describeObjectDbRow,
-    objectDetails,
-    g.NewQueryStruct("DescribeObject").
-        Describe().
-        SQL("OBJECT").
-        Name(),
-)
+    CreateOperation("https://docs.snowflake.com/...",
+        g.NewQueryStruct("CreateObject").
+            Create().
+            SQL("OBJECT").
+            Name().
+            OptionalComment(),
+    ).
+	AlterOperation(
+		"https://docs.snowflake.com/...",
+		g.NewQueryStruct("AlterObject").
+			Alter().
+			SQL("OBJECT").
+			IfExists().
+			Name().
+			OptionalSQL("PUBLISH").
+			OptionalIdentifier("RenameTo", g.KindOfTPointer[AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			OptionalQueryStructField(
+				"Set",
+				g.NewQueryStruct("ObjectSet").
+					OptionalComment(),
+				g.KeywordOptions().SQL("SET"),
+			).
+			OptionalQueryStructField(
+				"Unset",
+				g.NewQueryStruct("ObjectUnset").
+					OptionalSQL("COMMENT"),
+				g.KeywordOptions().SQL("UNSET"),
+			).
+			WithValidation(g.ValidIdentifier, "name").
+			WithValidation(g.ExactlyOneValueSet, "Publish", "RenameTo", "Set", "Unset"),
+	).
+	DropOperation(
+		"https://docs.snowflake.com/...",
+		g.NewQueryStruct("DropObject").
+			Drop().
+			SQL("OBJECT").
+			IfExists().
+			Name().
+			WithValidation(g.ValidIdentifier, "name"),
+	).
+    ShowOperation("https://docs.snowflake.com/...",
+        objectDbRow, object,
+        g.NewQueryStruct("ShowObjects").
+            Show().
+            SQL("OBJECTS").
+            OptionalLike().
+            OptionalExtendedIn(),
+    ).
+    ShowByIdOperationWithFiltering(
+        g.ShowByIDLikeFiltering,
+        g.ShowByIDExtendedInFiltering,
+    ).
+    DescribeOperation(
+        g.DescriptionMappingKindSingleValue,
+        "https://docs.snowflake.com/...",
+        describeObjectDbRow,
+        objectDetails,
+        g.NewQueryStruct("DescribeObject").
+            Describe().
+            SQL("OBJECT").
+            Name(),
+    )
 ```
 
 ### DSL Guidelines
@@ -156,13 +189,11 @@ The `DescribeOperation()` requires a `DescriptionMappingKind` parameter that det
 - **`DescriptionMappingKindSingleValue`**: Returns a single object (`*ObjectDetails`)
   - **Use when**: DESCRIBE returns object metadata as a single record (name, owner, comment, etc.)
   - **Generated method**: `Describe(ctx context.Context, id Identifier) (*ObjectDetails, error)`
-  - **Implementation**: Uses `validateAndQueryOne()` and `result.convert()`
   - **Examples**: Tasks, Streams, Services, Git Repositories, Secrets
 
 - **`DescriptionMappingKindSlice`**: Returns a slice of objects (`[]ObjectProperty`)
   - **Use when**: DESCRIBE returns property-value pairs or multiple configuration entries
   - **Generated method**: `Describe(ctx context.Context, id Identifier) ([]ObjectProperty, error)`
-  - **Implementation**: Uses `validateAndQuery()` and `convertRows()`
   - **Examples**: Procedures, Functions, Views, Storage Integrations, Network Policies
 
 **Pattern Recognition:**
@@ -171,12 +202,11 @@ The `DescribeOperation()` requires a `DescriptionMappingKind` parameter that det
 
 ### ShowByID Operation
 
-The `ShowByID` operation provides a convenient method to retrieve a single object by its identifier. It internally uses the `Show` operation with appropriate filtering to find the specific object.
+The `ShowByID` operation provides a convenient method to retrieve a single object by its identifier.
+It internally uses the `Show` operation with appropriate filtering to find the specific object.
 
-**Purpose and Implementation:**
-- **Generated methods**: `ShowByID(ctx context.Context, id Identifier) (*Object, error)` and `ShowByIDSafely(ctx context.Context, id Identifier) (*Object, error)`
-- **Implementation**: Calls `Show()` with filtering parameters, then uses `collections.FindFirst()` to locate the object by name
-- **Safety**: `ShowByIDSafely()` handles cases where the object might not exist without throwing errors
+**Generated methods:**
+`ShowByID(ctx context.Context, id Identifier) (*Object, error)` and `ShowByIDSafely(ctx context.Context, id Identifier) (*Object, error)`
 
 **Filtering Strategy Selection:**
 The filtering options for `ShowByID` must match the filtering capabilities available in the corresponding `Show` operation. Choose based on what the Snowflake `SHOW` command supports:

--- a/.cursor/rules/sdk-generator.mdc
+++ b/.cursor/rules/sdk-generator.mdc
@@ -10,6 +10,10 @@ alwaysApply: false
 
 You are working with the SDK generator that creates Go types and methods for Snowflake SQL commands using a custom DSL.
 
+**Scope**: This document covers the SDK generator workflow, DSL patterns, DDL tag system, testing requirements, and best practices for implementing new SDK objects.
+
+**Prerequisites**: Understand the SDK architecture and patterns from [SDK Development Rules](sdk-development.mdc) before using the generator.
+
 ## Creating SDK Object Definitions
 
 ### Definition File Structure
@@ -125,10 +129,10 @@ column *string `ddl:"parameter,no_equals,double_quotes" sql:"MODIFY COLUMN"`
 - **TODO comments**: Always include TODO comments explaining what needs to be filled in by the developer
 
 **Identifier Type Selection:**
-Choose the appropriate identifier type based on Snowflake object hierarchy:
-- `AccountObjectIdentifier` - Account-level objects (databases, warehouses, users, roles)
-- `DatabaseObjectIdentifier` - Database-level objects (schemas)
-- `SchemaObjectIdentifier` - Schema-level objects (tables, views, sequences)
+Choose the appropriate identifier type based on Snowflake object hierarchy (see [Object Hierarchies](sdk-development.mdc#object-hierarchies) for complete reference):
+- `AccountObjectIdentifier` - Account-level objects
+- `DatabaseObjectIdentifier` - Database-level objects
+- `SchemaObjectIdentifier` - Schema-level objects
 - `SchemaObjectIdentifierWithArguments` - Functions and procedures with arguments
 
 **Privilege and Permission Considerations:**
@@ -172,7 +176,7 @@ make run-generator-<object_name>  # Uses filename without _def suffix
 - Validate all DDL tags produce expected output
 
 ### 5. Generated Files Structure
-The generator creates these files following [SDK Development Rules](sdk-development.mdc):
+The generator creates files following the [File Organization Patterns](sdk-development.mdc#file-organization-patterns):
 - `*_gen.go` - Interface and option structs with DDL tags
 - `*_impl_gen.go` - Implementation methods (SQL execution)
 - `*_dto_gen.go` - Request DTOs for builder pattern
@@ -188,8 +192,7 @@ The generator creates these files following [SDK Development Rules](sdk-developm
 
 **Required Manual Work:**
 - Fill conversion mappings in the generated `_impl_gen.go` file
-- Fill unit test TODOs with realistic SQL expectations and add new cases to cover all usage paths
-- Implement integration tests in `testint/` directory to test against actual Snowflake instances
+- Complete all testing requirements following [Testing Strategy](./sdk-development.mdc#testing-strategy)
 - Document privilege requirements and edge cases
 
 ## Common Patterns
@@ -223,102 +226,20 @@ AlterOperation(url,
 )
 ```
 
-## Unit Testing Requirements
+## Testing After Generation
 
-**Generated Test Structure:**
-Generated unit tests follow this pattern and must be completed manually:
+**Generated Test Files:**
+The generator creates `*_gen_test.go` files with unit test templates containing TODO placeholders.
 
-```go
-func TestObjects_Create(t *testing.T) {
-    id := randomSchemaObjectIdentifier()
+**Manual Completion Required:**
+All generated tests must be completed manually following the comprehensive [Testing Strategy](./sdk-development.mdc#testing-strategy) in SDK Development Rules.
 
-    // Minimal valid options - TEST REQUIRED
-    defaultOpts := func() *CreateObjectOptions {
-        return &CreateObjectOptions{
-            name: id,
-            // Add other required fields based on Snowflake documentation
-        }
-    }
-
-    t.Run("validation: nil options", func(t *testing.T) {
-        // Auto-generated validation test
-    })
-
-    t.Run("basic", func(t *testing.T) {
-        opts := defaultOpts()
-        // TODO: fill me - MUST be replaced with expected SQL
-        assertOptsValidAndSQLEquals(t, opts, "CREATE OBJECT %s", id.FullyQualifiedName())
-    })
-
-    t.Run("all options", func(t *testing.T) {
-        opts := defaultOpts()
-        // TODO: fill me - MUST test comprehensive option combinations
-        // Set ALL optional fields to verify complete SQL generation
-        assertOptsValidAndSQLEquals(t, opts, "CREATE OBJECT %s COMMENT = 'test'", id.FullyQualifiedName())
-    })
-}
-```
-
-**Unit Test Completion Guidelines:**
-- **Replace ALL TODO comments** with actual expected SQL
-- **Test basic case** with minimal required parameters
-- **Test comprehensive case** with all optional parameters set
-- **Verify SQL syntax** matches official Snowflake documentation exactly
-- **Test validation cases** for conflicting options and required fields
-- **Use realistic values** not placeholder text
-
-## Integration Testing Patterns
-
-**Integration Test Structure:**
-```go
-//go:build !account_level_tests  // or account_level_tests for account operations
-
-func TestInt_Objects(t *testing.T) {
-    client := testClient(t)
-    ctx := testContext(t)
-
-    // Helper functions for test resource management
-    createObject := func(t *testing.T) (*sdk.Object, func()) {
-        t.Helper()
-        id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
-        req := sdk.NewCreateObjectRequest(id)
-        err := client.Objects.Create(ctx, req)
-        require.NoError(t, err)
-
-        object, err := client.Objects.ShowByID(ctx, id)
-        require.NoError(t, err)
-
-        cleanup := func() {
-            err := testClientHelper().Object.DropObjectFunc(t, id)()
-            require.NoError(t, err)
-        }
-
-        return object, cleanup
-    }
-
-    t.Run("create and show", func(t *testing.T) {
-        object, cleanup := createObject(t)
-        t.Cleanup(cleanup)
-
-        // Test object was created correctly
-        assert.Equal(t, expectedValue, object.Field)
-    })
-
-    // Test privilege requirements and edge cases
-    t.Run("privilege requirements", func(t *testing.T) {
-        // Document and test required privileges
-        // Test with insufficient privileges where applicable
-    })
-}
-```
-
-**Integration Test Requirements:**
-- Use `testClient()` and `testContext()` for setup
-- Implement proper cleanup with `t.Cleanup()`
-- Test all CRUD operations comprehensively
-- Test privilege requirements and edge cases
-- Use helper functions from `testClientHelper()` for common operations
-- Follow build constraints for account-level vs standard tests
+**Key Post-Generation Tasks:**
+- **Complete unit test TODOs** with realistic SQL expectations
+- **Implement integration tests** in `testint/` directory
+- **Test all CRUD operations** against real Snowflake instances
+- **Document and test privilege requirements**
+- **Verify SQL output** matches Snowflake documentation exactly
 
 ## Documentation and Privilege Requirements
 
@@ -355,10 +276,10 @@ func TestInt_Objects(t *testing.T) {
 - **Document privilege requirements** from Snowflake docs
 - **Consult developers** for ambiguous or complex syntax patterns
 
-**Code Quality:**
+**Generator-Specific Quality:**
 - **Complete all generated TODO comments** with realistic tests
-- **Validate SQL output** against Snowflake documentation
+- **Validate SQL output** against Snowflake documentation exactly
 - **Test comprehensive parameter combinations** in unit tests
-- **Implement thorough integration tests** with proper cleanup
+- **Verify DDL tag combinations** produce expected SQL patterns
 - **Use appropriate identifier types** for object hierarchy
-- **Follow SDK development patterns** from [SDK Development Rules](sdk-development.mdc)
+- **Follow architecture patterns** from [SDK Development Rules](sdk-development.mdc)

--- a/.cursor/rules/sdk-generator.mdc
+++ b/.cursor/rules/sdk-generator.mdc
@@ -130,48 +130,47 @@ var ObjectsDef = g.NewInterface(
 - **Accuracy Requirements**: Only include fields and options explicitly documented in "Syntax" and "Output" sections
 - **Conservative Approach**: When in doubt, ask for clarification rather than making assumptions
 
-**DSL Patterns and DDL Tag System**
+To completely understand how to utilize the SDK generator to end up with expected operations, struct containing fields with corrects types, tags, and modifiers,
+analyze [@pkg/sdk/poc/](mdc:pkg/sdk/poc/) generator and existing definitions [@pkg/sdk/*_def.go](mdc:pkg/sdk/*_def.go) along with unit tests [@pkg/sdk/*_test.go](mdc:pkg/sdk/*_test.go) which shows full path from definition to final SQL.
 
-The SDK uses a sophisticated DDL tag system to generate SQL from Go structs. Understanding these patterns is crucial for accurate implementation:
+**Common mapping patterns**
 
-**Core DDL Tags:**
-- `ddl:"static"` - Fixed SQL keywords (e.g., `CREATE`, `ALTER`, `DROP`)
-- `ddl:"keyword"` - Dynamic keywords with optional quoting and parentheses
-- `ddl:"parameter"` - Parameter assignments with `KEY = value` syntax
-- `ddl:"identifier"` - Snowflake object identifiers with proper escaping
-- `ddl:"list"` - Collections with configurable separators and parentheses
-
-**SQL Generation Modifiers:**
-- Quoting: `single_quotes`, `double_quotes`, `no_quotes`, `double_dollar_quotes`
-- Parentheses: `parentheses`, `no_parentheses`, `must_parentheses`
-- Equals: `no_equals` (for identifiers and special cases)
-- Separators: `comma`, `no_comma` (for lists)
-- Reverse: `reverse` (for reversed parameter syntax)
-
-**DSL Method Mapping:**
-- `SQL("TEXT")` → `ddl:"static" sql:"TEXT"`
-- `OptionalSQL("TEXT")` → `ddl:"keyword" sql:"TEXT"` (optional field)
-- `TextAssignment("FIELD", options)` → `ddl:"parameter" sql:"FIELD"`
-- `Name()` → `ddl:"identifier"` with appropriate identifier type
-- `OptionalComment()` → `ddl:"parameter,single_quotes" sql:"COMMENT"`
-
-**Complex Pattern Examples:**
-```go
-// Generates: ALLOWED_VALUES ('value1', 'value2')
-AllowedValues *AllowedValues `ddl:"keyword" sql:"ALLOWED_VALUES"`
-type AllowedValues struct {
-    Values []AllowedValue `ddl:"list,comma"`
-}
-type AllowedValue struct {
-    Value string `ddl:"keyword,single_quotes"`
-}
-
-// Generates: SET TAG (tag1 = 'value1', tag2 = 'value2')
-SetTags []TagAssociation `ddl:"keyword" sql:"SET TAG"`
-
-// Generates: MODIFY COLUMN "column_name" for column operations
-column *string `ddl:"parameter,no_equals,double_quotes" sql:"MODIFY COLUMN"`
+Here's an example syntax patterns seen in the documentation and how they usually map to the SDK DSL.
+By having the immitation of the CREATE command's syntax documentation:
+```sql
+CREATE [ OR REPLACE ] OBJECT [ IF NOT EXISTS ] <name>
+  [ ARGS = '<string_literal>' ]
+  [ VERSION = { FIRST | LAST } ]
+  [ BOOLEAN = { TRUE | FALSE } ]
+  COMMENT = '<string_literal>'
+  <clustering action>
 ```
+
+where:
+
+```sql
+clusteringAction ::=
+  {
+     CLUSTER BY ( <expr> [ , <expr> , ... ] )
+   | RECLUSTER [ MAX_SIZE = <budget_in_bytes> ] [ WHERE <condition> ]
+   | DROP CLUSTERING KEY
+  }
+```
+
+we can extract a few rules:
+- Static values like `CREATE` or `OBJECT` (not containing any dynamic value and always necessary to be specified when calling a given command) map to DSL's methods like `Create()` or `SQL("OBJECT")` if the static keyword is not directly supported by the DSL
+- Keyword values like `OR REPLACE` or `IF NOT EXISTS` (not containing any dynamic value but optional to be specified when calling a given command) map to DSL's methods like `OrReplace()`, `IfNotExists()`, or `OptionalSQL("KEYWORD")` if the static keyword is not directly supported by the DSL
+- `<name>` after main keywords like `CREATE` or `ALTER` refers to object's identifier, and in all cases maps to `Name()` method
+- Whenever something is wrapped with square brackets `[]` it means it's optional, and maps to DSL's methods like `OptionalXxx()`.
+- Whenever something is wrapped with curly braces `{}` it means it's a choice of one of the options separated by pipe `|`. It can be either express to map simple values as well as more complex structures which should result in nested structs (`QueryStructField`) within DSL.
+- Given structure `( <item> [ , <item>, ... ])` means a list of items separated by comma (it mostly prefixed by some keyword and sometimes equal sign, e.g. `KEYWORD = ( <item> [ , <item>, ... ])`), and most likely maps to `OptionalQueryStructField` (for more comprehensive example, take a look at [@network_policies_def.go](mdc:pkg/sdk/network_policies_def.go) how `AllowedNetworkRuleList` or `AllowedIpList` is defined).
+- Documentation can use angle brackets in different ways. Sometimes it can mean the definition is partial parsing the documentation further is required to understand the full context.
+- Simple dynamic values prefixed by static SQL like `WHERE <condition>` are mapped to DSL's methods like `<type>()` (in this case `Text("WhereCondition", g.KeywordOptions().SQL("WHERE"))`)
+- Assignments like `ARGS = '<string_literal>'` or `COMMENT = '<string_literal>'` (containing a dynamic value to be specified when calling a given command with additional complications like equal sign, or different quoting) map to DSL's methods like `<type>Assignment()` (in this case `TextAssignment("ARGS", g.ParameterOptions().SingleQuotes())`) or `Comment()`
+
+**DDL Tag System Reference**
+
+The SDK uses a sophisticated DDL tag system to generate SQL from Go structs. For complete understanding of all available tags, modifiers, and their behavior, analyze [@sql_builder.go](mdc:pkg/sdk/sql_builder.go).
 
 **Operation Types**
 - `CreateOperation()` - CREATE commands
@@ -226,11 +225,6 @@ The filtering options for `ShowByID` must match the filtering capabilities avail
 - **Application Objects**: `ShowByIDApplicationNameFiltering`
 - **No Filtering**: `ShowByIdOperationWithNoFiltering()` when SHOW has no filtering options
 
-**Common Pattern:**
-```go
-ShowByIdOperationWithFiltering(g.ShowByIDLikeFiltering, g.ShowByIDExtendedInFiltering)
-```
-
 **Selection Based on Documentation:**
 - Check SHOW command "Syntax" section for available clauses (`LIKE`, `IN`, `STARTS WITH`)
 - Prefer LIKE + IN combination when both are available for optimal performance
@@ -246,10 +240,6 @@ ShowByIdOperationWithFiltering(g.ShowByIDLikeFiltering, g.ShowByIDExtendedInFilt
 
 **Identifier Types:** Choose based on Snowflake hierarchy (see [Object Hierarchies](sdk-development.mdc#object-hierarchies)):
 - `AccountObjectIdentifier`, `DatabaseObjectIdentifier`, `SchemaObjectIdentifier`, `SchemaObjectIdentifierWithArguments`
-
-**Edge Cases and Considerations:**
-- Document privilege requirements when relevant (CREATE, ALTER, DROP, SHOW operations)
-- Consider ownership transfer, grants, and access patterns for complex objects
 
 ## Generator Workflow
 
@@ -276,14 +266,15 @@ If missing, create definition files and add it to the mapping in `pkg/sdk/poc/ma
 - When uncertain about DSL mapping, ask for guidance rather than guessing
 
 ### 4. Generation and Validation
+**Pre-generation check:**
+- Before running the generator you have to make sure all the previous changes regarding a given SDK object were commited as any re-generation may result in lost changes
+
 ```bash
 make run-generator-<object_name>  # Uses filename without _def suffix
 ```
-
-**Post-Generation Validation:**
-- Verify generated SQL matches documented Snowflake syntax
-- Test unit tests with realistic parameter combinations
-- Validate all DDL tags produce expected output
+**Post-generation check:**
+- If the generated files were previously existing, compare the newly generated content with previous one and revert the lines where adjustments are expected (filled generated unit tests,
+  filled convert functions, etc.) or where the manual adjustments were applied (places with `// manual adjustments` comment)
 
 ### 5. Generated Files Structure
 The generator creates files following the [File Organization Patterns](sdk-development.mdc#file-organization-patterns):
@@ -301,34 +292,8 @@ The generator creates files following the [File Organization Patterns](sdk-devel
 
 ## Common Patterns
 
-### Basic Object with CRUD
-```go
-var ObjectsDef = g.NewInterface("Objects", "Object", g.KindOfT[SchemaObjectIdentifier]()).
-    CreateOperation(url, createStruct).
-    AlterOperation(url, alterStruct).
-    DropOperation(url, dropStruct).
-    ShowOperation(url, dbRow, plainStruct, showStruct)
-```
-
-### Complex ALTER with SET/UNSET
-```go
-AlterOperation(url,
-    g.NewQueryStruct("AlterObject").
-        Alter().SQL("OBJECT").Name().
-        OptionalQueryStructField("Set",
-            g.NewQueryStruct("ObjectSet").
-                OptionalComment().
-                OptionalTextAssignment("FIELD", options),
-            g.KeywordOptions().SQL("SET"),
-        ).
-        OptionalQueryStructField("Unset",
-            g.NewQueryStruct("ObjectUnset").
-                OptionalSQL("COMMENT").
-                OptionalSQL("FIELD"),
-            g.ListOptions().NoParentheses().SQL("UNSET"),
-        ),
-)
-```
+Reference existing object definitions in [@sdk/](mdc:pkg/sdk/) for common patterns and DSL usage examples.
+The generator codebase contains comprehensive examples of all supported operation types and DSL patterns.
 
 ## Post-Generation Tasks
 

--- a/.cursor/rules/sdk-generator.mdc
+++ b/.cursor/rules/sdk-generator.mdc
@@ -26,6 +26,27 @@ import g "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/poc/gen
 
 //go:generate go run ./poc/main.go
 
+// Define output structures separately above the main definition
+var objectDbRow = g.DbStruct("objectDBRow").
+    Text("created_on").
+    Text("name").
+    Text("owner").
+    Text("comment")
+
+var object = g.PlainStruct("Object").
+    Time("CreatedOn").
+    Text("Name").
+    Text("Owner").
+    Text("Comment")
+
+var describeObjectDbRow = g.DbStruct("describeObjectDBRow").
+    Text("property").
+    Text("value")
+
+var objectDetails = g.PlainStruct("ObjectDetails").
+    Text("Property").
+    Text("Value")
+
 var ObjectsDef = g.NewInterface(
     "Objects",           // Interface name (plural)
     "Object",           // Struct name (singular)
@@ -39,10 +60,26 @@ CreateOperation("https://docs.snowflake.com/...",
         OptionalComment(),
 ).
 ShowOperation("https://docs.snowflake.com/...",
-    dbRow, plainStruct,
+    objectDbRow, object,
     g.NewQueryStruct("ShowObjects").
         Show().
-        SQL("OBJECTS"),
+        SQL("OBJECTS").
+        OptionalLike().
+        OptionalExtendedIn(),
+).
+ShowByIdOperationWithFiltering(
+    g.ShowByIDLikeFiltering,
+    g.ShowByIDExtendedInFiltering,
+).
+DescribeOperation(
+    g.DescriptionMappingKindSingleValue,
+    "https://docs.snowflake.com/...",
+    describeObjectDbRow,
+    objectDetails,
+    g.NewQueryStruct("DescribeObject").
+        Describe().
+        SQL("OBJECT").
+        Name(),
 )
 ```
 
@@ -53,12 +90,20 @@ ShowOperation("https://docs.snowflake.com/...",
 - Map SQL syntax directly to DSL operations
 - Include documentation URLs in operation definitions
 - **CRITICAL**: When creating SDK definitions from Snowflake documentation, examine the EXACT syntax from the specific command documentation pages
+- **Documentation Verification Workflow**:
+  1. **Verify each documentation URL** is accessible and contains expected content
+  2. **Check for "Syntax" sections** with command structure
+  3. **Check for "Output" sections** with field specifications for query commands like SHOW or DESC
+  4. **Ask for help** if any links are broken or sections are missing
+  5. **Never proceed** with made-up fields or syntax
 - **Documentation Parsing**: Always check nested links like:
   - `https://docs.snowflake.com/en/sql-reference/sql/create-dataset` for CREATE DATASET syntax
   - `https://docs.snowflake.com/en/sql-reference/sql/alter-dataset` for ALTER DATASET syntax
   - `https://docs.snowflake.com/en/sql-reference/sql/show-datasets` for SHOW DATASETS syntax
+  - `https://docs.snowflake.com/en/sql-reference/sql/desc-dataset` for DESCRIBE DATASET output
 - **Syntax Accuracy**: Only include fields and options that are explicitly documented in the "Syntax" section
-- **Conservative Approach**: When in doubt, implement minimal required syntax and expand later based on actual documentation
+- **Output Accuracy**: Only include output fields that are explicitly documented in the "Output" section
+- **Conservative Approach**: When in doubt, ask for clarification rather than making assumptions
 
 **DSL Patterns and DDL Tag System**
 
@@ -108,25 +153,152 @@ column *string `ddl:"parameter,no_equals,double_quotes" sql:"MODIFY COLUMN"`
 - `AlterOperation()` - ALTER commands
 - `DropOperation()` - DROP commands
 - `ShowOperation()` - SHOW commands
-- `DescribeOperation()` - DESCRIBE commands
+- `ShowByIdOperationWithFiltering()` - ShowByID with filtering options
+- `ShowByIdOperationWithNoFiltering()` - ShowByID without filtering
+- `DescribeOperation()` - DESCRIBE commands with mapping kind selection
 - `CustomOperation()` - Non-standard commands
+
+**DescriptionMappingKind Selection:**
+The `DescribeOperation()` requires a `DescriptionMappingKind` parameter that determines the return type and implementation:
+
+- **`DescriptionMappingKindSingleValue`**: Returns a single object (`*ObjectDetails`)
+  - **Use when**: DESCRIBE returns object metadata as a single record (name, owner, comment, etc.)
+  - **Generated method**: `Describe(ctx context.Context, id Identifier) (*ObjectDetails, error)`
+  - **Implementation**: Uses `validateAndQueryOne()` and `result.convert()`
+  - **Examples**: Tasks, Streams, Services, Git Repositories, Secrets
+
+- **`DescriptionMappingKindSlice`**: Returns a slice of objects (`[]ObjectProperty`)
+  - **Use when**: DESCRIBE returns property-value pairs or multiple configuration entries
+  - **Generated method**: `Describe(ctx context.Context, id Identifier) ([]ObjectProperty, error)`
+  - **Implementation**: Uses `validateAndQuery()` and `convertRows()`
+  - **Examples**: Procedures, Functions, Views, Storage Integrations, Network Policies
+
+**Pattern Recognition:**
+- **Single Value**: Object has fixed metadata structure (created_on, name, owner, comment, specific config fields)
+- **Slice**: Object has variable properties returned as key-value pairs (property, value, description columns)
+
+### ShowByID Operation
+
+The `ShowByID` operation provides a convenient method to retrieve a single object by its identifier. It internally uses the `Show` operation with appropriate filtering to find the specific object.
+
+**Purpose and Implementation:**
+- **Generated methods**: `ShowByID(ctx context.Context, id Identifier) (*Object, error)` and `ShowByIDSafely(ctx context.Context, id Identifier) (*Object, error)`
+- **Implementation**: Calls `Show()` with filtering parameters, then uses `collections.FindFirst()` to locate the object by name
+- **Safety**: `ShowByIDSafely()` handles cases where the object might not exist without throwing errors
+
+**Filtering Strategy Selection:**
+The filtering options for `ShowByID` must match the filtering capabilities available in the corresponding `Show` operation. Choose based on what the Snowflake `SHOW` command supports:
+
+**Available Filtering Types:**
+- **`ShowByIDLikeFiltering`**: Uses `LIKE` pattern matching with object name
+  - **Generated filter**: `WithLike(Like{Pattern: String(id.Name())})`
+  - **Use when**: `SHOW` command supports `LIKE` clause
+  - **Universal**: Works for all object types that support pattern matching
+
+- **`ShowByIDInFiltering`**: Uses `IN` clause to filter by parent container
+  - **Generated filter**: `WithIn(In{Schema: id.SchemaId()})` (for schema objects)
+  - **Use when**: `SHOW` command supports `IN` clause and object has hierarchical structure
+  - **Examples**: Schema-level objects can be filtered `IN SCHEMA`
+
+- **`ShowByIDExtendedInFiltering`**: Uses `ExtendedIn` for more complex hierarchical filtering
+  - **Generated filter**: `WithIn(ExtendedIn{In: In{Schema: id.SchemaId()}})`
+  - **Use when**: `SHOW` command supports extended `IN` syntax
+  - **Examples**: Objects that can be filtered by database, schema, or other containers
+
+- **`ShowByIDServiceInFiltering`**: Specialized filtering for service-related objects
+  - **Generated filter**: `WithIn(ServiceIn{In: In{Schema: id.SchemaId()}})`
+  - **Use when**: Object is service-related and supports service-specific filtering
+
+- **`ShowByIDApplicationNameFiltering`**: Specialized filtering for application objects
+  - **Generated filter**: `WithApplicationName(id.DatabaseId())`
+  - **Use when**: Object is application-related and uses application name filtering
+
+**Filtering Selection Guidelines:**
+
+**Ideal Combination (Most Common):**
+```go
+ShowByIdOperationWithFiltering(
+    g.ShowByIDLikeFiltering,           // Primary: Name pattern matching
+    g.ShowByIDExtendedInFiltering,     // Secondary: Hierarchical filtering
+)
+```
+
+**Selection Rules:**
+1. **Always include `ShowByIDLikeFiltering`** if the `SHOW` command supports `LIKE`
+2. **Add hierarchical filtering** based on object level:
+   - **Schema objects**: Add `ShowByIDInFiltering` or `ShowByIDExtendedInFiltering`
+   - **Database objects**: Add `ShowByIDInFiltering` if supported
+   - **Account objects**: Usually only `ShowByIDLikeFiltering`
+3. **Use specialized filtering** for specific object types (services, applications)
+4. **No filtering** only when `SHOW` command has no filtering options
+
+**Examples by Object Hierarchy:**
+
+**Account-Level Objects** (Users, Roles, Integrations):
+```go
+ShowByIdOperationWithFiltering(
+    g.ShowByIDLikeFiltering,  // Only LIKE filtering available
+)
+```
+
+**Database-Level Objects** (Schemas, Tables):
+```go
+ShowByIdOperationWithFiltering(
+    g.ShowByIDLikeFiltering,     // Name pattern matching
+    g.ShowByIDInFiltering,       // Filter by database
+)
+```
+
+**Schema-Level Objects** (Views, Functions, Procedures):
+```go
+ShowByIdOperationWithFiltering(
+    g.ShowByIDLikeFiltering,        // Name pattern matching
+    g.ShowByIDExtendedInFiltering,  // Filter by schema/database
+)
+```
+
+**Service Objects**:
+```go
+ShowByIdOperationWithFiltering(
+    g.ShowByIDLikeFiltering,        // Name pattern matching
+    g.ShowByIDServiceInFiltering,   // Service-specific filtering
+)
+```
+
+**No Filtering Required**:
+```go
+ShowByIdOperationWithNoFiltering()  // When SHOW has no filtering options
+```
+
+**Documentation-Driven Selection:**
+Base filtering choices on the Snowflake documentation for the `SHOW` command:
+- **Check "Syntax" section** for available clauses (`LIKE`, `IN`, `STARTS WITH`)
+- **Match filtering options** to what's documented in Snowflake
+- **Test combinations** that make sense for the object hierarchy
+- **Prefer LIKE + IN combination** when both are available for optimal performance
 
 **Data Structure Fields and Output Mapping**
 
+**Structure Definition Pattern:**
+- **Define output structures separately** above the main interface definition
+- **Use descriptive variable names**: `objectDbRow`, `object`, `describeObjectDbRow`, `objectDetails`
+- **Follow consistent naming**: `<object>DbRow` for database mapping, `<object>` for plain struct, `describe<Object>DbRow` and `<object>Details` for describe operations
+- **Reference structures by variable name** in operations, not inline definitions
+
 **Show/Describe Operations:**
 - **NEVER assume fields**: Do not guess or assume what fields SHOW, DESCRIBE, or other operations return
-- **Empty structs for unknown output**: If field structure is not documented, define empty structs with TODO comments:
+- **VERIFY documentation links first**: Always check that documentation URLs are correct and accessible
+- **Use documented OUTPUT sections**: When Snowflake documentation includes OUTPUT sections with field specifications, implement those fields exactly as documented
+- **ASK FOR HELP with broken links**: If documentation links are broken or OUTPUT sections are missing, ask for clarification before proceeding
+- **Use TODO only for completely unknown structures**:
   ```go
-  // TODO: Fields for SHOW OBJECTS output are not documented.
+  // TODO: Fields for SHOW OBJECTS output are not documented and no standard pattern applies.
   // Developer should examine actual SHOW OBJECTS output and fill in the correct fields.
   var objectDbRow = g.DbStruct("objectDBRow")
-
-  // TODO: Object struct fields should match the actual SHOW OBJECTS output.
-  // Developer should examine actual output and define the correct fields.
-  var object = g.PlainStruct("Object")
   ```
-- **Documentation requirement**: Only add fields when you have explicit documentation or can verify actual output structure
-- **TODO comments**: Always include TODO comments explaining what needs to be filled in by the developer
+- **Documentation requirement**: Add fields when OUTPUT sections are explicitly documented in Snowflake documentation
+- **Field accuracy**: Match field names, types, and descriptions exactly as specified in OUTPUT documentation
+- **Comment Policy**: Only add TODO comments when genuinely unsure about field mappings or when documentation is incomplete. If you've verified the documentation and are confident about the fields, don't add comments - developers will validate the mapping during implementation anyway
 
 **Identifier Type Selection:**
 Choose the appropriate identifier type based on Snowflake object hierarchy (see [Object Hierarchies](sdk-development.mdc#object-hierarchies) for complete reference):
@@ -153,10 +325,19 @@ If missing, create definition files and add it to the mapping in `pkg/sdk/poc/ma
 ### 2. Documentation Analysis
 **Critical Phase - Must Be Thorough:**
 - Request documentation URLs for ALL operations (CREATE, ALTER, DROP, SHOW, DESCRIBE)
+- **VERIFY ALL DOCUMENTATION LINKS** - Check that URLs are accessible and contain the expected content
+- **ASK FOR CLARIFICATION** if any documentation links are broken, missing, or incomplete
 - Examine EXACT syntax from "Syntax" sections only
+- Examine EXACT output fields from "Output" sections when available
 - Note ALL optional vs required parameters
+- **Analyze SHOW command filtering options** for ShowByID operation:
+  - Check for `LIKE` clause support
+  - Check for `IN` clause support (database, schema, application)
+  - Check for `STARTS WITH` or other filtering options
+  - Note object hierarchy level for appropriate filtering selection
 - Identify privilege requirements and edge cases
 - Document any unclear or ambiguous syntax patterns
+- **NEVER make up fields or syntax** - always verify against actual documentation
 - **Consult with developers** for unknown or complex scenarios to avoid generating unsupported DSL
 
 ### 3. Implementation and Verification

--- a/.cursor/rules/sdk-generator.mdc
+++ b/.cursor/rules/sdk-generator.mdc
@@ -1,0 +1,364 @@
+---
+description: Rules for using the SDK generator to create Snowflake object definitions
+globs:
+  - "pkg/sdk/**/*_def.go"
+  - "pkg/sdk/poc/**/*.go"
+alwaysApply: false
+---
+
+# SDK Generator Usage
+
+You are working with the SDK generator that creates Go types and methods for Snowflake SQL commands using a custom DSL.
+
+## Creating SDK Object Definitions
+
+### Definition File Structure
+Create `<object_name>_def.go` files with this pattern:
+
+```go
+package sdk
+
+import g "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/poc/generator"
+
+//go:generate go run ./poc/main.go
+
+var ObjectsDef = g.NewInterface(
+    "Objects",           // Interface name (plural)
+    "Object",           // Struct name (singular)
+    g.KindOfT[SchemaObjectIdentifier](), // Identifier type
+).
+CreateOperation("https://docs.snowflake.com/...",
+    g.NewQueryStruct("CreateObject").
+        Create().
+        SQL("OBJECT").
+        Name().
+        OptionalComment(),
+).
+ShowOperation("https://docs.snowflake.com/...",
+    dbRow, plainStruct,
+    g.NewQueryStruct("ShowObjects").
+        Show().
+        SQL("OBJECTS"),
+)
+```
+
+### DSL Guidelines
+
+**Documentation-Based Development:**
+- Use Snowflake documentation as the source of truth
+- Map SQL syntax directly to DSL operations
+- Include documentation URLs in operation definitions
+- **CRITICAL**: When creating SDK definitions from Snowflake documentation, examine the EXACT syntax from the specific command documentation pages
+- **Documentation Parsing**: Always check nested links like:
+  - `https://docs.snowflake.com/en/sql-reference/sql/create-dataset` for CREATE DATASET syntax
+  - `https://docs.snowflake.com/en/sql-reference/sql/alter-dataset` for ALTER DATASET syntax
+  - `https://docs.snowflake.com/en/sql-reference/sql/show-datasets` for SHOW DATASETS syntax
+- **Syntax Accuracy**: Only include fields and options that are explicitly documented in the "Syntax" section
+- **Conservative Approach**: When in doubt, implement minimal required syntax and expand later based on actual documentation
+
+**DSL Patterns and DDL Tag System**
+
+The SDK uses a sophisticated DDL tag system to generate SQL from Go structs. Understanding these patterns is crucial for accurate implementation:
+
+**Core DDL Tags:**
+- `ddl:"static"` - Fixed SQL keywords (e.g., `CREATE`, `ALTER`, `DROP`)
+- `ddl:"keyword"` - Dynamic keywords with optional quoting and parentheses
+- `ddl:"parameter"` - Parameter assignments with `KEY = value` syntax
+- `ddl:"identifier"` - Snowflake object identifiers with proper escaping
+- `ddl:"list"` - Collections with configurable separators and parentheses
+
+**SQL Generation Modifiers:**
+- Quoting: `single_quotes`, `double_quotes`, `no_quotes`, `double_dollar_quotes`
+- Parentheses: `parentheses`, `no_parentheses`, `must_parentheses`
+- Equals: `no_equals` (for identifiers and special cases)
+- Separators: `comma`, `no_comma` (for lists)
+- Reverse: `reverse` (for reversed parameter syntax)
+
+**DSL Method Mapping:**
+- `SQL("TEXT")` → `ddl:"static" sql:"TEXT"`
+- `OptionalSQL("TEXT")` → `ddl:"keyword" sql:"TEXT"` (optional field)
+- `TextAssignment("FIELD", options)` → `ddl:"parameter" sql:"FIELD"`
+- `Name()` → `ddl:"identifier"` with appropriate identifier type
+- `OptionalComment()` → `ddl:"parameter,single_quotes" sql:"COMMENT"`
+
+**Complex Pattern Examples:**
+```go
+// Generates: ALLOWED_VALUES ('value1', 'value2')
+AllowedValues *AllowedValues `ddl:"keyword" sql:"ALLOWED_VALUES"`
+type AllowedValues struct {
+    Values []AllowedValue `ddl:"list,comma"`
+}
+type AllowedValue struct {
+    Value string `ddl:"keyword,single_quotes"`
+}
+
+// Generates: SET TAG (tag1 = 'value1', tag2 = 'value2')
+SetTags []TagAssociation `ddl:"keyword" sql:"SET TAG"`
+
+// Generates: MODIFY COLUMN "column_name" for column operations
+column *string `ddl:"parameter,no_equals,double_quotes" sql:"MODIFY COLUMN"`
+```
+
+**Operation Types**
+- `CreateOperation()` - CREATE commands
+- `AlterOperation()` - ALTER commands
+- `DropOperation()` - DROP commands
+- `ShowOperation()` - SHOW commands
+- `DescribeOperation()` - DESCRIBE commands
+- `CustomOperation()` - Non-standard commands
+
+**Data Structure Fields and Output Mapping**
+
+**Show/Describe Operations:**
+- **NEVER assume fields**: Do not guess or assume what fields SHOW, DESCRIBE, or other operations return
+- **Empty structs for unknown output**: If field structure is not documented, define empty structs with TODO comments:
+  ```go
+  // TODO: Fields for SHOW OBJECTS output are not documented.
+  // Developer should examine actual SHOW OBJECTS output and fill in the correct fields.
+  var objectDbRow = g.DbStruct("objectDBRow")
+
+  // TODO: Object struct fields should match the actual SHOW OBJECTS output.
+  // Developer should examine actual output and define the correct fields.
+  var object = g.PlainStruct("Object")
+  ```
+- **Documentation requirement**: Only add fields when you have explicit documentation or can verify actual output structure
+- **TODO comments**: Always include TODO comments explaining what needs to be filled in by the developer
+
+**Identifier Type Selection:**
+Choose the appropriate identifier type based on Snowflake object hierarchy:
+- `AccountObjectIdentifier` - Account-level objects (databases, warehouses, users, roles)
+- `DatabaseObjectIdentifier` - Database-level objects (schemas)
+- `SchemaObjectIdentifier` - Schema-level objects (tables, views, sequences)
+- `SchemaObjectIdentifierWithArguments` - Functions and procedures with arguments
+
+**Privilege and Permission Considerations:**
+When implementing new objects, document privilege requirements:
+- Research required privileges for each operation (CREATE, ALTER, DROP, SHOW)
+- Document role requirements in comments
+- Consider edge cases like ownership transfer, grants, and access patterns
+- Reference Snowflake documentation for privilege requirements
+
+## Generator Workflow
+
+### 1. Setup
+If missing, create definition files and add it to the mapping in `pkg/sdk/poc/main.go`:
+```go
+"your_object_def.go": sdk.YourObjectDef,
+```
+
+### 2. Documentation Analysis
+**Critical Phase - Must Be Thorough:**
+- Request documentation URLs for ALL operations (CREATE, ALTER, DROP, SHOW, DESCRIBE)
+- Examine EXACT syntax from "Syntax" sections only
+- Note ALL optional vs required parameters
+- Identify privilege requirements and edge cases
+- Document any unclear or ambiguous syntax patterns
+- **Consult with developers** for unknown or complex scenarios to avoid generating unsupported DSL
+
+### 3. Implementation and Verification
+**Based on Documentation Analysis:**
+- Map each documented syntax element to appropriate DSL pattern
+- Reference similar existing objects for complex patterns
+- When uncertain about DSL mapping, ask for guidance rather than guessing
+
+### 4. Generation and Validation
+```bash
+make run-generator-<object_name>  # Uses filename without _def suffix
+```
+
+**Post-Generation Validation:**
+- Verify generated SQL matches documented Snowflake syntax
+- Test unit tests with realistic parameter combinations
+- Validate all DDL tags produce expected output
+
+### 5. Generated Files Structure
+The generator creates these files following [SDK Development Rules](sdk-development.mdc):
+- `*_gen.go` - Interface and option structs with DDL tags
+- `*_impl_gen.go` - Implementation methods (SQL execution)
+- `*_dto_gen.go` - Request DTOs for builder pattern
+- `*_dto_builders_gen.go` - Constructor and builder methods
+- `*_validations_gen.go` - Validation functions for all parameters
+- `*_gen_test.go` - Unit test templates with TODO placeholders
+
+### 6. Manual Extensions and Testing
+**Extension Files:**
+- **NEVER** edit generated files directly (unless it's expected by design, e.g. conversions or unit tests)
+- Create `<object_name>_ext.go` for custom extensions
+- Mark manual changes in generated files with `// manually adjusted`
+
+**Required Manual Work:**
+- Fill conversion mappings in the generated `_impl_gen.go` file
+- Fill unit test TODOs with realistic SQL expectations and add new cases to cover all usage paths
+- Implement integration tests in `testint/` directory to test against actual Snowflake instances
+- Document privilege requirements and edge cases
+
+## Common Patterns
+
+### Basic Object with CRUD
+```go
+var ObjectsDef = g.NewInterface("Objects", "Object", g.KindOfT[SchemaObjectIdentifier]()).
+    CreateOperation(url, createStruct).
+    AlterOperation(url, alterStruct).
+    DropOperation(url, dropStruct).
+    ShowOperation(url, dbRow, plainStruct, showStruct)
+```
+
+### Complex ALTER with SET/UNSET
+```go
+AlterOperation(url,
+    g.NewQueryStruct("AlterObject").
+        Alter().SQL("OBJECT").Name().
+        OptionalQueryStructField("Set",
+            g.NewQueryStruct("ObjectSet").
+                OptionalComment().
+                OptionalTextAssignment("FIELD", options),
+            g.KeywordOptions().SQL("SET"),
+        ).
+        OptionalQueryStructField("Unset",
+            g.NewQueryStruct("ObjectUnset").
+                OptionalSQL("COMMENT").
+                OptionalSQL("FIELD"),
+            g.ListOptions().NoParentheses().SQL("UNSET"),
+        ),
+)
+```
+
+## Unit Testing Requirements
+
+**Generated Test Structure:**
+Generated unit tests follow this pattern and must be completed manually:
+
+```go
+func TestObjects_Create(t *testing.T) {
+    id := randomSchemaObjectIdentifier()
+
+    // Minimal valid options - TEST REQUIRED
+    defaultOpts := func() *CreateObjectOptions {
+        return &CreateObjectOptions{
+            name: id,
+            // Add other required fields based on Snowflake documentation
+        }
+    }
+
+    t.Run("validation: nil options", func(t *testing.T) {
+        // Auto-generated validation test
+    })
+
+    t.Run("basic", func(t *testing.T) {
+        opts := defaultOpts()
+        // TODO: fill me - MUST be replaced with expected SQL
+        assertOptsValidAndSQLEquals(t, opts, "CREATE OBJECT %s", id.FullyQualifiedName())
+    })
+
+    t.Run("all options", func(t *testing.T) {
+        opts := defaultOpts()
+        // TODO: fill me - MUST test comprehensive option combinations
+        // Set ALL optional fields to verify complete SQL generation
+        assertOptsValidAndSQLEquals(t, opts, "CREATE OBJECT %s COMMENT = 'test'", id.FullyQualifiedName())
+    })
+}
+```
+
+**Unit Test Completion Guidelines:**
+- **Replace ALL TODO comments** with actual expected SQL
+- **Test basic case** with minimal required parameters
+- **Test comprehensive case** with all optional parameters set
+- **Verify SQL syntax** matches official Snowflake documentation exactly
+- **Test validation cases** for conflicting options and required fields
+- **Use realistic values** not placeholder text
+
+## Integration Testing Patterns
+
+**Integration Test Structure:**
+```go
+//go:build !account_level_tests  // or account_level_tests for account operations
+
+func TestInt_Objects(t *testing.T) {
+    client := testClient(t)
+    ctx := testContext(t)
+
+    // Helper functions for test resource management
+    createObject := func(t *testing.T) (*sdk.Object, func()) {
+        t.Helper()
+        id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
+        req := sdk.NewCreateObjectRequest(id)
+        err := client.Objects.Create(ctx, req)
+        require.NoError(t, err)
+
+        object, err := client.Objects.ShowByID(ctx, id)
+        require.NoError(t, err)
+
+        cleanup := func() {
+            err := testClientHelper().Object.DropObjectFunc(t, id)()
+            require.NoError(t, err)
+        }
+
+        return object, cleanup
+    }
+
+    t.Run("create and show", func(t *testing.T) {
+        object, cleanup := createObject(t)
+        t.Cleanup(cleanup)
+
+        // Test object was created correctly
+        assert.Equal(t, expectedValue, object.Field)
+    })
+
+    // Test privilege requirements and edge cases
+    t.Run("privilege requirements", func(t *testing.T) {
+        // Document and test required privileges
+        // Test with insufficient privileges where applicable
+    })
+}
+```
+
+**Integration Test Requirements:**
+- Use `testClient()` and `testContext()` for setup
+- Implement proper cleanup with `t.Cleanup()`
+- Test all CRUD operations comprehensively
+- Test privilege requirements and edge cases
+- Use helper functions from `testClientHelper()` for common operations
+- Follow build constraints for account-level vs standard tests
+
+## Documentation and Privilege Requirements
+
+**When implementing new objects, always document:**
+
+**Privilege Requirements:**
+```go
+// CREATE OBJECT requires:
+// - CREATE privileges on the schema
+// - USAGE privileges on the database and schema
+// - Additional privileges: [list specific requirements from Snowflake docs]
+
+// ALTER OBJECT requires:
+// - Object ownership OR ALTER privileges
+// - [specific privilege requirements]
+
+// DROP OBJECT requires:
+// - Object ownership OR DROP privileges
+```
+
+**Edge Cases and Limitations:**
+```go
+// Known limitations:
+// - Feature X requires Snowflake version Y or higher
+// - Operation Z requires specific account settings
+// - Privilege P may require account admin role in certain configurations
+```
+
+## Best Practices
+
+**Documentation-Driven Development:**
+- **Always start with official Snowflake documentation**
+- **Map syntax exactly** - do not add unsupported features
+- **Document privilege requirements** from Snowflake docs
+- **Consult developers** for ambiguous or complex syntax patterns
+
+**Code Quality:**
+- **Complete all generated TODO comments** with realistic tests
+- **Validate SQL output** against Snowflake documentation
+- **Test comprehensive parameter combinations** in unit tests
+- **Implement thorough integration tests** with proper cleanup
+- **Use appropriate identifier types** for object hierarchy
+- **Follow SDK development patterns** from [SDK Development Rules](sdk-development.mdc)

--- a/.cursor/rules/sdk-generator.mdc
+++ b/.cursor/rules/sdk-generator.mdc
@@ -26,7 +26,7 @@ import g "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/poc/gen
 
 //go:generate go run ./poc/main.go
 
-// Define output structures separately above the main definition
+// Define output structures separately above main definition
 var objectDbRow = g.DbStruct("objectDBRow").
     Text("created_on").
     Text("name").
@@ -86,23 +86,15 @@ DescribeOperation(
 ### DSL Guidelines
 
 **Documentation-Based Development:**
-- Use Snowflake documentation as the source of truth
-- Map SQL syntax directly to DSL operations
-- Include documentation URLs in operation definitions
-- **CRITICAL**: When creating SDK definitions from Snowflake documentation, examine the EXACT syntax from the specific command documentation pages
+- Use Snowflake documentation as the source of truth, map SQL syntax directly to DSL operations
+- **CRITICAL**: Examine EXACT syntax from specific command documentation pages
 - **Documentation Verification Workflow**:
   1. **Verify each documentation URL** is accessible and contains expected content
   2. **Check for "Syntax" sections** with command structure
-  3. **Check for "Output" sections** with field specifications for query commands like SHOW or DESC
+  3. **Check for "Output" sections** with field specifications for SHOW/DESCRIBE commands
   4. **Ask for help** if any links are broken or sections are missing
   5. **Never proceed** with made-up fields or syntax
-- **Documentation Parsing**: Always check nested links like:
-  - `https://docs.snowflake.com/en/sql-reference/sql/create-dataset` for CREATE DATASET syntax
-  - `https://docs.snowflake.com/en/sql-reference/sql/alter-dataset` for ALTER DATASET syntax
-  - `https://docs.snowflake.com/en/sql-reference/sql/show-datasets` for SHOW DATASETS syntax
-  - `https://docs.snowflake.com/en/sql-reference/sql/desc-dataset` for DESCRIBE DATASET output
-- **Syntax Accuracy**: Only include fields and options that are explicitly documented in the "Syntax" section
-- **Output Accuracy**: Only include output fields that are explicitly documented in the "Output" section
+- **Accuracy Requirements**: Only include fields and options explicitly documented in "Syntax" and "Output" sections
 - **Conservative Approach**: When in doubt, ask for clarification rather than making assumptions
 
 **DSL Patterns and DDL Tag System**
@@ -190,129 +182,44 @@ The `ShowByID` operation provides a convenient method to retrieve a single objec
 The filtering options for `ShowByID` must match the filtering capabilities available in the corresponding `Show` operation. Choose based on what the Snowflake `SHOW` command supports:
 
 **Available Filtering Types:**
-- **`ShowByIDLikeFiltering`**: Uses `LIKE` pattern matching with object name
-  - **Generated filter**: `WithLike(Like{Pattern: String(id.Name())})`
-  - **Use when**: `SHOW` command supports `LIKE` clause
-  - **Universal**: Works for all object types that support pattern matching
+- **`ShowByIDLikeFiltering`**: `LIKE` pattern matching (`WithLike(Like{Pattern: String(id.Name())})`) - Universal for all objects
+- **`ShowByIDInFiltering`**: `IN` clause filtering (`WithIn(In{Schema: id.SchemaId()})`) - For hierarchical objects
+- **`ShowByIDExtendedInFiltering`**: Extended `IN` syntax (`WithIn(ExtendedIn{...})`) - Complex hierarchical filtering
+- **`ShowByIDServiceInFiltering`**: Service-specific filtering (`WithIn(ServiceIn{...})`) - For service objects
+- **`ShowByIDApplicationNameFiltering`**: Application filtering (`WithApplicationName(id.DatabaseId())`) - For application objects
 
-- **`ShowByIDInFiltering`**: Uses `IN` clause to filter by parent container
-  - **Generated filter**: `WithIn(In{Schema: id.SchemaId()})` (for schema objects)
-  - **Use when**: `SHOW` command supports `IN` clause and object has hierarchical structure
-  - **Examples**: Schema-level objects can be filtered `IN SCHEMA`
+**Selection by Object Hierarchy:**
+- **Account-Level** (Users, Roles): `ShowByIDLikeFiltering` only
+- **Database-Level** (Schemas): `ShowByIDLikeFiltering` + `ShowByIDInFiltering`
+- **Schema-Level** (Views, Functions): `ShowByIDLikeFiltering` + `ShowByIDExtendedInFiltering` (most common)
+- **Service Objects**: `ShowByIDLikeFiltering` + `ShowByIDServiceInFiltering`
+- **Application Objects**: `ShowByIDApplicationNameFiltering`
+- **No Filtering**: `ShowByIdOperationWithNoFiltering()` when SHOW has no filtering options
 
-- **`ShowByIDExtendedInFiltering`**: Uses `ExtendedIn` for more complex hierarchical filtering
-  - **Generated filter**: `WithIn(ExtendedIn{In: In{Schema: id.SchemaId()}})`
-  - **Use when**: `SHOW` command supports extended `IN` syntax
-  - **Examples**: Objects that can be filtered by database, schema, or other containers
-
-- **`ShowByIDServiceInFiltering`**: Specialized filtering for service-related objects
-  - **Generated filter**: `WithIn(ServiceIn{In: In{Schema: id.SchemaId()}})`
-  - **Use when**: Object is service-related and supports service-specific filtering
-
-- **`ShowByIDApplicationNameFiltering`**: Specialized filtering for application objects
-  - **Generated filter**: `WithApplicationName(id.DatabaseId())`
-  - **Use when**: Object is application-related and uses application name filtering
-
-**Filtering Selection Guidelines:**
-
-**Ideal Combination (Most Common):**
+**Common Pattern:**
 ```go
-ShowByIdOperationWithFiltering(
-    g.ShowByIDLikeFiltering,           // Primary: Name pattern matching
-    g.ShowByIDExtendedInFiltering,     // Secondary: Hierarchical filtering
-)
+ShowByIdOperationWithFiltering(g.ShowByIDLikeFiltering, g.ShowByIDExtendedInFiltering)
 ```
 
-**Selection Rules:**
-1. **Always include `ShowByIDLikeFiltering`** if the `SHOW` command supports `LIKE`
-2. **Add hierarchical filtering** based on object level:
-   - **Schema objects**: Add `ShowByIDInFiltering` or `ShowByIDExtendedInFiltering`
-   - **Database objects**: Add `ShowByIDInFiltering` if supported
-   - **Account objects**: Usually only `ShowByIDLikeFiltering`
-3. **Use specialized filtering** for specific object types (services, applications)
-4. **No filtering** only when `SHOW` command has no filtering options
+**Selection Based on Documentation:**
+- Check SHOW command "Syntax" section for available clauses (`LIKE`, `IN`, `STARTS WITH`)
+- Prefer LIKE + IN combination when both are available for optimal performance
 
-**Examples by Object Hierarchy:**
-
-**Account-Level Objects** (Users, Roles, Integrations):
-```go
-ShowByIdOperationWithFiltering(
-    g.ShowByIDLikeFiltering,  // Only LIKE filtering available
-)
-```
-
-**Database-Level Objects** (Schemas, Tables):
-```go
-ShowByIdOperationWithFiltering(
-    g.ShowByIDLikeFiltering,     // Name pattern matching
-    g.ShowByIDInFiltering,       // Filter by database
-)
-```
-
-**Schema-Level Objects** (Views, Functions, Procedures):
-```go
-ShowByIdOperationWithFiltering(
-    g.ShowByIDLikeFiltering,        // Name pattern matching
-    g.ShowByIDExtendedInFiltering,  // Filter by schema/database
-)
-```
-
-**Service Objects**:
-```go
-ShowByIdOperationWithFiltering(
-    g.ShowByIDLikeFiltering,        // Name pattern matching
-    g.ShowByIDServiceInFiltering,   // Service-specific filtering
-)
-```
-
-**No Filtering Required**:
-```go
-ShowByIdOperationWithNoFiltering()  // When SHOW has no filtering options
-```
-
-**Documentation-Driven Selection:**
-Base filtering choices on the Snowflake documentation for the `SHOW` command:
-- **Check "Syntax" section** for available clauses (`LIKE`, `IN`, `STARTS WITH`)
-- **Match filtering options** to what's documented in Snowflake
-- **Test combinations** that make sense for the object hierarchy
-- **Prefer LIKE + IN combination** when both are available for optimal performance
-
-**Data Structure Fields and Output Mapping**
-
-**Structure Definition Pattern:**
-- **Define output structures separately** above the main interface definition
-- **Use descriptive variable names**: `objectDbRow`, `object`, `describeObjectDbRow`, `objectDetails`
-- **Follow consistent naming**: `<object>DbRow` for database mapping, `<object>` for plain struct, `describe<Object>DbRow` and `<object>Details` for describe operations
-- **Reference structures by variable name** in operations, not inline definitions
-
-**Show/Describe Operations:**
-- **NEVER assume fields**: Do not guess or assume what fields SHOW, DESCRIBE, or other operations return
-- **VERIFY documentation links first**: Always check that documentation URLs are correct and accessible
-- **Use documented OUTPUT sections**: When Snowflake documentation includes OUTPUT sections with field specifications, implement those fields exactly as documented
-- **ASK FOR HELP with broken links**: If documentation links are broken or OUTPUT sections are missing, ask for clarification before proceeding
-- **Use TODO only for completely unknown structures**:
+**Query Output Structure Definition Guidelines:**
+- **Define separately** above main interface (see example above)
+- **Naming**: `<object>DbRow`, `<object>`, `describe<Object>DbRow`, `<object>Details`
+- **Field Mapping**: Use documented OUTPUT sections exactly. Only add TODO comments when genuinely unsure:
   ```go
-  // TODO: Fields for SHOW OBJECTS output are not documented and no standard pattern applies.
-  // Developer should examine actual SHOW OBJECTS output and fill in the correct fields.
+  // TODO: Fields not documented - examine actual output and update
   var objectDbRow = g.DbStruct("objectDBRow")
   ```
-- **Documentation requirement**: Add fields when OUTPUT sections are explicitly documented in Snowflake documentation
-- **Field accuracy**: Match field names, types, and descriptions exactly as specified in OUTPUT documentation
-- **Comment Policy**: Only add TODO comments when genuinely unsure about field mappings or when documentation is incomplete. If you've verified the documentation and are confident about the fields, don't add comments - developers will validate the mapping during implementation anyway
 
-**Identifier Type Selection:**
-Choose the appropriate identifier type based on Snowflake object hierarchy (see [Object Hierarchies](sdk-development.mdc#object-hierarchies) for complete reference):
-- `AccountObjectIdentifier` - Account-level objects
-- `DatabaseObjectIdentifier` - Database-level objects
-- `SchemaObjectIdentifier` - Schema-level objects
-- `SchemaObjectIdentifierWithArguments` - Functions and procedures with arguments
+**Identifier Types:** Choose based on Snowflake hierarchy (see [Object Hierarchies](sdk-development.mdc#object-hierarchies)):
+- `AccountObjectIdentifier`, `DatabaseObjectIdentifier`, `SchemaObjectIdentifier`, `SchemaObjectIdentifierWithArguments`
 
-**Privilege and Permission Considerations:**
-When implementing new objects, document privilege requirements:
-- Research required privileges for each operation (CREATE, ALTER, DROP, SHOW)
-- Document role requirements in comments
-- Consider edge cases like ownership transfer, grants, and access patterns
-- Reference Snowflake documentation for privilege requirements
+**Edge Cases and Considerations:**
+- Document privilege requirements when relevant (CREATE, ALTER, DROP, SHOW operations)
+- Consider ownership transfer, grants, and access patterns for complex objects
 
 ## Generator Workflow
 
@@ -325,20 +232,12 @@ If missing, create definition files and add it to the mapping in `pkg/sdk/poc/ma
 ### 2. Documentation Analysis
 **Critical Phase - Must Be Thorough:**
 - Request documentation URLs for ALL operations (CREATE, ALTER, DROP, SHOW, DESCRIBE)
-- **VERIFY ALL DOCUMENTATION LINKS** - Check that URLs are accessible and contain the expected content
-- **ASK FOR CLARIFICATION** if any documentation links are broken, missing, or incomplete
-- Examine EXACT syntax from "Syntax" sections only
-- Examine EXACT output fields from "Output" sections when available
+- Follow the **Documentation Verification Workflow** from DSL Guidelines section
 - Note ALL optional vs required parameters
-- **Analyze SHOW command filtering options** for ShowByID operation:
-  - Check for `LIKE` clause support
-  - Check for `IN` clause support (database, schema, application)
-  - Check for `STARTS WITH` or other filtering options
-  - Note object hierarchy level for appropriate filtering selection
+- **Analyze SHOW command filtering options** for ShowByID operation (LIKE, IN, STARTS WITH)
+- Note object hierarchy level for appropriate filtering selection
 - Identify privilege requirements and edge cases
-- Document any unclear or ambiguous syntax patterns
-- **NEVER make up fields or syntax** - always verify against actual documentation
-- **Consult with developers** for unknown or complex scenarios to avoid generating unsupported DSL
+- **Consult with developers** for unknown or complex scenarios
 
 ### 3. Implementation and Verification
 **Based on Documentation Analysis:**
@@ -365,16 +264,10 @@ The generator creates files following the [File Organization Patterns](sdk-devel
 - `*_validations_gen.go` - Validation functions for all parameters
 - `*_gen_test.go` - Unit test templates with TODO placeholders
 
-### 6. Manual Extensions and Testing
-**Extension Files:**
-- **NEVER** edit generated files directly (unless it's expected by design, e.g. conversions or unit tests)
+### 6. Manual Completion
+- **NEVER** edit generated files directly (except conversions/unit tests)
 - Create `<object_name>_ext.go` for custom extensions
-- Mark manual changes in generated files with `// manually adjusted`
-
-**Required Manual Work:**
-- Fill conversion mappings in the generated `_impl_gen.go` file
-- Complete all testing requirements following [Testing Strategy](./sdk-development.mdc#testing-strategy)
-- Document privilege requirements and edge cases
+- See **Post-Generation Tasks** section for required manual work
 
 ## Common Patterns
 
@@ -407,60 +300,18 @@ AlterOperation(url,
 )
 ```
 
-## Testing After Generation
+## Post-Generation Tasks
 
-**Generated Test Files:**
-The generator creates `*_gen_test.go` files with unit test templates containing TODO placeholders.
+**Testing:** Complete generated unit test TODOs and implement integration tests following [Testing Strategy](sdk-development.mdc#testing-strategy).
 
-**Manual Completion Required:**
-All generated tests must be completed manually following the comprehensive [Testing Strategy](./sdk-development.mdc#testing-strategy) in SDK Development Rules.
+**Manual Work:**
+- Fill conversion mappings in `*_impl_gen.go`
+- Verify SQL output matches Snowflake documentation
+- Test comprehensive parameter combinations
 
-**Key Post-Generation Tasks:**
-- **Complete unit test TODOs** with realistic SQL expectations
-- **Implement integration tests** in `testint/` directory
-- **Test all CRUD operations** against real Snowflake instances
-- **Document and test privilege requirements**
-- **Verify SQL output** matches Snowflake documentation exactly
-
-## Documentation and Privilege Requirements
-
-**When implementing new objects, always document:**
-
-**Privilege Requirements:**
-```go
-// CREATE OBJECT requires:
-// - CREATE privileges on the schema
-// - USAGE privileges on the database and schema
-// - Additional privileges: [list specific requirements from Snowflake docs]
-
-// ALTER OBJECT requires:
-// - Object ownership OR ALTER privileges
-// - [specific privilege requirements]
-
-// DROP OBJECT requires:
-// - Object ownership OR DROP privileges
-```
-
-**Edge Cases and Limitations:**
-```go
-// Known limitations:
-// - Feature X requires Snowflake version Y or higher
-// - Operation Z requires specific account settings
-// - Privilege P may require account admin role in certain configurations
-```
 
 ## Best Practices
 
-**Documentation-Driven Development:**
-- **Always start with official Snowflake documentation**
-- **Map syntax exactly** - do not add unsupported features
-- **Document privilege requirements** from Snowflake docs
-- **Consult developers** for ambiguous or complex syntax patterns
-
-**Generator-Specific Quality:**
-- **Complete all generated TODO comments** with realistic tests
-- **Validate SQL output** against Snowflake documentation exactly
-- **Test comprehensive parameter combinations** in unit tests
-- **Verify DDL tag combinations** produce expected SQL patterns
-- **Use appropriate identifier types** for object hierarchy
-- **Follow architecture patterns** from [SDK Development Rules](sdk-development.mdc)
+- **Documentation-driven**: Start with official Snowflake docs, map syntax exactly
+- **Quality assurance**: Complete all TODOs, validate SQL output, test comprehensive combinations
+- **Architecture**: Use appropriate identifier types, follow [SDK Development Rules](sdk-development.mdc)

--- a/.cursor/rules/self-improvement.mdc
+++ b/.cursor/rules/self-improvement.mdc
@@ -1,0 +1,64 @@
+---
+description: Guidelines for continuously improving Cursor rules based on emerging code patterns and best practices
+globs:
+  - "**/*"
+alwaysApply: false
+---
+# Rule Improvement Triggers
+
+- New code patterns not covered by existing rules
+- Repeated similar implementations across files
+- Common error patterns that could be prevented
+- New libraries or tools being used consistently
+- Emerging best practices in the codebase
+- Code changes in particular places, trigger other actions (e.g. documentation or examples updates)
+
+# Analysis Process
+
+- Compare new code with existing rules
+- Identify patterns that should be standardized
+- Look for references to internal and external documentation
+- Check for consistent error handling patterns
+- Monitor test patterns and coverage
+
+# Rule Updates
+
+- **Add New Rules When**
+  - A new technology/pattern is used in 3+ files
+  - Common bugs could be prevented by a rule
+  - Developer repeatedly mentions the same feedback to the proposed Agent actions
+  - New security or performance patterns emerge
+
+- **Modify Existing Rules When**
+  - Better examples exist in the codebase
+  - Additional edge cases are discovered
+  - Related rules have been updated
+  - Implementation details have changed
+
+- **Rule Quality Checks**
+  - Rules should be actionable and specific
+  - Examples should come from actual code
+  - References should be up to date
+  - Patterns should be consistently enforced
+
+## Continuous Improvement
+
+- Track common questions or suggestions during development with Agent
+- Update rules after major refactors
+- Add links to relevant documentation
+- Cross-reference related rules
+
+## Rule Deprecation
+
+- Mark outdated patterns as deprecated
+- Remove rules that no longer apply
+- Update references to deprecated rules
+- Document migration paths for old patterns
+
+## Documentation Updates
+
+- Keep examples synchronized with code
+- Maintain links between documents
+- Document breaking changes
+
+In case of any changes, follow [cursor-rules.mdc](./cursor-rules.mdc) for proper rule formatting and structure


### PR DESCRIPTION
## Changes
- Introduce base cursor rules and rules for sdk development (mainly for the use case of adding/maintaining sdk objects used later in resource implementations)
- Basic rules are divided into two. One for defining what rules should look like a how they should be generally structured. The second one is for automatic cursor analysis and rule improvement (this needs to be monitored with increased usage as I didn't notice it working, but it may be because I was mainly working on rules not the actual implementations).
- The sdk rules were mainly added with new SDK object generation in mind. I have tested it a few times with different objects and I can confirm there was some improvement once the rules were added (I also improved them a bit when generating different objects).

## Next prs
- I wanted to complete the whole use case of adding support for the new object by adding the resource (and maybe data source) part, which includes: resource schema generation and implementing CRUD functions, generating models and asserts, generating and writing schema for SHOW/DESC outputs, writing common acceptance test scenarios, etc.