### PR TITLE
fix: Fix panic in snowflake_view when last column has masking policy without using clause

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -261,6 +261,22 @@ The `snowflake_grant_ownership` resource now supports granting ownership on `DBT
 
 No changes in configuration are required.
 
+### *(bugfix)* Fixed panic in `snowflake_view` when the last column has a masking policy without a `using` clause
+
+The `snowflake_view` resource could panic with `index out of range` during plan, apply, or refresh when the last column definition included a `masking_policy` block without a `using` argument. The error could be as follows:
+```
+panic: runtime error: index out of range [276] with length 276
+
+goroutine 149 [running]:
+github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake.(*ViewSelectStatementExtractor).consumeToken(0x1400077c818, {0x103fb7629, 0x11})
+	github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/snowflake/parser.go:242 +0x150
+...
+```
+
+This was caused by a missing early-exit check in the internal SQL parser used to extract the view's `SELECT` statement after consuming the masking policy identifier.
+
+No changes in configuration are required. If this error happened during object creation, the state of this resource may be empty. In this case, just reimport the object.
+
 ## v2.14.0 ➞ v2.14.1
 
 ### *(breaking change)* Adjustments in `snowflake_authentication_policy` and `snowflake_authentication_policies` due to `DESC AUTHENTICATION POLICY` output change

--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/view_resource_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/view_resource_ext.go
@@ -1,9 +1,11 @@
 package resourceassert
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 )
 
 func (v *ViewResourceAssert) HasColumnLength(len int) *ViewResourceAssert {
@@ -48,5 +50,17 @@ func (v *ViewResourceAssert) HasNoDataMetricScheduleByLength() *ViewResourceAsse
 
 func (v *ViewResourceAssert) HasNoDataMetricFunctionByLength() *ViewResourceAssert {
 	v.AddAssertion(assert.ValueNotSet("data_metric_function.#"))
+	return v
+}
+
+func (v *ViewResourceAssert) HasColumns(columns []sdk.ViewColumn) *ViewResourceAssert {
+	v.AddAssertion(assert.ValueSet("column.#", strconv.Itoa(len(columns))))
+	for i, col := range columns {
+		v.AddAssertion(assert.ValueSet(fmt.Sprintf("column.%d.column_name", i), col.Name))
+		if col.MaskingPolicy != nil {
+			v.AddAssertion(assert.ValueSet(fmt.Sprintf("column.%d.masking_policy.#", i), "1"))
+			v.AddAssertion(assert.ValueSet(fmt.Sprintf("column.%d.masking_policy.0.policy_name", i), col.MaskingPolicy.MaskingPolicy.FullyQualifiedName()))
+		}
+	}
 	return v
 }

--- a/pkg/snowflake/parser.go
+++ b/pkg/snowflake/parser.go
@@ -96,6 +96,11 @@ func (e *ViewSelectStatementExtractor) consumeColumn() (isLast bool) {
 	if ok {
 		e.consumeSpace()
 		e.consumeID()
+		if e.input[e.pos-1] == ')' {
+			isLast = true
+			e.consumeSpace()
+			return
+		}
 		e.consumeSpace()
 		if ok := e.consumeToken("using"); ok {
 			e.consumeSpace()
@@ -112,7 +117,7 @@ func (e *ViewSelectStatementExtractor) consumeColumn() (isLast bool) {
 	e.consumeQuotedParameter("comment", false)
 	e.consumeSpace()
 	e.consumeToken(",")
-	if e.input[e.pos] == ')' {
+	if e.input[e.pos] == ')' { // e.pos < len(e.input) &&
 		e.consumeToken(")")
 		isLast = true
 	}

--- a/pkg/snowflake/parser.go
+++ b/pkg/snowflake/parser.go
@@ -117,7 +117,7 @@ func (e *ViewSelectStatementExtractor) consumeColumn() (isLast bool) {
 	e.consumeQuotedParameter("comment", false)
 	e.consumeSpace()
 	e.consumeToken(",")
-	if e.input[e.pos] == ')' { // e.pos < len(e.input) &&
+	if e.input[e.pos] == ')' {
 		e.consumeToken(")")
 		isLast = true
 	}

--- a/pkg/snowflake/parser_test.go
+++ b/pkg/snowflake/parser_test.go
@@ -42,6 +42,9 @@ from bar;`
 	columnsListEndingWithComment := `CREATE OR REPLACE SECURE TEMPORARY VIEW "rgdxfmnfhh"."PUBLIC"."rgdxfmnfhh" (id PROJECTION POLICY pp MASKING POLICY mp COMMENT 'asdf', foo PROJECTION POLICY pp COMMENT 'foo (bar) hoge') COMMENT = 'Terraform test resource' ROW ACCESS policy rap on (title, title2) AGGREGATION POLICY rap ENTITY KEY (foo, bar)  AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES`
 	columnsListEndingWithID := `CREATE OR REPLACE SECURE TEMPORARY VIEW "rgdxfmnfhh"."PUBLIC"."rgdxfmnfhh" ("ID", "FOO") COMMENT = 'Terraform test resource' ROW ACCESS policy rap on (title, title2) AGGREGATION POLICY rap ENTITY KEY (foo, bar)  AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES`
 	allFields := `CREATE OR REPLACE SECURE TEMPORARY VIEW "rgdxfmnfhh"."PUBLIC"."rgdxfmnfhh" (id PROJECTION POLICY pp MASKING POLICY mp USING ("col1", "cond1") COMMENT 'asdf', foo MASKING POLICY mp USING ("col1", "cond1")) COMMENT = 'Terraform test resource' ROW ACCESS policy rap on (title, title2) AGGREGATION POLICY rap ENTITY KEY (foo, bar)  AS SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES`
