### PR TITLE
fix: Add IMPORT_BOOLEAN_DEFAULT experiment to fix post-import permadiff on stage resources

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -63,6 +63,20 @@ Other than that, no configuration changes are necessary.
 
 References: [#4557](https://github.com/snowflakedb/terraform-provider-snowflake/issues/4557)
 
+### *(bugfix)* Importing boolean fields in stage resources
+
+When importing stage resources (`snowflake_stage_external_s3`, `snowflake_stage_external_azure`, `snowflake_stage_external_gcs`, `snowflake_stage_external_s3_compatible`, and `snowflake_stage_internal`), boolean fields like `auto_refresh`, `trim_space`, `skip_blank_lines`, etc. were set to the actual Snowflake value (e.g., `"false"`) instead of the schema default `"default"`. This caused an unavoidable diff on every `terraform plan` after import. Some of these fields are mutually exclusive with others, so they can't be set in the configuration to match the actual value in Snowflake.
+
+To fix this, we introduce the new `IMPORT_BOOLEAN_DEFAULT` experiment. The fix is enabled by such flag because the import behavior differs from other resources.
+
+When this experiment is enabled, boolean fields that use special default values are set to `"default"` during import, preventing the persistent plan diff.
+
+To use this feature, add `IMPORT_BOOLEAN_DEFAULT` to the `experimental_features_enabled` field in the provider configuration.
+
+Without the flag enabled, the behavior remains the same as in previous versions.
+
+References: [#4549](https://github.com/snowflakedb/terraform-provider-snowflake/issues/4549).
+
 ## v2.13.x ➞ v2.14.0
 
 ### *(new feature)* Added `DECFLOAT` support

--- a/docs/index.md
+++ b/docs/index.md
@@ -123,7 +123,7 @@ provider "snowflake" {
 - `disable_telemetry` (Boolean) Disables telemetry in the driver. Can also be sourced from the `DISABLE_TELEMETRY` environment variable.
 - `driver_tracing` (String) Specifies the logging level to be used by the driver. Valid options are: `trace` | `debug` | `info` | `print` | `warning` | `error` | `fatal` | `panic`. Can also be sourced from the `SNOWFLAKE_DRIVER_TRACING` environment variable.
 - `enable_single_use_refresh_tokens` (Boolean) Enables single use refresh tokens for Snowflake IdP. Can also be sourced from the `SNOWFLAKE_ENABLE_SINGLE_USE_REFRESH_TOKENS` environment variable.
-- `experimental_features_enabled` (Set of String) A list of experimental features. Similarly to preview features, they are not yet stable features of the provider. Enabling given experiment is still considered a preview feature, even when applied to the stable resource. These switches offer experiments altering the provider behavior. If the given experiment is successful, it can be considered an addition in the future provider versions. This field can not be set with environmental variables. Check more details in the [experimental features section](#experimental-features). Active experiments are: `WAREHOUSE_SHOW_IMPROVED_PERFORMANCE` | `GRANTS_STRICT_PRIVILEGE_MANAGEMENT` | `PARAMETERS_IGNORE_VALUE_CHANGES_IF_NOT_ON_OBJECT_LEVEL` | `PARAMETERS_REDUCED_OUTPUT` | `USER_ENABLE_DEFAULT_WORKLOAD_IDENTITY` | `GRANTS_IMPORT_VALIDATION`.
+- `experimental_features_enabled` (Set of String) A list of experimental features. Similarly to preview features, they are not yet stable features of the provider. Enabling given experiment is still considered a preview feature, even when applied to the stable resource. These switches offer experiments altering the provider behavior. If the given experiment is successful, it can be considered an addition in the future provider versions. This field can not be set with environmental variables. Check more details in the [experimental features section](#experimental-features). Active experiments are: `WAREHOUSE_SHOW_IMPROVED_PERFORMANCE` | `GRANTS_STRICT_PRIVILEGE_MANAGEMENT` | `PARAMETERS_IGNORE_VALUE_CHANGES_IF_NOT_ON_OBJECT_LEVEL` | `PARAMETERS_REDUCED_OUTPUT` | `USER_ENABLE_DEFAULT_WORKLOAD_IDENTITY` | `GRANTS_IMPORT_VALIDATION` | `IMPORT_BOOLEAN_DEFAULT`.
 - `external_browser_timeout` (Number) The timeout in seconds for the external browser to complete the authentication. Can also be sourced from the `SNOWFLAKE_EXTERNAL_BROWSER_TIMEOUT` environment variable.
 - `host` (String) Specifies a custom host value used by the driver for privatelink connections. Can also be sourced from the `SNOWFLAKE_HOST` environment variable.
 - `include_retry_reason` (String) Should retried request contain retry reason. Can also be sourced from the `SNOWFLAKE_INCLUDE_RETRY_REASON` environment variable.
@@ -949,3 +949,10 @@ Enables import validation for the `snowflake_grant_privileges_to_account_role` r
 When enabled, importing a grant resource with a fixed set of privileges (`privileges` field) will validate that the specified privileges actually exist in Snowflake with the correct `with_grant_option` setting, and error immediately if they don't match.
 
 This feature works independently of the `GRANTS_STRICT_PRIVILEGE_MANAGEMENT` flag.
+
+#### IMPORT_BOOLEAN_DEFAULT
+Changes import behavior for fields using special default values, like "default" or -1.
+
+When enabled, fields using special default values are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`). This prevents unavoidable diffs on every plan after import.
+
+Note: this is supported only on all stage resources (`snowflake_stage_external_s3`, `snowflake_stage_external_azure`, `snowflake_stage_external_gcs`, `snowflake_stage_external_s3_compatible`, and `snowflake_stage_internal`).

--- a/docs/index.md
+++ b/docs/index.md
@@ -951,8 +951,8 @@ When enabled, importing a grant resource with a fixed set of privileges (`privil
 This feature works independently of the `GRANTS_STRICT_PRIVILEGE_MANAGEMENT` flag.
 
 #### IMPORT_BOOLEAN_DEFAULT
-Changes import behavior for fields using special default values, like "default" or -1.
+Changes import behavior for boolean fields using the special `"default"` value.
 
-When enabled, fields using special default values are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`). This prevents unavoidable diffs on every plan after import.
+When enabled, boolean fields using the special `"default"` value are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`). This prevents unavoidable diffs on every plan after import.
 
 Note: this is supported only on all stage resources (`snowflake_stage_external_s3`, `snowflake_stage_external_azure`, `snowflake_stage_external_gcs`, `snowflake_stage_external_s3_compatible`, and `snowflake_stage_internal`).

--- a/docs/resources/stage_external_azure.md
+++ b/docs/resources/stage_external_azure.md
@@ -13,7 +13,7 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
-~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # snowflake_stage_external_azure (Resource)
 

--- a/docs/resources/stage_external_azure.md
+++ b/docs/resources/stage_external_azure.md
@@ -13,6 +13,8 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
+~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+
 # snowflake_stage_external_azure (Resource)
 
 Resource used to manage external Azure stages. For more information, check [external stage documentation](https://docs.snowflake.com/en/sql-reference/sql/create-stage#external-stage-parameters-externalstageparams).

--- a/docs/resources/stage_external_azure.md
+++ b/docs/resources/stage_external_azure.md
@@ -13,7 +13,7 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
-~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) and reimport the resource for the fix to take effect. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # snowflake_stage_external_azure (Resource)
 

--- a/docs/resources/stage_external_gcs.md
+++ b/docs/resources/stage_external_gcs.md
@@ -13,7 +13,7 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
-~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # snowflake_stage_external_gcs (Resource)
 

--- a/docs/resources/stage_external_gcs.md
+++ b/docs/resources/stage_external_gcs.md
@@ -13,7 +13,7 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
-~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) and reimport the resource for the fix to take effect. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # snowflake_stage_external_gcs (Resource)
 

--- a/docs/resources/stage_external_gcs.md
+++ b/docs/resources/stage_external_gcs.md
@@ -13,6 +13,8 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
+~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+
 # snowflake_stage_external_gcs (Resource)
 
 Resource used to manage external GCS stages. For more information, check [external stage documentation](https://docs.snowflake.com/en/sql-reference/sql/create-stage#external-stage-parameters-externalstageparams).

--- a/docs/resources/stage_external_s3.md
+++ b/docs/resources/stage_external_s3.md
@@ -17,7 +17,7 @@ description: |-
 
 -> **Note** This resource is meant only for S3 stages, not S3-compatible stages. For S3-compatible stages, use the `snowflake_stage_external_s3_compatible` resource instead. Do not use this resource with `s3compat://` URLs.
 
-~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) and reimport the resource for the fix to take effect. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # snowflake_stage_external_s3 (Resource)
 

--- a/docs/resources/stage_external_s3.md
+++ b/docs/resources/stage_external_s3.md
@@ -17,6 +17,8 @@ description: |-
 
 -> **Note** This resource is meant only for S3 stages, not S3-compatible stages. For S3-compatible stages, use the `snowflake_stage_external_s3_compatible` resource instead. Do not use this resource with `s3compat://` URLs.
 
+~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+
 # snowflake_stage_external_s3 (Resource)
 
 Resource used to manage external S3 stages. For more information, check [external stage documentation](https://docs.snowflake.com/en/sql-reference/sql/create-stage#external-stage-parameters-externalstageparams).

--- a/docs/resources/stage_external_s3.md
+++ b/docs/resources/stage_external_s3.md
@@ -17,7 +17,7 @@ description: |-
 
 -> **Note** This resource is meant only for S3 stages, not S3-compatible stages. For S3-compatible stages, use the `snowflake_stage_external_s3_compatible` resource instead. Do not use this resource with `s3compat://` URLs.
 
-~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # snowflake_stage_external_s3 (Resource)
 

--- a/docs/resources/stage_external_s3_compatible.md
+++ b/docs/resources/stage_external_s3_compatible.md
@@ -15,7 +15,7 @@ description: |-
 
 -> **Note** This resource is meant only for S3-compatible stages, not S3 stages. For S3 stages, use the `snowflake_stage_external_s3` resource instead. Do not use this resource with `s3://` URLs.
 
-~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) and reimport the resource for the fix to take effect. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # snowflake_stage_external_s3_compatible (Resource)
 

--- a/docs/resources/stage_external_s3_compatible.md
+++ b/docs/resources/stage_external_s3_compatible.md
@@ -15,7 +15,7 @@ description: |-
 
 -> **Note** This resource is meant only for S3-compatible stages, not S3 stages. For S3 stages, use the `snowflake_stage_external_s3` resource instead. Do not use this resource with `s3://` URLs.
 
-~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # snowflake_stage_external_s3_compatible (Resource)
 

--- a/docs/resources/stage_external_s3_compatible.md
+++ b/docs/resources/stage_external_s3_compatible.md
@@ -15,6 +15,8 @@ description: |-
 
 -> **Note** This resource is meant only for S3-compatible stages, not S3 stages. For S3 stages, use the `snowflake_stage_external_s3` resource instead. Do not use this resource with `s3://` URLs.
 
+~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+
 # snowflake_stage_external_s3_compatible (Resource)
 
 Resource used to manage external S3-compatible stages. For more information, check [external stage documentation](https://docs.snowflake.com/en/sql-reference/sql/create-stage#external-stage-parameters-externalstageparams).

--- a/docs/resources/stage_internal.md
+++ b/docs/resources/stage_internal.md
@@ -13,7 +13,7 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
-~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # snowflake_stage_internal (Resource)
 

--- a/docs/resources/stage_internal.md
+++ b/docs/resources/stage_internal.md
@@ -13,7 +13,7 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
-~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) and reimport the resource for the fix to take effect. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # snowflake_stage_internal (Resource)
 

--- a/docs/resources/stage_internal.md
+++ b/docs/resources/stage_internal.md
@@ -13,6 +13,8 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
+~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+
 # snowflake_stage_internal (Resource)
 
 Resource used to manage internal stages. For more information, check [internal stage documentation](https://docs.snowflake.com/en/sql-reference/sql/create-stage#internal-stage-parameters-internalstageparams).

--- a/examples/additional/experimental_features.MD
+++ b/examples/additional/experimental_features.MD
@@ -51,3 +51,4 @@ When enabled, boolean fields using the special `"default"` value are set to `"de
 
 Note: this is supported only on all stage resources (`snowflake_stage_external_s3`, `snowflake_stage_external_azure`, `snowflake_stage_external_gcs`, `snowflake_stage_external_s3_compatible`, and `snowflake_stage_internal`).
 
+

--- a/examples/additional/experimental_features.MD
+++ b/examples/additional/experimental_features.MD
@@ -45,9 +45,9 @@ When enabled, importing a grant resource with a fixed set of privileges (`privil
 This feature works independently of the `GRANTS_STRICT_PRIVILEGE_MANAGEMENT` flag.
 
 #### IMPORT_BOOLEAN_DEFAULT
-Changes import behavior for fields using special default values, like "default" or -1.
+Changes import behavior for boolean fields using the special `"default"` value.
 
-When enabled, fields using special default values are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`). This prevents unavoidable diffs on every plan after import.
+When enabled, boolean fields using the special `"default"` value are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`). This prevents unavoidable diffs on every plan after import.
 
 Note: this is supported only on all stage resources (`snowflake_stage_external_s3`, `snowflake_stage_external_azure`, `snowflake_stage_external_gcs`, `snowflake_stage_external_s3_compatible`, and `snowflake_stage_internal`).
 

--- a/examples/additional/experimental_features.MD
+++ b/examples/additional/experimental_features.MD
@@ -44,4 +44,10 @@ When enabled, importing a grant resource with a fixed set of privileges (`privil
 
 This feature works independently of the `GRANTS_STRICT_PRIVILEGE_MANAGEMENT` flag.
 
+#### IMPORT_BOOLEAN_DEFAULT
+Changes import behavior for fields using special default values, like "default" or -1.
+
+When enabled, fields using special default values are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`). This prevents unavoidable diffs on every plan after import.
+
+Note: this is supported only on all stage resources (`snowflake_stage_external_s3`, `snowflake_stage_external_azure`, `snowflake_stage_external_gcs`, `snowflake_stage_external_s3_compatible`, and `snowflake_stage_internal`).
 

--- a/pkg/provider/experimentalfeatures/experimental_features.go
+++ b/pkg/provider/experimentalfeatures/experimental_features.go
@@ -101,8 +101,8 @@ var allExperiments = []Experiment{
 		ImportBooleanDefault,
 		ExperimentalFeatureStateActive,
 		joinWithDoubleNewline(
-			"Changes import behavior for fields using special default values, like \"default\" or -1.",
-			"When enabled, fields using special default values are set to `\"default\"` during import instead of the actual Snowflake value (e.g., `\"false\"`). This prevents unavoidable diffs on every plan after import.",
+			"Changes import behavior for boolean fields using the special `\"default\"` value.",
+			"When enabled, boolean fields using the special `\"default\"` value are set to `\"default\"` during import instead of the actual Snowflake value (e.g., `\"false\"`). This prevents unavoidable diffs on every plan after import.",
 			"Note: this is supported only on all stage resources (`snowflake_stage_external_s3`, `snowflake_stage_external_azure`, `snowflake_stage_external_gcs`, `snowflake_stage_external_s3_compatible`, and `snowflake_stage_internal`).",
 		),
 	},

--- a/pkg/provider/experimentalfeatures/experimental_features.go
+++ b/pkg/provider/experimentalfeatures/experimental_features.go
@@ -103,7 +103,7 @@ var allExperiments = []Experiment{
 		joinWithDoubleNewline(
 			"Changes import behavior for fields using special default values, like \"default\" or -1.",
 			"When enabled, fields using special default values are set to `\"default\"` during import instead of the actual Snowflake value (e.g., `\"false\"`). This prevents unavoidable diffs on every plan after import.",
-			"Currently only affects JSON file format fields and `use_privatelink_endpoint` on `snowflake_stage_external_s3`.",
+			"Note: this is supported only on all stage resources (`snowflake_stage_external_s3`, `snowflake_stage_external_azure`, `snowflake_stage_external_gcs`, `snowflake_stage_external_s3_compatible`, and `snowflake_stage_internal`).",
 		),
 	},
 }

--- a/pkg/provider/experimentalfeatures/experimental_features.go
+++ b/pkg/provider/experimentalfeatures/experimental_features.go
@@ -19,6 +19,7 @@ const (
 	GrantsImportValidation                         ExperimentalFeature = "GRANTS_IMPORT_VALIDATION"
 	// TODO [SNOW-2739299]: Discuss having an additional ParametersNoOutput experiment
 	ParametersReducedOutput ExperimentalFeature = "PARAMETERS_REDUCED_OUTPUT"
+	ImportBooleanDefault    ExperimentalFeature = "IMPORT_BOOLEAN_DEFAULT"
 )
 
 type experimentalFeatureState string
@@ -94,6 +95,15 @@ var allExperiments = []Experiment{
 			"Enables import validation for the `snowflake_grant_privileges_to_account_role` resource.",
 			"When enabled, importing a grant resource with a fixed set of privileges (`privileges` field) will validate that the specified privileges actually exist in Snowflake with the correct `with_grant_option` setting, and error immediately if they don't match.",
 			fmt.Sprintf("This feature works independently of the `%s` flag.", GrantsStrictPrivilegeManagement),
+		),
+	},
+	{
+		ImportBooleanDefault,
+		ExperimentalFeatureStateActive,
+		joinWithDoubleNewline(
+			"Changes import behavior for fields using special default values, like \"default\" or -1.",
+			"When enabled, fields using special default values are set to `\"default\"` during import instead of the actual Snowflake value (e.g., `\"false\"`). This prevents unavoidable diffs on every plan after import.",
+			"Currently only affects JSON file format fields and `use_privatelink_endpoint` on `snowflake_stage_external_s3`.",
 		),
 	},
 }

