### PR TITLE
chore: Add SafeUnsetTag for graceful tag unset on missing objects

### DIFF
--- a/pkg/sdk/operation_helpers.go
+++ b/pkg/sdk/operation_helpers.go
@@ -156,6 +156,18 @@ func SafeRevokePrivileges(revoke func() error) error {
 	return err
 }
 
+// SafeUnsetTag is a helper function that wraps a tag unset function
+// and handles the case where the target object no longer exists.
+// When the referenced object (e.g. a table, view, schema, database, warehouse)
+// does not exist, Snowflake returns ErrObjectNotExistOrAuthorized.
+func SafeUnsetTag(unset func() error) error {
+	err := unset()
+	if errors.Is(err, ErrObjectNotExistOrAuthorized) {
+		return nil
+	}
+	return err
+}
+
 // SafeShowProgrammaticAccessTokenByName is a helper function with specific implementation for PATs.
 func SafeShowProgrammaticAccessTokenByName(
 	client *Client,

--- a/pkg/sdk/tags.go
+++ b/pkg/sdk/tags.go
@@ -17,6 +17,7 @@ type Tags interface {
 	Undrop(ctx context.Context, request *UndropTagRequest) error
 	Set(ctx context.Context, request *SetTagRequest) error
 	Unset(ctx context.Context, request *UnsetTagRequest) error
+	UnsetSafely(ctx context.Context, request *UnsetTagRequest) error
 	SetOnCurrentAccount(ctx context.Context, request *SetTagOnCurrentAccountRequest) error
 	UnsetOnCurrentAccount(ctx context.Context, request *UnsetTagOnCurrentAccountRequest) error
 }

--- a/pkg/sdk/tags_impl.go
+++ b/pkg/sdk/tags_impl.go
@@ -92,7 +92,7 @@ func (v *tags) Unset(ctx context.Context, request *UnsetTagRequest) error {
 
 func (v *tags) UnsetSafely(ctx context.Context, request *UnsetTagRequest) error {
 	return SafeUnsetTag(func() error {
-		return v.Unset(ctx, request)
+		return v.Unset(ctx, request.WithIfExists(true))
 	})
 }
 

--- a/pkg/sdk/tags_impl.go
+++ b/pkg/sdk/tags_impl.go
@@ -90,6 +90,12 @@ func (v *tags) Unset(ctx context.Context, request *UnsetTagRequest) error {
 	return validateAndExec(v.client, ctx, opts)
 }
 
+func (v *tags) UnsetSafely(ctx context.Context, request *UnsetTagRequest) error {
+	return SafeUnsetTag(func() error {
+		return v.Unset(ctx, request)
+	})
+}
+
 func (v *tags) SetOnCurrentAccount(ctx context.Context, request *SetTagOnCurrentAccountRequest) error {
 	return v.client.Accounts.Alter(ctx, &AlterAccountOptions{
 		SetTag: request.SetTags,

--- a/pkg/sdk/testint/safe_tag_handlers_integration_test.go
+++ b/pkg/sdk/testint/safe_tag_handlers_integration_test.go
@@ -94,6 +94,24 @@ func TestInt_SafeUnsetTagFromColumn(t *testing.T) {
 		err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(sdk.ObjectTypeColumn, nonExistingColumnId).WithUnsetTags(unsetTags))
 		assert.NoError(t, err)
 	})
+
+	t.Run("non-existing table", func(t *testing.T) {
+		missingTableCol := sdk.NewTableColumnIdentifier(table.ID().DatabaseName(), table.ID().SchemaName(), "does_not_exist", "ID")
+		err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(sdk.ObjectTypeColumn, missingTableCol).WithUnsetTags(unsetTags))
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-existing schema", func(t *testing.T) {
+		missingSchemaCol := sdk.NewTableColumnIdentifier(table.ID().DatabaseName(), "does_not_exist", "does_not_exist", "ID")
+		err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(sdk.ObjectTypeColumn, missingSchemaCol).WithUnsetTags(unsetTags))
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-existing database", func(t *testing.T) {
+		missingDbCol := sdk.NewTableColumnIdentifier("does_not_exist", "does_not_exist", "does_not_exist", "ID")
+		err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(sdk.ObjectTypeColumn, missingDbCol).WithUnsetTags(unsetTags))
+		assert.NoError(t, err)
+	})
 }
 
 func TestInt_SafeUnsetTagOnNonExistingSchemaObject(t *testing.T) {

--- a/pkg/sdk/testint/safe_tag_handlers_integration_test.go
+++ b/pkg/sdk/testint/safe_tag_handlers_integration_test.go
@@ -1,0 +1,199 @@
+//go:build non_account_level_tests
+
+package testint
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInt_SafeUnsetTagFromTable(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	tag, tagCleanup := testClientHelper().Tag.CreateTag(t)
+	t.Cleanup(tagCleanup)
+
+	table, tableCleanup := testClientHelper().Table.Create(t)
+	t.Cleanup(tableCleanup)
+
+	tags := []sdk.TagAssociation{
+		{
+			Name:  tag.ID(),
+			Value: "abc",
+		},
+	}
+	unsetTags := []sdk.ObjectIdentifier{tag.ID()}
+
+	err := client.Tags.Set(ctx, sdk.NewSetTagRequest(sdk.ObjectTypeTable, table.ID()).WithSetTags(tags))
+	require.NoError(t, err)
+
+	t.Run("unset existing tag", func(t *testing.T) {
+		err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(sdk.ObjectTypeTable, table.ID()).WithUnsetTags(unsetTags))
+		assert.NoError(t, err)
+	})
+
+	t.Run("unset already-unset tag", func(t *testing.T) {
+		// Snowflake returns success when unsetting a tag that was never set.
+		err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(sdk.ObjectTypeTable, table.ID()).WithUnsetTags(unsetTags))
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-existing tag on existing table", func(t *testing.T) {
+		nonExistingTagIds := []sdk.ObjectIdentifier{NonExistingSchemaObjectIdentifierWithNonExistingDatabaseAndSchema}
+		err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(sdk.ObjectTypeTable, table.ID()).WithUnsetTags(nonExistingTagIds))
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-existing table", func(t *testing.T) {
+		err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(sdk.ObjectTypeTable, NonExistingSchemaObjectIdentifierWithNonExistingDatabaseAndSchema).WithUnsetTags(unsetTags))
+		assert.NoError(t, err)
+	})
+}
+
+func TestInt_SafeUnsetTagFromColumn(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	tag, tagCleanup := testClientHelper().Tag.CreateTag(t)
+	t.Cleanup(tagCleanup)
+
+	table, tableCleanup := testClientHelper().Table.Create(t)
+	t.Cleanup(tableCleanup)
+
+	columnId := sdk.NewTableColumnIdentifier(table.ID().DatabaseName(), table.ID().SchemaName(), table.ID().Name(), "ID")
+
+	tags := []sdk.TagAssociation{
+		{
+			Name:  tag.ID(),
+			Value: "abc",
+		},
+	}
+	unsetTags := []sdk.ObjectIdentifier{tag.ID()}
+
+	err := client.Tags.Set(ctx, sdk.NewSetTagRequest(sdk.ObjectTypeColumn, columnId).WithSetTags(tags))
+	require.NoError(t, err)
+
+	t.Run("unset existing tag on column", func(t *testing.T) {
+		err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(sdk.ObjectTypeColumn, columnId).WithUnsetTags(unsetTags))
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-existing tag on existing column", func(t *testing.T) {
+		nonExistingTagIds := []sdk.ObjectIdentifier{NonExistingSchemaObjectIdentifierWithNonExistingDatabaseAndSchema}
+		err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(sdk.ObjectTypeColumn, columnId).WithUnsetTags(nonExistingTagIds))
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-existing column", func(t *testing.T) {
+		nonExistingColumnId := sdk.NewTableColumnIdentifier("does_not_exist", "does_not_exist", "does_not_exist", "does_not_exist")
+		err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(sdk.ObjectTypeColumn, nonExistingColumnId).WithUnsetTags(unsetTags))
+		assert.NoError(t, err)
+	})
+}
+
+func TestInt_SafeUnsetTagOnNonExistingSchemaObject(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	unsetTags := []sdk.ObjectIdentifier{NonExistingSchemaObjectIdentifier}
+
+	testCases := []struct {
+		ObjectType sdk.ObjectType
+	}{
+		{ObjectType: sdk.ObjectTypeTable},
+		{ObjectType: sdk.ObjectTypeExternalTable},
+		{ObjectType: sdk.ObjectTypeEventTable},
+		{ObjectType: sdk.ObjectTypeView},
+		{ObjectType: sdk.ObjectTypeMaterializedView},
+		{ObjectType: sdk.ObjectTypePipe},
+		{ObjectType: sdk.ObjectTypeStage},
+		{ObjectType: sdk.ObjectTypeStream},
+		{ObjectType: sdk.ObjectTypeTask},
+		{ObjectType: sdk.ObjectTypeAlert},
+		{ObjectType: sdk.ObjectTypeMaskingPolicy},
+		{ObjectType: sdk.ObjectTypeRowAccessPolicy},
+		{ObjectType: sdk.ObjectTypeImageRepository},
+		{ObjectType: sdk.ObjectTypeGitRepository},
+		{ObjectType: sdk.ObjectTypeService},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.ObjectType.String(), func(t *testing.T) {
+			err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(tt.ObjectType, NonExistingSchemaObjectIdentifierWithNonExistingDatabaseAndSchema).WithUnsetTags(unsetTags))
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestInt_SafeUnsetTagOnNonExistingSchemaObjectWithArguments(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	unsetTags := []sdk.ObjectIdentifier{NonExistingSchemaObjectIdentifier}
+
+	testCases := []struct {
+		ObjectType sdk.ObjectType
+	}{
+		{ObjectType: sdk.ObjectTypeFunction},
+		{ObjectType: sdk.ObjectTypeProcedure},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.ObjectType.String(), func(t *testing.T) {
+			err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(tt.ObjectType, NonExistingSchemaObjectIdentifierWithArgumentsWithNonExistingDatabaseAndSchema).WithUnsetTags(unsetTags))
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestInt_SafeUnsetTagOnNonExistingAccountObject(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	unsetTags := []sdk.ObjectIdentifier{NonExistingSchemaObjectIdentifier}
+
+	testCases := []struct {
+		ObjectType sdk.ObjectType
+	}{
+		{ObjectType: sdk.ObjectTypeDatabase},
+		{ObjectType: sdk.ObjectTypeWarehouse},
+		{ObjectType: sdk.ObjectTypeComputePool},
+		{ObjectType: sdk.ObjectTypeRole},
+		{ObjectType: sdk.ObjectTypeUser},
+		{ObjectType: sdk.ObjectTypeIntegration},
+		{ObjectType: sdk.ObjectTypeNetworkPolicy},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.ObjectType.String(), func(t *testing.T) {
+			err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(tt.ObjectType, NonExistingAccountObjectIdentifier).WithUnsetTags(unsetTags))
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestInt_SafeUnsetTagOnNonExistingDatabaseObject(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	unsetTags := []sdk.ObjectIdentifier{NonExistingSchemaObjectIdentifier}
+
+	testCases := []struct {
+		ObjectType sdk.ObjectType
+	}{
+		{ObjectType: sdk.ObjectTypeSchema},
+		{ObjectType: sdk.ObjectTypeDatabaseRole},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.ObjectType.String(), func(t *testing.T) {
+			err := client.Tags.UnsetSafely(ctx, sdk.NewUnsetTagRequest(tt.ObjectType, NonExistingDatabaseObjectIdentifierWithNonExistingDatabase).WithUnsetTags(unsetTags))
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `SafeUnsetTag` helper in `pkg/sdk/operation_helpers.go` that suppresses `ErrObjectNotExistOrAuthorized`, mirroring the existing `SafeRevokePrivileges` pattern
- Add `UnsetSafely` method to the `Tags` interface and implement it in `tags_impl.go`
- Add integration tests covering: real objects, columns, and table-driven tests for non-existing schema/account/database-level objects (including functions and procedures with argument-aware identifiers)

Follows up on #4543 which introduced `SafeRevokePrivileges`. This applies the same approach to tag associations so that `terraform destroy` succeeds when tagged objects are already deleted.

No resource code is modified in this PR — only SDK-level changes and tests.

## TODO
- When SAFE_DESTROY is enabled, in the resource's Read function, call d.SetId("") when correctObjectIds is empty to mark the resource as absent.
- When SAFE_DESTROY is enabled, in the resource's Drop function, simply call UnsetSafely.