### PR TITLE
chore: Add protected security integrations in sweepers

### DIFF
--- a/pkg/sdk/sweepers_test.go
+++ b/pkg/sdk/sweepers_test.go
@@ -412,6 +412,9 @@ func nukeUsers(client *sdk.Client, suffix string) func() error {
 }
 
 func nukeSecurityIntegrations(client *sdk.Client, suffix string) func() error {
+	protectedSecurityIntegrations := []sdk.AccountObjectIdentifier{
+		sdk.NewAccountObjectIdentifier("SNOWFLAKE$LOCAL_APPLICATION"),
+	}
 	return func() error {
 		ctx := context.Background()
 
@@ -438,7 +441,7 @@ func nukeSecurityIntegrations(client *sdk.Client, suffix string) func() error {
 		for idx, integration := range integrations {
 			log.Printf("[DEBUG] Processing security integration [%d/%d]: %s...", idx+1, len(integrations), integration.Name)
 
-			if integrationDropCondition(integration) {
+			if !slices.Contains(protectedSecurityIntegrations, integration.ID()) && integrationDropCondition(integration) {
 				log.Printf("[DEBUG] Dropping security integration %s", integration.Name)
 				if err := client.SecurityIntegrations.DropSafely(ctx, integration.ID()); err != nil {
 					errs = append(errs, fmt.Errorf("sweeping security integration %s ended with an error, err = %w", integration.Name, err))


### PR DESCRIPTION
The sweepers are failing because of a new security integration present on each account that can't be removed - see the related BCR. This change adds a protected security integrations list with this object name to the sweepers.

## References
https://docs.snowflake.com/en/release-notes/bcr-bundles/un-bundled/bcr-2056