### PR TITLE
chore: Add chmod +x for dev-setup binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ dev-setup: ## setup development dependencies
 	cd tools && mkdir -p bin/
 	cd tools && env GOBIN=$$PWD/bin go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 	cd tools && env GOBIN=$$PWD/bin go install mvdan.cc/gofumpt
+	chmod +x bin/* tools/bin/*
 
 dev-cleanup: ## cleanup development dependencies
 	rm -rf bin/*


### PR DESCRIPTION
## Summary
- Adds `chmod +x` for `bin/golangci-lint` and `tools/bin/*` in the `dev-setup` Makefile target to ensure installed binaries are executable.