### PR TITLE
fix(sdk): map CORTEX_AGENT_SERVER to MCP SERVER in grant show

### DIFF
--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -239,6 +239,9 @@ func (row grantRow) convert() (*Grant, error) {
 	if row.GrantedOn == "MODULE" {
 		grantedOn = ObjectTypeModel
 	}
+	if row.GrantedOn == "CORTEX_AGENT_SERVER" {
+		grantedOn = ObjectTypeMcpServer
+	}
 
 	var grantOn ObjectType
 	// true for future grants
@@ -250,6 +253,9 @@ func (row grantRow) convert() (*Grant, error) {
 	}
 	if row.GrantOn == "MODULE" {
 		grantOn = ObjectTypeModel
+	}
+	if row.GrantOn == "CORTEX_AGENT_SERVER" {
+		grantOn = ObjectTypeMcpServer
 	}
 
 	var name ObjectIdentifier

--- a/pkg/testacc/resource_grant_privileges_to_database_role_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_database_role_acceptance_test.go
@@ -1402,6 +1402,42 @@ func TestAcc_GrantPrivilegesToDatabaseRole_OnFutureModels_issue3050(t *testing.T
 	})
 }
 
+func TestAcc_GrantPrivilegesToDatabaseRole_OnFutureMcpServers(t *testing.T) {
+	databaseRole, databaseRoleCleanup := testClient().DatabaseRole.CreateDatabaseRole(t)
+	t.Cleanup(databaseRoleCleanup)
+
+	configVariables := config.Variables{
+		"name":               config.StringVariable(databaseRole.ID().Name()),
+		"privileges":         config.ListVariable(config.StringVariable("USAGE")),
+		"database":           config.StringVariable(TestDatabaseName),
+		"object_type_plural": config.StringVariable(sdk.PluralObjectTypeMcpServers.String()),
+		"with_grant_option":  config.BoolVariable(false),
+	}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy:             CheckDatabaseRolePrivilegesRevoked(t),
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: ConfigurationDirectory("TestAcc_GrantPrivilegesToDatabaseRole/OnSchemaObject_OnFuture_InDatabase"),
+				ConfigVariables: configVariables,
+			},
+			{
+				ConfigDirectory: ConfigurationDirectory("TestAcc_GrantPrivilegesToDatabaseRole/OnSchemaObject_OnFuture_InDatabase"),
+				ConfigVariables: configVariables,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func grantPrivilegesToDatabaseRoleOnFutureInDatabaseConfig(databaseRoleId sdk.DatabaseObjectIdentifier, privileges []string, objectTypePlural sdk.PluralObjectType, databaseName string) string {
 	return fmt.Sprintf(`
 resource "snowflake_database_role" "test" {


### PR DESCRIPTION
Added new mappings for the new "MCP Server" object type that returns in the `SHOW GRANTS` query as a different type: "CORTEX_AGENT_SERVER"

## Test Plan
* [X] acceptance tests - included an acceptance test that creates a grant, applies, the re-applies and asserts the plan returns empty

* [X] Ran a local dev override on my actual implementation, worked like a charm

* [X] Also ran unit tests, lint, and pre push

## References
Resolves issue https://github.com/snowflakedb/terraform-provider-snowflake/issues/4524

This fix is almost identical to the fix made for models: https://github.com/snowflakedb/terraform-provider-snowflake/issues/3050
Also similar to the fix made for Volumes: https://github.com/snowflakedb/terraform-provider-snowflake/pull/2538