### PR TITLE
chore: Skip failing warehouse integration test

### DIFF
--- a/pkg/sdk/testint/warehouses_integration_test.go
+++ b/pkg/sdk/testint/warehouses_integration_test.go
@@ -84,6 +84,7 @@ func TestInt_Warehouses(t *testing.T) {
 	})
 
 	t.Run("show: with starts with, and limit", func(t *testing.T) {
+		t.Skip("TODO(SNOW-2683898): Unskip after the regression is fixed in Snowflake")
 		showOptions := &sdk.ShowWarehouseOptions{
 			StartsWith: sdk.String(precreatedWarehouseId.Name()),
 			LimitFrom: &sdk.LimitFrom{


### PR DESCRIPTION
Skip failing warehouse integration test due to regression in Snowflake. This is not a problem for the provider, because in the production code, we also use the LIKE filter, which works correctly.