### PR TITLE
fix: Pass context properly instead of context.Background()

### DIFF
--- a/pkg/datasources/cortex_search_services.go
+++ b/pkg/datasources/cortex_search_services.go
@@ -167,7 +167,7 @@ func ReadCortexSearchServices(ctx context.Context, d *schema.ResourceData, meta 
 		request.WithLimit(limit)
 	}
 
-	dts, err := client.CortexSearchServices.Show(context.Background(), request)
+	dts, err := client.CortexSearchServices.Show(ctx, request)
 	if err != nil {
 		log.Printf("[DEBUG] snowflake_cortex_search_services.go: %v", err)
 		d.SetId("")

--- a/pkg/datasources/dynamic_tables.go
+++ b/pkg/datasources/dynamic_tables.go
@@ -252,7 +252,7 @@ func ReadDynamicTables(ctx context.Context, d *schema.ResourceData, meta any) di
 		request.WithLimit(&limit)
 	}
 
-	dts, err := client.DynamicTables.Show(context.Background(), request)
+	dts, err := client.DynamicTables.Show(ctx, request)
 	if err != nil {
 		log.Printf("[DEBUG] snowflake_dynamic_tables.go: %v", err)
 		d.SetId("")

--- a/pkg/datasources/system_get_snowflake_platform_info.go
+++ b/pkg/datasources/system_get_snowflake_platform_info.go
@@ -47,7 +47,7 @@ func ReadSystemGetSnowflakePlatformInfo(ctx context.Context, d *schema.ResourceD
 	sel := snowflake.SystemGetSnowflakePlatformInfoQuery()
 	row := snowflake.QueryRow(db, sel)
 
-	acc, err := client.ContextFunctions.CurrentSessionDetails(context.Background())
+	acc, err := client.ContextFunctions.CurrentSessionDetails(ctx)
 	if err != nil {
 		// If not found, mark resource to be removed from state file during apply or refresh
 		d.SetId("")

--- a/pkg/resources/account.go
+++ b/pkg/resources/account.go
@@ -196,7 +196,7 @@ func ImportAccount(ctx context.Context, d *schema.ResourceData, meta any) ([]*sc
 		return nil, err
 	}
 
-	if _, err := ImportName[sdk.AccountIdentifier](context.Background(), d, nil); err != nil {
+	if _, err := ImportName[sdk.AccountIdentifier](ctx, d, nil); err != nil {
 		return nil, err
 	}
 

--- a/pkg/resources/api_authentication_integration_common.go
+++ b/pkg/resources/api_authentication_integration_common.go
@@ -211,10 +211,10 @@ func handleApiAuthCreate(d *schema.ResourceData) (commonApiAuthCreate, error) {
 	return create, nil
 }
 
-func handleApiAuthImport(d *schema.ResourceData, integration *sdk.SecurityIntegration,
+func handleApiAuthImport(ctx context.Context, d *schema.ResourceData, integration *sdk.SecurityIntegration,
 	properties []sdk.SecurityIntegrationProperty,
 ) error {
-	if _, err := ImportName[sdk.AccountObjectIdentifier](context.Background(), d, nil); err != nil {
+	if _, err := ImportName[sdk.AccountObjectIdentifier](ctx, d, nil); err != nil {
 		return err
 	}
 

--- a/pkg/resources/api_authentication_integration_with_authorization_code_grant.go
+++ b/pkg/resources/api_authentication_integration_with_authorization_code_grant.go
@@ -75,7 +75,7 @@ func ImportApiAuthenticationWithAuthorizationCodeGrant(ctx context.Context, d *s
 		return nil, err
 	}
 
-	if err := handleApiAuthImport(d, integration, properties); err != nil {
+	if err := handleApiAuthImport(ctx, d, integration, properties); err != nil {
 		return nil, err
 	}
 	oauthAuthorizationEndpoint, err := collections.FindFirst(properties, func(property sdk.SecurityIntegrationProperty) bool {

--- a/pkg/resources/api_authentication_integration_with_client_credentials.go
+++ b/pkg/resources/api_authentication_integration_with_client_credentials.go
@@ -68,7 +68,7 @@ func ImportApiAuthenticationWithClientCredentials(ctx context.Context, d *schema
 	if err != nil {
 		return nil, err
 	}
-	if err := handleApiAuthImport(d, integration, properties); err != nil {
+	if err := handleApiAuthImport(ctx, d, integration, properties); err != nil {
 		return nil, err
 	}
 	oauthAllowedScopes, err := collections.FindFirst(properties, func(property sdk.SecurityIntegrationProperty) bool { return property.Name == "OAUTH_ALLOWED_SCOPES" })

--- a/pkg/resources/api_authentication_integration_with_jwt_bearer.go
+++ b/pkg/resources/api_authentication_integration_with_jwt_bearer.go
@@ -71,7 +71,7 @@ func ImportApiAuthenticationWithJwtBearer(ctx context.Context, d *schema.Resourc
 	if err != nil {
 		return nil, err
 	}
-	if err := handleApiAuthImport(d, integration, properties); err != nil {
+	if err := handleApiAuthImport(ctx, d, integration, properties); err != nil {
 		return nil, err
 	}
 	oauthAuthorizationEndpoint, err := collections.FindFirst(properties, func(property sdk.SecurityIntegrationProperty) bool {

--- a/pkg/resources/authentication_policy.go
+++ b/pkg/resources/authentication_policy.go
@@ -281,7 +281,7 @@ func ImportAuthenticationPolicy(ctx context.Context, d *schema.ResourceData, met
 		return nil, err
 	}
 
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](ctx, d, nil); err != nil {
 		return nil, err
 	}
 

--- a/pkg/resources/common.go
+++ b/pkg/resources/common.go
@@ -64,7 +64,9 @@ func ctyValToSliceString(valueElems []cty.Value) []string {
 	return elems
 }
 
-func ImportName[T sdk.AccountObjectIdentifier | sdk.DatabaseObjectIdentifier | sdk.SchemaObjectIdentifier | sdk.AccountIdentifier](ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+// ImportName parses the resource ID into the appropriate identifier type and sets the matching schema fields.
+// context.Context is unused but required to satisfy schema.StateContextFunc from the Terraform SDK.
+func ImportName[T sdk.AccountObjectIdentifier | sdk.DatabaseObjectIdentifier | sdk.SchemaObjectIdentifier | sdk.AccountIdentifier](_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	switch any(new(T)).(type) {
 	case *sdk.AccountObjectIdentifier:
 		id, err := sdk.ParseAccountObjectIdentifier(d.Id())

--- a/pkg/resources/external_azure_stage.go
+++ b/pkg/resources/external_azure_stage.go
@@ -190,7 +190,7 @@ func ImportExternalAzureStage(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		return nil, err
 	}
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](ctx, d, nil); err != nil {
 		return nil, err
 	}
 	stage, err := client.Stages.ShowByIDSafely(ctx, id)

--- a/pkg/resources/external_gcs_stage.go
+++ b/pkg/resources/external_gcs_stage.go
@@ -159,7 +159,7 @@ func ImportExternalGcsStage(ctx context.Context, d *schema.ResourceData, meta an
 	if err != nil {
 		return nil, err
 	}
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](ctx, d, nil); err != nil {
 		return nil, err
 	}
 	stage, err := client.Stages.ShowByIDSafely(ctx, id)

--- a/pkg/resources/external_s3_compatible_stage.go
+++ b/pkg/resources/external_s3_compatible_stage.go
@@ -142,7 +142,7 @@ func ImportExternalS3CompatStage(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		return nil, err
 	}
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](ctx, d, nil); err != nil {
 		return nil, err
 	}
 	stage, err := client.Stages.ShowByIDSafely(ctx, id)

--- a/pkg/resources/external_s3_stage.go
+++ b/pkg/resources/external_s3_stage.go
@@ -241,7 +241,7 @@ func ImportExternalS3Stage(ctx context.Context, d *schema.ResourceData, meta any
 	if err != nil {
 		return nil, err
 	}
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](ctx, d, nil); err != nil {
 		return nil, err
 	}
 	stage, err := client.Stages.ShowByIDSafely(ctx, id)

--- a/pkg/resources/notebook.go
+++ b/pkg/resources/notebook.go
@@ -155,7 +155,7 @@ func ImportNotebook(ctx context.Context, d *schema.ResourceData, meta any) ([]*s
 		return nil, err
 	}
 
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](ctx, d, nil); err != nil {
 		return nil, err
 	}
 

--- a/pkg/resources/secret_common.go
+++ b/pkg/resources/secret_common.go
@@ -60,8 +60,8 @@ var secretCommonSchema = map[string]*schema.Schema{
 	FullyQualifiedNameAttributeName: schemas.FullyQualifiedNameSchema,
 }
 
-func handleSecretImport(d *schema.ResourceData) error {
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+func handleSecretImport(ctx context.Context, d *schema.ResourceData) error {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](ctx, d, nil); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/resources/secret_with_basic_authentication.go
+++ b/pkg/resources/secret_with_basic_authentication.go
@@ -64,7 +64,7 @@ func ImportSecretWithBasicAuthentication(ctx context.Context, d *schema.Resource
 		return nil, err
 	}
 
-	if err := handleSecretImport(d); err != nil {
+	if err := handleSecretImport(ctx, d); err != nil {
 		return nil, err
 	}
 	secretDescription, err := client.Secrets.Describe(ctx, id)

--- a/pkg/resources/secret_with_generic_string.go
+++ b/pkg/resources/secret_with_generic_string.go
@@ -56,7 +56,7 @@ func ImportSecretWithGenericString(ctx context.Context, d *schema.ResourceData, 
 		return nil, err
 	}
 
-	if err := handleSecretImport(d); err != nil {
+	if err := handleSecretImport(ctx, d); err != nil {
 		return nil, err
 	}
 

--- a/pkg/resources/secret_with_oauth_authorization_code_grant.go
+++ b/pkg/resources/secret_with_oauth_authorization_code_grant.go
@@ -69,7 +69,7 @@ func ImportSecretWithAuthorizationCodeGrant(ctx context.Context, d *schema.Resou
 	if err != nil {
 		return nil, err
 	}
-	if err = handleSecretImport(d); err != nil {
+	if err = handleSecretImport(ctx, d); err != nil {
 		return nil, err
 	}
 

--- a/pkg/resources/secret_with_oauth_client_credentials.go
+++ b/pkg/resources/secret_with_oauth_client_credentials.go
@@ -65,7 +65,7 @@ func ImportSecretWithClientCredentials(ctx context.Context, d *schema.ResourceDa
 		return nil, err
 	}
 
-	if err := handleSecretImport(d); err != nil {
+	if err := handleSecretImport(ctx, d); err != nil {
 		return nil, err
 	}
 	secretDescription, err := client.Secrets.Describe(ctx, id)

--- a/pkg/resources/stream_on_external_table.go
+++ b/pkg/resources/stream_on_external_table.go
@@ -79,7 +79,7 @@ func ImportStreamOnExternalTable(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		return nil, err
 	}
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](ctx, d, nil); err != nil {
 		return nil, err
 	}
 	if err := d.Set("insert_only", booleanStringFromBool(v.IsInsertOnly())); err != nil {

--- a/pkg/resources/stream_on_table.go
+++ b/pkg/resources/stream_on_table.go
@@ -86,7 +86,7 @@ func ImportStreamOnTable(ctx context.Context, d *schema.ResourceData, meta any) 
 	if err != nil {
 		return nil, err
 	}
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](ctx, d, nil); err != nil {
 		return nil, err
 	}
 	if err := d.Set("append_only", booleanStringFromBool(v.IsAppendOnly())); err != nil {

--- a/pkg/resources/stream_on_view.go
+++ b/pkg/resources/stream_on_view.go
@@ -86,7 +86,7 @@ func ImportStreamOnView(ctx context.Context, d *schema.ResourceData, meta any) (
 	if err != nil {
 		return nil, err
 	}
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](ctx, d, nil); err != nil {
 		return nil, err
 	}
 	if err := d.Set("append_only", booleanStringFromBool(v.IsAppendOnly())); err != nil {

--- a/pkg/resources/task.go
+++ b/pkg/resources/task.go
@@ -264,7 +264,7 @@ func ImportTask(ctx context.Context, d *schema.ResourceData, meta any) ([]*schem
 		return nil, err
 	}
 
-	if _, err := ImportName[sdk.SchemaObjectIdentifier](context.Background(), d, nil); err != nil {
+	if _, err := ImportName[sdk.SchemaObjectIdentifier](ctx, d, nil); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

- Replace `context.Background()` with the caller-provided `ctx` in resource import functions and datasource read functions
- Ensures cancellation, timeouts, and tracing metadata from Terraform's framework are properly propagated to SDK calls