### PR TITLE
fix: issue 4398

### DIFF
--- a/pkg/testacc/resource_share_acceptance_test.go
+++ b/pkg/testacc/resource_share_acceptance_test.go
@@ -7,6 +7,9 @@ import (
 	"regexp"
 	"testing"
 
+	accconfig "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/previewfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -114,6 +117,84 @@ func TestAcc_Share_validateAccounts(t *testing.T) {
 			{
 				Config:      shareConfigTwoAccounts(id, "any comment", "correct.one", "incorrect"),
 				ExpectError: regexp.MustCompile("Unable to parse the account identifier"),
+			},
+		},
+	})
+}
+
+// proves https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/4398 is fixed
+func TestAcc_Share_issue4398(t *testing.T) {
+	database, databaseCleanup := testClient().Database.CreateDatabase(t)
+	t.Cleanup(databaseCleanup)
+
+	account2 := secondaryTestClient().Account.GetAccountIdentifier(t)
+	id := testClient().Ids.RandomAccountObjectIdentifier()
+
+	providerModel := providermodel.SnowflakeProvider().WithPreviewFeaturesEnabled(string(previewfeatures.ShareResource))
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Share),
+		Steps: []resource.TestStep{
+			// Step 1: Share with no accounts
+			{
+				ExternalProviders: ExternalProviderWithExactVersion("2.13.0"),
+				Config:            shareConfig(id, "") + accconfig.FromModels(t, providerModel),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_share.test", "name", id.Name()),
+					resource.TestCheckResourceAttr("snowflake_share.test", "accounts.#", "0"),
+				),
+			},
+			// Step 2: Grant USAGE on database to the share externally, then add accounts.
+			// v2.13.0 fails because setShareAccounts creates a temp database and tries to
+			// grant USAGE on it, conflicting with the already-granted USAGE on the real database.
+			{
+				PreConfig: func() {
+					testClient().Grant.GrantPrivilegeOnDatabaseToShare(t, database.ID(), id, []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage})
+				},
+				ExternalProviders: ExternalProviderWithExactVersion("2.13.0"),
+				Config:            shareConfigOneAccount(id, "", account2.Name()) + accconfig.FromModels(t, providerModel),
+				ExpectError:       regexp.MustCompile("does not belong to the database that is being shared"),
+			},
+			// Step 3: Succeeds after fix (skip temp database when share already has a database granted).
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   shareConfigOneAccount(id, "", account2.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_share.test", "accounts.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_share.test", "accounts.0", account2.Name()),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_Share_issue4398_updateAccountsWithoutDatabaseGranted(t *testing.T) {
+	account2 := secondaryTestClient().Account.GetAccountIdentifier(t)
+	id := testClient().Ids.RandomAccountObjectIdentifier()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Share),
+		Steps: []resource.TestStep{
+			{
+				Config: shareConfig(id, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_share.test", "name", id.Name()),
+					resource.TestCheckResourceAttr("snowflake_share.test", "accounts.#", "0"),
+				),
+			},
+			{
+				Config: shareConfigOneAccount(id, "", account2.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_share.test", "accounts.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_share.test", "accounts.0", account2.Name()),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
## Changes
- Fix the Update logic in the share resource to only use the temporary database workaround whenever no other database is granted to a given share
- Add the test proving it now works, and the previous behavior of using the workaround on Update (when no database is assigned to the share) still works

References: #4398