### PR TITLE
chore: Remove warehouse resource dependencies in acceptance tests

### DIFF
--- a/pkg/testacc/resource_cortex_search_service_acceptance_test.go
+++ b/pkg/testacc/resource_cortex_search_service_acceptance_test.go
@@ -16,7 +16,8 @@ import (
 func TestAcc_CortexSearchService_basic(t *testing.T) {
 	id := testClient().Ids.RandomSchemaObjectIdentifier()
 	tableId := testClient().Ids.RandomSchemaObjectIdentifier()
-	newWarehouseId := testClient().Ids.RandomAccountObjectIdentifier()
+	newWarehouse, newWarehouseCleanup := testClient().Warehouse.CreateWarehouse(t)
+	t.Cleanup(newWarehouseCleanup)
 	m := func() map[string]config.Variable {
 		return map[string]config.Variable{
 			"name":       config.StringVariable(id.Name()),
@@ -31,7 +32,7 @@ func TestAcc_CortexSearchService_basic(t *testing.T) {
 	}
 	variableSet2 := m()
 	variableSet2["attributes"] = config.SetVariable(config.StringVariable("SOME_OTHER_TEXT"))
-	variableSet2["warehouse"] = config.StringVariable(newWarehouseId.Name())
+	variableSet2["warehouse"] = config.StringVariable(newWarehouse.ID().Name())
 	variableSet2["comment"] = config.StringVariable("Terraform acceptance test - updated")
 	variableSet2["query"] = config.StringVariable(fmt.Sprintf("select SOME_TEXT, SOME_OTHER_TEXT from %s", tableId.FullyQualifiedName()))
 	variableSet2["embedding_model"] = config.StringVariable("snowflake-arctic-embed-m-v1.5")
@@ -103,7 +104,7 @@ func TestAcc_CortexSearchService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "on", "SOME_TEXT"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "attributes.0", "SOME_OTHER_TEXT"),
-					resource.TestCheckResourceAttr(resourceName, "warehouse", newWarehouseId.Name()),
+					resource.TestCheckResourceAttr(resourceName, "warehouse", newWarehouse.ID().Name()),
 					resource.TestCheckResourceAttr(resourceName, "target_lag", "2 minutes"),
 					resource.TestCheckResourceAttr(resourceName, "comment", "Terraform acceptance test - updated"),
 					resource.TestCheckResourceAttr(resourceName, "query", fmt.Sprintf("select SOME_TEXT, SOME_OTHER_TEXT from %s", tableId.FullyQualifiedName())),
@@ -115,7 +116,7 @@ func TestAcc_CortexSearchService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "describe_output.0.database_name", TestDatabaseName),
 					resource.TestCheckResourceAttr(resourceName, "describe_output.0.schema_name", TestSchemaName),
 					resource.TestCheckResourceAttr(resourceName, "describe_output.0.target_lag", "2 minutes"),
-					resource.TestCheckResourceAttr(resourceName, "describe_output.0.warehouse", newWarehouseId.Name()),
+					resource.TestCheckResourceAttr(resourceName, "describe_output.0.warehouse", newWarehouse.ID().Name()),
 					resource.TestCheckResourceAttr(resourceName, "describe_output.0.search_column", "SOME_TEXT"),
 					resource.TestCheckResourceAttr(resourceName, "describe_output.0.attribute_columns.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "describe_output.0.attribute_columns.0", "SOME_OTHER_TEXT"),

--- a/pkg/testacc/resource_dynamic_table_acceptance_test.go
+++ b/pkg/testacc/resource_dynamic_table_acceptance_test.go
@@ -19,7 +19,8 @@ import (
 func TestAcc_DynamicTable_basic(t *testing.T) {
 	dynamicTableId := testClient().Ids.RandomSchemaObjectIdentifier()
 	tableId := testClient().Ids.RandomSchemaObjectIdentifier()
-	newWarehouseId := testClient().Ids.RandomAccountObjectIdentifier()
+	newWarehouse, newWarehouseCleanup := testClient().Warehouse.CreateWarehouse(t)
+	t.Cleanup(newWarehouseCleanup)
 	comment := random.Comment()
 	newComment := random.Comment()
 
@@ -35,7 +36,7 @@ func TestAcc_DynamicTable_basic(t *testing.T) {
 		}
 	}
 	variableSet2 := m()
-	variableSet2["warehouse"] = config.StringVariable(newWarehouseId.Name())
+	variableSet2["warehouse"] = config.StringVariable(newWarehouse.ID().Name())
 	variableSet2["comment"] = config.StringVariable(newComment)
 
 	variableSet3 := m()
@@ -103,7 +104,7 @@ func TestAcc_DynamicTable_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "fully_qualified_name", dynamicTableId.FullyQualifiedName()),
 					resource.TestCheckResourceAttr(resourceName, "database", TestDatabaseName),
 					resource.TestCheckResourceAttr(resourceName, "schema", TestSchemaName),
-					resource.TestCheckResourceAttr(resourceName, "warehouse", newWarehouseId.Name()),
+					resource.TestCheckResourceAttr(resourceName, "warehouse", newWarehouse.ID().Name()),
 					resource.TestCheckResourceAttr(resourceName, "target_lag.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "target_lag.0.downstream", "true"),
 					resource.TestCheckResourceAttr(resourceName, "comment", newComment),

--- a/pkg/testacc/testdata/TestAcc_CortexSearchService_basic/2/test.tf
+++ b/pkg/testacc/testdata/TestAcc_CortexSearchService_basic/2/test.tf
@@ -1,8 +1,3 @@
-resource "snowflake_warehouse" "t" {
-  name           = var.warehouse
-  warehouse_size = "XSMALL"
-}
-
 resource "snowflake_table" "t" {
   database        = var.database
   schema          = var.schema
@@ -26,7 +21,7 @@ resource "snowflake_table" "t" {
 }
 
 resource "snowflake_cortex_search_service" "css" {
-  depends_on      = [snowflake_table.t, snowflake_warehouse.t]
+  depends_on      = [snowflake_table.t]
   on              = var.on
   attributes      = var.attributes
   name            = var.name

--- a/pkg/testacc/testdata/TestAcc_CortexSearchService_basic/3/test.tf
+++ b/pkg/testacc/testdata/TestAcc_CortexSearchService_basic/3/test.tf
@@ -1,8 +1,3 @@
-resource "snowflake_warehouse" "t" {
-  name           = var.warehouse
-  warehouse_size = "XSMALL"
-}
-
 resource "snowflake_table" "t" {
   database        = var.database
   schema          = var.schema
@@ -26,7 +21,7 @@ resource "snowflake_table" "t" {
 }
 
 resource "snowflake_cortex_search_service" "css" {
-  depends_on = [snowflake_table.t, snowflake_warehouse.t]
+  depends_on = [snowflake_table.t]
   on         = var.on
   attributes = var.attributes
   name       = var.name

--- a/pkg/testacc/testdata/TestAcc_DynamicTable_basic/2/test.tf
+++ b/pkg/testacc/testdata/TestAcc_DynamicTable_basic/2/test.tf
@@ -1,8 +1,3 @@
-resource "snowflake_warehouse" "t" {
-  name           = var.warehouse
-  warehouse_size = "XSMALL"
-}
-
 resource "snowflake_table" "t" {
   database        = var.database
   schema          = var.schema
@@ -15,7 +10,7 @@ resource "snowflake_table" "t" {
 }
 
 resource "snowflake_dynamic_table" "dt" {
-  depends_on = [snowflake_table.t, snowflake_warehouse.t]
+  depends_on = [snowflake_table.t]
   name       = var.name
   database   = var.database
   schema     = var.schema


### PR DESCRIPTION
Instead of defining warehouses as resources, prepare them before running the TF suite. Reason: Sometimes, the produced test plans were not empty due to parameter changes in the accounts.