--- a/pkg/resources/external_azure_stage.go
+++ b/pkg/resources/external_azure_stage.go
@@ -225,7 +225,7 @@ func ImportExternalAzureStage(ctx context.Context, d *schema.ResourceData, meta 
 	if err := d.Set("url", stage.Url); err != nil {
 		return nil, err
 	}
-	if fileFormat := stageFileFormatToSchema(details); fileFormat != nil {
+	if fileFormat := stageFileFormatToSchema(details, false); fileFormat != nil {
 		if err := d.Set("file_format", fileFormat); err != nil {
 			return nil, err
 		}

--- a/pkg/resources/external_azure_stage.go
+++ b/pkg/resources/external_azure_stage.go
@@ -186,43 +186,38 @@ func ExternalAzureStage() *schema.Resource {
 }
 
 func ImportExternalAzureStage(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+		return nil, err
+	}
+
 	providerCtx := meta.(*provider.Context)
 	client := providerCtx.Client
+
 	id, err := sdk.ParseSchemaObjectIdentifier(d.Id())
 	if err != nil {
 		return nil, err
 	}
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
-		return nil, err
-	}
+
 	stage, err := client.Stages.ShowByIDSafely(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	stageDetails, err := client.Stages.Describe(ctx, id)
+	stageProperties, err := client.Stages.Describe(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	details, err := sdk.ParseStageDetails(stageDetails)
+	details, err := sdk.ParseStageDetails(stageProperties)
 	if err != nil {
 		return nil, err
 	}
+
 	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
-	if details.DirectoryTable != nil {
-		autoRefreshValue := booleanStringFromBool(details.DirectoryTable.AutoRefresh)
-		if setDefaults {
-			autoRefreshValue = BooleanDefault
-		}
-		if err := d.Set("directory", []map[string]any{
-			{
-				"enable":       details.DirectoryTable.Enable,
-				"auto_refresh": autoRefreshValue,
-			},
-		}); err != nil {
-			return nil, err
-		}
+
+	if err := importStageCommonFields(d, details, setDefaults); err != nil {
+		return nil, err
 	}
+
 	if details.PrivateLink != nil {
 		usePrivatelinkEndpointValue := booleanStringFromBool(details.PrivateLink.UsePrivatelinkEndpoint)
 		if setDefaults {
@@ -235,11 +230,6 @@ func ImportExternalAzureStage(ctx context.Context, d *schema.ResourceData, meta 
 	// If PrivateLink is nil, let the schema default (BooleanDefault) apply
 	if err := d.Set("url", stage.Url); err != nil {
 		return nil, err
-	}
-	if fileFormat := stageFileFormatToSchema(details, setDefaults); fileFormat != nil {
-		if err := d.Set("file_format", fileFormat); err != nil {
-			return nil, err
-		}
 	}
 	if stage.StorageIntegration != nil {
 		if err := d.Set("storage_integration", stage.StorageIntegration.Name()); err != nil {

--- a/pkg/resources/external_azure_stage.go
+++ b/pkg/resources/external_azure_stage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/previewfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -185,7 +186,8 @@ func ExternalAzureStage() *schema.Resource {
 }
 
 func ImportExternalAzureStage(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	client := meta.(*provider.Context).Client
+	providerCtx := meta.(*provider.Context)
+	client := providerCtx.Client
 	id, err := sdk.ParseSchemaObjectIdentifier(d.Id())
 	if err != nil {
 		return nil, err
@@ -206,18 +208,27 @@ func ImportExternalAzureStage(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		return nil, err
 	}
+	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
 	if details.DirectoryTable != nil {
+		autoRefreshValue := booleanStringFromBool(details.DirectoryTable.AutoRefresh)
+		if setDefaults {
+			autoRefreshValue = BooleanDefault
+		}
 		if err := d.Set("directory", []map[string]any{
 			{
 				"enable":       details.DirectoryTable.Enable,
-				"auto_refresh": booleanStringFromBool(details.DirectoryTable.AutoRefresh),
+				"auto_refresh": autoRefreshValue,
 			},
 		}); err != nil {
 			return nil, err
 		}
 	}
 	if details.PrivateLink != nil {
-		if err := d.Set("use_privatelink_endpoint", booleanStringFromBool(details.PrivateLink.UsePrivatelinkEndpoint)); err != nil {
+		usePrivatelinkEndpointValue := booleanStringFromBool(details.PrivateLink.UsePrivatelinkEndpoint)
+		if setDefaults {
+			usePrivatelinkEndpointValue = BooleanDefault
+		}
+		if err := d.Set("use_privatelink_endpoint", usePrivatelinkEndpointValue); err != nil {
 			return nil, err
 		}
 	}
@@ -225,7 +236,7 @@ func ImportExternalAzureStage(ctx context.Context, d *schema.ResourceData, meta 
 	if err := d.Set("url", stage.Url); err != nil {
 		return nil, err
 	}
-	if fileFormat := stageFileFormatToSchema(details, false); fileFormat != nil {
+	if fileFormat := stageFileFormatToSchema(details, setDefaults); fileFormat != nil {
 		if err := d.Set("file_format", fileFormat); err != nil {
 			return nil, err
 		}

--- a/pkg/resources/external_gcs_stage.go
+++ b/pkg/resources/external_gcs_stage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/previewfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -154,7 +155,8 @@ func ExternalGcsStage() *schema.Resource {
 }
 
 func ImportExternalGcsStage(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	client := meta.(*provider.Context).Client
+	providerCtx := meta.(*provider.Context)
+	client := providerCtx.Client
 	id, err := sdk.ParseSchemaObjectIdentifier(d.Id())
 	if err != nil {
 		return nil, err
@@ -175,17 +177,22 @@ func ImportExternalGcsStage(ctx context.Context, d *schema.ResourceData, meta an
 	if err != nil {
 		return nil, err
 	}
+	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
 	if details.DirectoryTable != nil {
+		autoRefreshValue := booleanStringFromBool(details.DirectoryTable.AutoRefresh)
+		if setDefaults {
+			autoRefreshValue = BooleanDefault
+		}
 		if err := d.Set("directory", []map[string]any{
 			{
 				"enable":       details.DirectoryTable.Enable,
-				"auto_refresh": booleanStringFromBool(details.DirectoryTable.AutoRefresh),
+				"auto_refresh": autoRefreshValue,
 			},
 		}); err != nil {
 			return nil, err
 		}
 	}
-	if fileFormat := stageFileFormatToSchema(details, false); fileFormat != nil {
+	if fileFormat := stageFileFormatToSchema(details, setDefaults); fileFormat != nil {
 		if err := d.Set("file_format", fileFormat); err != nil {
 			return nil, err
 		}

--- a/pkg/resources/external_gcs_stage.go
+++ b/pkg/resources/external_gcs_stage.go
@@ -155,48 +155,38 @@ func ExternalGcsStage() *schema.Resource {
 }
 
 func ImportExternalGcsStage(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+		return nil, err
+	}
+
 	providerCtx := meta.(*provider.Context)
 	client := providerCtx.Client
+
 	id, err := sdk.ParseSchemaObjectIdentifier(d.Id())
 	if err != nil {
 		return nil, err
 	}
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
-		return nil, err
-	}
+
 	stage, err := client.Stages.ShowByIDSafely(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	stageDetails, err := client.Stages.Describe(ctx, id)
+	stageProperties, err := client.Stages.Describe(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	details, err := sdk.ParseStageDetails(stageDetails)
+	details, err := sdk.ParseStageDetails(stageProperties)
 	if err != nil {
 		return nil, err
 	}
+
 	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
-	if details.DirectoryTable != nil {
-		autoRefreshValue := booleanStringFromBool(details.DirectoryTable.AutoRefresh)
-		if setDefaults {
-			autoRefreshValue = BooleanDefault
-		}
-		if err := d.Set("directory", []map[string]any{
-			{
-				"enable":       details.DirectoryTable.Enable,
-				"auto_refresh": autoRefreshValue,
-			},
-		}); err != nil {
-			return nil, err
-		}
+
+	if err := importStageCommonFields(d, details, setDefaults); err != nil {
+		return nil, err
 	}
-	if fileFormat := stageFileFormatToSchema(details, setDefaults); fileFormat != nil {
-		if err := d.Set("file_format", fileFormat); err != nil {
-			return nil, err
-		}
-	}
+
 	if err := d.Set("url", stage.Url); err != nil {
 		return nil, err
 	}

--- a/pkg/resources/external_gcs_stage.go
+++ b/pkg/resources/external_gcs_stage.go
@@ -185,7 +185,7 @@ func ImportExternalGcsStage(ctx context.Context, d *schema.ResourceData, meta an
 			return nil, err
 		}
 	}
-	if fileFormat := stageFileFormatToSchema(details); fileFormat != nil {
+	if fileFormat := stageFileFormatToSchema(details, false); fileFormat != nil {
 		if err := d.Set("file_format", fileFormat); err != nil {
 			return nil, err
 		}

--- a/pkg/resources/external_s3_compatible_stage.go
+++ b/pkg/resources/external_s3_compatible_stage.go
@@ -138,53 +138,43 @@ func ExternalS3CompatibleStage() *schema.Resource {
 }
 
 func ImportExternalS3CompatStage(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+		return nil, err
+	}
+
 	providerCtx := meta.(*provider.Context)
 	client := providerCtx.Client
+
 	id, err := sdk.ParseSchemaObjectIdentifier(d.Id())
 	if err != nil {
 		return nil, err
 	}
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
-		return nil, err
-	}
+
 	stage, err := client.Stages.ShowByIDSafely(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	stageDetails, err := client.Stages.Describe(ctx, id)
+	stageProperties, err := client.Stages.Describe(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	details, err := sdk.ParseStageDetails(stageDetails)
+	details, err := sdk.ParseStageDetails(stageProperties)
 	if err != nil {
 		return nil, err
 	}
+
 	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
-	if details.DirectoryTable != nil {
-		autoRefreshValue := booleanStringFromBool(details.DirectoryTable.AutoRefresh)
-		if setDefaults {
-			autoRefreshValue = BooleanDefault
-		}
-		if err := d.Set("directory", []map[string]any{
-			{
-				"enable":       details.DirectoryTable.Enable,
-				"auto_refresh": autoRefreshValue,
-			},
-		}); err != nil {
-			return nil, err
-		}
+
+	if err := importStageCommonFields(d, details, setDefaults); err != nil {
+		return nil, err
 	}
+
 	if err := d.Set("url", stage.Url); err != nil {
 		return nil, err
 	}
 	if stage.Endpoint != nil {
 		if err := d.Set("endpoint", *stage.Endpoint); err != nil {
-			return nil, err
-		}
-	}
-	if fileFormat := stageFileFormatToSchema(details, setDefaults); fileFormat != nil {
-		if err := d.Set("file_format", fileFormat); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/resources/external_s3_compatible_stage.go
+++ b/pkg/resources/external_s3_compatible_stage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/previewfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -137,7 +138,8 @@ func ExternalS3CompatibleStage() *schema.Resource {
 }
 
 func ImportExternalS3CompatStage(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	client := meta.(*provider.Context).Client
+	providerCtx := meta.(*provider.Context)
+	client := providerCtx.Client
 	id, err := sdk.ParseSchemaObjectIdentifier(d.Id())
 	if err != nil {
 		return nil, err
@@ -158,11 +160,16 @@ func ImportExternalS3CompatStage(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		return nil, err
 	}
+	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
 	if details.DirectoryTable != nil {
+		autoRefreshValue := booleanStringFromBool(details.DirectoryTable.AutoRefresh)
+		if setDefaults {
+			autoRefreshValue = BooleanDefault
+		}
 		if err := d.Set("directory", []map[string]any{
 			{
 				"enable":       details.DirectoryTable.Enable,
-				"auto_refresh": booleanStringFromBool(details.DirectoryTable.AutoRefresh),
+				"auto_refresh": autoRefreshValue,
 			},
 		}); err != nil {
 			return nil, err
@@ -176,7 +183,7 @@ func ImportExternalS3CompatStage(ctx context.Context, d *schema.ResourceData, me
 			return nil, err
 		}
 	}
-	if fileFormat := stageFileFormatToSchema(details, false); fileFormat != nil {
+	if fileFormat := stageFileFormatToSchema(details, setDefaults); fileFormat != nil {
 		if err := d.Set("file_format", fileFormat); err != nil {
 			return nil, err
 		}

--- a/pkg/resources/external_s3_compatible_stage.go
+++ b/pkg/resources/external_s3_compatible_stage.go
@@ -176,7 +176,7 @@ func ImportExternalS3CompatStage(ctx context.Context, d *schema.ResourceData, me
 			return nil, err
 		}
 	}
-	if fileFormat := stageFileFormatToSchema(details); fileFormat != nil {
+	if fileFormat := stageFileFormatToSchema(details, false); fileFormat != nil {
 		if err := d.Set("file_format", fileFormat); err != nil {
 			return nil, err
 		}

--- a/pkg/resources/external_s3_stage.go
+++ b/pkg/resources/external_s3_stage.go
@@ -237,48 +237,38 @@ func ExternalS3Stage() *schema.Resource {
 }
 
 func ImportExternalS3Stage(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+		return nil, err
+	}
+
 	providerCtx := meta.(*provider.Context)
 	client := providerCtx.Client
+
 	id, err := sdk.ParseSchemaObjectIdentifier(d.Id())
 	if err != nil {
 		return nil, err
 	}
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
-		return nil, err
-	}
+
 	stage, err := client.Stages.ShowByIDSafely(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	stageDetails, err := client.Stages.Describe(ctx, id)
+	stageProperties, err := client.Stages.Describe(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	details, err := sdk.ParseStageDetails(stageDetails)
+	details, err := sdk.ParseStageDetails(stageProperties)
 	if err != nil {
 		return nil, err
 	}
+
 	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
-	if details.DirectoryTable != nil {
-		autoRefreshValue := booleanStringFromBool(details.DirectoryTable.AutoRefresh)
-		if setDefaults {
-			autoRefreshValue = BooleanDefault
-		}
-		if err := d.Set("directory", []map[string]any{
-			{
-				"enable":       details.DirectoryTable.Enable,
-				"auto_refresh": autoRefreshValue,
-			},
-		}); err != nil {
-			return nil, err
-		}
+
+	if err := importStageCommonFields(d, details, setDefaults); err != nil {
+		return nil, err
 	}
-	if fileFormat := stageFileFormatToSchema(details, setDefaults); fileFormat != nil {
-		if err := d.Set("file_format", fileFormat); err != nil {
-			return nil, err
-		}
-	}
+
 	if details.PrivateLink != nil {
 		usePrivatelinkEndpointValue := booleanStringFromBool(details.PrivateLink.UsePrivatelinkEndpoint)
 		if setDefaults {

--- a/pkg/resources/external_s3_stage.go
+++ b/pkg/resources/external_s3_stage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/previewfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -236,7 +237,8 @@ func ExternalS3Stage() *schema.Resource {
 }
 
 func ImportExternalS3Stage(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	client := meta.(*provider.Context).Client
+	providerCtx := meta.(*provider.Context)
+	client := providerCtx.Client
 	id, err := sdk.ParseSchemaObjectIdentifier(d.Id())
 	if err != nil {
 		return nil, err
@@ -267,13 +269,18 @@ func ImportExternalS3Stage(ctx context.Context, d *schema.ResourceData, meta any
 			return nil, err
 		}
 	}
-	if fileFormat := stageFileFormatToSchema(details); fileFormat != nil {
+	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
+	if fileFormat := stageFileFormatToSchema(details, setDefaults); fileFormat != nil {
 		if err := d.Set("file_format", fileFormat); err != nil {
 			return nil, err
 		}
 	}
 	if details.PrivateLink != nil {
-		if err := d.Set("use_privatelink_endpoint", booleanStringFromBool(details.PrivateLink.UsePrivatelinkEndpoint)); err != nil {
+		usePrivatelinkEndpointValue := booleanStringFromBool(details.PrivateLink.UsePrivatelinkEndpoint)
+		if setDefaults {
+			usePrivatelinkEndpointValue = BooleanDefault
+		}
+		if err := d.Set("use_privatelink_endpoint", usePrivatelinkEndpointValue); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/resources/external_s3_stage.go
+++ b/pkg/resources/external_s3_stage.go
@@ -259,17 +259,21 @@ func ImportExternalS3Stage(ctx context.Context, d *schema.ResourceData, meta any
 	if err != nil {
 		return nil, err
 	}
+	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
 	if details.DirectoryTable != nil {
+		autoRefreshValue := booleanStringFromBool(details.DirectoryTable.AutoRefresh)
+		if setDefaults {
+			autoRefreshValue = BooleanDefault
+		}
 		if err := d.Set("directory", []map[string]any{
 			{
 				"enable":       details.DirectoryTable.Enable,
-				"auto_refresh": booleanStringFromBool(details.DirectoryTable.AutoRefresh),
+				"auto_refresh": autoRefreshValue,
 			},
 		}); err != nil {
 			return nil, err
 		}
 	}
-	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
 	if fileFormat := stageFileFormatToSchema(details, setDefaults); fileFormat != nil {
 		if err := d.Set("file_format", fileFormat); err != nil {
 			return nil, err

--- a/pkg/resources/internal_stage.go
+++ b/pkg/resources/internal_stage.go
@@ -117,41 +117,33 @@ func InternalStage() *schema.Resource {
 }
 
 func ImportInternalStage(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+		return nil, err
+	}
+
 	providerCtx := meta.(*provider.Context)
 	client := providerCtx.Client
+
 	id, err := sdk.ParseSchemaObjectIdentifier(d.Id())
 	if err != nil {
 		return nil, err
 	}
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](ctx, d, nil); err != nil {
-		return nil, err
-	}
-	stageDetails, err := client.Stages.Describe(ctx, id)
+
+	stageProperties, err := client.Stages.Describe(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	details, err := sdk.ParseStageDetails(stageDetails)
+	details, err := sdk.ParseStageDetails(stageProperties)
 	if err != nil {
 		return nil, err
 	}
+
 	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
-	autoRefreshValue := booleanStringFromBool(details.DirectoryTable.AutoRefresh)
-	if setDefaults {
-		autoRefreshValue = BooleanDefault
-	}
-	if err := d.Set("directory", []map[string]any{
-		{
-			"enable":       details.DirectoryTable.Enable,
-			"auto_refresh": autoRefreshValue,
-		},
-	}); err != nil {
+
+	if err := importStageCommonFields(d, details, setDefaults); err != nil {
 		return nil, err
 	}
-	if fileFormat := stageFileFormatToSchema(details, setDefaults); fileFormat != nil {
-		if err := d.Set("file_format", fileFormat); err != nil {
-			return nil, err
-		}
-	}
+
 	return []*schema.ResourceData{d}, nil
 }
 

--- a/pkg/resources/internal_stage.go
+++ b/pkg/resources/internal_stage.go
@@ -140,7 +140,7 @@ func ImportInternalStage(ctx context.Context, d *schema.ResourceData, meta any) 
 	}); err != nil {
 		return nil, err
 	}
-	if fileFormat := stageFileFormatToSchema(details); fileFormat != nil {
+	if fileFormat := stageFileFormatToSchema(details, false); fileFormat != nil {
 		if err := d.Set("file_format", fileFormat); err != nil {
 			return nil, err
 		}

--- a/pkg/resources/internal_stage.go
+++ b/pkg/resources/internal_stage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/previewfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -116,7 +117,8 @@ func InternalStage() *schema.Resource {
 }
 
 func ImportInternalStage(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	client := meta.(*provider.Context).Client
+	providerCtx := meta.(*provider.Context)
+	client := providerCtx.Client
 	id, err := sdk.ParseSchemaObjectIdentifier(d.Id())
 	if err != nil {
 		return nil, err
@@ -132,15 +134,20 @@ func ImportInternalStage(ctx context.Context, d *schema.ResourceData, meta any) 
 	if err != nil {
 		return nil, err
 	}
+	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
+	autoRefreshValue := booleanStringFromBool(details.DirectoryTable.AutoRefresh)
+	if setDefaults {
+		autoRefreshValue = BooleanDefault
+	}
 	if err := d.Set("directory", []map[string]any{
 		{
 			"enable":       details.DirectoryTable.Enable,
-			"auto_refresh": booleanStringFromBool(details.DirectoryTable.AutoRefresh),
+			"auto_refresh": autoRefreshValue,
 		},
 	}); err != nil {
 		return nil, err
 	}
-	if fileFormat := stageFileFormatToSchema(details, false); fileFormat != nil {
+	if fileFormat := stageFileFormatToSchema(details, setDefaults); fileFormat != nil {
 		if err := d.Set("file_format", fileFormat); err != nil {
 			return nil, err
 		}

--- a/pkg/resources/stage_file_format.go
+++ b/pkg/resources/stage_file_format.go
@@ -784,7 +784,7 @@ func parseStageFileFormatStringOrAuto(v string) *sdk.StageFileFormatStringOrAuto
 }
 
 // stageFileFormatToSchema converts the SDK details to a Terraform schema.
-func stageFileFormatToSchema(details *sdk.StageDetails) []map[string]any {
+func stageFileFormatToSchema(details *sdk.StageDetails, setDefaults bool) []map[string]any {
 	if details == nil {
 		return nil
 	}
@@ -807,7 +807,7 @@ func stageFileFormatToSchema(details *sdk.StageDetails) []map[string]any {
 	}
 
 	if details.FileFormatJson != nil {
-		jsonSchema := stageJsonFileFormatToSchema(details.FileFormatJson)
+		jsonSchema := stageJsonFileFormatToSchema(details.FileFormatJson, setDefaults)
 		return []map[string]any{
 			{
 				"json": []map[string]any{jsonSchema},
@@ -883,25 +883,38 @@ func stageCsvFileFormatToSchema(csv *sdk.FileFormatCsv) map[string]any {
 }
 
 // stageJsonFileFormatToSchema converts the SDK details for a JSON file format to a Terraform schema.
-func stageJsonFileFormatToSchema(json *sdk.FileFormatJson) map[string]any {
-	return map[string]any{
-		"compression":                json.Compression,
-		"date_format":                json.DateFormat,
-		"time_format":                json.TimeFormat,
-		"timestamp_format":           json.TimestampFormat,
-		"binary_format":              json.BinaryFormat,
-		"trim_space":                 booleanStringFromBool(json.TrimSpace),
-		"multi_line":                 booleanStringFromBool(json.MultiLine),
-		"null_if":                    collections.Map(json.NullIf, func(v string) any { return v }),
-		"file_extension":             json.FileExtension,
-		"enable_octal":               booleanStringFromBool(json.EnableOctal),
-		"allow_duplicate":            booleanStringFromBool(json.AllowDuplicate),
-		"strip_outer_array":          booleanStringFromBool(json.StripOuterArray),
-		"strip_null_values":          booleanStringFromBool(json.StripNullValues),
-		"replace_invalid_characters": booleanStringFromBool(json.ReplaceInvalidCharacters),
-		"ignore_utf8_errors":         booleanStringFromBool(json.IgnoreUtf8Errors),
-		"skip_byte_order_mark":       booleanStringFromBool(json.SkipByteOrderMark),
+func stageJsonFileFormatToSchema(json *sdk.FileFormatJson, setDefaults bool) map[string]any {
+	state := map[string]any{
+		"compression":      json.Compression,
+		"date_format":      json.DateFormat,
+		"time_format":      json.TimeFormat,
+		"timestamp_format": json.TimestampFormat,
+		"binary_format":    json.BinaryFormat,
+		"null_if":          collections.Map(json.NullIf, func(v string) any { return v }),
+		"file_extension":   json.FileExtension,
 	}
+	if setDefaults {
+		state["ignore_utf8_errors"] = BooleanDefault
+		state["skip_byte_order_mark"] = BooleanDefault
+		state["trim_space"] = BooleanDefault
+		state["multi_line"] = BooleanDefault
+		state["allow_duplicate"] = BooleanDefault
+		state["strip_outer_array"] = BooleanDefault
+		state["strip_null_values"] = BooleanDefault
+		state["replace_invalid_characters"] = BooleanDefault
+		state["enable_octal"] = BooleanDefault
+	} else {
+		state["ignore_utf8_errors"] = booleanStringFromBool(json.IgnoreUtf8Errors)
+		state["skip_byte_order_mark"] = booleanStringFromBool(json.SkipByteOrderMark)
+		state["trim_space"] = booleanStringFromBool(json.TrimSpace)
+		state["multi_line"] = booleanStringFromBool(json.MultiLine)
+		state["allow_duplicate"] = booleanStringFromBool(json.AllowDuplicate)
+		state["strip_outer_array"] = booleanStringFromBool(json.StripOuterArray)
+		state["strip_null_values"] = booleanStringFromBool(json.StripNullValues)
+		state["replace_invalid_characters"] = booleanStringFromBool(json.ReplaceInvalidCharacters)
+		state["enable_octal"] = booleanStringFromBool(json.EnableOctal)
+	}
+	return state
 }
 
 // stageAvroFileFormatToSchema converts the SDK details for an AVRO file format to a Terraform schema.
@@ -957,7 +970,7 @@ func handleStageFileFormatRead(d *schema.ResourceData, details *sdk.StageDetails
 	fileFormatToCompare := collections.Map(fileFormatSchema["file_format"].([]map[string]any), func(v map[string]any) any {
 		return v
 	})
-	fileFormatToSet := stageFileFormatToSchema(details)
+	fileFormatToSet := stageFileFormatToSchema(details, false)
 	return handleExternalChangesToObjectInFlatDescribeDeepEqual(d,
 		outputMapping{"file_format", "file_format", fileFormatToCompare, fileFormatToSet, nil},
 	)

--- a/pkg/resources/stage_file_format.go
+++ b/pkg/resources/stage_file_format.go
@@ -798,7 +798,7 @@ func stageFileFormatToSchema(details *sdk.StageDetails, setDefaults bool) []map[
 	}
 
 	if details.FileFormatCsv != nil {
-		csvSchema := stageCsvFileFormatToSchema(details.FileFormatCsv)
+		csvSchema := stageCsvFileFormatToSchema(details.FileFormatCsv, setDefaults)
 		return []map[string]any{
 			{
 				"csv": []map[string]any{csvSchema},
@@ -816,7 +816,7 @@ func stageFileFormatToSchema(details *sdk.StageDetails, setDefaults bool) []map[
 	}
 
 	if details.FileFormatAvro != nil {
-		avroSchema := stageAvroFileFormatToSchema(details.FileFormatAvro)
+		avroSchema := stageAvroFileFormatToSchema(details.FileFormatAvro, setDefaults)
 		return []map[string]any{
 			{
 				"avro": []map[string]any{avroSchema},
@@ -825,7 +825,7 @@ func stageFileFormatToSchema(details *sdk.StageDetails, setDefaults bool) []map[
 	}
 
 	if details.FileFormatOrc != nil {
-		orcSchema := stageOrcFileFormatToSchema(details.FileFormatOrc)
+		orcSchema := stageOrcFileFormatToSchema(details.FileFormatOrc, setDefaults)
 		return []map[string]any{
 			{
 				"orc": []map[string]any{orcSchema},
@@ -834,7 +834,7 @@ func stageFileFormatToSchema(details *sdk.StageDetails, setDefaults bool) []map[
 	}
 
 	if details.FileFormatParquet != nil {
-		parquetSchema := stageParquetFileFormatToSchema(details.FileFormatParquet)
+		parquetSchema := stageParquetFileFormatToSchema(details.FileFormatParquet, setDefaults)
 		return []map[string]any{
 			{
 				"parquet": []map[string]any{parquetSchema},
@@ -843,7 +843,7 @@ func stageFileFormatToSchema(details *sdk.StageDetails, setDefaults bool) []map[
 	}
 
 	if details.FileFormatXml != nil {
-		xmlSchema := stageXmlFileFormatToSchema(details.FileFormatXml)
+		xmlSchema := stageXmlFileFormatToSchema(details.FileFormatXml, setDefaults)
 		return []map[string]any{
 			{
 				"xml": []map[string]any{xmlSchema},
@@ -855,31 +855,43 @@ func stageFileFormatToSchema(details *sdk.StageDetails, setDefaults bool) []map[
 }
 
 // stageCsvFileFormatToSchema converts the SDK details for a CSV file format to a Terraform schema.
-func stageCsvFileFormatToSchema(csv *sdk.FileFormatCsv) map[string]any {
-	return map[string]any{
-		"record_delimiter":               csv.RecordDelimiter,
-		"field_delimiter":                csv.FieldDelimiter,
-		"file_extension":                 csv.FileExtension,
-		"skip_header":                    csv.SkipHeader,
-		"parse_header":                   booleanStringFromBool(csv.ParseHeader),
-		"date_format":                    csv.DateFormat,
-		"time_format":                    csv.TimeFormat,
-		"timestamp_format":               csv.TimestampFormat,
-		"binary_format":                  csv.BinaryFormat,
-		"escape":                         csv.Escape,
-		"escape_unenclosed_field":        csv.EscapeUnenclosedField,
-		"trim_space":                     booleanStringFromBool(csv.TrimSpace),
-		"field_optionally_enclosed_by":   csv.FieldOptionallyEnclosedBy,
-		"null_if":                        collections.Map(csv.NullIf, func(v string) any { return v }),
-		"compression":                    csv.Compression,
-		"error_on_column_count_mismatch": booleanStringFromBool(csv.ErrorOnColumnCountMismatch),
-		"skip_blank_lines":               booleanStringFromBool(csv.SkipBlankLines),
-		"replace_invalid_characters":     booleanStringFromBool(csv.ReplaceInvalidCharacters),
-		"empty_field_as_null":            booleanStringFromBool(csv.EmptyFieldAsNull),
-		"skip_byte_order_mark":           booleanStringFromBool(csv.SkipByteOrderMark),
-		"encoding":                       csv.Encoding,
-		"multi_line":                     booleanStringFromBool(csv.MultiLine),
+func stageCsvFileFormatToSchema(csv *sdk.FileFormatCsv, setDefaults bool) map[string]any {
+	state := map[string]any{
+		"record_delimiter":             csv.RecordDelimiter,
+		"field_delimiter":              csv.FieldDelimiter,
+		"file_extension":               csv.FileExtension,
+		"skip_header":                  csv.SkipHeader,
+		"date_format":                  csv.DateFormat,
+		"time_format":                  csv.TimeFormat,
+		"timestamp_format":             csv.TimestampFormat,
+		"binary_format":                csv.BinaryFormat,
+		"escape":                       csv.Escape,
+		"escape_unenclosed_field":      csv.EscapeUnenclosedField,
+		"field_optionally_enclosed_by": csv.FieldOptionallyEnclosedBy,
+		"null_if":                      collections.Map(csv.NullIf, func(v string) any { return v }),
+		"compression":                  csv.Compression,
+		"encoding":                     csv.Encoding,
 	}
+	if setDefaults {
+		state["parse_header"] = BooleanDefault
+		state["trim_space"] = BooleanDefault
+		state["error_on_column_count_mismatch"] = BooleanDefault
+		state["skip_blank_lines"] = BooleanDefault
+		state["replace_invalid_characters"] = BooleanDefault
+		state["empty_field_as_null"] = BooleanDefault
+		state["skip_byte_order_mark"] = BooleanDefault
+		state["multi_line"] = BooleanDefault
+	} else {
+		state["parse_header"] = booleanStringFromBool(csv.ParseHeader)
+		state["trim_space"] = booleanStringFromBool(csv.TrimSpace)
+		state["error_on_column_count_mismatch"] = booleanStringFromBool(csv.ErrorOnColumnCountMismatch)
+		state["skip_blank_lines"] = booleanStringFromBool(csv.SkipBlankLines)
+		state["replace_invalid_characters"] = booleanStringFromBool(csv.ReplaceInvalidCharacters)
+		state["empty_field_as_null"] = booleanStringFromBool(csv.EmptyFieldAsNull)
+		state["skip_byte_order_mark"] = booleanStringFromBool(csv.SkipByteOrderMark)
+		state["multi_line"] = booleanStringFromBool(csv.MultiLine)
+	}
+	return state
 }
 
 // stageJsonFileFormatToSchema converts the SDK details for a JSON file format to a Terraform schema.
@@ -918,48 +930,79 @@ func stageJsonFileFormatToSchema(json *sdk.FileFormatJson, setDefaults bool) map
 }
 
 // stageAvroFileFormatToSchema converts the SDK details for an AVRO file format to a Terraform schema.
-func stageAvroFileFormatToSchema(avro *sdk.FileFormatAvro) map[string]any {
-	return map[string]any{
-		"compression":                avro.Compression,
-		"trim_space":                 booleanStringFromBool(avro.TrimSpace),
-		"replace_invalid_characters": booleanStringFromBool(avro.ReplaceInvalidCharacters),
-		"null_if":                    collections.Map(avro.NullIf, func(v string) any { return v }),
+func stageAvroFileFormatToSchema(avro *sdk.FileFormatAvro, setDefaults bool) map[string]any {
+	state := map[string]any{
+		"compression": avro.Compression,
+		"null_if":     collections.Map(avro.NullIf, func(v string) any { return v }),
 	}
+	if setDefaults {
+		state["trim_space"] = BooleanDefault
+		state["replace_invalid_characters"] = BooleanDefault
+	} else {
+		state["trim_space"] = booleanStringFromBool(avro.TrimSpace)
+		state["replace_invalid_characters"] = booleanStringFromBool(avro.ReplaceInvalidCharacters)
+	}
+	return state
 }
 
 // stageOrcFileFormatToSchema converts the SDK details for an ORC file format to a Terraform schema.
-func stageOrcFileFormatToSchema(orc *sdk.FileFormatOrc) map[string]any {
-	return map[string]any{
-		"trim_space":                 booleanStringFromBool(orc.TrimSpace),
-		"replace_invalid_characters": booleanStringFromBool(orc.ReplaceInvalidCharacters),
-		"null_if":                    collections.Map(orc.NullIf, func(v string) any { return v }),
+func stageOrcFileFormatToSchema(orc *sdk.FileFormatOrc, setDefaults bool) map[string]any {
+	state := map[string]any{
+		"null_if": collections.Map(orc.NullIf, func(v string) any { return v }),
 	}
+	if setDefaults {
+		state["trim_space"] = BooleanDefault
+		state["replace_invalid_characters"] = BooleanDefault
+	} else {
+		state["trim_space"] = booleanStringFromBool(orc.TrimSpace)
+		state["replace_invalid_characters"] = booleanStringFromBool(orc.ReplaceInvalidCharacters)
+	}
+	return state
 }
 
 // stageParquetFileFormatToSchema converts the SDK details for a Parquet file format to a Terraform schema.
-func stageParquetFileFormatToSchema(parquet *sdk.FileFormatParquet) map[string]any {
-	return map[string]any{
-		"compression":                parquet.Compression,
-		"binary_as_text":             booleanStringFromBool(parquet.BinaryAsText),
-		"use_logical_type":           booleanStringFromBool(parquet.UseLogicalType),
-		"trim_space":                 booleanStringFromBool(parquet.TrimSpace),
-		"use_vectorized_scanner":     booleanStringFromBool(parquet.UseVectorizedScanner),
-		"replace_invalid_characters": booleanStringFromBool(parquet.ReplaceInvalidCharacters),
-		"null_if":                    collections.Map(parquet.NullIf, func(v string) any { return v }),
+func stageParquetFileFormatToSchema(parquet *sdk.FileFormatParquet, setDefaults bool) map[string]any {
+	state := map[string]any{
+		"compression": parquet.Compression,
+		"null_if":     collections.Map(parquet.NullIf, func(v string) any { return v }),
 	}
+	if setDefaults {
+		state["binary_as_text"] = BooleanDefault
+		state["use_logical_type"] = BooleanDefault
+		state["trim_space"] = BooleanDefault
+		state["use_vectorized_scanner"] = BooleanDefault
+		state["replace_invalid_characters"] = BooleanDefault
+	} else {
+		state["binary_as_text"] = booleanStringFromBool(parquet.BinaryAsText)
+		state["use_logical_type"] = booleanStringFromBool(parquet.UseLogicalType)
+		state["trim_space"] = booleanStringFromBool(parquet.TrimSpace)
+		state["use_vectorized_scanner"] = booleanStringFromBool(parquet.UseVectorizedScanner)
+		state["replace_invalid_characters"] = booleanStringFromBool(parquet.ReplaceInvalidCharacters)
+	}
+	return state
 }
 
 // stageXmlFileFormatToSchema converts the SDK details for an XML file format to a Terraform schema.
-func stageXmlFileFormatToSchema(xml *sdk.FileFormatXml) map[string]any {
-	return map[string]any{
-		"compression":                xml.Compression,
-		"ignore_utf8_errors":         booleanStringFromBool(xml.IgnoreUtf8Errors),
-		"preserve_space":             booleanStringFromBool(xml.PreserveSpace),
-		"strip_outer_element":        booleanStringFromBool(xml.StripOuterElement),
-		"disable_auto_convert":       booleanStringFromBool(xml.DisableAutoConvert),
-		"replace_invalid_characters": booleanStringFromBool(xml.ReplaceInvalidCharacters),
-		"skip_byte_order_mark":       booleanStringFromBool(xml.SkipByteOrderMark),
+func stageXmlFileFormatToSchema(xml *sdk.FileFormatXml, setDefaults bool) map[string]any {
+	state := map[string]any{
+		"compression": xml.Compression,
 	}
+	if setDefaults {
+		state["ignore_utf8_errors"] = BooleanDefault
+		state["preserve_space"] = BooleanDefault
+		state["strip_outer_element"] = BooleanDefault
+		state["disable_auto_convert"] = BooleanDefault
+		state["replace_invalid_characters"] = BooleanDefault
+		state["skip_byte_order_mark"] = BooleanDefault
+	} else {
+		state["ignore_utf8_errors"] = booleanStringFromBool(xml.IgnoreUtf8Errors)
+		state["preserve_space"] = booleanStringFromBool(xml.PreserveSpace)
+		state["strip_outer_element"] = booleanStringFromBool(xml.StripOuterElement)
+		state["disable_auto_convert"] = booleanStringFromBool(xml.DisableAutoConvert)
+		state["replace_invalid_characters"] = booleanStringFromBool(xml.ReplaceInvalidCharacters)
+		state["skip_byte_order_mark"] = booleanStringFromBool(xml.SkipByteOrderMark)
+	}
+	return state
 }
 
 func handleStageFileFormatRead(d *schema.ResourceData, details *sdk.StageDetails) error {

--- a/pkg/resources/stages_common.go
+++ b/pkg/resources/stages_common.go
@@ -148,3 +148,28 @@ func directoryTableOutputMapping(directoryTable sdk.StageDirectoryTable) outputM
 		"directory_table", "directory", directoryTableToCompare(directoryTable), directoryTableToSet(directoryTable), nil,
 	}
 }
+
+func importStageCommonFields(d *schema.ResourceData, details *sdk.StageDetails, setDefaults bool) error {
+	if details.DirectoryTable != nil {
+		autoRefreshValue := booleanStringFromBool(details.DirectoryTable.AutoRefresh)
+		if setDefaults {
+			autoRefreshValue = BooleanDefault
+		}
+		if err := d.Set("directory", []map[string]any{
+			{
+				"enable":       details.DirectoryTable.Enable,
+				"auto_refresh": autoRefreshValue,
+			},
+		}); err != nil {
+			return err
+		}
+	}
+
+	if fileFormat := stageFileFormatToSchema(details, setDefaults); fileFormat != nil {
+		if err := d.Set("file_format", fileFormat); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/testacc/resource_external_s3_stage_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_external_s3_stage_experimental_features_acceptance_test.go
@@ -1,0 +1,213 @@
+//go:build account_level_tests
+
+package testacc
+
+import (
+	"testing"
+
+	accconfig "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/importchecks"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/planchecks"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
+	resourcehelpers "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
+	r "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+// TestAcc_Experimental_ExternalS3Stage_ImportJsonBooleanDefaults verifies that importing an external S3 stage
+// without the IMPORT_BOOLEAN_DEFAULT experiment causes a permadiff (non-empty plan), and that enabling
+// the experiment fixes it by setting BooleanDefault fields to "default" instead of the actual Snowflake value.
+// Regression test for https://github.com/snowflakedb/terraform-provider-snowflake/issues/4549.
+func TestAcc_Experimental_ExternalS3Stage_ImportJsonBooleanDefaults(t *testing.T) {
+	id := testClient().Ids.RandomSchemaObjectIdentifier()
+	awsUrl := testenvs.GetOrSkipTest(t, testenvs.AwsExternalBucketUrl)
+	// storageIntegrationId := ids.PrecreatedS3StorageIntegration
+
+	providerModelWithExperiment := providermodel.SnowflakeProvider().
+		WithExperimentalFeaturesEnabled(experimentalfeatures.ImportBooleanDefault)
+
+	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_ExternalS3Stage_ImportJsonBooleanDefaults")
+
+	stageModel := model.ExternalS3StageWithId(id, awsUrl).
+		WithDirectoryEnabledAndOptions(sdk.StageS3CommonDirectoryTableOptionsRequest{
+			Enable:      false,
+			AutoRefresh: sdk.Pointer(false),
+		}).
+		WithFileFormatJson(sdk.FileFormatJsonOptions{
+			BinaryFormat: sdk.Pointer(sdk.BinaryFormatHex),
+			Compression:  sdk.Pointer(sdk.JSONCompressionAuto),
+			DateFormat: sdk.Pointer(sdk.StageFileFormatStringOrAuto{
+				Value: sdk.Pointer("AUTO"),
+			}),
+			TimeFormat: sdk.Pointer(sdk.StageFileFormatStringOrAuto{
+				Value: sdk.Pointer("AUTO"),
+			}),
+			TimestampFormat: sdk.Pointer(sdk.StageFileFormatStringOrAuto{
+				Value: sdk.Pointer("AUTO"),
+			}),
+		})
+	stageModelPure := model.ExternalS3StageWithId(id, awsUrl).
+		WithFileFormatJson(sdk.FileFormatJsonOptions{
+			BinaryFormat: sdk.Pointer(sdk.BinaryFormatHex),
+			Compression:  sdk.Pointer(sdk.JSONCompressionAuto),
+			DateFormat: sdk.Pointer(sdk.StageFileFormatStringOrAuto{
+				Value: sdk.Pointer("AUTO"),
+			}),
+			TimeFormat: sdk.Pointer(sdk.StageFileFormatStringOrAuto{
+				Value: sdk.Pointer("AUTO"),
+			}),
+			TimestampFormat: sdk.Pointer(sdk.StageFileFormatStringOrAuto{
+				Value: sdk.Pointer("AUTO"),
+			}),
+		})
+	createStage := func() {
+		_, dropStage := testClient().Stage.CreateStageOnS3WithRequest(t, sdk.NewCreateOnS3StageRequest(id, *sdk.NewExternalS3StageParamsRequest(awsUrl)).
+			// WithStorageIntegration(storageIntegrationId)
+			WithFileFormat(sdk.StageFileFormatRequest{
+				FileFormatOptions: &sdk.FileFormatOptions{
+					JsonOptions: &sdk.FileFormatJsonOptions{
+						BinaryFormat: sdk.Pointer(sdk.BinaryFormatHex),
+						Compression:  sdk.Pointer(sdk.JSONCompressionAuto),
+						DateFormat: sdk.Pointer(sdk.StageFileFormatStringOrAuto{
+							Value: sdk.Pointer("AUTO"),
+						}),
+						TimeFormat: sdk.Pointer(sdk.StageFileFormatStringOrAuto{
+							Value: sdk.Pointer("AUTO"),
+						}),
+						TimestampFormat: sdk.Pointer(sdk.StageFileFormatStringOrAuto{
+							Value: sdk.Pointer("AUTO"),
+						}),
+					},
+				},
+			}))
+		t.Cleanup(dropStage)
+	}
+	createStage()
+
+	resourceId := resourcehelpers.EncodeResourceIdentifier(id)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			// Import WITHOUT experiment — booleans are imported as actual Snowflake values ("false"), causing a permadiff.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   accconfig.FromModels(t, stageModel),
+				ResourceName:             stageModel.ResourceReference(),
+				ImportState:              true,
+				ImportStateId:            id.FullyQualifiedName(),
+				ImportStateCheck: importchecks.ComposeAggregateImportStateCheck(
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.ignore_utf8_errors", "false"),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.trim_space", "false"),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.multi_line", "true"),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.enable_octal", "false"),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.allow_duplicate", "false"),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.strip_outer_array", "false"),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.strip_null_values", "false"),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.replace_invalid_characters", "false"),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.skip_byte_order_mark", "true"),
+				),
+				ImportStatePersist: true,
+			},
+			// Plan WITHOUT experiment — proves the bug: config has "default", state has "false" → permadiff
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   accconfig.FromModels(t, stageModel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(stageModel.ResourceReference(), plancheck.ResourceActionUpdate),
+						// planchecks.ExpectChange(stageModel.ResourceReference(), "file_format.0.json.0.ignore_utf8_errors", tfjson.ActionUpdate, sdk.String("false"), sdk.String("default")),
+						planchecks.PrintPlanDetails(stageModel.ResourceReference(), "file_format", "directory", "use_privatelink_endpoint", "credentials"),
+					},
+				},
+			},
+			// Destroy to clear Terraform state before reimporting with the experiment enabled.
+			// This also drops the stage, so we recreate it in the next step's PreConfig.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   accconfig.FromModels(t, stageModel),
+				Destroy:                  true,
+			},
+			// Import WITH experiment — booleans are imported as "default" (matching schema defaults)
+			{
+				PreConfig:                createStage,
+				ProtoV6ProviderFactories: experimentFactory,
+				Config:                   accconfig.FromModels(t, providerModelWithExperiment, stageModel),
+				ResourceName:             stageModel.ResourceReference(),
+				ImportState:              true,
+				ImportStatePersist:       true,
+				ImportStateId:            id.FullyQualifiedName(),
+				ImportStateCheck: importchecks.ComposeAggregateImportStateCheck(
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.ignore_utf8_errors", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.trim_space", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.multi_line", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.enable_octal", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.allow_duplicate", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.strip_outer_array", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.strip_null_values", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.replace_invalid_characters", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.skip_byte_order_mark", r.BooleanDefault),
+				),
+			},
+			// Plan WITH experiment — proves the fix: config and state both have "default" -> no diff
+			{
+				ProtoV6ProviderFactories: experimentFactory,
+				Config:                   accconfig.FromModels(t, providerModelWithExperiment, stageModel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+						planchecks.PrintPlanDetails(stageModel.ResourceReference(), "file_format", "directory", "use_privatelink_endpoint", "credentials"),
+					},
+				},
+			},
+			// Destroy to clear Terraform state before reimporting with the experiment enabled.
+			// This also drops the stage, so we recreate it in the next step's PreConfig.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   accconfig.FromModels(t, stageModelPure),
+				Destroy:                  true,
+			},
+			// Import WITH experiment — booleans are imported as "default" (matching schema defaults)
+			{
+				PreConfig:                createStage,
+				ProtoV6ProviderFactories: experimentFactory,
+				Config:                   accconfig.FromModels(t, providerModelWithExperiment, stageModelPure),
+				ResourceName:             stageModelPure.ResourceReference(),
+				ImportState:              true,
+				ImportStatePersist:       true,
+				ImportStateId:            id.FullyQualifiedName(),
+				ImportStateCheck: importchecks.ComposeAggregateImportStateCheck(
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.ignore_utf8_errors", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.trim_space", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.multi_line", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.enable_octal", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.allow_duplicate", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.strip_outer_array", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.strip_null_values", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.replace_invalid_characters", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.skip_byte_order_mark", r.BooleanDefault),
+				),
+			},
+			// Plan WITH experiment — proves the fix: config and state both have "default" -> no diff
+			{
+				ProtoV6ProviderFactories: experimentFactory,
+				Config:                   accconfig.FromModels(t, providerModelWithExperiment, stageModelPure),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+						planchecks.PrintPlanDetails(stageModel.ResourceReference(), "file_format", "directory", "use_privatelink_endpoint", "credentials"),
+					},
+				},
+			},
+		},
+	})
+}

--- a/pkg/testacc/resource_external_s3_stage_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_external_s3_stage_experimental_features_acceptance_test.go
@@ -23,36 +23,24 @@ import (
 // TestAcc_Experimental_ExternalS3Stage_ImportJsonBooleanDefaults verifies that importing an external S3 stage
 // without the IMPORT_BOOLEAN_DEFAULT experiment causes a permadiff (non-empty plan), and that enabling
 // the experiment fixes it by setting BooleanDefault fields to "default" instead of the actual Snowflake value.
+// It covers all tri-value boolean attributes: JSON file format booleans, directory table booleans, and use_privatelink_endpoint.
 // Regression test for https://github.com/snowflakedb/terraform-provider-snowflake/issues/4549.
 func TestAcc_Experimental_ExternalS3Stage_ImportJsonBooleanDefaults(t *testing.T) {
 	id := testClient().Ids.RandomSchemaObjectIdentifier()
 	awsUrl := testenvs.GetOrSkipTest(t, testenvs.AwsExternalBucketUrl)
-	// storageIntegrationId := ids.PrecreatedS3StorageIntegration
 
 	providerModelWithExperiment := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.ImportBooleanDefault)
 
 	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_ExternalS3Stage_ImportJsonBooleanDefaults")
 
+	// stageModel: directory block with enable=false but NO explicit auto_refresh,
+	// so auto_refresh defaults to "default" in config. This lets us detect the permadiff
+	// (import sets "false", config has "default") and verify the experiment fixes it.
 	stageModel := model.ExternalS3StageWithId(id, awsUrl).
 		WithDirectoryEnabledAndOptions(sdk.StageS3CommonDirectoryTableOptionsRequest{
-			Enable:      false,
-			AutoRefresh: sdk.Pointer(false),
+			Enable: false,
 		}).
-		WithFileFormatJson(sdk.FileFormatJsonOptions{
-			BinaryFormat: sdk.Pointer(sdk.BinaryFormatHex),
-			Compression:  sdk.Pointer(sdk.JSONCompressionAuto),
-			DateFormat: sdk.Pointer(sdk.StageFileFormatStringOrAuto{
-				Value: sdk.Pointer("AUTO"),
-			}),
-			TimeFormat: sdk.Pointer(sdk.StageFileFormatStringOrAuto{
-				Value: sdk.Pointer("AUTO"),
-			}),
-			TimestampFormat: sdk.Pointer(sdk.StageFileFormatStringOrAuto{
-				Value: sdk.Pointer("AUTO"),
-			}),
-		})
-	stageModelPure := model.ExternalS3StageWithId(id, awsUrl).
 		WithFileFormatJson(sdk.FileFormatJsonOptions{
 			BinaryFormat: sdk.Pointer(sdk.BinaryFormatHex),
 			Compression:  sdk.Pointer(sdk.JSONCompressionAuto),
@@ -68,7 +56,6 @@ func TestAcc_Experimental_ExternalS3Stage_ImportJsonBooleanDefaults(t *testing.T
 		})
 	createStage := func() {
 		_, dropStage := testClient().Stage.CreateStageOnS3WithRequest(t, sdk.NewCreateOnS3StageRequest(id, *sdk.NewExternalS3StageParamsRequest(awsUrl)).
-			// WithStorageIntegration(storageIntegrationId)
 			WithFileFormat(sdk.StageFileFormatRequest{
 				FileFormatOptions: &sdk.FileFormatOptions{
 					JsonOptions: &sdk.FileFormatJsonOptions{
@@ -97,7 +84,7 @@ func TestAcc_Experimental_ExternalS3Stage_ImportJsonBooleanDefaults(t *testing.T
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
 		Steps: []resource.TestStep{
-			// Import WITHOUT experiment — booleans are imported as actual Snowflake values ("false"), causing a permadiff.
+			// Import WITHOUT experiment — booleans are imported as actual Snowflake values ("false"/"true"), causing a permadiff.
 			{
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				Config:                   accconfig.FromModels(t, stageModel),
@@ -114,10 +101,12 @@ func TestAcc_Experimental_ExternalS3Stage_ImportJsonBooleanDefaults(t *testing.T
 					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.strip_null_values", "false"),
 					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.replace_invalid_characters", "false"),
 					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.skip_byte_order_mark", "true"),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "directory.0.auto_refresh", "false"),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "use_privatelink_endpoint", "false"),
 				),
 				ImportStatePersist: true,
 			},
-			// Plan WITHOUT experiment — proves the bug: config has "default", state has "false" → permadiff
+			// Plan WITHOUT experiment — proves the bug: config has "default", state has "false"/"true" → permadiff
 			{
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				Config:                   accconfig.FromModels(t, stageModel),
@@ -125,19 +114,20 @@ func TestAcc_Experimental_ExternalS3Stage_ImportJsonBooleanDefaults(t *testing.T
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectNonEmptyPlan(),
 						plancheck.ExpectResourceAction(stageModel.ResourceReference(), plancheck.ResourceActionUpdate),
-						// planchecks.ExpectChange(stageModel.ResourceReference(), "file_format.0.json.0.ignore_utf8_errors", tfjson.ActionUpdate, sdk.String("false"), sdk.String("default")),
 						planchecks.PrintPlanDetails(stageModel.ResourceReference(), "file_format", "directory", "use_privatelink_endpoint", "credentials"),
 					},
 				},
 			},
 			// Destroy to clear Terraform state before reimporting with the experiment enabled.
+			// Unfortunately, one can't import a resource when it's already in the state,
+			// and the framework doesn't support state removal.
 			// This also drops the stage, so we recreate it in the next step's PreConfig.
 			{
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				Config:                   accconfig.FromModels(t, stageModel),
 				Destroy:                  true,
 			},
-			// Import WITH experiment — booleans are imported as "default" (matching schema defaults)
+			// Import WITH experiment — all tri-value booleans are imported as "default"
 			{
 				PreConfig:                createStage,
 				ProtoV6ProviderFactories: experimentFactory,
@@ -156,51 +146,14 @@ func TestAcc_Experimental_ExternalS3Stage_ImportJsonBooleanDefaults(t *testing.T
 					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.strip_null_values", r.BooleanDefault),
 					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.replace_invalid_characters", r.BooleanDefault),
 					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.skip_byte_order_mark", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "directory.0.auto_refresh", r.BooleanDefault),
+					importchecks.TestCheckResourceAttrInstanceState(resourceId, "use_privatelink_endpoint", r.BooleanDefault),
 				),
 			},
-			// Plan WITH experiment — proves the fix: config and state both have "default" -> no diff
+			// Plan WITH experiment — proves the fix: config and state both have "default" → no diff
 			{
 				ProtoV6ProviderFactories: experimentFactory,
 				Config:                   accconfig.FromModels(t, providerModelWithExperiment, stageModel),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-						planchecks.PrintPlanDetails(stageModel.ResourceReference(), "file_format", "directory", "use_privatelink_endpoint", "credentials"),
-					},
-				},
-			},
-			// Destroy to clear Terraform state before reimporting with the experiment enabled.
-			// This also drops the stage, so we recreate it in the next step's PreConfig.
-			{
-				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-				Config:                   accconfig.FromModels(t, stageModelPure),
-				Destroy:                  true,
-			},
-			// Import WITH experiment — booleans are imported as "default" (matching schema defaults)
-			{
-				PreConfig:                createStage,
-				ProtoV6ProviderFactories: experimentFactory,
-				Config:                   accconfig.FromModels(t, providerModelWithExperiment, stageModelPure),
-				ResourceName:             stageModelPure.ResourceReference(),
-				ImportState:              true,
-				ImportStatePersist:       true,
-				ImportStateId:            id.FullyQualifiedName(),
-				ImportStateCheck: importchecks.ComposeAggregateImportStateCheck(
-					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.ignore_utf8_errors", r.BooleanDefault),
-					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.trim_space", r.BooleanDefault),
-					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.multi_line", r.BooleanDefault),
-					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.enable_octal", r.BooleanDefault),
-					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.allow_duplicate", r.BooleanDefault),
-					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.strip_outer_array", r.BooleanDefault),
-					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.strip_null_values", r.BooleanDefault),
-					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.replace_invalid_characters", r.BooleanDefault),
-					importchecks.TestCheckResourceAttrInstanceState(resourceId, "file_format.0.json.0.skip_byte_order_mark", r.BooleanDefault),
-				),
-			},
-			// Plan WITH experiment — proves the fix: config and state both have "default" -> no diff
-			{
-				ProtoV6ProviderFactories: experimentFactory,
-				Config:                   accconfig.FromModels(t, providerModelWithExperiment, stageModelPure),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),

--- a/templates/resources/stage_external_azure.md.tmpl
+++ b/templates/resources/stage_external_azure.md.tmpl
@@ -17,7 +17,7 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
-~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) and reimport the resource for the fix to take effect. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # {{.Name}} ({{.Type}})
 

--- a/templates/resources/stage_external_azure.md.tmpl
+++ b/templates/resources/stage_external_azure.md.tmpl
@@ -17,7 +17,7 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
-~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # {{.Name}} ({{.Type}})
 

--- a/templates/resources/stage_external_azure.md.tmpl
+++ b/templates/resources/stage_external_azure.md.tmpl
@@ -17,6 +17,8 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
+~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+
 # {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}

--- a/templates/resources/stage_external_gcs.md.tmpl
+++ b/templates/resources/stage_external_gcs.md.tmpl
@@ -17,7 +17,7 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
-~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) and reimport the resource for the fix to take effect. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # {{.Name}} ({{.Type}})
 

--- a/templates/resources/stage_external_gcs.md.tmpl
+++ b/templates/resources/stage_external_gcs.md.tmpl
@@ -17,7 +17,7 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
-~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # {{.Name}} ({{.Type}})
 

--- a/templates/resources/stage_external_gcs.md.tmpl
+++ b/templates/resources/stage_external_gcs.md.tmpl
@@ -17,6 +17,8 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
+~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+
 # {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}

--- a/templates/resources/stage_external_s3.md.tmpl
+++ b/templates/resources/stage_external_s3.md.tmpl
@@ -21,7 +21,7 @@ description: |-
 
 -> **Note** This resource is meant only for S3 stages, not S3-compatible stages. For S3-compatible stages, use the `snowflake_stage_external_s3_compatible` resource instead. Do not use this resource with `s3compat://` URLs.
 
-~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # {{.Name}} ({{.Type}})
 

--- a/templates/resources/stage_external_s3.md.tmpl
+++ b/templates/resources/stage_external_s3.md.tmpl
@@ -21,6 +21,8 @@ description: |-
 
 -> **Note** This resource is meant only for S3 stages, not S3-compatible stages. For S3-compatible stages, use the `snowflake_stage_external_s3_compatible` resource instead. Do not use this resource with `s3compat://` URLs.
 
+~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+
 # {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}

--- a/templates/resources/stage_external_s3.md.tmpl
+++ b/templates/resources/stage_external_s3.md.tmpl
@@ -21,7 +21,7 @@ description: |-
 
 -> **Note** This resource is meant only for S3 stages, not S3-compatible stages. For S3-compatible stages, use the `snowflake_stage_external_s3_compatible` resource instead. Do not use this resource with `s3compat://` URLs.
 
-~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) and reimport the resource for the fix to take effect. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # {{.Name}} ({{.Type}})
 

--- a/templates/resources/stage_external_s3_compatible.md.tmpl
+++ b/templates/resources/stage_external_s3_compatible.md.tmpl
@@ -19,7 +19,7 @@ description: |-
 
 -> **Note** This resource is meant only for S3-compatible stages, not S3 stages. For S3 stages, use the `snowflake_stage_external_s3` resource instead. Do not use this resource with `s3://` URLs.
 
-~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # {{.Name}} ({{.Type}})
 

--- a/templates/resources/stage_external_s3_compatible.md.tmpl
+++ b/templates/resources/stage_external_s3_compatible.md.tmpl
@@ -19,6 +19,8 @@ description: |-
 
 -> **Note** This resource is meant only for S3-compatible stages, not S3 stages. For S3 stages, use the `snowflake_stage_external_s3` resource instead. Do not use this resource with `s3://` URLs.
 
+~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+
 # {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}

--- a/templates/resources/stage_external_s3_compatible.md.tmpl
+++ b/templates/resources/stage_external_s3_compatible.md.tmpl
@@ -19,7 +19,7 @@ description: |-
 
 -> **Note** This resource is meant only for S3-compatible stages, not S3 stages. For S3 stages, use the `snowflake_stage_external_s3` resource instead. Do not use this resource with `s3://` URLs.
 
-~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) and reimport the resource for the fix to take effect. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # {{.Name}} ({{.Type}})
 

--- a/templates/resources/stage_internal.md.tmpl
+++ b/templates/resources/stage_internal.md.tmpl
@@ -17,7 +17,7 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
-~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) and reimport the resource for the fix to take effect. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # {{.Name}} ({{.Type}})
 

--- a/templates/resources/stage_internal.md.tmpl
+++ b/templates/resources/stage_internal.md.tmpl
@@ -17,7 +17,7 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
-~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+~> **Note** If you experience persistent diffs after importing this resource, enable the `IMPORT_BOOLEAN_DEFAULT` [experimental feature](../#experimental_features_enabled-1) to fix it. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for details.
 
 # {{.Name}} ({{.Type}})
 

--- a/templates/resources/stage_internal.md.tmpl
+++ b/templates/resources/stage_internal.md.tmpl
@@ -17,6 +17,8 @@ description: |-
 
 -> **Note** Due to Snowflake limitations, when `directory.auto_refresh` is set to a new value in the configuration, the resource is recreated. When it is unset, the provider alters the whole `directory` field with the `enable` value from the configuration.
 
+~> **Note** A new `IMPORT_BOOLEAN_DEFAULT` experimental feature is available for this resource. When enabled, fields using special default values (like `"default"`) are set to `"default"` during import instead of the actual Snowflake value (e.g., `"false"`), preventing unavoidable diffs on every plan after import. Without the flag, the import behavior is unchanged from previous versions and consistent with other resources. To enable it, add `IMPORT_BOOLEAN_DEFAULT` to the [`experimental_features_enabled`](../#experimental_features_enabled-1) provider field. See the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#bugfix-importing-boolean-fields-in-stage-resources) for more details.
+
 # {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}


### PR DESCRIPTION
## Summary

- Introduces a new `IMPORT_BOOLEAN_DEFAULT` experimental feature that fixes unavoidable diffs after importing stage resources (`snowflake_stage_external_s3`, `snowflake_stage_external_azure`, `snowflake_stage_external_gcs`, `snowflake_stage_external_s3_compatible`, `snowflake_stage_internal`).
- When enabled, tri-value boolean fields (e.g., `ignore_utf8_errors`, `trim_space`, `use_privatelink_endpoint`, `auto_refresh`) are set to `"default"` during import instead of the actual Snowflake value (`"false"` / `"true"`), preventing a permadiff on the next plan.
- Updates `stageFileFormatToSchema` to accept a `setDefaults` parameter so all file format boolean fields across CSV, JSON, Avro, ORC, Parquet, and XML formats are handled consistently.
- Adds acceptance test that verifies both the broken behavior (without experiment) and the fix (with experiment) for the external S3 stage.

References #4549