### PR TITLE
docs: Remove deprecated fields from examples

### DIFF
--- a/docs/resources/notification_integration.md
+++ b/docs/resources/notification_integration.md
@@ -17,28 +17,53 @@ description: |-
 <!-- TODO(SNOW-1634854): include an example showing both methods-->
 
 ```terraform
-resource "snowflake_notification_integration" "integration" {
-  name    = "notification"
-  comment = "A notification integration."
+# basic resource with AZURE_STORAGE_QUEUE
+resource "snowflake_notification_integration" "azure" {
+  name                            = "notification"
+  enabled                         = true
 
-  enabled   = true
-  type      = "QUEUE"
-  direction = "OUTBOUND"
-
-  # AZURE_STORAGE_QUEUE
   notification_provider           = "AZURE_STORAGE_QUEUE"
-  azure_storage_queue_primary_uri = "..."
-  azure_tenant_id                 = "..."
+  azure_storage_queue_primary_uri = "https://myaccount.queue.core.windows.net/myqueue"
+  azure_tenant_id                 = "a123b4c5-1234-123a-a12b-1a23b45678c9"
+}
 
-  # AWS_SQS
-  #notification_provider = "AWS_SQS"
-  #aws_sqs_arn           = "..."
-  #aws_sqs_role_arn      = "..."
+# basic resource with AWS_SNS
+resource "snowflake_notification_integration" "aws" {
+  name                  = "notification"
+  enabled               = true
 
-  # AWS_SNS
-  #notification_provider = "AWS_SNS"
-  #aws_sns_topic_arn     = "..."
-  #aws_sns_role_arn      = "..."
+  notification_provider = "AWS_SNS"
+  aws_sns_topic_arn     = "arn:aws:sns:us-east-1:001234567890:mytopic"
+  aws_sns_role_arn      = "arn:aws:iam::001234567890:role/myrole"
+}
+
+# basic resource with GCP_PUBSUB (subscription)
+resource "snowflake_notification_integration" "gcp_subscription" {
+  name                         = "notification"
+  enabled                      = true
+
+  notification_provider        = "GCP_PUBSUB"
+  gcp_pubsub_subscription_name = "projects/myproject/subscriptions/mysubscription"
+}
+
+# basic resource with GCP_PUBSUB (topic)
+resource "snowflake_notification_integration" "gcp_topic" {
+  name                  = "notification"
+  enabled               = true
+
+  notification_provider = "GCP_PUBSUB"
+  gcp_pubsub_topic_name = "projects/myproject/topics/mytopic"
+}
+
+# resource with all non-provider-specific fields set
+resource "snowflake_notification_integration" "complete" {
+  name                            = "notification"
+  enabled                         = true
+  comment                         = "A notification integration."
+
+  notification_provider           = "AZURE_STORAGE_QUEUE"
+  azure_storage_queue_primary_uri = "https://myaccount.queue.core.windows.net/myqueue"
+  azure_tenant_id                 = "a123b4c5-1234-123a-a12b-1a23b45678c9"
 }
 ```
 

--- a/docs/resources/table.md
+++ b/docs/resources/table.md
@@ -76,11 +76,6 @@ resource "snowflake_table" "table" {
     type    = "VARIANT"
     comment = "extra data"
   }
-
-  primary_key {
-    name = "my_key"
-    keys = ["data"]
-  }
 }
 ```
 

--- a/docs/resources/table_constraint.md
+++ b/docs/resources/table_constraint.md
@@ -73,7 +73,6 @@ resource "snowflake_table_constraint" "primary_key" {
   type     = "PRIMARY KEY"
   table_id = snowflake_table.t.fully_qualified_name
   columns  = ["col1"]
-  comment  = "hello world"
 }
 
 resource "snowflake_table_constraint" "foreign_key" {
@@ -81,16 +80,17 @@ resource "snowflake_table_constraint" "foreign_key" {
   type     = "FOREIGN KEY"
   table_id = snowflake_table.t.fully_qualified_name
   columns  = ["col2"]
+
   foreign_key_properties {
     references {
       table_id = snowflake_table.fk_t.fully_qualified_name
       columns  = ["fk_col1"]
     }
   }
+
   enforced   = false
   deferrable = false
   initially  = "IMMEDIATE"
-  comment    = "hello fk"
 }
 
 resource "snowflake_table_constraint" "unique" {
@@ -98,7 +98,6 @@ resource "snowflake_table_constraint" "unique" {
   type     = "UNIQUE"
   table_id = snowflake_table.t.fully_qualified_name
   columns  = ["col3"]
-  comment  = "hello unique"
 }
 ```
 

