### PR TITLE
chore: Fix future grant tests

### DIFF
--- a/pkg/testacc/resource_grant_privileges_to_account_role_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_account_role_acceptance_test.go
@@ -2045,10 +2045,11 @@ func TestAcc_GrantPrivilegesToAccountRole_OnFutureModels_issue3050(t *testing.T)
 		CheckDestroy: CheckAccountRolePrivilegesRevoked(t),
 		Steps: []resource.TestStep{
 			{
-				PreConfig:          func() { SetV097CompatibleConfigPathEnv(t) },
-				ExternalProviders:  ExternalProviderWithExactVersion("0.95.0"),
-				Config:             grantPrivilegesToAccountRoleOnFutureInDatabaseConfig(accountRoleName, []string{"USAGE"}, sdk.PluralObjectTypeModels, databaseName),
-				ExpectNonEmptyPlan: true,
+				PreConfig:         func() { SetV097CompatibleConfigPathEnv(t) },
+				ExternalProviders: ExternalProviderWithExactVersion("0.95.0"),
+				Config:            grantPrivilegesToAccountRoleOnFutureInDatabaseConfig(accountRoleName, []string{"USAGE"}, sdk.PluralObjectTypeModels, databaseName),
+				// Previously, we expected a non-empty plan, because Snowflake returned MODULE instead of MODEL in SHOW FUTURE GRANTS.
+				// Now, this behavior is fixed in Snowflake, and the plan is empty.
 			},
 			{
 				PreConfig:                func() { UnsetConfigPathEnv(t) },

--- a/pkg/testacc/resource_grant_privileges_to_database_role_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_database_role_acceptance_test.go
@@ -1381,10 +1381,11 @@ func TestAcc_GrantPrivilegesToDatabaseRole_OnFutureModels_issue3050(t *testing.T
 		CheckDestroy: CheckAccountRolePrivilegesRevoked(t),
 		Steps: []resource.TestStep{
 			{
-				PreConfig:          func() { SetV097CompatibleConfigPathEnv(t) },
-				ExternalProviders:  ExternalProviderWithExactVersion("0.95.0"),
-				Config:             grantPrivilegesToDatabaseRoleOnFutureInDatabaseConfig(databaseRoleId, []string{"USAGE"}, sdk.PluralObjectTypeModels, databaseRoleId.DatabaseName()),
-				ExpectNonEmptyPlan: true,
+				PreConfig:         func() { SetV097CompatibleConfigPathEnv(t) },
+				ExternalProviders: ExternalProviderWithExactVersion("0.95.0"),
+				Config:            grantPrivilegesToDatabaseRoleOnFutureInDatabaseConfig(databaseRoleId, []string{"USAGE"}, sdk.PluralObjectTypeModels, databaseRoleId.DatabaseName()),
+				// Previously, we expected a non-empty plan, because Snowflake returned MODULE instead of MODEL in SHOW FUTURE GRANTS.
+				// Now, this behavior is fixed in Snowflake, and the plan is empty.
 			},
 			{
 				PreConfig:                func() { UnsetConfigPathEnv(t) },


### PR DESCRIPTION
Adjust the assertions due to recent changes in Snowflake. Previously, `MODULE` was returned instead of `MODEL`. This behavior is now fixed in Snowflake.
- There was no migration guide in https://github.com/snowflakedb/terraform-provider-snowflake/pull/3070, so I'm not adjusting it for now.
- We can discuss whether to keep the object type replacement in that PR. However, this is not breaking anything for now.
- I verified this change locally, so we can skip the tests in the PR.