### PR TITLE
chore: SDK Updates for Webhook Notification Integration

### DIFF
--- a/pkg/sdk/generator/defs/notification_integrations_def.go
+++ b/pkg/sdk/generator/defs/notification_integrations_def.go
@@ -9,6 +9,11 @@ import (
 var NotificationIntegrationAllowedRecipientDef = g.NewQueryStruct("NotificationIntegrationAllowedRecipient").
 	Text("Email", g.KeywordOptions().SingleQuotes().Required())
 
+var NotificationIntegrationWebhookHeaderDef = g.NewQueryStruct("WebhookHeader").
+	Text("Header", g.KeywordOptions().SingleQuotes().Required()).
+	PredefinedQueryStructField("equals", "bool", g.StaticOptions().SQL("=")).
+	Text("Value", g.KeywordOptions().SingleQuotes().Required())
+
 // TODO [SNOW-1016561]: all integrations reuse almost the same show, drop, and describe. For now we are copying it. Consider reusing in linked issue.
 var notificationIntegrationsDef = g.NewInterface(
 	"NotificationIntegrations",
@@ -84,11 +89,22 @@ var notificationIntegrationsDef = g.NewInterface(
 					ListAssignment("ALLOWED_RECIPIENTS", "NotificationIntegrationAllowedRecipient", g.ParameterOptions().Parentheses()),
 				g.KeywordOptions(),
 			).
+			OptionalQueryStructField(
+				"WebhookParams",
+				g.NewQueryStruct("WebhookParams").
+					SQLWithCustomFieldName("webhookType", "TYPE = WEBHOOK").
+					TextAssignment("WEBHOOK_URL", g.ParameterOptions().SingleQuotes().Required()).
+					OptionalIdentifier("WebhookSecret", g.KindOfTPointer[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Equals().SQL("WEBHOOK_SECRET")).
+					OptionalTextAssignment("WEBHOOK_BODY_TEMPLATE", g.ParameterOptions().SingleQuotes()).
+					ListQueryStructField("WebhookHeaders", NotificationIntegrationWebhookHeaderDef, g.ParameterOptions().SQL("WEBHOOK_HEADERS").Parentheses()),
+				g.KeywordOptions(),
+			).
 			OptionalComment().
 			WithValidation(g.ValidIdentifier, "name").
 			WithValidation(g.ConflictingFields, "IfNotExists", "OrReplace").
-			WithValidation(g.ExactlyOneValueSet, "AutomatedDataLoadsParams", "PushNotificationParams", "EmailParams"),
+			WithValidation(g.ExactlyOneValueSet, "AutomatedDataLoadsParams", "PushNotificationParams", "EmailParams", "WebhookParams"),
 		NotificationIntegrationAllowedRecipientDef,
+		NotificationIntegrationWebhookHeaderDef,
 	).
 	AlterOperation(
 		"https://docs.snowflake.com/en/sql-reference/sql/alter-notification-integration",
@@ -134,9 +150,18 @@ var notificationIntegrationsDef = g.NewInterface(
 							WithValidation(g.ValidateValueSet, "AllowedRecipients"),
 						g.KeywordOptions(),
 					).
+					OptionalQueryStructField(
+						"SetWebhookParams",
+						g.NewQueryStruct("SetWebhookParams").
+							OptionalTextAssignment("WEBHOOK_URL", g.ParameterOptions().SingleQuotes()).
+							OptionalIdentifier("WebhookSecret", g.KindOfTPointer[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Equals().SQL("WEBHOOK_SECRET")).
+							OptionalTextAssignment("WEBHOOK_BODY_TEMPLATE", g.ParameterOptions().SingleQuotes()).
+							ListQueryStructField("WebhookHeaders", NotificationIntegrationWebhookHeaderDef, g.ParameterOptions().SQL("WEBHOOK_HEADERS").Parentheses()),
+						g.KeywordOptions(),
+					).
 					OptionalComment().
-					WithValidation(g.ConflictingFields, "SetPushParams", "SetEmailParams").
-					WithValidation(g.AtLeastOneValueSet, "Enabled", "SetPushParams", "SetEmailParams", "Comment"),
+					WithValidation(g.ConflictingFields, "SetPushParams", "SetEmailParams", "SetWebhookParams").
+					WithValidation(g.AtLeastOneValueSet, "Enabled", "SetPushParams", "SetEmailParams", "SetWebhookParams", "Comment"),
 				g.KeywordOptions().SQL("SET"),
 			).
 			// UNSET is supported only for the email notifications
@@ -148,10 +173,20 @@ var notificationIntegrationsDef = g.NewInterface(
 					WithValidation(g.AtLeastOneValueSet, "AllowedRecipients", "Comment"),
 				g.ListOptions().NoParentheses().SQL("UNSET"),
 			).
+			OptionalQueryStructField(
+				"UnsetWebhookParams",
+				g.NewQueryStruct("NotificationIntegrationUnsetWebhookParams").
+					OptionalSQL("WEBHOOK_SECRET").
+					OptionalSQL("WEBHOOK_BODY_TEMPLATE").
+					OptionalSQL("WEBHOOK_HEADERS").
+					OptionalSQL("COMMENT").
+					WithValidation(g.AtLeastOneValueSet, "WebhookSecret", "WebhookBodyTemplate", "WebhookHeaders", "Comment"),
+				g.ListOptions().NoParentheses().SQL("UNSET"),
+			).
 			OptionalSetTags().
 			OptionalUnsetTags().
 			WithValidation(g.ValidIdentifier, "name").
-			WithValidation(g.ExactlyOneValueSet, "Set", "UnsetEmailParams", "SetTags", "UnsetTags"),
+			WithValidation(g.ExactlyOneValueSet, "Set", "UnsetEmailParams", "UnsetWebhookParams", "SetTags", "UnsetTags"),
 	).
 	DropOperation(
 		"https://docs.snowflake.com/en/sql-reference/sql/drop-integration",

--- a/pkg/sdk/notification_integrations_dto_builders_gen.go
+++ b/pkg/sdk/notification_integrations_dto_builders_gen.go
@@ -37,6 +37,11 @@ func (s *CreateNotificationIntegrationRequest) WithEmailParams(emailParams Email
 	return s
 }
 
+func (s *CreateNotificationIntegrationRequest) WithWebhookParams(webhookParams WebhookParamsRequest) *CreateNotificationIntegrationRequest {
+	s.WebhookParams = &webhookParams
+	return s
+}
+
 func (s *CreateNotificationIntegrationRequest) WithComment(comment string) *CreateNotificationIntegrationRequest {
 	s.Comment = &comment
 	return s
@@ -133,6 +138,34 @@ func (s *EmailParamsRequest) WithAllowedRecipients(allowedRecipients []Notificat
 	return s
 }
 
+func NewWebhookParamsRequest(webhookUrl string) *WebhookParamsRequest {
+	s := WebhookParamsRequest{}
+	s.WebhookUrl = webhookUrl
+	return &s
+}
+
+func (s *WebhookParamsRequest) WithWebhookSecret(secretId SchemaObjectIdentifier) *WebhookParamsRequest {
+	s.WebhookSecret = &secretId
+	return s
+}
+
+func (s *WebhookParamsRequest) WithWebhookBodyTemplate(webhookBodyTemplate string) *WebhookParamsRequest {
+	s.WebhookBodyTemplate = &webhookBodyTemplate
+	return s
+}
+
+func (s *WebhookParamsRequest) WithWebhookHeaders(webhookHeaders []WebhookHeaderRequest) *WebhookParamsRequest {
+	s.WebhookHeaders = webhookHeaders
+	return s
+}
+
+func NewWebhookHeaderRequest(header string, value string) *WebhookHeaderRequest {
+	s := WebhookHeaderRequest{}
+	s.Header = header
+	s.Value = value
+	return &s
+}
+
 func NewAlterNotificationIntegrationRequest(
 	name AccountObjectIdentifier,
 ) *AlterNotificationIntegrationRequest {
@@ -153,6 +186,11 @@ func (s *AlterNotificationIntegrationRequest) WithSet(set NotificationIntegratio
 
 func (s *AlterNotificationIntegrationRequest) WithUnsetEmailParams(unsetEmailParams NotificationIntegrationUnsetEmailParamsRequest) *AlterNotificationIntegrationRequest {
 	s.UnsetEmailParams = &unsetEmailParams
+	return s
+}
+
+func (s *AlterNotificationIntegrationRequest) WithUnsetWebhookParams(unsetWebhookParams NotificationIntegrationUnsetWebhookParamsRequest) *AlterNotificationIntegrationRequest {
+	s.UnsetWebhookParams = &unsetWebhookParams
 	return s
 }
 
@@ -183,6 +221,11 @@ func (s *NotificationIntegrationSetRequest) WithSetPushParams(setPushParams SetP
 
 func (s *NotificationIntegrationSetRequest) WithSetEmailParams(setEmailParams SetEmailParamsRequest) *NotificationIntegrationSetRequest {
 	s.SetEmailParams = &setEmailParams
+	return s
+}
+
+func (s *NotificationIntegrationSetRequest) WithSetWebhookParams(setWebhookParams SetWebhookParamsRequest) *NotificationIntegrationSetRequest {
+	s.SetWebhookParams = &setWebhookParams
 	return s
 }
 
@@ -247,6 +290,31 @@ func NewSetEmailParamsRequest(
 	return &s
 }
 
+func NewSetWebhookParamsRequest() *SetWebhookParamsRequest {
+	s := SetWebhookParamsRequest{}
+	return &s
+}
+
+func (s *SetWebhookParamsRequest) WithWebhookUrl(webhookUrl string) *SetWebhookParamsRequest {
+	s.WebhookUrl = &webhookUrl
+	return s
+}
+
+func (s *SetWebhookParamsRequest) WithWebhookSecret(secretId SchemaObjectIdentifier) *SetWebhookParamsRequest {
+	s.WebhookSecret = &secretId
+	return s
+}
+
+func (s *SetWebhookParamsRequest) WithWebhookBodyTemplate(webhookBodyTemplate string) *SetWebhookParamsRequest {
+	s.WebhookBodyTemplate = &webhookBodyTemplate
+	return s
+}
+
+func (s *SetWebhookParamsRequest) WithWebhookHeaders(webhookHeaders []WebhookHeaderRequest) *SetWebhookParamsRequest {
+	s.WebhookHeaders = webhookHeaders
+	return s
+}
+
 func NewNotificationIntegrationUnsetEmailParamsRequest() *NotificationIntegrationUnsetEmailParamsRequest {
 	s := NotificationIntegrationUnsetEmailParamsRequest{}
 	return &s
@@ -258,6 +326,31 @@ func (s *NotificationIntegrationUnsetEmailParamsRequest) WithAllowedRecipients(a
 }
 
 func (s *NotificationIntegrationUnsetEmailParamsRequest) WithComment(comment bool) *NotificationIntegrationUnsetEmailParamsRequest {
+	s.Comment = &comment
+	return s
+}
+
+func NewNotificationIntegrationUnsetWebhookParamsRequest() *NotificationIntegrationUnsetWebhookParamsRequest {
+	s := NotificationIntegrationUnsetWebhookParamsRequest{}
+	return &s
+}
+
+func (s *NotificationIntegrationUnsetWebhookParamsRequest) WithWebhookSecret(webhookSecret bool) *NotificationIntegrationUnsetWebhookParamsRequest {
+	s.WebhookSecret = &webhookSecret
+	return s
+}
+
+func (s *NotificationIntegrationUnsetWebhookParamsRequest) WithWebhookBodyTemplate(webhookBodyTemplate bool) *NotificationIntegrationUnsetWebhookParamsRequest {
+	s.WebhookBodyTemplate = &webhookBodyTemplate
+	return s
+}
+
+func (s *NotificationIntegrationUnsetWebhookParamsRequest) WithWebhookHeaders(webhookHeaders bool) *NotificationIntegrationUnsetWebhookParamsRequest {
+	s.WebhookHeaders = &webhookHeaders
+	return s
+}
+
+func (s *NotificationIntegrationUnsetWebhookParamsRequest) WithComment(comment bool) *NotificationIntegrationUnsetWebhookParamsRequest {
 	s.Comment = &comment
 	return s
 }

--- a/pkg/sdk/notification_integrations_dto_builders_gen.go
+++ b/pkg/sdk/notification_integrations_dto_builders_gen.go
@@ -138,14 +138,16 @@ func (s *EmailParamsRequest) WithAllowedRecipients(allowedRecipients []Notificat
 	return s
 }
 
-func NewWebhookParamsRequest(webhookUrl string) *WebhookParamsRequest {
+func NewWebhookParamsRequest(
+	webhookUrl string,
+) *WebhookParamsRequest {
 	s := WebhookParamsRequest{}
 	s.WebhookUrl = webhookUrl
 	return &s
 }
 
-func (s *WebhookParamsRequest) WithWebhookSecret(secretId SchemaObjectIdentifier) *WebhookParamsRequest {
-	s.WebhookSecret = &secretId
+func (s *WebhookParamsRequest) WithWebhookSecret(webhookSecret SchemaObjectIdentifier) *WebhookParamsRequest {
+	s.WebhookSecret = &webhookSecret
 	return s
 }
 
@@ -159,7 +161,10 @@ func (s *WebhookParamsRequest) WithWebhookHeaders(webhookHeaders []WebhookHeader
 	return s
 }
 
-func NewWebhookHeaderRequest(header string, value string) *WebhookHeaderRequest {
+func NewWebhookHeaderRequest(
+	header string,
+	value string,
+) *WebhookHeaderRequest {
 	s := WebhookHeaderRequest{}
 	s.Header = header
 	s.Value = value
@@ -300,8 +305,8 @@ func (s *SetWebhookParamsRequest) WithWebhookUrl(webhookUrl string) *SetWebhookP
 	return s
 }
 
-func (s *SetWebhookParamsRequest) WithWebhookSecret(secretId SchemaObjectIdentifier) *SetWebhookParamsRequest {
-	s.WebhookSecret = &secretId
+func (s *SetWebhookParamsRequest) WithWebhookSecret(webhookSecret SchemaObjectIdentifier) *SetWebhookParamsRequest {
+	s.WebhookSecret = &webhookSecret
 	return s
 }
 

--- a/pkg/sdk/notification_integrations_dto_gen.go
+++ b/pkg/sdk/notification_integrations_dto_gen.go
@@ -18,6 +18,7 @@ type CreateNotificationIntegrationRequest struct {
 	AutomatedDataLoadsParams *AutomatedDataLoadsParamsRequest
 	PushNotificationParams   *PushNotificationParamsRequest
 	EmailParams              *EmailParamsRequest
+	WebhookParams            *WebhookParamsRequest
 	Comment                  *string
 }
 
@@ -59,20 +60,34 @@ type EmailParamsRequest struct {
 	AllowedRecipients []NotificationIntegrationAllowedRecipient
 }
 
+type WebhookParamsRequest struct {
+	WebhookUrl          string // required
+	WebhookSecret       *SchemaObjectIdentifier
+	WebhookBodyTemplate *string
+	WebhookHeaders      []WebhookHeaderRequest
+}
+
+type WebhookHeaderRequest struct {
+	Header string // required
+	Value  string // required
+}
+
 type AlterNotificationIntegrationRequest struct {
-	IfExists         *bool
-	name             AccountObjectIdentifier // required
-	Set              *NotificationIntegrationSetRequest
-	UnsetEmailParams *NotificationIntegrationUnsetEmailParamsRequest
-	SetTags          []TagAssociation
-	UnsetTags        []ObjectIdentifier
+	IfExists           *bool
+	name               AccountObjectIdentifier // required
+	Set                *NotificationIntegrationSetRequest
+	UnsetEmailParams   *NotificationIntegrationUnsetEmailParamsRequest
+	UnsetWebhookParams *NotificationIntegrationUnsetWebhookParamsRequest
+	SetTags            []TagAssociation
+	UnsetTags          []ObjectIdentifier
 }
 
 type NotificationIntegrationSetRequest struct {
-	Enabled        *bool
-	SetPushParams  *SetPushParamsRequest
-	SetEmailParams *SetEmailParamsRequest
-	Comment        *string
+	Enabled          *bool
+	SetPushParams    *SetPushParamsRequest
+	SetEmailParams   *SetEmailParamsRequest
+	SetWebhookParams *SetWebhookParamsRequest
+	Comment          *string
 }
 
 type SetPushParamsRequest struct {
@@ -99,9 +114,23 @@ type SetEmailParamsRequest struct {
 	AllowedRecipients []NotificationIntegrationAllowedRecipient // required
 }
 
+type SetWebhookParamsRequest struct {
+	WebhookUrl          *string
+	WebhookSecret       *SchemaObjectIdentifier
+	WebhookBodyTemplate *string
+	WebhookHeaders      []WebhookHeaderRequest
+}
+
 type NotificationIntegrationUnsetEmailParamsRequest struct {
 	AllowedRecipients *bool
 	Comment           *bool
+}
+
+type NotificationIntegrationUnsetWebhookParamsRequest struct {
+	WebhookSecret       *bool
+	WebhookBodyTemplate *bool
+	WebhookHeaders      *bool
+	Comment             *bool
 }
 
 type DropNotificationIntegrationRequest struct {

--- a/pkg/sdk/notification_integrations_gen.go
+++ b/pkg/sdk/notification_integrations_gen.go
@@ -38,6 +38,12 @@ type NotificationIntegrationAllowedRecipient struct {
 	Email string `ddl:"keyword,single_quotes"`
 }
 
+type WebhookHeader struct {
+	Header string `ddl:"keyword,single_quotes"`
+	equals bool   `ddl:"static" sql:"="`
+	Value  string `ddl:"keyword,single_quotes"`
+}
+
 type AutomatedDataLoadsParams struct {
 	notificationType string            `ddl:"static" sql:"TYPE = QUEUE"`
 	GoogleAutoParams *GoogleAutoParams `ddl:"keyword"`
@@ -85,38 +91,25 @@ type EmailParams struct {
 	AllowedRecipients []NotificationIntegrationAllowedRecipient `ddl:"parameter,parentheses" sql:"ALLOWED_RECIPIENTS"`
 }
 
-// WebhookParams is based on https://docs.snowflake.com/en/sql-reference/sql/create-notification-integration-webhooks.
 type WebhookParams struct {
 	webhookType         bool                    `ddl:"static" sql:"TYPE = WEBHOOK"`
 	WebhookUrl          string                  `ddl:"parameter,single_quotes" sql:"WEBHOOK_URL"`
-	WebhookSecret       *WebhookSecretReference `ddl:"keyword"`
+	WebhookSecret       *SchemaObjectIdentifier `ddl:"identifier,equals" sql:"WEBHOOK_SECRET"`
 	WebhookBodyTemplate *string                 `ddl:"parameter,single_quotes" sql:"WEBHOOK_BODY_TEMPLATE"`
 	WebhookHeaders      []WebhookHeader         `ddl:"parameter,parentheses" sql:"WEBHOOK_HEADERS"`
 }
 
-type WebhookSecretReference struct {
-	webhookSecret bool                   `ddl:"static" sql:"WEBHOOK_SECRET"`
-	equals        bool                   `ddl:"static" sql:"="`
-	SecretId      SchemaObjectIdentifier `ddl:"identifier"`
-}
-
-type WebhookHeader struct {
-	Header string `ddl:"keyword,single_quotes"`
-	equals bool   `ddl:"static" sql:"="`
-	Value  string `ddl:"keyword,single_quotes"`
-}
-
 // AlterNotificationIntegrationOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-notification-integration.
 type AlterNotificationIntegrationOptions struct {
-	alter                    bool                                      `ddl:"static" sql:"ALTER"`
-	notificationIntegration  bool                                      `ddl:"static" sql:"NOTIFICATION INTEGRATION"`
-	IfExists                 *bool                                     `ddl:"keyword" sql:"IF EXISTS"`
-	name                     AccountObjectIdentifier                   `ddl:"identifier"`
-	Set                      *NotificationIntegrationSet               `ddl:"keyword" sql:"SET"`
-	UnsetEmailParams         *NotificationIntegrationUnsetEmailParams  `ddl:"list,no_parentheses" sql:"UNSET"`
-	UnsetWebhookParams       *NotificationIntegrationUnsetWebhookParams `ddl:"list,no_parentheses" sql:"UNSET"`
-	SetTags                  []TagAssociation                          `ddl:"keyword" sql:"SET TAG"`
-	UnsetTags                []ObjectIdentifier                        `ddl:"keyword" sql:"UNSET TAG"`
+	alter                   bool                                       `ddl:"static" sql:"ALTER"`
+	notificationIntegration bool                                       `ddl:"static" sql:"NOTIFICATION INTEGRATION"`
+	IfExists                *bool                                      `ddl:"keyword" sql:"IF EXISTS"`
+	name                    AccountObjectIdentifier                    `ddl:"identifier"`
+	Set                     *NotificationIntegrationSet                `ddl:"keyword" sql:"SET"`
+	UnsetEmailParams        *NotificationIntegrationUnsetEmailParams   `ddl:"list,no_parentheses" sql:"UNSET"`
+	UnsetWebhookParams      *NotificationIntegrationUnsetWebhookParams `ddl:"list,no_parentheses" sql:"UNSET"`
+	SetTags                 []TagAssociation                           `ddl:"keyword" sql:"SET TAG"`
+	UnsetTags               []ObjectIdentifier                         `ddl:"keyword" sql:"UNSET TAG"`
 }
 
 type NotificationIntegrationSet struct {
@@ -153,7 +146,7 @@ type SetEmailParams struct {
 
 type SetWebhookParams struct {
 	WebhookUrl          *string                 `ddl:"parameter,single_quotes" sql:"WEBHOOK_URL"`
-	WebhookSecret       *WebhookSecretReference `ddl:"keyword"`
+	WebhookSecret       *SchemaObjectIdentifier `ddl:"identifier,equals" sql:"WEBHOOK_SECRET"`
 	WebhookBodyTemplate *string                 `ddl:"parameter,single_quotes" sql:"WEBHOOK_BODY_TEMPLATE"`
 	WebhookHeaders      []WebhookHeader         `ddl:"parameter,parentheses" sql:"WEBHOOK_HEADERS"`
 }

--- a/pkg/sdk/notification_integrations_gen.go
+++ b/pkg/sdk/notification_integrations_gen.go
@@ -30,6 +30,7 @@ type CreateNotificationIntegrationOptions struct {
 	AutomatedDataLoadsParams *AutomatedDataLoadsParams `ddl:"keyword"`
 	PushNotificationParams   *PushNotificationParams   `ddl:"keyword"`
 	EmailParams              *EmailParams              `ddl:"keyword"`
+	WebhookParams            *WebhookParams            `ddl:"keyword"`
 	Comment                  *string                   `ddl:"parameter,single_quotes" sql:"COMMENT"`
 }
 
@@ -84,23 +85,46 @@ type EmailParams struct {
 	AllowedRecipients []NotificationIntegrationAllowedRecipient `ddl:"parameter,parentheses" sql:"ALLOWED_RECIPIENTS"`
 }
 
+// WebhookParams is based on https://docs.snowflake.com/en/sql-reference/sql/create-notification-integration-webhooks.
+type WebhookParams struct {
+	webhookType         bool                    `ddl:"static" sql:"TYPE = WEBHOOK"`
+	WebhookUrl          string                  `ddl:"parameter,single_quotes" sql:"WEBHOOK_URL"`
+	WebhookSecret       *WebhookSecretReference `ddl:"keyword"`
+	WebhookBodyTemplate *string                 `ddl:"parameter,single_quotes" sql:"WEBHOOK_BODY_TEMPLATE"`
+	WebhookHeaders      []WebhookHeader         `ddl:"parameter,parentheses" sql:"WEBHOOK_HEADERS"`
+}
+
+type WebhookSecretReference struct {
+	webhookSecret bool                   `ddl:"static" sql:"WEBHOOK_SECRET"`
+	equals        bool                   `ddl:"static" sql:"="`
+	SecretId      SchemaObjectIdentifier `ddl:"identifier"`
+}
+
+type WebhookHeader struct {
+	Header string `ddl:"keyword,single_quotes"`
+	equals bool   `ddl:"static" sql:"="`
+	Value  string `ddl:"keyword,single_quotes"`
+}
+
 // AlterNotificationIntegrationOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-notification-integration.
 type AlterNotificationIntegrationOptions struct {
-	alter                   bool                                     `ddl:"static" sql:"ALTER"`
-	notificationIntegration bool                                     `ddl:"static" sql:"NOTIFICATION INTEGRATION"`
-	IfExists                *bool                                    `ddl:"keyword" sql:"IF EXISTS"`
-	name                    AccountObjectIdentifier                  `ddl:"identifier"`
-	Set                     *NotificationIntegrationSet              `ddl:"keyword" sql:"SET"`
-	UnsetEmailParams        *NotificationIntegrationUnsetEmailParams `ddl:"list,no_parentheses" sql:"UNSET"`
-	SetTags                 []TagAssociation                         `ddl:"keyword" sql:"SET TAG"`
-	UnsetTags               []ObjectIdentifier                       `ddl:"keyword" sql:"UNSET TAG"`
+	alter                    bool                                      `ddl:"static" sql:"ALTER"`
+	notificationIntegration  bool                                      `ddl:"static" sql:"NOTIFICATION INTEGRATION"`
+	IfExists                 *bool                                     `ddl:"keyword" sql:"IF EXISTS"`
+	name                     AccountObjectIdentifier                   `ddl:"identifier"`
+	Set                      *NotificationIntegrationSet               `ddl:"keyword" sql:"SET"`
+	UnsetEmailParams         *NotificationIntegrationUnsetEmailParams  `ddl:"list,no_parentheses" sql:"UNSET"`
+	UnsetWebhookParams       *NotificationIntegrationUnsetWebhookParams `ddl:"list,no_parentheses" sql:"UNSET"`
+	SetTags                  []TagAssociation                          `ddl:"keyword" sql:"SET TAG"`
+	UnsetTags                []ObjectIdentifier                        `ddl:"keyword" sql:"UNSET TAG"`
 }
 
 type NotificationIntegrationSet struct {
-	Enabled        *bool           `ddl:"parameter" sql:"ENABLED"`
-	SetPushParams  *SetPushParams  `ddl:"keyword"`
-	SetEmailParams *SetEmailParams `ddl:"keyword"`
-	Comment        *string         `ddl:"parameter,single_quotes" sql:"COMMENT"`
+	Enabled          *bool             `ddl:"parameter" sql:"ENABLED"`
+	SetPushParams    *SetPushParams    `ddl:"keyword"`
+	SetEmailParams   *SetEmailParams   `ddl:"keyword"`
+	SetWebhookParams *SetWebhookParams `ddl:"keyword"`
+	Comment          *string           `ddl:"parameter,single_quotes" sql:"COMMENT"`
 }
 
 type SetPushParams struct {
@@ -127,9 +151,23 @@ type SetEmailParams struct {
 	AllowedRecipients []NotificationIntegrationAllowedRecipient `ddl:"parameter,parentheses" sql:"ALLOWED_RECIPIENTS"`
 }
 
+type SetWebhookParams struct {
+	WebhookUrl          *string                 `ddl:"parameter,single_quotes" sql:"WEBHOOK_URL"`
+	WebhookSecret       *WebhookSecretReference `ddl:"keyword"`
+	WebhookBodyTemplate *string                 `ddl:"parameter,single_quotes" sql:"WEBHOOK_BODY_TEMPLATE"`
+	WebhookHeaders      []WebhookHeader         `ddl:"parameter,parentheses" sql:"WEBHOOK_HEADERS"`
+}
+
 type NotificationIntegrationUnsetEmailParams struct {
 	AllowedRecipients *bool `ddl:"keyword" sql:"ALLOWED_RECIPIENTS"`
 	Comment           *bool `ddl:"keyword" sql:"COMMENT"`
+}
+
+type NotificationIntegrationUnsetWebhookParams struct {
+	WebhookSecret       *bool `ddl:"keyword" sql:"WEBHOOK_SECRET"`
+	WebhookBodyTemplate *bool `ddl:"keyword" sql:"WEBHOOK_BODY_TEMPLATE"`
+	WebhookHeaders      *bool `ddl:"keyword" sql:"WEBHOOK_HEADERS"`
+	Comment             *bool `ddl:"keyword" sql:"COMMENT"`
 }
 
 // DropNotificationIntegrationOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-integration.

--- a/pkg/sdk/notification_integrations_gen_test.go
+++ b/pkg/sdk/notification_integrations_gen_test.go
@@ -190,7 +190,7 @@ func TestNotificationIntegrations_Create(t *testing.T) {
 		opts := defaultOptsWebhook()
 		opts.IfNotExists = Bool(true)
 		opts.Comment = String("slack webhook")
-		opts.WebhookParams.WebhookSecret = &WebhookSecretReference{SecretId: secretId}
+		opts.WebhookParams.WebhookSecret = &secretId
 		opts.WebhookParams.WebhookBodyTemplate = String("SNOWFLAKE_WEBHOOK_MESSAGE")
 		opts.WebhookParams.WebhookHeaders = []WebhookHeader{
 			{Header: "Content-Type", Value: "application/json"},
@@ -376,7 +376,7 @@ func TestNotificationIntegrations_Alter(t *testing.T) {
 			Enabled: Bool(true),
 			SetWebhookParams: &SetWebhookParams{
 				WebhookUrl: String(webhookUrl),
-				WebhookSecret: &WebhookSecretReference{SecretId: secretId},
+				WebhookSecret: &secretId,
 				WebhookBodyTemplate: String("SNOWFLAKE_WEBHOOK_MESSAGE"),
 				WebhookHeaders: []WebhookHeader{
 					{Header: "Content-Type", Value: "application/json"},
@@ -391,9 +391,11 @@ func TestNotificationIntegrations_Alter(t *testing.T) {
 		opts := defaultOpts()
 		opts.UnsetWebhookParams = &NotificationIntegrationUnsetWebhookParams{
 			WebhookSecret: Bool(true),
+			WebhookBodyTemplate: Bool(true),
+			WebhookHeaders: Bool(true),
 			Comment:       Bool(true),
 		}
-		assertOptsValidAndSQLEquals(t, opts, "ALTER NOTIFICATION INTEGRATION %s UNSET WEBHOOK_SECRET, COMMENT", id.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, "ALTER NOTIFICATION INTEGRATION %s UNSET WEBHOOK_SECRET, WEBHOOK_BODY_TEMPLATE, WEBHOOK_HEADERS, COMMENT", id.FullyQualifiedName())
 	})
 
 	t.Run("unset single", func(t *testing.T) {

--- a/pkg/sdk/notification_integrations_gen_test.go
+++ b/pkg/sdk/notification_integrations_gen_test.go
@@ -13,12 +13,24 @@ const (
 	azureStorageQueuePrimaryUri = "azure://great-bucket/great-path/"
 	azureEventGridTopicEndpoint = "https://apim-hello-world.azure-api.net/dev"
 	awsSnsTopicArn              = "arn:aws:sns:us-east-2:123456789012:MyTopic"
+	webhookUrl                  = "https://hooks.slack.com/services/SNOWFLAKE_WEBHOOK_SECRET"
 )
 
 func TestNotificationIntegrations_Create(t *testing.T) {
 	id := randomAccountObjectIdentifier()
 
 	// minimal option for each variant added manually
+	// Minimal valid CreateNotificationIntegrationOptions for Webhook
+	defaultOptsWebhook := func() *CreateNotificationIntegrationOptions {
+		return &CreateNotificationIntegrationOptions{
+			name:    id,
+			Enabled: true,
+			WebhookParams: &WebhookParams{
+				WebhookUrl: webhookUrl,
+			},
+		}
+	}
+
 	// Minimal valid CreateNotificationIntegrationOptions for AutomatedDataLoads
 	defaultOptsAutomatedDataLoads := func() *CreateNotificationIntegrationOptions {
 		return &CreateNotificationIntegrationOptions{
@@ -75,16 +87,16 @@ func TestNotificationIntegrations_Create(t *testing.T) {
 		assertOptsInvalidJoinedErrors(t, opts, errOneOf("CreateNotificationIntegrationOptions", "IfNotExists", "OrReplace"))
 	})
 
-	t.Run("validation: exactly one field from [opts.AutomatedDataLoadsParams opts.PushNotificationParams opts.EmailParams] should be present", func(t *testing.T) {
+	t.Run("validation: exactly one field from [opts.AutomatedDataLoadsParams opts.PushNotificationParams opts.EmailParams opts.WebhookParams] should be present", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.EmailParams = nil
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateNotificationIntegrationOptions", "AutomatedDataLoadsParams", "PushNotificationParams", "EmailParams"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateNotificationIntegrationOptions", "AutomatedDataLoadsParams", "PushNotificationParams", "EmailParams", "WebhookParams"))
 	})
 
-	t.Run("validation: exactly one field from [opts.AutomatedDataLoadsParams opts.PushNotificationParams opts.EmailParams] should be present - more present", func(t *testing.T) {
+	t.Run("validation: exactly one field from [opts.AutomatedDataLoadsParams opts.PushNotificationParams opts.EmailParams opts.WebhookParams] should be present - more present", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.PushNotificationParams = &PushNotificationParams{}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateNotificationIntegrationOptions", "AutomatedDataLoadsParams", "PushNotificationParams", "EmailParams"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateNotificationIntegrationOptions", "AutomatedDataLoadsParams", "PushNotificationParams", "EmailParams", "WebhookParams"))
 	})
 
 	t.Run("validation: exactly one field from [opts.AutomatedDataLoadsParams.GoogleAutoParams opts.AutomatedDataLoadsParams.AzureAutoParams] should be present", func(t *testing.T) {
@@ -168,6 +180,24 @@ func TestNotificationIntegrations_Create(t *testing.T) {
 		assertOptsValidAndSQLEquals(t, opts, "CREATE NOTIFICATION INTEGRATION IF NOT EXISTS %s ENABLED = true DIRECTION = OUTBOUND TYPE = QUEUE NOTIFICATION_PROVIDER = AZURE_EVENT_GRID AZURE_EVENT_GRID_TOPIC_ENDPOINT = '%s' AZURE_TENANT_ID = '%s' COMMENT = 'some comment'", id.FullyQualifiedName(), azureEventGridTopicEndpoint, azureTenantId)
 	})
 
+	t.Run("all options - webhook minimal", func(t *testing.T) {
+		opts := defaultOptsWebhook()
+		assertOptsValidAndSQLEquals(t, opts, "CREATE NOTIFICATION INTEGRATION %s ENABLED = true TYPE = WEBHOOK WEBHOOK_URL = '%s'", id.FullyQualifiedName(), webhookUrl)
+	})
+
+	t.Run("all options - webhook with secret and headers", func(t *testing.T) {
+		secretId := NewSchemaObjectIdentifier("metrics_catalog", "metric_config", "slack_integration_webhook")
+		opts := defaultOptsWebhook()
+		opts.IfNotExists = Bool(true)
+		opts.Comment = String("slack webhook")
+		opts.WebhookParams.WebhookSecret = &WebhookSecretReference{SecretId: secretId}
+		opts.WebhookParams.WebhookBodyTemplate = String("SNOWFLAKE_WEBHOOK_MESSAGE")
+		opts.WebhookParams.WebhookHeaders = []WebhookHeader{
+			{Header: "Content-Type", Value: "application/json"},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `CREATE NOTIFICATION INTEGRATION IF NOT EXISTS %s ENABLED = true TYPE = WEBHOOK WEBHOOK_URL = '%s' WEBHOOK_SECRET = %s WEBHOOK_BODY_TEMPLATE = 'SNOWFLAKE_WEBHOOK_MESSAGE' WEBHOOK_HEADERS = ('Content-Type' = 'application/json') COMMENT = 'slack webhook'`, id.FullyQualifiedName(), webhookUrl, secretId.FullyQualifiedName())
+	})
+
 	t.Run("all options - email", func(t *testing.T) {
 		email := "some.email@some.com"
 		otherEmail := "some.other.email@some.com"
@@ -203,12 +233,12 @@ func TestNotificationIntegrations_Alter(t *testing.T) {
 		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
-	t.Run("validation: exactly one field from [opts.Set opts.UnsetEmailParams opts.SetTags opts.UnsetTags] should be present", func(t *testing.T) {
+	t.Run("validation: exactly one field from [opts.Set opts.UnsetEmailParams opts.UnsetWebhookParams opts.SetTags opts.UnsetTags] should be present", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterNotificationIntegrationOptions", "Set", "UnsetEmailParams", "SetTags", "UnsetTags"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterNotificationIntegrationOptions", "Set", "UnsetEmailParams", "UnsetWebhookParams", "SetTags", "UnsetTags"))
 	})
 
-	t.Run("validation: exactly one field from [opts.Set opts.UnsetEmailParams opts.SetTags opts.UnsetTags] should be present - more present", func(t *testing.T) {
+	t.Run("validation: exactly one field from [opts.Set opts.UnsetEmailParams opts.UnsetWebhookParams opts.SetTags opts.UnsetTags] should be present - more present", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Set = &NotificationIntegrationSet{
 			Enabled: Bool(true),
@@ -216,22 +246,22 @@ func TestNotificationIntegrations_Alter(t *testing.T) {
 		opts.UnsetEmailParams = &NotificationIntegrationUnsetEmailParams{
 			Comment: Bool(true),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterNotificationIntegrationOptions", "Set", "UnsetEmailParams", "SetTags", "UnsetTags"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterNotificationIntegrationOptions", "Set", "UnsetEmailParams", "UnsetWebhookParams", "SetTags", "UnsetTags"))
 	})
 
-	t.Run("validation: conflicting fields for [opts.Set.SetPushParams opts.Set.SetEmailParams]", func(t *testing.T) {
+	t.Run("validation: conflicting fields for [opts.Set.SetPushParams opts.Set.SetEmailParams opts.Set.SetWebhookParams]", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Set = &NotificationIntegrationSet{
 			SetPushParams:  &SetPushParams{},
 			SetEmailParams: &SetEmailParams{},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errOneOf("AlterNotificationIntegrationOptions.Set", "SetPushParams", "SetEmailParams"))
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("AlterNotificationIntegrationOptions.Set", "SetPushParams", "SetEmailParams", "SetWebhookParams"))
 	})
 
-	t.Run("validation: at least one of the fields [opts.Set.Enabled opts.Set.SetPushParams opts.Set.SetEmailParams opts.Set.Comment] should be set", func(t *testing.T) {
+	t.Run("validation: at least one of the fields [opts.Set.Enabled opts.Set.SetPushParams opts.Set.SetEmailParams opts.Set.SetWebhookParams opts.Set.Comment] should be set", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Set = &NotificationIntegrationSet{}
-		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterNotificationIntegrationOptions.Set", "Enabled", "SetPushParams", "SetEmailParams", "Comment"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterNotificationIntegrationOptions.Set", "Enabled", "SetPushParams", "SetEmailParams", "SetWebhookParams", "Comment"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Set.SetPushParams.SetAmazonPush opts.Set.SetPushParams.SetGooglePush opts.Set.SetPushParams.SetAzurePush] should be present", func(t *testing.T) {
@@ -337,6 +367,33 @@ func TestNotificationIntegrations_Alter(t *testing.T) {
 			Comment: String("some comment"),
 		}
 		assertOptsValidAndSQLEquals(t, opts, "ALTER NOTIFICATION INTEGRATION %s SET ENABLED = true ALLOWED_RECIPIENTS = ('%s', '%s') COMMENT = 'some comment'", id.FullyQualifiedName(), email, otherEmail)
+	})
+
+	t.Run("set - webhook", func(t *testing.T) {
+		secretId := NewSchemaObjectIdentifier("metrics_catalog", "metric_config", "slack_integration_webhook")
+		opts := defaultOpts()
+		opts.Set = &NotificationIntegrationSet{
+			Enabled: Bool(true),
+			SetWebhookParams: &SetWebhookParams{
+				WebhookUrl: String(webhookUrl),
+				WebhookSecret: &WebhookSecretReference{SecretId: secretId},
+				WebhookBodyTemplate: String("SNOWFLAKE_WEBHOOK_MESSAGE"),
+				WebhookHeaders: []WebhookHeader{
+					{Header: "Content-Type", Value: "application/json"},
+				},
+			},
+			Comment: String("some comment"),
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER NOTIFICATION INTEGRATION %s SET ENABLED = true WEBHOOK_URL = '%s' WEBHOOK_SECRET = %s WEBHOOK_BODY_TEMPLATE = 'SNOWFLAKE_WEBHOOK_MESSAGE' WEBHOOK_HEADERS = ('Content-Type' = 'application/json') COMMENT = 'some comment'`, id.FullyQualifiedName(), webhookUrl, secretId.FullyQualifiedName())
+	})
+
+	t.Run("unset webhook", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.UnsetWebhookParams = &NotificationIntegrationUnsetWebhookParams{
+			WebhookSecret: Bool(true),
+			Comment:       Bool(true),
+		}
+		assertOptsValidAndSQLEquals(t, opts, "ALTER NOTIFICATION INTEGRATION %s UNSET WEBHOOK_SECRET, COMMENT", id.FullyQualifiedName())
 	})
 
 	t.Run("unset single", func(t *testing.T) {

--- a/pkg/sdk/notification_integrations_gen_test.go
+++ b/pkg/sdk/notification_integrations_gen_test.go
@@ -375,8 +375,8 @@ func TestNotificationIntegrations_Alter(t *testing.T) {
 		opts.Set = &NotificationIntegrationSet{
 			Enabled: Bool(true),
 			SetWebhookParams: &SetWebhookParams{
-				WebhookUrl: String(webhookUrl),
-				WebhookSecret: &secretId,
+				WebhookUrl:          String(webhookUrl),
+				WebhookSecret:       &secretId,
 				WebhookBodyTemplate: String("SNOWFLAKE_WEBHOOK_MESSAGE"),
 				WebhookHeaders: []WebhookHeader{
 					{Header: "Content-Type", Value: "application/json"},
@@ -390,10 +390,10 @@ func TestNotificationIntegrations_Alter(t *testing.T) {
 	t.Run("unset webhook", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.UnsetWebhookParams = &NotificationIntegrationUnsetWebhookParams{
-			WebhookSecret: Bool(true),
+			WebhookSecret:       Bool(true),
 			WebhookBodyTemplate: Bool(true),
-			WebhookHeaders: Bool(true),
-			Comment:       Bool(true),
+			WebhookHeaders:      Bool(true),
+			Comment:             Bool(true),
 		}
 		assertOptsValidAndSQLEquals(t, opts, "ALTER NOTIFICATION INTEGRATION %s UNSET WEBHOOK_SECRET, WEBHOOK_BODY_TEMPLATE, WEBHOOK_HEADERS, COMMENT", id.FullyQualifiedName())
 	})

--- a/pkg/sdk/notification_integrations_impl_gen.go
+++ b/pkg/sdk/notification_integrations_impl_gen.go
@@ -119,6 +119,23 @@ func (r *CreateNotificationIntegrationRequest) toOpts() *CreateNotificationInteg
 			AllowedRecipients: r.EmailParams.AllowedRecipients,
 		}
 	}
+	if r.WebhookParams != nil {
+		opts.WebhookParams = &WebhookParams{
+			WebhookUrl:          r.WebhookParams.WebhookUrl,
+			WebhookBodyTemplate: r.WebhookParams.WebhookBodyTemplate,
+		}
+		if r.WebhookParams.WebhookSecret != nil {
+			opts.WebhookParams.WebhookSecret = &WebhookSecretReference{
+				SecretId: *r.WebhookParams.WebhookSecret,
+			}
+		}
+		for _, h := range r.WebhookParams.WebhookHeaders {
+			opts.WebhookParams.WebhookHeaders = append(opts.WebhookParams.WebhookHeaders, WebhookHeader{
+				Header: h.Header,
+				Value:  h.Value,
+			})
+		}
+	}
 	return opts
 }
 
@@ -159,11 +176,36 @@ func (r *AlterNotificationIntegrationRequest) toOpts() *AlterNotificationIntegra
 				AllowedRecipients: r.Set.SetEmailParams.AllowedRecipients,
 			}
 		}
+		if r.Set.SetWebhookParams != nil {
+			opts.Set.SetWebhookParams = &SetWebhookParams{
+				WebhookUrl:          r.Set.SetWebhookParams.WebhookUrl,
+				WebhookBodyTemplate: r.Set.SetWebhookParams.WebhookBodyTemplate,
+			}
+			if r.Set.SetWebhookParams.WebhookSecret != nil {
+				opts.Set.SetWebhookParams.WebhookSecret = &WebhookSecretReference{
+					SecretId: *r.Set.SetWebhookParams.WebhookSecret,
+				}
+			}
+			for _, h := range r.Set.SetWebhookParams.WebhookHeaders {
+				opts.Set.SetWebhookParams.WebhookHeaders = append(opts.Set.SetWebhookParams.WebhookHeaders, WebhookHeader{
+					Header: h.Header,
+					Value:  h.Value,
+				})
+			}
+		}
 	}
 	if r.UnsetEmailParams != nil {
 		opts.UnsetEmailParams = &NotificationIntegrationUnsetEmailParams{
 			AllowedRecipients: r.UnsetEmailParams.AllowedRecipients,
 			Comment:           r.UnsetEmailParams.Comment,
+		}
+	}
+	if r.UnsetWebhookParams != nil {
+		opts.UnsetWebhookParams = &NotificationIntegrationUnsetWebhookParams{
+			WebhookSecret:       r.UnsetWebhookParams.WebhookSecret,
+			WebhookBodyTemplate: r.UnsetWebhookParams.WebhookBodyTemplate,
+			WebhookHeaders:      r.UnsetWebhookParams.WebhookHeaders,
+			Comment:             r.UnsetWebhookParams.Comment,
 		}
 	}
 	return opts

--- a/pkg/sdk/notification_integrations_impl_gen.go
+++ b/pkg/sdk/notification_integrations_impl_gen.go
@@ -122,12 +122,8 @@ func (r *CreateNotificationIntegrationRequest) toOpts() *CreateNotificationInteg
 	if r.WebhookParams != nil {
 		opts.WebhookParams = &WebhookParams{
 			WebhookUrl:          r.WebhookParams.WebhookUrl,
+			WebhookSecret:       r.WebhookParams.WebhookSecret,
 			WebhookBodyTemplate: r.WebhookParams.WebhookBodyTemplate,
-		}
-		if r.WebhookParams.WebhookSecret != nil {
-			opts.WebhookParams.WebhookSecret = &WebhookSecretReference{
-				SecretId: *r.WebhookParams.WebhookSecret,
-			}
 		}
 		for _, h := range r.WebhookParams.WebhookHeaders {
 			opts.WebhookParams.WebhookHeaders = append(opts.WebhookParams.WebhookHeaders, WebhookHeader{
@@ -179,12 +175,8 @@ func (r *AlterNotificationIntegrationRequest) toOpts() *AlterNotificationIntegra
 		if r.Set.SetWebhookParams != nil {
 			opts.Set.SetWebhookParams = &SetWebhookParams{
 				WebhookUrl:          r.Set.SetWebhookParams.WebhookUrl,
+				WebhookSecret:       r.Set.SetWebhookParams.WebhookSecret,
 				WebhookBodyTemplate: r.Set.SetWebhookParams.WebhookBodyTemplate,
-			}
-			if r.Set.SetWebhookParams.WebhookSecret != nil {
-				opts.Set.SetWebhookParams.WebhookSecret = &WebhookSecretReference{
-					SecretId: *r.Set.SetWebhookParams.WebhookSecret,
-				}
 			}
 			for _, h := range r.Set.SetWebhookParams.WebhookHeaders {
 				opts.Set.SetWebhookParams.WebhookHeaders = append(opts.Set.SetWebhookParams.WebhookHeaders, WebhookHeader{

--- a/pkg/sdk/notification_integrations_validations_gen.go
+++ b/pkg/sdk/notification_integrations_validations_gen.go
@@ -21,8 +21,8 @@ func (opts *CreateNotificationIntegrationOptions) validate() error {
 	if everyValueSet(opts.IfNotExists, opts.OrReplace) {
 		errs = append(errs, errOneOf("CreateNotificationIntegrationOptions", "IfNotExists", "OrReplace"))
 	}
-	if !exactlyOneValueSet(opts.AutomatedDataLoadsParams, opts.PushNotificationParams, opts.EmailParams) {
-		errs = append(errs, errExactlyOneOf("CreateNotificationIntegrationOptions", "AutomatedDataLoadsParams", "PushNotificationParams", "EmailParams"))
+	if !exactlyOneValueSet(opts.AutomatedDataLoadsParams, opts.PushNotificationParams, opts.EmailParams, opts.WebhookParams) {
+		errs = append(errs, errExactlyOneOf("CreateNotificationIntegrationOptions", "AutomatedDataLoadsParams", "PushNotificationParams", "EmailParams", "WebhookParams"))
 	}
 	if valueSet(opts.AutomatedDataLoadsParams) {
 		if !exactlyOneValueSet(opts.AutomatedDataLoadsParams.GoogleAutoParams, opts.AutomatedDataLoadsParams.AzureAutoParams) {
@@ -45,15 +45,15 @@ func (opts *AlterNotificationIntegrationOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.Set, opts.UnsetEmailParams, opts.SetTags, opts.UnsetTags) {
-		errs = append(errs, errExactlyOneOf("AlterNotificationIntegrationOptions", "Set", "UnsetEmailParams", "SetTags", "UnsetTags"))
+	if !exactlyOneValueSet(opts.Set, opts.UnsetEmailParams, opts.UnsetWebhookParams, opts.SetTags, opts.UnsetTags) {
+		errs = append(errs, errExactlyOneOf("AlterNotificationIntegrationOptions", "Set", "UnsetEmailParams", "UnsetWebhookParams", "SetTags", "UnsetTags"))
 	}
 	if valueSet(opts.Set) {
-		if everyValueSet(opts.Set.SetPushParams, opts.Set.SetEmailParams) {
-			errs = append(errs, errOneOf("AlterNotificationIntegrationOptions.Set", "SetPushParams", "SetEmailParams"))
+		if moreThanOneValueSet(opts.Set.SetPushParams, opts.Set.SetEmailParams, opts.Set.SetWebhookParams) {
+			errs = append(errs, errOneOf("AlterNotificationIntegrationOptions.Set", "SetPushParams", "SetEmailParams", "SetWebhookParams"))
 		}
-		if !anyValueSet(opts.Set.Enabled, opts.Set.SetPushParams, opts.Set.SetEmailParams, opts.Set.Comment) {
-			errs = append(errs, errAtLeastOneOf("AlterNotificationIntegrationOptions.Set", "Enabled", "SetPushParams", "SetEmailParams", "Comment"))
+		if !anyValueSet(opts.Set.Enabled, opts.Set.SetPushParams, opts.Set.SetEmailParams, opts.Set.SetWebhookParams, opts.Set.Comment) {
+			errs = append(errs, errAtLeastOneOf("AlterNotificationIntegrationOptions.Set", "Enabled", "SetPushParams", "SetEmailParams", "SetWebhookParams", "Comment"))
 		}
 		if valueSet(opts.Set.SetPushParams) {
 			if !exactlyOneValueSet(opts.Set.SetPushParams.SetAmazonPush, opts.Set.SetPushParams.SetGooglePush, opts.Set.SetPushParams.SetAzurePush) {
@@ -69,6 +69,11 @@ func (opts *AlterNotificationIntegrationOptions) validate() error {
 	if valueSet(opts.UnsetEmailParams) {
 		if !anyValueSet(opts.UnsetEmailParams.AllowedRecipients, opts.UnsetEmailParams.Comment) {
 			errs = append(errs, errAtLeastOneOf("AlterNotificationIntegrationOptions.UnsetEmailParams", "AllowedRecipients", "Comment"))
+		}
+	}
+	if valueSet(opts.UnsetWebhookParams) {
+		if !anyValueSet(opts.UnsetWebhookParams.WebhookSecret, opts.UnsetWebhookParams.WebhookBodyTemplate, opts.UnsetWebhookParams.WebhookHeaders, opts.UnsetWebhookParams.Comment) {
+			errs = append(errs, errAtLeastOneOf("AlterNotificationIntegrationOptions.UnsetWebhookParams", "WebhookSecret", "WebhookBodyTemplate", "WebhookHeaders", "Comment"))
 		}
 	}
 	return JoinErrors(errs...)

--- a/pkg/sdk/notification_integrations_validations_gen.go
+++ b/pkg/sdk/notification_integrations_validations_gen.go
@@ -49,6 +49,7 @@ func (opts *AlterNotificationIntegrationOptions) validate() error {
 		errs = append(errs, errExactlyOneOf("AlterNotificationIntegrationOptions", "Set", "UnsetEmailParams", "UnsetWebhookParams", "SetTags", "UnsetTags"))
 	}
 	if valueSet(opts.Set) {
+		// Adjusted manually: moreThanOneValueSet for 3+ conflicting fields (generator produces everyValueSet which only catches all-three-set)
 		if moreThanOneValueSet(opts.Set.SetPushParams, opts.Set.SetEmailParams, opts.Set.SetWebhookParams) {
 			errs = append(errs, errOneOf("AlterNotificationIntegrationOptions.Set", "SetPushParams", "SetEmailParams", "SetWebhookParams"))
 		}


### PR DESCRIPTION
## SDK support for `TYPE = WEBHOOK` notification integrations                                                           
                                                                                                                       
  Extends the notification integrations SDK layer to support `TYPE = WEBHOOK`, enabling `CREATE`, `ALTER SET`, and `ALTER 
  UNSET` operations for webhook-type notification integrations.
                                                                                                                          
  ---                                                       
                                                                                                                          
  **DDL structs (`_gen.go`)**                               
  - `WebhookParams` — `TYPE = WEBHOOK`, `WEBHOOK_URL`, optional `WEBHOOK_SECRET`, `WEBHOOK_BODY_TEMPLATE`,
  `WEBHOOK_HEADERS`
  - `WebhookSecretReference` — renders `WEBHOOK_SECRET = db.schema.name` using a `SchemaObjectIdentifier`
  - `WebhookHeader` — renders a single `'key' = 'value'` pair inside the `WEBHOOK_HEADERS` parenthesised list
  - `SetWebhookParams` — ALTER SET equivalent of the above
  - `NotificationIntegrationUnsetWebhookParams` — supports unsetting `WEBHOOK_SECRET`, `WEBHOOK_BODY_TEMPLATE`,
  `WEBHOOK_HEADERS`, and `COMMENT`

  **Request/builder layer (`_dto_gen.go`, `_dto_builders_gen.go`)**
  - `WebhookParamsRequest` / `NewWebhookParamsRequest(webhookUrl)`
  - `WebhookHeaderRequest` / `NewWebhookHeaderRequest(header, value)`
  - `SetWebhookParamsRequest` / `NewSetWebhookParamsRequest()`
  - `NotificationIntegrationUnsetWebhookParamsRequest`
  - Full fluent builder chain (`WithWebhookSecret`, `WithWebhookBodyTemplate`, `WithWebhookHeaders`, etc.)

  **`toOpts` wiring (`_impl_gen.go`)**
  Create and Alter requests map DTO fields to DDL options structs.

  **Validations (`_validations_gen.go`)**
  `WebhookParams` added to the `exactlyOneValueSet` check on Create; `SetWebhookParams` added to the SET conflict and
  `anyValueSet` checks on Alter; `UnsetWebhookParams` validation block added.

  **Unit tests (`_gen_test.go`)**
  SQL generation tests for minimal webhook CREATE, full CREATE (secret + headers + body template), `ALTER SET` webhook
  params, and `ALTER UNSET` webhook params.

  ---

  ## Test Plan

  * [x] Unit tests in `notification_integrations_gen_test.go` covering SQL generation for all new webhook DDL paths
  * [ ] Integration tests (covered in a follow-up PR against `pkg/sdk/testint/`)
  * [ ] Acceptance tests (covered in the resource PR)

  ## References

  * [Snowflake webhook notification integration
  docs](https://docs.snowflake.com/en/sql-reference/sql/create-notification-integration-webhooks)