--- a/examples/resources/snowflake_notification_integration/resource.tf
+++ b/examples/resources/snowflake_notification_integration/resource.tf
@@ -1,23 +1,48 @@
-resource "snowflake_notification_integration" "integration" {
-  name    = "notification"
-  comment = "A notification integration."
+# basic resource with AZURE_STORAGE_QUEUE
+resource "snowflake_notification_integration" "azure" {
+  name                            = "notification"
+  enabled                         = true
 
-  enabled   = true
-  type      = "QUEUE"
-  direction = "OUTBOUND"
-
-  # AZURE_STORAGE_QUEUE
   notification_provider           = "AZURE_STORAGE_QUEUE"
-  azure_storage_queue_primary_uri = "..."
-  azure_tenant_id                 = "..."
+  azure_storage_queue_primary_uri = "https://myaccount.queue.core.windows.net/myqueue"
+  azure_tenant_id                 = "a123b4c5-1234-123a-a12b-1a23b45678c9"
+}
 
-  # AWS_SQS
-  #notification_provider = "AWS_SQS"
-  #aws_sqs_arn           = "..."
-  #aws_sqs_role_arn      = "..."
+# basic resource with AWS_SNS
+resource "snowflake_notification_integration" "aws" {
+  name                  = "notification"
+  enabled               = true
 
-  # AWS_SNS
-  #notification_provider = "AWS_SNS"
-  #aws_sns_topic_arn     = "..."
-  #aws_sns_role_arn      = "..."
+  notification_provider = "AWS_SNS"
+  aws_sns_topic_arn     = "arn:aws:sns:us-east-1:001234567890:mytopic"
+  aws_sns_role_arn      = "arn:aws:iam::001234567890:role/myrole"
+}
+
+# basic resource with GCP_PUBSUB (subscription)
+resource "snowflake_notification_integration" "gcp_subscription" {
+  name                         = "notification"
+  enabled                      = true
+
+  notification_provider        = "GCP_PUBSUB"
+  gcp_pubsub_subscription_name = "projects/myproject/subscriptions/mysubscription"
+}
+
+# basic resource with GCP_PUBSUB (topic)
+resource "snowflake_notification_integration" "gcp_topic" {
+  name                  = "notification"
+  enabled               = true
+
+  notification_provider = "GCP_PUBSUB"
+  gcp_pubsub_topic_name = "projects/myproject/topics/mytopic"
+}
+
+# resource with all non-provider-specific fields set
+resource "snowflake_notification_integration" "complete" {
+  name                            = "notification"
+  enabled                         = true
+  comment                         = "A notification integration."
+
+  notification_provider           = "AZURE_STORAGE_QUEUE"
+  azure_storage_queue_primary_uri = "https://myaccount.queue.core.windows.net/myqueue"
+  azure_tenant_id                 = "a123b4c5-1234-123a-a12b-1a23b45678c9"
 }

--- a/examples/resources/snowflake_table/resource.tf
+++ b/examples/resources/snowflake_table/resource.tf
@@ -57,9 +57,4 @@ resource "snowflake_table" "table" {
     type    = "VARIANT"
     comment = "extra data"
   }
-
-  primary_key {
-    name = "my_key"
-    keys = ["data"]
-  }
 }

--- a/examples/resources/snowflake_table_constraint/resource.tf
+++ b/examples/resources/snowflake_table_constraint/resource.tf
@@ -54,7 +54,6 @@ resource "snowflake_table_constraint" "primary_key" {
   type     = "PRIMARY KEY"
   table_id = snowflake_table.t.fully_qualified_name
   columns  = ["col1"]
-  comment  = "hello world"
 }
 
 resource "snowflake_table_constraint" "foreign_key" {
@@ -62,16 +61,17 @@ resource "snowflake_table_constraint" "foreign_key" {
   type     = "FOREIGN KEY"
   table_id = snowflake_table.t.fully_qualified_name
   columns  = ["col2"]
+
   foreign_key_properties {
     references {
       table_id = snowflake_table.fk_t.fully_qualified_name
       columns  = ["fk_col1"]
     }
   }
+
   enforced   = false
   deferrable = false
   initially  = "IMMEDIATE"
-  comment    = "hello fk"
 }
 
 resource "snowflake_table_constraint" "unique" {
@@ -79,5 +79,4 @@ resource "snowflake_table_constraint" "unique" {
   type     = "UNIQUE"
   table_id = snowflake_table.t.fully_qualified_name
   columns  = ["col3"]
-  comment  = "hello unique"
 }


### PR DESCRIPTION
## Changes
- Remove deprecated fields from config examples
- Adjust notification integration docs to contain full examples for every variant

References: #4289, #4290, #4291