### PR TITLE
fix: Map CORTEX_AGENT_SERVER to ObjectTypeMcpServer in grant conversion

### DIFF
--- a/pkg/scripts/migration_script/converter_grants.go
+++ b/pkg/scripts/migration_script/converter_grants.go
@@ -36,6 +36,9 @@ func (row GrantCsvRow) convert() (*sdk.Grant, error) {
 	if row.GrantedOn == "MODULE" {
 		grantedOn = sdk.ObjectTypeModel
 	}
+	if row.GrantedOn == "CORTEX_AGENT_SERVER" {
+		grantedOn = sdk.ObjectTypeMcpServer
+	}
 
 	var grantOn sdk.ObjectType
 	// true for future grants
@@ -47,6 +50,9 @@ func (row GrantCsvRow) convert() (*sdk.Grant, error) {
 	}
 	if row.GrantOn == "MODULE" {
 		grantOn = sdk.ObjectTypeModel
+	}
+	if row.GrantOn == "CORTEX_AGENT_SERVER" {
+		grantOn = sdk.ObjectTypeMcpServer
 	}
 
 	var name sdk.ObjectIdentifier

--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -239,6 +239,9 @@ func (row grantRow) convert() (*Grant, error) {
 	if row.GrantedOn == "MODULE" {
 		grantedOn = ObjectTypeModel
 	}
+	if row.GrantedOn == "CORTEX_AGENT_SERVER" {
+		grantedOn = ObjectTypeMcpServer
+	}
 
 	var grantOn ObjectType
 	// true for future grants
@@ -250,6 +253,9 @@ func (row grantRow) convert() (*Grant, error) {
 	}
 	if row.GrantOn == "MODULE" {
 		grantOn = ObjectTypeModel
+	}
+	if row.GrantOn == "CORTEX_AGENT_SERVER" {
+		grantOn = ObjectTypeMcpServer
 	}
 
 	var name ObjectIdentifier


### PR DESCRIPTION
## Summary
- Snowflake returns `CORTEX_AGENT_SERVER` in `SHOW GRANTS` / `SHOW FUTURE GRANTS` output for MCP Server objects, but the provider defines the type as `ObjectTypeMcpServer` (`"MCP SERVER"`). Without a mapping, grants on MCP Servers are not recognized and get recreated on every apply.
- Adds the `CORTEX_AGENT_SERVER` → `ObjectTypeMcpServer` mapping in both `pkg/sdk/grants.go` and `pkg/scripts/migration_script/converter_grants.go`, following the existing pattern for `VOLUME` → `ExternalVolume` and `MODULE` → `Model`.

Closes #4524

## Test plan
- [ ] Apply a grant on an MCP Server (e.g. `snowflake_grant_privileges_to_database_role` with `object_type_plural = "MCP Servers"`)
- [ ] Run `terraform apply` a second time and confirm no changes are detected
- [ ] Verify current grants (non-future) on MCP Servers also show no diff on subsequent applies