### PR TITLE
chore: Passthrough environment variables in docker compose

### DIFF
--- a/packaging/docker-compose.yml
+++ b/packaging/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    environment:
+      TEST_SF_TF_GENERATED_RANDOM_VALUE: ${TEST_SF_TF_GENERATED_RANDOM_VALUE}
+      TEST_SF_TF_TEST_OBJECT_SUFFIX: ${TEST_SF_TF_TEST_OBJECT_SUFFIX}
     volumes:
       - ./../:/terraform-provider-snowflake
       - ${SNOWFLAKE_CONFIG_PATH}:/root/.snowflake/config


### PR DESCRIPTION
This pull request makes a small update to the Docker Compose configuration by passing two new environment variables to the service.

- Docker Compose now passes `TEST_SF_TF_GENERATED_RANDOM_VALUE` and `TEST_SF_TF_TEST_OBJECT_SUFFIX` as environment variables to the service in `packaging/docker-compose.yml`.