### PR TITLE
chore: Adjust GH actions

### DIFF
--- a/.github/workflows/new-driver-version-jira-issues.yml
+++ b/.github/workflows/new-driver-version-jira-issues.yml
@@ -16,10 +16,12 @@ jobs:
     steps:
       - name: Extract version
         id: extract_version
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Extract the target version from the PR title using regex.
           # Example: "chore(deps): bump github.com/snowflakedb/gosnowflake from 0.45.0 to 0.47.0" will match and extract "0.47.0".
-          version=$(echo "${{ github.event.pull_request.title }}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+$' || echo "")
+          version=$(echo "$PR_TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+$' || echo "")
           if [ -z "$version" ]; then
             echo "Error: Could not extract version from PR title"
             exit 1

--- a/.github/workflows/tests-account-level.yml
+++ b/.github/workflows/tests-account-level.yml
@@ -7,6 +7,11 @@
 # Run secret-dependent integration tests only after /ok-to-test approval
 name: Account-Level Tests
 
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
 concurrency:
   group: ${{ github.workflow }}
@@ -47,16 +52,21 @@ jobs:
 
       - id: verify_sha_input
         if: github.event_name == 'repository_dispatch'
+        env:
+          PR_HEAD_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+          SLASH_SHA: ${{ github.event.client_payload.slash_command.args.named.sha }}
+          PR_HEAD_REPO: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          PR_HEAD_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         run: |
-          echo \"${{ github.event.client_payload.pull_request.head.sha }}\"
-          echo \"${{ github.event.client_payload.slash_command.args.named.sha }}\"
-          echo \"${{ github.event.client_payload.pull_request.head.repo.full_name }}\"
-          echo \"${{ github.event.client_payload.pull_request.head.ref }}\"
-          SHAINPUT=$(echo ${{ github.event.client_payload.slash_command.args.named.sha }} | cut -c1-7)
+          echo "$PR_HEAD_SHA"
+          echo "$SLASH_SHA"
+          echo "$PR_HEAD_REPO"
+          echo "$PR_HEAD_REF"
+          SHAINPUT=$(echo "$SLASH_SHA" | cut -c1-7)
           if [ ${#SHAINPUT} -le 6 ]; then echo "error::input sha not at least 7 characters long" ; exit 1
           else echo "done"
           fi
-          SHAHEAD=$(echo ${{ github.event.client_payload.pull_request.head.sha }} | cut -c1-7)
+          SHAHEAD=$(echo "$PR_HEAD_SHA" | cut -c1-7)
           echo ${#SHAINPUT}
           echo ${#SHAHEAD}
           if [ "${SHAHEAD}" != "${SHAINPUT}" ]; then echo "sha input from slash command does not equal the head sha" ; exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,6 @@ jobs:
               - 'go.mod'
 
       - id: verify_sha_input
-        if: github.event_name == 'repository_dispatch'
         env:
           PR_HEAD_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
           SLASH_SHA: ${{ github.event.client_payload.slash_command.args.named.sha }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
   all-tests:
     environment: test
     env:
-      TEST_SF_TF_TEST_OBJECT_SUFFIX: ${{ github.event.pull_request.head.sha }}
+      TEST_SF_TF_TEST_OBJECT_SUFFIX: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.pull_request.head.sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) }}
     name: Run All
     runs-on: ubuntu-latest
     if: (github.event_name == 'repository_dispatch') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
@@ -42,10 +42,10 @@ jobs:
 
       - id: verify_sha_input
         env:
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          SLASH_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+          SLASH_SHA: ${{ github.event.client_payload.slash_command.args.named.sha }}
+          PR_HEAD_REPO: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          PR_HEAD_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         run: |
           echo "$PR_HEAD_SHA"
           echo "$SLASH_SHA"
@@ -67,7 +67,7 @@ jobs:
         if: (github.event_name == 'repository_dispatch')
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.client_payload.slash_command.args.named.sha }}
           persist-credentials: false
 
       - name: Checkout Code (Pull Request Event)
@@ -173,20 +173,20 @@ jobs:
         if: ${{ always() }}
         uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666 # v3.0.0
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
           body: |
-            Integration tests ${{ job.status }} for [${{ github.event.pull_request.head.sha }}](https://github.com/snowflakedb/terraform-provider-snowflake/actions/runs/${{ github.run_id }})
+            Integration tests ${{ job.status }} for [${{ github.event.client_payload.slash_command.args.named.sha || github.event.pull_request.head.sha }}](https://github.com/snowflakedb/terraform-provider-snowflake/actions/runs/${{ github.run_id }})
 
       - name: Set fork job status
         uses: actions/github-script@v6
         if: ${{ always() }}
         id: update_check_run
         env:
-          number: ${{ github.event.pull_request.number }}
+          number: ${{ github.event.client_payload.pull_request.number }}
           job: ${{ github.job }}
           # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
           conclusion: ${{ job.status }}
-          sha: ${{ github.event.pull_request.head.sha }}
+          sha: ${{ github.event.client_payload.slash_command.args.named.sha }}
           event_name: ${{ github.event_name }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 # Run secret-dependent integration tests only after /ok-to-test approval
 name: Tests
 
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -37,16 +42,21 @@ jobs:
 
       - id: verify_sha_input
         if: github.event_name == 'repository_dispatch'
+        env:
+          PR_HEAD_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+          SLASH_SHA: ${{ github.event.client_payload.slash_command.args.named.sha }}
+          PR_HEAD_REPO: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          PR_HEAD_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         run: |
-          echo \"${{ github.event.client_payload.pull_request.head.sha }}\"
-          echo \"${{ github.event.client_payload.slash_command.args.named.sha }}\"
-          echo \"${{ github.event.client_payload.pull_request.head.repo.full_name }}\"
-          echo \"${{ github.event.client_payload.pull_request.head.ref }}\"
-          SHAINPUT=$(echo ${{ github.event.client_payload.slash_command.args.named.sha }} | cut -c1-7)
+          echo "$PR_HEAD_SHA"
+          echo "$SLASH_SHA"
+          echo "$PR_HEAD_REPO"
+          echo "$PR_HEAD_REF"
+          SHAINPUT=$(echo "$SLASH_SHA" | cut -c1-7)
           if [ ${#SHAINPUT} -le 6 ]; then echo "error::input sha not at least 7 characters long" ; exit 1
           else echo "done"
           fi
-          SHAHEAD=$(echo ${{ github.event.client_payload.pull_request.head.sha }} | cut -c1-7)
+          SHAHEAD=$(echo "$PR_HEAD_SHA" | cut -c1-7)
           echo ${#SHAINPUT}
           echo ${#SHAHEAD}
           if [ "${SHAHEAD}" != "${SHAINPUT}" ]; then echo "sha input from slash command does not equal the head sha" ; exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,7 @@ jobs:
               - 'go.mod'
 
       - id: verify_sha_input
+        if: github.event_name == 'repository_dispatch'
         env:
           PR_HEAD_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
           SLASH_SHA: ${{ github.event.client_payload.slash_command.args.named.sha }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
   all-tests:
     environment: test
     env:
-      TEST_SF_TF_TEST_OBJECT_SUFFIX: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.pull_request.head.sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) }}
+      TEST_SF_TF_TEST_OBJECT_SUFFIX: ${{ github.event.pull_request.head.sha }}
     name: Run All
     runs-on: ubuntu-latest
     if: (github.event_name == 'repository_dispatch') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
@@ -42,10 +42,10 @@ jobs:
 
       - id: verify_sha_input
         env:
-          PR_HEAD_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
-          SLASH_SHA: ${{ github.event.client_payload.slash_command.args.named.sha }}
-          PR_HEAD_REPO: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-          PR_HEAD_REF: ${{ github.event.client_payload.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          SLASH_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           echo "$PR_HEAD_SHA"
           echo "$SLASH_SHA"
@@ -67,7 +67,7 @@ jobs:
         if: (github.event_name == 'repository_dispatch')
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.client_payload.slash_command.args.named.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Checkout Code (Pull Request Event)
@@ -173,20 +173,20 @@ jobs:
         if: ${{ always() }}
         uses: peter-evans/create-or-update-comment@3383acd359705b10cb1eeef05c0e88c056ea4666 # v3.0.0
         with:
-          issue-number: ${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
+          issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Integration tests ${{ job.status }} for [${{ github.event.client_payload.slash_command.args.named.sha || github.event.pull_request.head.sha }}](https://github.com/snowflakedb/terraform-provider-snowflake/actions/runs/${{ github.run_id }})
+            Integration tests ${{ job.status }} for [${{ github.event.pull_request.head.sha }}](https://github.com/snowflakedb/terraform-provider-snowflake/actions/runs/${{ github.run_id }})
 
       - name: Set fork job status
         uses: actions/github-script@v6
         if: ${{ always() }}
         id: update_check_run
         env:
-          number: ${{ github.event.client_payload.pull_request.number }}
+          number: ${{ github.event.pull_request.number }}
           job: ${{ github.job }}
           # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
           conclusion: ${{ job.status }}
-          sha: ${{ github.event.client_payload.slash_command.args.named.sha }}
+          sha: ${{ github.event.pull_request.head.sha }}
           event_name: ${{ github.event_name }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

Moving `${{ }}` expressions values to `env` variables ensures they are treated as data, not code. Additionally, explicit `permissions` blocks are added to follow the principle of least privilege.

The approach replaces inline `${{ }}` interpolation in shell `run` blocks with environment variables set via the `env` key. This is the recommended remediation from GitHub's security hardening guide — environment variables are passed as strings and never interpreted as shell code.
