### PR TITLE
chore: Remove legacy columns from managed accounts SDK

### DIFF
--- a/pkg/sdk/managed_accounts_def.go
+++ b/pkg/sdk/managed_accounts_def.go
@@ -3,14 +3,11 @@ package sdk
 import g "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/poc/generator"
 
 var managedAccountDbRow = g.DbStruct("managedAccountDBRow").
-	OptionalText("name").
 	OptionalText("account_name").
 	Text("cloud").
 	Text("region").
-	OptionalText("locator").
 	OptionalText("account_locator").
 	Text("created_on").
-	OptionalText("url").
 	OptionalText("account_url").
 	Text("account_locator_url").
 	Bool("is_reader").

--- a/pkg/sdk/managed_accounts_gen.go
+++ b/pkg/sdk/managed_accounts_gen.go
@@ -47,14 +47,11 @@ type ShowManagedAccountOptions struct {
 }
 
 type managedAccountDBRow struct {
-	Name              sql.NullString `db:"name"`
 	AccountName       sql.NullString `db:"account_name"`
 	Cloud             string         `db:"cloud"`
 	Region            string         `db:"region"`
-	Locator           sql.NullString `db:"locator"`
 	AccountLocator    sql.NullString `db:"account_locator"`
 	CreatedOn         string         `db:"created_on"`
-	Url               sql.NullString `db:"url"`
 	AccountUrl        sql.NullString `db:"account_url"`
 	AccountLocatorUrl string         `db:"account_locator_url"`
 	IsReader          bool           `db:"is_reader"`

--- a/pkg/sdk/managed_accounts_impl_gen.go
+++ b/pkg/sdk/managed_accounts_impl_gen.go
@@ -92,20 +92,14 @@ func (r managedAccountDBRow) convert() (*ManagedAccount, error) {
 
 	if r.AccountName.Valid {
 		managedAccount.Name = r.AccountName.String
-	} else if r.Name.Valid {
-		managedAccount.Name = r.Name.String
 	}
 
 	if r.AccountLocator.Valid {
 		managedAccount.Locator = r.AccountLocator.String
-	} else if r.Locator.Valid {
-		managedAccount.Locator = r.Locator.String
 	}
 
 	if r.AccountUrl.Valid {
 		managedAccount.URL = r.AccountUrl.String
-	} else if r.Url.Valid {
-		managedAccount.URL = r.Url.String
 	}
 
 	if r.Comment.Valid {

--- a/pkg/testacc/resource_managed_account_acceptance_test.go
+++ b/pkg/testacc/resource_managed_account_acceptance_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
@@ -50,41 +49,6 @@ func TestAcc_ManagedAccount(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"admin_name", "admin_password"},
-			},
-		},
-	})
-}
-
-func TestAcc_ManagedAccount_HandleShowOutputChanges_BCR_2024_08(t *testing.T) {
-	// TODO [SNOW-1011985]: unskip the tests
-	testenvs.SkipTestIfSet(t, testenvs.SkipManagedAccountTest, "error: 090337 (23001): Number of managed accounts allowed exceeded the limit. Please contact Snowflake support")
-
-	id := testClient().Ids.RandomAccountObjectIdentifier()
-	adminName := random.AdminName()
-	adminPass := random.Password()
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.RequireAbove(tfversion.Version1_5_0),
-		},
-		CheckDestroy: CheckDestroy(t, resources.ManagedAccount),
-		Steps: []resource.TestStep{
-			{
-				Config: managedAccountConfig(id.Name(), adminName, adminPass),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("snowflake_managed_account.test", plancheck.ResourceActionNoop),
-					},
-				},
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("snowflake_managed_account.test", "name", id.Name()),
-					resource.TestCheckResourceAttr("snowflake_managed_account.test", "fully_qualified_name", id.FullyQualifiedName()),
-					resource.TestCheckResourceAttr("snowflake_managed_account.test", "admin_name", adminName),
-					resource.TestCheckResourceAttr("snowflake_managed_account.test", "admin_password", adminPass),
-					resource.TestCheckResourceAttr("snowflake_managed_account.test", "comment", managedAccountComment),
-					resource.TestCheckResourceAttr("snowflake_managed_account.test", "type", "READER"),
-				),
 			},
 		},
 	})


### PR DESCRIPTION
- Remove unnecessary fields from Managed Account after 2024_08 BCR is generally enabled. We already sourced this data from renamed columns in the SDK conversion implementation.
- The acceptance tests are skipped for now in the pipeline, but I verified the change manually.
- Add the retry in assertions due to create propagation time.
- Adjust a few assertions.
- Remove unnecessary BCR acceptance test.

## References
https://docs.snowflake.com/en/release-notes/bcr-bundles/2024_08/bcr-1738