### PR TITLE
chore: Bump slash command dispatch version

### DIFF
--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -22,7 +22,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4 # v4
+        uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5.0.2
         with:
           token: ${{ steps.create-token.outputs.token }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes
- Bump ok-to-test slash command dispatch version (v4 -> v5.0.2), which contains fix for: https://github.com/peter-evans/slash-command-dispatch/issues/396