### PR TITLE
chore: Adjust user sweepers

### DIFF
--- a/pkg/sdk/sweepers_test.go
+++ b/pkg/sdk/sweepers_test.go
@@ -356,14 +356,10 @@ func nukeDatabases(client *sdk.Client, prefix string, suffix string) func() erro
 
 func nukeUsers(client *sdk.Client, suffix string) func() error {
 	protectedUsers := []string{
-		"SNOWFLAKE", // delete
 		"ARTUR_SAWICKI",
-		"ARTUR_SAWICKI_LEGACY", // delete
 		"JAKUB_MICHALAK",
-		"JAKUB_MICHALAK_LEGACY", // delete
 		"JAN_CIESLAK",
-		"JAN_CIESLAK_LEGACY",    // delete
-		"TERRAFORM_SVC_ACCOUNT", // delete
+		"KAMIL_WASILEWSKI",
 		"TEST_CI_SERVICE_USER",
 		"PENTESTING_USER_1",
 		"PENTESTING_USER_2",


### PR DESCRIPTION
- Remove not-needed users from the protected users list in sweepers
- Not-needed users are SNOWFLAKE (due to the 2025_04 BCR) and legacy service users.

References: https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_04/bcr-1976