### PR TITLE
chore: Revert driver bump to v1.17.1

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -47,31 +47,6 @@ panic: oauth_refresh_token_validity: '' expected type 'int', got unconvertible t
 
 No changes in configuration and state are required.
 
-### *(bugfix)* Fixed panics because of nil pointer dereferences
-
-In v2.8.0, the following error was reported during handling materialized view with lots of records:
-```
-Error: Plugin did not respond
-The plugin encountered an error, and failed to respond to the
-plugin6.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain
-more details.
-Stack trace from the terraform-provider-snowflake_v2.8.0 plugin:
-panic: runtime error: invalid memory address or nil pointer dereference
-...
-[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x193f359]
-goroutine 41 [running]:
-github.com/snowflakedb/gosnowflake.postRestfulQueryHelper.func1()
-github.com/snowflakedb/gosnowflake@v1.17.0/restful.go:241 +0x19
-panic({0x257d740?, 0x41e1700?})
-runtime/panic.go:785 +0x132
-...
-```
-
-This was caused by the Go driver dependency. The Go driver fixed this in [v1.17.1](https://docs.snowflake.com/en/release-notes/clients-drivers/golang-2025#version-1-17-1-november-4-2025). We upgraded the driver on our side to that version.
-No changes in configuration and state are required.
-
-References [#4092](https://github.com/snowflakedb/terraform-provider-snowflake/issues/4092).
-
 ### *(bugfix)* Fixed updating the value of `enabled` in `snowflake_oauth_integration_for_partner_applications` resource
 
 Previously, whenever we detected change for the `enabled` field,

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/pelletier/go-toml/v2 v2.2.4
-	github.com/snowflakedb/gosnowflake v1.17.1
+	github.com/snowflakedb/gosnowflake v1.17.0
 	github.com/stretchr/testify v1.10.0
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
 	golang.org/x/crypto v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -265,8 +265,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/snowflakedb/gosnowflake v1.17.1 h1:sBYExPDRv6hHF7fCqeXMT745L326Byw/cROxvCiEJzo=
-github.com/snowflakedb/gosnowflake v1.17.1/go.mod h1:TaHvQGh9MA2lopZZMm1AvvENDfwcnKtuskIr1e6Fpic=
+github.com/snowflakedb/gosnowflake v1.17.0 h1:be50vC0buiOitvneyRHiqNkvPMcunGD3EcTnL2zYATg=
+github.com/snowflakedb/gosnowflake v1.17.0/go.mod h1:TaHvQGh9MA2lopZZMm1AvvENDfwcnKtuskIr1e6Fpic=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=


### PR DESCRIPTION
This reverts commit db4a60b8fe778803edfe523e64720b4d0b18eeda.

This brings back the v1.17.0 version of the driver. We are doing it because we want to release other changes (https://github.com/snowflakedb/terraform-provider-snowflake/pull/4167), and there's a regression in v1.17.1: https://github.com/snowflakedb/gosnowflake/issues/1615