### PR TITLE
chore: Increase VSCode Go test timeout to 30 minutes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
         "-v",
         "--tags=account_level_tests,non_account_level_tests"
     ],
-    "go.testTimeout": "600s",
+    "go.testTimeout": "1800s",
     "go.lintTool": "golangci-lint",
     "go.lintFlags": [
         "--fast"


### PR DESCRIPTION
## Summary
- Increase go.testTimeout in .vscode/settings.json from 600s (10 min) to 1800s (30 min)
- The previous timeout was too short for longer-running acceptance tests, causing them to be killed before completion