### PR TITLE
chore: Add network policy setup automation

### DIFF
--- a/pkg/scripts/network_policy/.gitignore
+++ b/pkg/scripts/network_policy/.gitignore
@@ -1,0 +1,2 @@
+# Downloaded GitHub IPs
+github_ipv4_subnets.txt

--- a/pkg/scripts/network_policy/main.sh
+++ b/pkg/scripts/network_policy/main.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Filter out only IPv4 CIDR lines from test.txt and overwrite test.txt
+curl https://api.github.com/meta | jq -r '.actions[]' |grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?$' > github_ipv4_subnets.txt
+
+terraform plan

--- a/pkg/scripts/network_policy/main.tf
+++ b/pkg/scripts/network_policy/main.tf
@@ -36,31 +36,32 @@ locals {
   extra_ips       = var.extra_ips
   all_allowed_ips = concat(local.extra_ips, local.all_github_ips)
   comment         = "Allows for connections only comming from GitHub Actions or behind VPN"
+  policy_name     = "RESTRICTED_ACCESS"
 }
 
 resource "snowflake_network_policy" "restricted_access_primary" {
-  name            = "RESTRICTED_ACCESS"
+  name            = local.policy_name
   allowed_ip_list = local.all_allowed_ips
   comment         = local.comment
 }
 
-# resource "snowflake_network_policy" "restricted_access_secondary" {
-#   provider        = snowflake.secondary
-#   name            = "RESTRICTED_ACCESS"
-#   allowed_ip_list = local.all_allowed_ips
-#   comment         = local.comment
-# }
+resource "snowflake_network_policy" "restricted_access_secondary" {
+  provider        = snowflake.secondary
+  name            = local.policy_name
+  allowed_ip_list = local.all_allowed_ips
+  comment         = local.comment
+}
 
-# resource "snowflake_network_policy" "restricted_access_third" {
-#   provider        = snowflake.third
-#   name            = "RESTRICTED_ACCESS"
-#   allowed_ip_list = local.all_allowed_ips
-#   comment         = local.comment
-# }
+resource "snowflake_network_policy" "restricted_access_third" {
+  provider        = snowflake.third
+  name            = local.policy_name
+  allowed_ip_list = local.all_allowed_ips
+  comment         = local.comment
+}
 
-# resource "snowflake_network_policy" "restricted_access_fourth" {
-#   provider        = snowflake.fourth
-#   name            = "RESTRICTED_ACCESS"
-#   allowed_ip_list = local.all_allowed_ips
-#   comment         = local.comment
-# }
+resource "snowflake_network_policy" "restricted_access_fourth" {
+  provider        = snowflake.fourth
+  name            = local.policy_name
+  allowed_ip_list = local.all_allowed_ips
+  comment         = local.comment
+}

--- a/pkg/scripts/network_policy/main.tf
+++ b/pkg/scripts/network_policy/main.tf
@@ -1,0 +1,66 @@
+variable "extra_ips" {
+  type = list(string)
+  # This variable is required on purpose. It should be set to other extra IPs we have in the network policies.
+}
+
+terraform {
+  required_providers {
+    snowflake = {
+      source  = "snowflakedb/snowflake"
+      version = "2.8.0"
+    }
+  }
+}
+
+provider "snowflake" {
+  profile = "default"
+}
+
+provider "snowflake" {
+  profile = "secondary_test_account"
+  alias   = "secondary"
+}
+
+provider "snowflake" {
+  profile = "third_test_account"
+  alias   = "third"
+}
+
+provider "snowflake" {
+  profile = "fourth_test_account"
+  alias   = "fourth"
+}
+
+locals {
+  all_github_ips  = compact(split("\n", file("github_ipv4_subnets.txt")))
+  extra_ips       = var.extra_ips
+  all_allowed_ips = concat(local.extra_ips, local.all_github_ips)
+  comment         = "Allows for connections only comming from GitHub Actions or behind VPN"
+}
+
+resource "snowflake_network_policy" "restricted_access_primary" {
+  name            = "RESTRICTED_ACCESS"
+  allowed_ip_list = local.all_allowed_ips
+  comment         = local.comment
+}
+
+# resource "snowflake_network_policy" "restricted_access_secondary" {
+#   provider        = snowflake.secondary
+#   name            = "RESTRICTED_ACCESS"
+#   allowed_ip_list = local.all_allowed_ips
+#   comment         = local.comment
+# }
+
+# resource "snowflake_network_policy" "restricted_access_third" {
+#   provider        = snowflake.third
+#   name            = "RESTRICTED_ACCESS"
+#   allowed_ip_list = local.all_allowed_ips
+#   comment         = local.comment
+# }
+
+# resource "snowflake_network_policy" "restricted_access_fourth" {
+#   provider        = snowflake.fourth
+#   name            = "RESTRICTED_ACCESS"
+#   allowed_ip_list = local.all_allowed_ips
+#   comment         = local.comment
+# }


### PR DESCRIPTION
When GitHub IPs are changed, we need to adjust our network policies. This script:
- downloads the current IPs from the GH API,
- filters the IPv4 addresses,
- lets you add your own IPs,
- runs terraform plan for four accounts.