### PR TITLE
chore: Adjust docker compose commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,13 +89,14 @@ test-acceptance-%: ## run acceptance tests (both non-account and account level o
 	TF_ACC=1 TF_LOG=DEBUG SNOWFLAKE_DRIVER_TRACING=debug SF_TF_ACC_TEST_CONFIGURE_CLIENT_ONCE=true SF_TF_ACC_TEST_ENABLE_ALL_PREVIEW_FEATURES=true go test --tags=non_account_level_tests,account_level_tests -run ^TestAcc_$* -v -timeout=20m ./pkg/testacc
 
 test-main-terraform-use-cases: ## run test for main terraform use cases
-	TF_ACC=1 SF_TF_ACC_TEST_CONFIGURE_CLIENT_ONCE=true TEST_SF_TF_REQUIRE_TEST_OBJECT_SUFFIX=1 TEST_SF_TF_REQUIRE_GENERATED_RANDOM_VALUE=1 SF_TF_ACC_TEST_ENABLE_ALL_PREVIEW_FEATURES=true go test --tags=non_account_level_tests,account_level_tests -run "^(TestAcc_GrantPrivilegesToDatabaseRole_OnSchema_ExactlyOneOf)$$" -v -cover -json -timeout=20m ./pkg/testacc
+	TF_ACC=1 SF_TF_ACC_TEST_CONFIGURE_CLIENT_ONCE=true TEST_SF_TF_REQUIRE_TEST_OBJECT_SUFFIX=1 TEST_SF_TF_REQUIRE_GENERATED_RANDOM_VALUE=1 SF_TF_ACC_TEST_ENABLE_ALL_PREVIEW_FEATURES=true go test --tags=non_account_level_tests,account_level_tests -run "^(TestAcc_.*_BasicUseCase.*|TestAcc_.*_CompleteUseCase.*)$$" -v -cover -json -timeout=20m ./pkg/testacc
 
 test-main-terraform-use-cases-docker-compose: ## run main terraform use cases tests within docker environment
-	docker compose -f ./packaging/docker-compose.yml run --rm test-main-terraform-use-cases
+	docker compose -f ./packaging/docker-compose.yml build --quiet 1>&2
+	docker compose -f ./packaging/docker-compose.yml run --quiet-pull --rm test-main-terraform-use-cases
 
 process-test-output-docker-compose: ## run test output processor within docker environment
-	docker compose -f ./packaging/docker-compose.yml run --rm process-test-output
+	docker compose -f ./packaging/docker-compose.yml run --quiet-pull --rm process-test-output
 
 build-local: ## build the binary locally
 	go build -o $(BASE_BINARY_NAME) .

--- a/packaging/docker-compose.yml
+++ b/packaging/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ${SNOWFLAKE_CONFIG_PATH}:/root/.snowflake/config
       - shared_data:/shared
     working_dir: /terraform-provider-snowflake
-    command: sh -c "make --silent test-main-terraform-use-cases > /shared/test_output.json"
+    command: sh -c "make --silent test-main-terraform-use-cases 1> /shared/test_output.json"
   process-test-output:
     build:
       context: .


### PR DESCRIPTION
Bring back `sh` to the test running Docker Compose and small Makefile changes