### PR TITLE
fix: Fix nil pointer dereference panics in snowflake_account

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -26,6 +26,16 @@ for changes required after enabling given [Snowflake BCR Bundle](https://docs.sn
 
 ## v2.14.x ➞ v2.15.0
 
+### *(bug fix)* snowflake_account: fix nil pointer dereference panics
+
+Previously, the `snowflake_account` resource could panic with a nil pointer dereference in the following scenarios:
+- During **import**, if some fields (`edition`, `is_org_admin`, `consumption_billing_entity`) were not returned by `SHOW ACCOUNTS`.
+- During **read** (plan/apply), if the same fields were missing from the Snowflake response.
+
+These panics are now replaced with proper nil checks and error messages.
+
+References: [#4101](https://github.com/snowflakedb/terraform-provider-snowflake/issues/4101#issuecomment-4069319904).
+
 ### *(improvement)* Go driver bumped to v2
 
 There was a recent major release for the underlying Go Snowflake driver ([summary](https://github.com/snowflakedb/gosnowflake/issues/1586) and [v2.0.0 release notes](https://github.com/snowflakedb/gosnowflake/releases/tag/v2.0.0)). It introduced a few breaking changes but the provider adopted them in a non-breaking way - summary in the sections below. Keep in mind, that we will align the behavior with the driver in the next major release of the provider.

--- a/pkg/resources/account.go
+++ b/pkg/resources/account.go
@@ -211,12 +211,27 @@ func ImportAccount(ctx context.Context, d *schema.ResourceData, meta any) ([]*sc
 		comment = *account.Comment
 	}
 
+	var edition string
+	if account.Edition != nil {
+		edition = string(*account.Edition)
+	}
+
+	var isOrgAdmin string
+	if account.IsOrgAdmin != nil {
+		isOrgAdmin = booleanStringFromBool(*account.IsOrgAdmin)
+	}
+
+	var consumptionBillingEntity string
+	if account.ConsumptionBillingEntityName != nil {
+		consumptionBillingEntity = *account.ConsumptionBillingEntityName
+	}
+
 	if err := errors.Join(
-		d.Set("edition", string(*account.Edition)),
+		d.Set("edition", edition),
 		d.Set("region", account.SnowflakeRegion),
 		d.Set("comment", comment),
-		d.Set("is_org_admin", booleanStringFromBool(*account.IsOrgAdmin)),
-		d.Set("consumption_billing_entity", *account.ConsumptionBillingEntityName),
+		d.Set("is_org_admin", isOrgAdmin),
+		d.Set("consumption_billing_entity", consumptionBillingEntity),
 	); err != nil {
 		return nil, err
 	}
@@ -356,9 +371,19 @@ func ReadAccount(withExternalChangesMarking bool) schema.ReadContextFunc {
 				consumptionBillingEntityName = *account.ConsumptionBillingEntityName
 			}
 
+			var edition sdk.AccountEdition
+			if account.Edition != nil {
+				edition = *account.Edition
+			}
+
+			var isOrgAdmin bool
+			if account.IsOrgAdmin != nil {
+				isOrgAdmin = *account.IsOrgAdmin
+			}
+
 			if err = handleExternalChangesToObjectInShow(d,
-				outputMapping{"edition", "edition", *account.Edition, *account.Edition, nil},
-				outputMapping{"is_org_admin", "is_org_admin", *account.IsOrgAdmin, booleanStringFromBool(*account.IsOrgAdmin), nil},
+				outputMapping{"edition", "edition", edition, edition, nil},
+				outputMapping{"is_org_admin", "is_org_admin", isOrgAdmin, booleanStringFromBool(isOrgAdmin), nil},
 				outputMapping{"region_group", "region_group", regionGroup, regionGroup, nil},
 				outputMapping{"snowflake_region", "region", account.SnowflakeRegion, account.SnowflakeRegion, nil},
 				outputMapping{"comment", "comment", comment, comment, nil},

--- a/pkg/resources/external_volume.go
+++ b/pkg/resources/external_volume.go
@@ -771,6 +771,8 @@ func extractStorageLocations(v any) ([]sdk.ExternalVolumeStorageLocationItem, er
 					},
 				},
 			}
+		default:
+			return nil, fmt.Errorf("unsupported storage provider: %s", storageProvider)
 		}
 		storageLocations[i] = storageLocation
 	}
@@ -853,6 +855,8 @@ func addStorageLocation(
 			},
 		)
 		newStorageLocationreq = sdk.NewExternalVolumeStorageLocationRequest(addedLocationItem.ExternalVolumeStorageLocation.Name).WithS3CompatStorageLocationParams(*s3CompatParamsRequest)
+	default:
+		return fmt.Errorf("unsupported storage provider: %s", storageProvider)
 	}
 
 	return client.ExternalVolumes.Alter(ctx, sdk.NewAlterExternalVolumeRequest(id).WithAddStorageLocation(sdk.ExternalVolumeStorageLocationItemRequest{ExternalVolumeStorageLocation: *newStorageLocationreq}))

--- a/pkg/testacc/resource_external_volume_acceptance_test.go
+++ b/pkg/testacc/resource_external_volume_acceptance_test.go
@@ -2795,7 +2795,7 @@ func TestAcc_ExternalVolume_Validations(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
-		CheckDestroy: CheckDestroy(t, resources.Warehouse),
+		CheckDestroy: CheckDestroy(t, resources.ExternalVolume),
 		Steps: []resource.TestStep{
 			// invalid storage provider test
 			{


### PR DESCRIPTION
## Summary
- **snowflake_account**: Fix nil pointer dereference panics during import and read when `Edition`, `IsOrgAdmin`, or `ConsumptionBillingEntityName` fields are not returned by `SHOW ACCOUNTS`. Adds proper nil checks before dereferencing these pointer fields.
- **snowflake_external_volume**: Add missing `default` cases in storage provider `switch` statements in `extractStorageLocations` and `addStorageLocation` to return explicit errors for unsupported providers instead of silently ignoring them. This shouldn't break any behaviors, as we already support all provider types.
- **Test fix**: Correct `CheckDestroy` in `TestAcc_ExternalVolume_Validations` from `resources.Warehouse` to `resources.ExternalVolume`.
- Note: this PR doesn't have acceptance tests, similarly to https://github.com/snowflakedb/terraform-provider-snowflake/pull/4105. The reason is SHOW returns always these values in our environments. They are dependend on internal Snowflake behavior/parameters. I ran the current account acceptance tests locally, and they passed.

References: [#4101 (comment)](https://github.com/snowflakedb/terraform-provider-snowflake/issues/4101#issuecomment-4069319904)