### PR TITLE
feat: Add RevokePrivilegeFromShareSafely to SDK Grants interface

### DIFF
--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -15,6 +15,7 @@ type Grants interface {
 	RevokePrivilegesFromDatabaseRole(ctx context.Context, privileges *DatabaseRoleGrantPrivileges, on *DatabaseRoleGrantOn, role DatabaseObjectIdentifier, opts *RevokePrivilegesFromDatabaseRoleOptions) error
 	GrantPrivilegeToShare(ctx context.Context, privileges []ObjectPrivilege, on *ShareGrantOn, to AccountObjectIdentifier) error
 	RevokePrivilegeFromShare(ctx context.Context, privileges []ObjectPrivilege, on *ShareGrantOn, from AccountObjectIdentifier) error
+	RevokePrivilegeFromShareSafely(ctx context.Context, privileges []ObjectPrivilege, on *ShareGrantOn, from AccountObjectIdentifier) error
 	GrantOwnership(ctx context.Context, on OwnershipGrantOn, to OwnershipGrantTo, opts *GrantOwnershipOptions) error
 
 	Show(ctx context.Context, opts *ShowGrantOptions) ([]Grant, error)

--- a/pkg/sdk/grants_impl.go
+++ b/pkg/sdk/grants_impl.go
@@ -208,6 +208,12 @@ func (v *grants) RevokePrivilegeFromShare(ctx context.Context, privileges []Obje
 	return validateAndExec(v.client, ctx, opts)
 }
 
+func (v *grants) RevokePrivilegeFromShareSafely(ctx context.Context, privileges []ObjectPrivilege, on *ShareGrantOn, id AccountObjectIdentifier) error {
+	return SafeRevokePrivileges(func() error {
+		return v.RevokePrivilegeFromShare(ctx, privileges, on, id)
+	})
+}
+
 func (v *grants) GrantOwnership(ctx context.Context, on OwnershipGrantOn, to OwnershipGrantTo, opts *GrantOwnershipOptions) error {
 	if opts == nil {
 		opts = &GrantOwnershipOptions{}

--- a/pkg/sdk/testint/safe_grant_handlers_integration_test.go
+++ b/pkg/sdk/testint/safe_grant_handlers_integration_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInt_SafeRevokePrivilegesFromAccountRole(t *testing.T) {
@@ -328,6 +329,80 @@ func TestInt_ShowFutureGrantsInNonExistingContainer(t *testing.T) {
 				In:     tt.In,
 			})
 			assert.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
+		})
+	}
+}
+
+func TestInt_SafeRevokePrivilegeFromShare(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	share, shareCleanup := testClientHelper().Share.CreateShare(t)
+	t.Cleanup(shareCleanup)
+
+	// Grant USAGE on the test database to the share (prerequisite for schema-level grants).
+	revokeGrant := testClientHelper().Grant.GrantPrivilegeOnDatabaseToShare(t, testClientHelper().Ids.DatabaseId(), share.ID(), []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage})
+	t.Cleanup(revokeGrant)
+
+	t.Run("privilege never granted", func(t *testing.T) {
+		// Snowflake returns success (0 rows affected) when revoking a privilege that was never granted.
+		err := client.Grants.RevokePrivilegeFromShare(ctx, []sdk.ObjectPrivilege{sdk.ObjectPrivilegeSelect}, &sdk.ShareGrantOn{
+			Table: &sdk.OnTable{
+				AllInSchema: testClientHelper().Ids.SchemaId(),
+			},
+		}, share.ID())
+		require.NoError(t, err)
+	})
+
+	t.Run("non-existing share", func(t *testing.T) {
+		err := client.Grants.RevokePrivilegeFromShareSafely(ctx, []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage}, &sdk.ShareGrantOn{
+			Database: testClientHelper().Ids.DatabaseId(),
+		}, NonExistingAccountObjectIdentifier)
+		require.NoError(t, err)
+	})
+
+	t.Run("non-existing database", func(t *testing.T) {
+		err := client.Grants.RevokePrivilegeFromShareSafely(ctx, []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage}, &sdk.ShareGrantOn{
+			Database: NonExistingAccountObjectIdentifier,
+		}, share.ID())
+		require.NoError(t, err)
+	})
+}
+
+func TestInt_SafeRevokeFromShareOnNonExistingSchemaLevelObjects(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	share, shareCleanup := testClientHelper().Share.CreateShare(t)
+	t.Cleanup(shareCleanup)
+
+	// Grant USAGE on the test database to the share (prerequisite for schema-level grants).
+	revokeGrant := testClientHelper().Grant.GrantPrivilegeOnDatabaseToShare(t, testClientHelper().Ids.DatabaseId(), share.ID(), []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage})
+	t.Cleanup(revokeGrant)
+
+	testCases := []struct {
+		Name       string
+		Privileges []sdk.ObjectPrivilege
+		On         *sdk.ShareGrantOn
+	}{
+		{Name: "non-existing schema", Privileges: []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage}, On: &sdk.ShareGrantOn{Schema: NonExistingDatabaseObjectIdentifier}},
+		{Name: "non-existing schema in non-existing database", Privileges: []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage}, On: &sdk.ShareGrantOn{Schema: NonExistingDatabaseObjectIdentifierWithNonExistingDatabase}},
+		{Name: "non-existing table", Privileges: []sdk.ObjectPrivilege{sdk.ObjectPrivilegeSelect}, On: &sdk.ShareGrantOn{Table: &sdk.OnTable{Name: NonExistingSchemaObjectIdentifier}}},
+		{Name: "non-existing table in non-existing database and schema", Privileges: []sdk.ObjectPrivilege{sdk.ObjectPrivilegeSelect}, On: &sdk.ShareGrantOn{Table: &sdk.OnTable{Name: NonExistingSchemaObjectIdentifierWithNonExistingDatabaseAndSchema}}},
+		{Name: "all tables in non-existing schema", Privileges: []sdk.ObjectPrivilege{sdk.ObjectPrivilegeSelect}, On: &sdk.ShareGrantOn{Table: &sdk.OnTable{AllInSchema: NonExistingDatabaseObjectIdentifier}}},
+		{Name: "all tables in non-existing schema in non-existing database", Privileges: []sdk.ObjectPrivilege{sdk.ObjectPrivilegeSelect}, On: &sdk.ShareGrantOn{Table: &sdk.OnTable{AllInSchema: NonExistingDatabaseObjectIdentifierWithNonExistingDatabase}}},
+		{Name: "non-existing view", Privileges: []sdk.ObjectPrivilege{sdk.ObjectPrivilegeSelect}, On: &sdk.ShareGrantOn{View: NonExistingSchemaObjectIdentifier}},
+		{Name: "non-existing view in non-existing database and schema", Privileges: []sdk.ObjectPrivilege{sdk.ObjectPrivilegeSelect}, On: &sdk.ShareGrantOn{View: NonExistingSchemaObjectIdentifierWithNonExistingDatabaseAndSchema}},
+		{Name: "non-existing tag", Privileges: []sdk.ObjectPrivilege{sdk.ObjectPrivilegeRead}, On: &sdk.ShareGrantOn{Tag: NonExistingSchemaObjectIdentifier}},
+		{Name: "non-existing tag in non-existing database and schema", Privileges: []sdk.ObjectPrivilege{sdk.ObjectPrivilegeRead}, On: &sdk.ShareGrantOn{Tag: NonExistingSchemaObjectIdentifierWithNonExistingDatabaseAndSchema}},
+		{Name: "non-existing function", Privileges: []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage}, On: &sdk.ShareGrantOn{Function: NonExistingSchemaObjectIdentifierWithArguments}},
+		{Name: "non-existing function in non-existing database and schema", Privileges: []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage}, On: &sdk.ShareGrantOn{Function: NonExistingSchemaObjectIdentifierWithArgumentsWithNonExistingDatabaseAndSchema}},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.Name, func(t *testing.T) {
+			err := client.Grants.RevokePrivilegeFromShareSafely(ctx, tt.Privileges, tt.On, share.ID())
+			assert.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `RevokePrivilegeFromShareSafely` to the `Grants` interface and implementation, following the same pattern as `RevokePrivilegesFromAccountRoleSafely` (PR #4543)
- The safe variant wraps `RevokePrivilegeFromShare` with `SafeRevokePrivileges`, which swallows `ErrObjectNotExistOrAuthorized` — the error Snowflake returns when the share or grant target object no longer exists
- Adds integration tests covering non-existing shares, databases, schemas, tables, and views (including fully non-existing hierarchy)