### PR TITLE
Added workload identity examples to user resource documentation

### DIFF
--- a/examples/resources/snowflake_service_user/resource.tf
+++ b/examples/resources/snowflake_service_user/resource.tf
@@ -88,6 +88,18 @@ resource "snowflake_service_user" "u" {
   week_start                                    = 1
 }
 
+# service user with workload identity for AWS
+resource "snowflake_service_user" "service_user_with_aws_workload_identity" {
+  name     = "AWS Service User"
+  comment  = "Service user with AWS workload identity for automated workflows"
+  disabled = "false"
+  workload_identity {
+    type = "AWS"
+    arn  = "arn:aws:iam::123456789012:role/SnowflakeServiceRole"
+  }
+  default_role = "SYSADMIN"
+}
+
 variable "email" {
   type      = string
   sensitive = true

--- a/examples/resources/snowflake_user/resource.tf
+++ b/examples/resources/snowflake_user/resource.tf
@@ -96,6 +96,57 @@ resource "snowflake_user" "u" {
   week_start                                    = 1
 }
 
+# user with workload identity for AWS
+resource "snowflake_user" "user_with_aws_workload_identity" {
+  name     = "AWS Service User"
+  comment  = "Service user with AWS workload identity"
+  disabled = "false"
+  workload_identity {
+    type = "AWS"
+    arn  = "arn:aws:iam::123456789012:role/MySnowflakeRole"
+  }
+  default_role = snowflake_role.service_role.fully_qualified_name
+}
+
+# user with workload identity for Azure
+resource "snowflake_user" "user_with_azure_workload_identity" {
+  name     = "Azure Service User"
+  comment  = "Service user with Azure workload identity"
+  disabled = "false"
+  workload_identity {
+    type    = "AZURE"
+    issuer  = "https://login.microsoftonline.com/tenant-id/v2.0"
+    subject = "application-id"
+  }
+  default_role = snowflake_role.service_role.fully_qualified_name
+}
+
+# user with workload identity for GCP
+resource "snowflake_user" "user_with_gcp_workload_identity" {
+  name     = "GCP Service User"
+  comment  = "Service user with GCP workload identity"
+  disabled = "false"
+  workload_identity {
+    type    = "GCP"
+    subject = "service-account@project-id.iam.gserviceaccount.com"
+  }
+  default_role = snowflake_role.service_role.fully_qualified_name
+}
+
+# user with workload identity for OIDC
+resource "snowflake_user" "user_with_oidc_workload_identity" {
+  name     = "OIDC Service User"
+  comment  = "Service user with OIDC workload identity"
+  disabled = "false"
+  workload_identity {
+    type              = "OIDC"
+    issuer            = "https://token.actions.githubusercontent.com"
+    subject           = "repo:myorg/myrepo:ref:refs/heads/main"
+    oidc_audience_list = ["https://github.com/myorg/myrepo"]
+  }
+  default_role = snowflake_role.service_role.fully_qualified_name
+}
+
 variable "email" {
   type      = string
   sensitive = true


### PR DESCRIPTION
  ## Summary
  - Added comprehensive workload identity examples for snowflake_user resource
  - Added AWS workload identity example for snowflake_service_user resource
  - Examples cover all supported provider types: AWS, Azure, GCP, and OIDC

  ## Test plan
  - [x] Examples follow existing documentation patterns
  - [x] Syntax matches current workload identity implementation