### PR TITLE
chore: Make the repository compatible with git-worktree

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,5 @@
+{
+  "setup-worktree": [
+    "make dev-setup"
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ dev-cleanup: ## cleanup development dependencies
 	rm -rf tools/bin/*
 
 docs: generate-docs-additional-files ## generate docs
-	tools/bin/tfplugindocs generate
+	tools/bin/tfplugindocs generate --provider-name=terraform-provider-snowflake
 
 docs-check: docs ## check that docs have been generated
 	git diff --exit-code -- docs


### PR DESCRIPTION
- Add a new configuration for cursor worktrees.
- Add a new flag for provider name in the docs generator. By default, the directory name is used, but this is changed in git workspaces, making the generator fail.