+	// Regression test for SNOW-3308280: panic when consumeToken reaches end of input (off-by-one in bounds check).
+	// The last column has a masking policy and no trailing options, so the parser hits end-of-input while probing optional tokens.
+	snow3308280 := `CREATE OR REPLACE VIEW "DB"."SCHEMA"."VIEW_NAME" (col1 MASKING POLICY "DB"."SCHEMA"."MASK_POLICY") AS SELECT col1 FROM DB.SCHEMA.SOURCE_TABLE`
 	testStatement := "SELECT ROLE_NAME, ROLE_OWNER FROM INFORMATION_SCHEMA.APPLICABLE_ROLES"
 	type args struct {
 		input string
@@ -76,6 +79,7 @@ from bar;`
 		{"with column list ending with comment", args{columnsListEndingWithComment}, testStatement, false},
 		{"with column list ending with column name", args{columnsListEndingWithID}, testStatement, false},
 		{"all fields", args{allFields}, testStatement, false},
+		{"SNOW-3308280: masking policy on last column reaching end of input", args{snow3308280}, "SELECT col1 FROM DB.SCHEMA.SOURCE_TABLE", false},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/pkg/testacc/resource_view_acceptance_test.go
+++ b/pkg/testacc/resource_view_acceptance_test.go
@@ -1487,7 +1487,7 @@ func TestAcc_View_Issue3676_fix(t *testing.T) {
 // This test proves the fix for SNOW-3308280: panic when consumeToken reaches end of input (off-by-one in bounds check).
 // The error happened when the last column had a masking policy and no trailing options (USING clause), so the parser hits end-of-input while probing optional tokens.
 func TestAcc_View_SNOW_3308280_fix(t *testing.T) {
-	// Masking policy: 2-arg VARCHAR signature (from CreateMaskingPolicy helper)
+	// Use the identity masking policy to avoid the USING clause.
 	maskingPolicy, maskingPolicyCleanup := testClient().MaskingPolicy.CreateMaskingPolicyIdentity(t, testdatatypes.DataTypeVarchar)
 	t.Cleanup(maskingPolicyCleanup)
 

--- a/pkg/testacc/resource_view_acceptance_test.go
+++ b/pkg/testacc/resource_view_acceptance_test.go
@@ -1532,18 +1532,15 @@ func TestAcc_View_SNOW_3308280_fix(t *testing.T) {
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				PreConfig:                testClient().View.DropViewFunc(t, id),
 				Config:                   accconfig.FromModels(t, viewModel),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("snowflake_view.test", "name", id.Name()),
-					resource.TestCheckResourceAttr("snowflake_view.test", "database", id.DatabaseName()),
-					resource.TestCheckResourceAttr("snowflake_view.test", "schema", id.SchemaName()),
-					resource.TestCheckResourceAttr("snowflake_view.test", "column.#", "2"),
-					resource.TestCheckResourceAttr("snowflake_view.test", "column.1.column_name", "COL2"),
-					resource.TestCheckResourceAttr("snowflake_view.test", "column.1.masking_policy.#", "1"),
-					resource.TestCheckResourceAttr(
-						"snowflake_view.test",
-						"column.1.masking_policy.0.policy_name",
-						maskingPolicy.ID().FullyQualifiedName(),
-					),
+				Check: assertThat(t, resourceassert.ViewResource(t, viewModel.ResourceReference()).
+					HasNameString(id.Name()).
+					HasDatabaseString(id.DatabaseName()).
+					HasSchemaString(id.SchemaName()).
+					HasStatementString(statement).
+					HasColumns([]sdk.ViewColumn{
+						{Name: "COL1"},
+						{Name: "COL2", MaskingPolicy: &sdk.ViewColumnMaskingPolicy{MaskingPolicy: maskingPolicy.ID()}},
+					}),
 				),
 			},
 		},

--- a/pkg/testacc/resource_view_acceptance_test.go
+++ b/pkg/testacc/resource_view_acceptance_test.go
@@ -1483,3 +1483,69 @@ func TestAcc_View_Issue3676_fix(t *testing.T) {
 		},
 	})
 }
+
+// This test proves the fix for SNOW-3308280: panic when consumeToken reaches end of input (off-by-one in bounds check).
+// The error happened when the last column had a masking policy and no trailing options (USING clause), so the parser hits end-of-input while probing optional tokens.
+func TestAcc_View_SNOW_3308280_fix(t *testing.T) {
+	// Masking policy: 2-arg VARCHAR signature (from CreateMaskingPolicy helper)
+	maskingPolicy, maskingPolicyCleanup := testClient().MaskingPolicy.CreateMaskingPolicyIdentity(t, testdatatypes.DataTypeVarchar)
+	t.Cleanup(maskingPolicyCleanup)
+
+	table, tableCleanup := testClient().Table.CreateWithColumns(t, []sdk.TableColumnRequest{
+		*sdk.NewTableColumnRequest("COL1", sdk.DataTypeVARCHAR),
+		*sdk.NewTableColumnRequest("COL2", sdk.DataTypeVARCHAR),
+	})
+	t.Cleanup(tableCleanup)
+
+	id := testClient().Ids.RandomSchemaObjectIdentifier()
+	statement := fmt.Sprintf("SELECT COL1, COL2 FROM %s", table.ID().FullyQualifiedName())
+	viewModel := model.ViewWithDefaultMeta(id.DatabaseName(), id.SchemaName(), id.Name(),
+		statement).
+		WithColumnValue(config.TupleVariable(
+			config.ObjectVariable(map[string]config.Variable{
+				"column_name": config.StringVariable("COL1"),
+			}),
+			config.ObjectVariable(map[string]config.Variable{
+				"column_name": config.StringVariable("COL2"),
+				"masking_policy": config.ObjectVariable(map[string]config.Variable{
+					"policy_name": config.StringVariable(maskingPolicy.ID().FullyQualifiedName()),
+				}),
+			}),
+		))
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.View),
+		Steps: []resource.TestStep{
+			// v2.14.1: provider panics during Read after Create
+			{
+				ExternalProviders: ExternalProviderWithExactVersion("2.14.1"),
+				Config:            accconfig.FromModels(t, viewModel),
+				ExpectError:       regexp.MustCompile(`index out of range`),
+			},
+			// It is fixed on the latest version of the provider.
+			// The view was created by step 1 but not saved to state.
+			// PreConfig drops the orphaned view so the apply can recreate it cleanly.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				PreConfig:                testClient().View.DropViewFunc(t, id),
+				Config:                   accconfig.FromModels(t, viewModel),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_view.test", "name", id.Name()),
+					resource.TestCheckResourceAttr("snowflake_view.test", "database", id.DatabaseName()),
+					resource.TestCheckResourceAttr("snowflake_view.test", "schema", id.SchemaName()),
+					resource.TestCheckResourceAttr("snowflake_view.test", "column.#", "2"),
+					resource.TestCheckResourceAttr("snowflake_view.test", "column.1.column_name", "COL2"),
+					resource.TestCheckResourceAttr("snowflake_view.test", "column.1.masking_policy.#", "1"),
+					resource.TestCheckResourceAttr(
+						"snowflake_view.test",
+						"column.1.masking_policy.0.policy_name",
+						maskingPolicy.ID().FullyQualifiedName(),
+					),
+				),
+			},
+		},
+	})
+}

--- a/pkg/testacc/resource_view_acceptance_test.go
+++ b/pkg/testacc/resource_view_acceptance_test.go
@@ -1486,7 +1486,7 @@ func TestAcc_View_Issue3676_fix(t *testing.T) {
 
 // This test proves the fix for SNOW-3308280: panic when consumeToken reaches end of input (off-by-one in bounds check).
 // The error happened when the last column had a masking policy and no trailing options (USING clause), so the parser hits end-of-input while probing optional tokens.
-func TestAcc_View_SNOW_3308280_fix(t *testing.T) {
+func TestAcc_View_MaskingPolicyWithoutUsingClausePanicFix(t *testing.T) {
 	// Use the identity masking policy to avoid the USING clause.
 	maskingPolicy, maskingPolicyCleanup := testClient().MaskingPolicy.CreateMaskingPolicyIdentity(t, testdatatypes.DataTypeVarchar)
 	t.Cleanup(maskingPolicyCleanup)


### PR DESCRIPTION
## Summary

- Fixes a panic (`index out of range`) in `ViewSelectStatementExtractor.consumeColumn` that occurred when a view's last column had a `masking_policy` block but no `using` argument
- The root cause was a missing early-exit check after parsing the masking policy identifier: the parser continued into optional token probing off the end of the input buffer
- Adds an acceptance test `TestAcc_View_SNOW_3308280_fix` that reproduces the bug against provider v2.14.1 and verifies it is fixed in the current version
- Adds a migration guide entry under `v2.14.x ➞ v2.15.0`