### PR TITLE
chore: Rename adaptive warehouse fields to match Snowflake SQL names

### DIFF
--- a/pkg/acceptance/bettertestspoc/assert/objectassert/warehouse_snowflake_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/warehouse_snowflake_ext.go
@@ -118,22 +118,22 @@ func (w *WarehouseAssert) HasNoQueryAccelerationMaxScaleFactor() *WarehouseAsser
 	return w
 }
 
-func (w *WarehouseAssert) HasNoMaxStatementSize() *WarehouseAssert {
+func (w *WarehouseAssert) HasNoMaxQueryPerformanceLevel() *WarehouseAssert {
 	w.AddAssertion(func(t *testing.T, o *sdk.Warehouse) error {
 		t.Helper()
-		if o.MaxStatementSize != nil {
-			return fmt.Errorf("expected max statement size to be empty; got: %s", *o.MaxStatementSize)
+		if o.MaxQueryPerformanceLevel != nil {
+			return fmt.Errorf("expected max query performance level to be empty; got: %s", *o.MaxQueryPerformanceLevel)
 		}
 		return nil
 	})
 	return w
 }
 
-func (w *WarehouseAssert) HasNoMaxBurstRateCredits() *WarehouseAssert {
+func (w *WarehouseAssert) HasNoQueryThroughputMultiplier() *WarehouseAssert {
 	w.AddAssertion(func(t *testing.T, o *sdk.Warehouse) error {
 		t.Helper()
-		if o.MaxBurstRateCredits != nil {
-			return fmt.Errorf("expected max burst rate credits to be empty; got: %d", *o.MaxBurstRateCredits)
+		if o.QueryThroughputMultiplier != nil {
+			return fmt.Errorf("expected query throughput multiplier to be empty; got: %d", *o.QueryThroughputMultiplier)
 		}
 		return nil
 	})

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/warehouse_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/warehouse_snowflake_gen.go
@@ -387,28 +387,28 @@ func (w *WarehouseAssert) HasGeneration(expected sdk.WarehouseGeneration) *Wareh
 	return w
 }
 
-func (w *WarehouseAssert) HasMaxStatementSize(expected sdk.MaxStatementSize) *WarehouseAssert {
+func (w *WarehouseAssert) HasMaxQueryPerformanceLevel(expected sdk.MaxQueryPerformanceLevel) *WarehouseAssert {
 	w.AddAssertion(func(t *testing.T, o *sdk.Warehouse) error {
 		t.Helper()
-		if o.MaxStatementSize == nil {
-			return fmt.Errorf("expected max statement size to have value; got: nil")
+		if o.MaxQueryPerformanceLevel == nil {
+			return fmt.Errorf("expected max query performance level to have value; got: nil")
 		}
-		if *o.MaxStatementSize != expected {
-			return fmt.Errorf("expected max statement size: %v; got: %v", expected, *o.MaxStatementSize)
+		if *o.MaxQueryPerformanceLevel != expected {
+			return fmt.Errorf("expected max query performance level: %v; got: %v", expected, *o.MaxQueryPerformanceLevel)
 		}
 		return nil
 	})
 	return w
 }
 
-func (w *WarehouseAssert) HasMaxBurstRateCredits(expected int) *WarehouseAssert {
+func (w *WarehouseAssert) HasQueryThroughputMultiplier(expected int) *WarehouseAssert {
 	w.AddAssertion(func(t *testing.T, o *sdk.Warehouse) error {
 		t.Helper()
-		if o.MaxBurstRateCredits == nil {
-			return fmt.Errorf("expected max burst rate credits to have value; got: nil")
+		if o.QueryThroughputMultiplier == nil {
+			return fmt.Errorf("expected query throughput multiplier to have value; got: nil")
 		}
-		if *o.MaxBurstRateCredits != expected {
-			return fmt.Errorf("expected max burst rate credits: %v; got: %v", expected, *o.MaxBurstRateCredits)
+		if *o.QueryThroughputMultiplier != expected {
+			return fmt.Errorf("expected query throughput multiplier: %v; got: %v", expected, *o.QueryThroughputMultiplier)
 		}
 		return nil
 	})

--- a/pkg/sdk/testint/warehouses_integration_test.go
+++ b/pkg/sdk/testint/warehouses_integration_test.go
@@ -179,8 +179,8 @@ func TestInt_Warehouses(t *testing.T) {
 			HasQueryAccelerationMaxScaleFactor(90).
 			HasGeneration(sdk.WarehouseGenerationStandardGen2).
 			HasNoResourceConstraint().
-			HasNoMaxStatementSize().
-			HasNoMaxBurstRateCredits())
+			HasNoMaxQueryPerformanceLevel().
+			HasNoQueryThroughputMultiplier())
 
 		warehouse, err := client.Warehouses.ShowByID(ctx, id)
 		require.NoError(t, err)
@@ -200,8 +200,8 @@ func TestInt_Warehouses(t *testing.T) {
 		assert.Nil(t, warehouse.ResourceConstraint)
 		assert.NotNil(t, warehouse.Generation)
 		assert.Equal(t, sdk.WarehouseGenerationStandardGen2, *warehouse.Generation)
-		assert.Nil(t, warehouse.MaxStatementSize)
-		assert.Nil(t, warehouse.MaxBurstRateCredits)
+		assert.Nil(t, warehouse.MaxQueryPerformanceLevel)
+		assert.Nil(t, warehouse.QueryThroughputMultiplier)
 
 		// we can also use the read object to initialize:
 		assertThatObject(t, objectassert.WarehouseFromObject(t, warehouse).
@@ -220,8 +220,8 @@ func TestInt_Warehouses(t *testing.T) {
 			HasQueryAccelerationMaxScaleFactor(90).
 			HasNoResourceConstraint().
 			HasGeneration(sdk.WarehouseGenerationStandardGen2).
-			HasNoMaxStatementSize().
-			HasNoMaxBurstRateCredits())
+			HasNoMaxQueryPerformanceLevel().
+			HasNoQueryThroughputMultiplier())
 
 		tag1Value, err := client.SystemFunctions.GetTag(ctx, tag.ID(), warehouse.ID(), sdk.ObjectTypeWarehouse)
 		require.NoError(t, err)
@@ -254,8 +254,8 @@ func TestInt_Warehouses(t *testing.T) {
 		assert.Nil(t, result.ResourceConstraint)
 		assert.NotNil(t, result.Generation)
 		assert.Equal(t, sdk.WarehouseGenerationStandardGen1, *result.Generation)
-		assert.Nil(t, result.MaxStatementSize)
-		assert.Nil(t, result.MaxBurstRateCredits)
+		assert.Nil(t, result.MaxQueryPerformanceLevel)
+		assert.Nil(t, result.QueryThroughputMultiplier)
 	})
 
 	t.Run("create: empty comment", func(t *testing.T) {
@@ -289,8 +289,8 @@ func TestInt_Warehouses(t *testing.T) {
 			HasAutoResume(true).
 			HasNoEnableQueryAcceleration().
 			HasNoQueryAccelerationMaxScaleFactor().
-			HasMaxStatementSize(sdk.MaxStatementSizeLarge).
-			HasMaxBurstRateCredits(44),
+			HasMaxQueryPerformanceLevel(sdk.MaxQueryPerformanceLevelLarge).
+			HasQueryThroughputMultiplier(0),
 		)
 		assertThatObject(t, objectparametersassert.WarehouseParameters(t, id).
 			HasStatementQueuedTimeoutInSeconds(0).
@@ -302,7 +302,8 @@ func TestInt_Warehouses(t *testing.T) {
 		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
 		err := client.Warehouses.CreateAdaptive(ctx, id, &sdk.CreateAdaptiveWarehouseOptions{
 			Comment:                         sdk.String("test adaptive warehouse"),
-			MaxStatementSize:                sdk.Pointer(sdk.MaxStatementSizeMedium),
+			MaxQueryPerformanceLevel:        sdk.Pointer(sdk.MaxQueryPerformanceLevelMedium),
+			QueryThroughputMultiplier:       sdk.Int(22),
 			StatementQueuedTimeoutInSeconds: sdk.Int(30),
 			StatementTimeoutInSeconds:       sdk.Int(60),
 		})
@@ -323,8 +324,8 @@ func TestInt_Warehouses(t *testing.T) {
 			HasAutoResume(true).
 			HasNoEnableQueryAcceleration().
 			HasNoQueryAccelerationMaxScaleFactor().
-			HasMaxStatementSize(sdk.MaxStatementSizeMedium).
-			HasMaxBurstRateCredits(22),
+			HasMaxQueryPerformanceLevel(sdk.MaxQueryPerformanceLevelMedium).
+			HasQueryThroughputMultiplier(22),
 		)
 		assertThatObject(t, objectparametersassert.WarehouseParameters(t, id).
 			HasStatementQueuedTimeoutInSeconds(30).
@@ -350,8 +351,8 @@ func TestInt_Warehouses(t *testing.T) {
 		assert.Nil(t, warehouse.ResourceConstraint)
 		assert.NotNil(t, warehouse.Generation)
 		assert.Equal(t, sdk.WarehouseGenerationStandardGen1, *warehouse.Generation)
-		assert.Nil(t, warehouse.MaxStatementSize)
-		assert.Nil(t, warehouse.MaxBurstRateCredits)
+		assert.Nil(t, warehouse.MaxQueryPerformanceLevel)
+		assert.Nil(t, warehouse.QueryThroughputMultiplier)
 
 		alterOptions := &sdk.AlterWarehouseOptions{
 			// WarehouseType omitted on purpose - it requires suspending the warehouse (separate test cases)
@@ -388,8 +389,8 @@ func TestInt_Warehouses(t *testing.T) {
 		assert.Nil(t, warehouseAfterSet.ResourceConstraint)
 		assert.NotNil(t, warehouseAfterSet.Generation)
 		assert.Equal(t, sdk.WarehouseGenerationStandardGen1, *warehouseAfterSet.Generation)
-		assert.Nil(t, warehouseAfterSet.MaxStatementSize)
-		assert.Nil(t, warehouseAfterSet.MaxBurstRateCredits)
+		assert.Nil(t, warehouseAfterSet.MaxQueryPerformanceLevel)
+		assert.Nil(t, warehouseAfterSet.QueryThroughputMultiplier)
 
 		alterOptions = &sdk.AlterWarehouseOptions{
 			// WarehouseSize omitted on purpose - UNSET is not supported for warehouse size
@@ -424,8 +425,8 @@ func TestInt_Warehouses(t *testing.T) {
 		assert.Equal(t, sdk.WarehouseTypeStandard, warehouseAfterUnset.Type)
 		assert.Equal(t, sdk.Pointer(sdk.ScalingPolicyStandard), warehouseAfterUnset.ScalingPolicy)
 		assert.True(t, warehouseAfterUnset.AutoResume)
-		assert.Nil(t, warehouseAfterUnset.MaxStatementSize)
-		assert.Nil(t, warehouseAfterUnset.MaxBurstRateCredits)
+		assert.Nil(t, warehouseAfterUnset.MaxQueryPerformanceLevel)
+		assert.Nil(t, warehouseAfterUnset.QueryThroughputMultiplier)
 	})
 
 	t.Run("alter adaptive: change warehouse type", func(t *testing.T) {
@@ -459,8 +460,8 @@ func TestInt_Warehouses(t *testing.T) {
 			HasAutoResume(true).
 			HasNoEnableQueryAcceleration().
 			HasNoQueryAccelerationMaxScaleFactor().
-			HasMaxStatementSize(sdk.MaxStatementSizeMedium).
-			HasMaxBurstRateCredits(11),
+			HasMaxQueryPerformanceLevel(sdk.MaxQueryPerformanceLevelMedium).
+			HasQueryThroughputMultiplier(0),
 		)
 
 		// Change warehouse type back from adaptive to standard
@@ -475,17 +476,17 @@ func TestInt_Warehouses(t *testing.T) {
 		assertThatObject(t, objectassert.Warehouse(t, warehouse.ID()).
 			HasType(sdk.WarehouseTypeStandard).
 			HasSize(sdk.WarehouseSizeMedium).
-			HasGeneration(sdk.WarehouseGenerationStandardGen1).
+			HasGeneration(sdk.WarehouseGenerationStandardGen2).
 			HasNoResourceConstraint().
 			HasMaxClusterCount(1).
 			HasMinClusterCount(1).
 			HasScalingPolicy(sdk.ScalingPolicyStandard).
-			HasAutoSuspend(600).
+			HasAutoSuspend(34).
 			HasAutoResume(true).
-			HasEnableQueryAcceleration(false).
-			HasQueryAccelerationMaxScaleFactor(8).
-			HasNoMaxStatementSize().
-			HasNoMaxBurstRateCredits(),
+			HasEnableQueryAcceleration(true).
+			HasQueryAccelerationMaxScaleFactor(2).
+			HasNoMaxQueryPerformanceLevel().
+			HasNoQueryThroughputMultiplier(),
 		)
 	})
 

--- a/pkg/sdk/testint/warehouses_integration_test.go
+++ b/pkg/sdk/testint/warehouses_integration_test.go
@@ -476,15 +476,15 @@ func TestInt_Warehouses(t *testing.T) {
 		assertThatObject(t, objectassert.Warehouse(t, warehouse.ID()).
 			HasType(sdk.WarehouseTypeStandard).
 			HasSize(sdk.WarehouseSizeMedium).
-			HasGeneration(sdk.WarehouseGenerationStandardGen2).
+			HasGeneration(sdk.WarehouseGenerationStandardGen1).
 			HasNoResourceConstraint().
 			HasMaxClusterCount(1).
 			HasMinClusterCount(1).
 			HasScalingPolicy(sdk.ScalingPolicyStandard).
-			HasAutoSuspend(34).
+			HasAutoSuspend(600).
 			HasAutoResume(true).
-			HasEnableQueryAcceleration(true).
-			HasQueryAccelerationMaxScaleFactor(2).
+			HasEnableQueryAcceleration(false).
+			HasQueryAccelerationMaxScaleFactor(8).
 			HasNoMaxQueryPerformanceLevel().
 			HasNoQueryThroughputMultiplier(),
 		)

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -279,36 +279,36 @@ func (s WarehouseGeneration) ToWarehouseResourceConstraint() (WarehouseResourceC
 	}
 }
 
-type MaxStatementSize string
+type MaxQueryPerformanceLevel string
 
 const (
-	MaxStatementSizeXSmall   MaxStatementSize = "XSMALL"
-	MaxStatementSizeSmall    MaxStatementSize = "SMALL"
-	MaxStatementSizeMedium   MaxStatementSize = "MEDIUM"
-	MaxStatementSizeLarge    MaxStatementSize = "LARGE"
-	MaxStatementSizeXLarge   MaxStatementSize = "XLARGE"
-	MaxStatementSizeXXLarge  MaxStatementSize = "XXLARGE"
-	MaxStatementSizeXXXLarge MaxStatementSize = "XXXLARGE"
-	MaxStatementSizeX4Large  MaxStatementSize = "X4LARGE"
+	MaxQueryPerformanceLevelXSmall   MaxQueryPerformanceLevel = "XSMALL"
+	MaxQueryPerformanceLevelSmall    MaxQueryPerformanceLevel = "SMALL"
+	MaxQueryPerformanceLevelMedium   MaxQueryPerformanceLevel = "MEDIUM"
+	MaxQueryPerformanceLevelLarge    MaxQueryPerformanceLevel = "LARGE"
+	MaxQueryPerformanceLevelXLarge   MaxQueryPerformanceLevel = "XLARGE"
+	MaxQueryPerformanceLevelXXLarge  MaxQueryPerformanceLevel = "XXLARGE"
+	MaxQueryPerformanceLevelXXXLarge MaxQueryPerformanceLevel = "XXXLARGE"
+	MaxQueryPerformanceLevelX4Large  MaxQueryPerformanceLevel = "X4LARGE"
 )
 
-var AllMaxStatementSizes = []string{
-	string(MaxStatementSizeXSmall),
-	string(MaxStatementSizeSmall),
-	string(MaxStatementSizeMedium),
-	string(MaxStatementSizeLarge),
-	string(MaxStatementSizeXLarge),
-	string(MaxStatementSizeXXLarge),
-	string(MaxStatementSizeXXXLarge),
-	string(MaxStatementSizeX4Large),
+var AllMaxQueryPerformanceLevels = []string{
+	string(MaxQueryPerformanceLevelXSmall),
+	string(MaxQueryPerformanceLevelSmall),
+	string(MaxQueryPerformanceLevelMedium),
+	string(MaxQueryPerformanceLevelLarge),
+	string(MaxQueryPerformanceLevelXLarge),
+	string(MaxQueryPerformanceLevelXXLarge),
+	string(MaxQueryPerformanceLevelXXXLarge),
+	string(MaxQueryPerformanceLevelX4Large),
 }
 
-func ToMaxStatementSize(s string) (MaxStatementSize, error) {
+func ToMaxQueryPerformanceLevel(s string) (MaxQueryPerformanceLevel, error) {
 	s = strings.ToUpper(s)
-	if slices.Contains(AllMaxStatementSizes, s) {
-		return MaxStatementSize(s), nil
+	if slices.Contains(AllMaxQueryPerformanceLevels, s) {
+		return MaxQueryPerformanceLevel(s), nil
 	}
-	return "", fmt.Errorf("invalid max statement size: %s", s)
+	return "", fmt.Errorf("invalid max query performance level: %s", s)
 }
 
 // CreateWarehouseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-warehouse.
@@ -388,8 +388,9 @@ type CreateAdaptiveWarehouseOptions struct {
 	warehouseType bool                    `ddl:"static" sql:"WAREHOUSE_TYPE = 'ADAPTIVE'"`
 
 	// Object properties
-	Comment          *string           `ddl:"parameter,single_quotes" sql:"COMMENT"`
-	MaxStatementSize *MaxStatementSize `ddl:"parameter,single_quotes" sql:"MAX_STATEMENT_SIZE"`
+	Comment                   *string                   `ddl:"parameter,single_quotes" sql:"COMMENT"`
+	MaxQueryPerformanceLevel  *MaxQueryPerformanceLevel `ddl:"parameter,single_quotes" sql:"MAX_QUERY_PERFORMANCE_LEVEL"`
+	QueryThroughputMultiplier *int                      `ddl:"parameter" sql:"QUERY_THROUGHPUT_MULTIPLIER"`
 
 	// Tags
 	Tag []TagAssociation `ddl:"keyword,parentheses" sql:"TAG"`
@@ -409,6 +410,9 @@ func (opts *CreateAdaptiveWarehouseOptions) validate() error {
 	}
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateAdaptiveWarehouseOptions", "OrReplace", "IfNotExists"))
+	}
+	if valueSet(opts.QueryThroughputMultiplier) && !validateIntGreaterThanOrEqual(*opts.QueryThroughputMultiplier, 0) {
+		errs = append(errs, fmt.Errorf("QueryThroughputMultiplier must be greater than or equal to 0"))
 	}
 	return errors.Join(errs...)
 }
@@ -499,6 +503,7 @@ type WarehouseSet struct {
 	MaxConcurrencyLevel             *int `ddl:"parameter" sql:"MAX_CONCURRENCY_LEVEL"`
 	StatementQueuedTimeoutInSeconds *int `ddl:"parameter" sql:"STATEMENT_QUEUED_TIMEOUT_IN_SECONDS"`
 	StatementTimeoutInSeconds       *int `ddl:"parameter" sql:"STATEMENT_TIMEOUT_IN_SECONDS"`
+	QueryThroughputMultiplier       *int `ddl:"parameter" sql:"QUERY_THROUGHPUT_MULTIPLIER"`
 }
 
 func (v *WarehouseSet) validate() error {
@@ -518,8 +523,13 @@ func (v *WarehouseSet) validate() error {
 			return fmt.Errorf("QueryAccelerationMaxScaleFactor must be between 0 and 100")
 		}
 	}
-	if everyValueNil(v.WarehouseType, v.WarehouseSize, v.WaitForCompletion, v.MaxClusterCount, v.MinClusterCount, v.ScalingPolicy, v.AutoSuspend, v.AutoResume, v.ResourceMonitor, v.Comment, v.EnableQueryAcceleration, v.QueryAccelerationMaxScaleFactor, v.ResourceConstraint, v.Generation, v.MaxConcurrencyLevel, v.StatementQueuedTimeoutInSeconds, v.StatementTimeoutInSeconds) {
-		return errAtLeastOneOf("WarehouseSet", "WarehouseType", "WarehouseSize", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds")
+	if v.QueryThroughputMultiplier != nil {
+		if ok := validateIntGreaterThanOrEqual(*v.QueryThroughputMultiplier, 0); !ok {
+			return fmt.Errorf("QueryThroughputMultiplier must be greater than or equal to 0")
+		}
+	}
+	if everyValueNil(v.WarehouseType, v.WarehouseSize, v.WaitForCompletion, v.MaxClusterCount, v.MinClusterCount, v.ScalingPolicy, v.AutoSuspend, v.AutoResume, v.ResourceMonitor, v.Comment, v.EnableQueryAcceleration, v.QueryAccelerationMaxScaleFactor, v.ResourceConstraint, v.Generation, v.MaxConcurrencyLevel, v.StatementQueuedTimeoutInSeconds, v.StatementTimeoutInSeconds, v.QueryThroughputMultiplier) {
+		return errAtLeastOneOf("WarehouseSet", "WarehouseType", "WarehouseSize", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds", "QueryThroughputMultiplier")
 	}
 	return nil
 }
@@ -544,11 +554,12 @@ type WarehouseUnset struct {
 	MaxConcurrencyLevel             *bool `ddl:"keyword" sql:"MAX_CONCURRENCY_LEVEL"`
 	StatementQueuedTimeoutInSeconds *bool `ddl:"keyword" sql:"STATEMENT_QUEUED_TIMEOUT_IN_SECONDS"`
 	StatementTimeoutInSeconds       *bool `ddl:"keyword" sql:"STATEMENT_TIMEOUT_IN_SECONDS"`
+	QueryThroughputMultiplier       *bool `ddl:"keyword" sql:"QUERY_THROUGHPUT_MULTIPLIER"`
 }
 
 func (v *WarehouseUnset) validate() error {
-	if everyValueNil(v.WarehouseType, v.WaitForCompletion, v.MaxClusterCount, v.MinClusterCount, v.ScalingPolicy, v.AutoSuspend, v.AutoResume, v.ResourceMonitor, v.Comment, v.EnableQueryAcceleration, v.QueryAccelerationMaxScaleFactor, v.ResourceConstraint, v.Generation, v.MaxConcurrencyLevel, v.StatementQueuedTimeoutInSeconds, v.StatementTimeoutInSeconds) {
-		return errAtLeastOneOf("WarehouseUnset", "WarehouseType", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds")
+	if everyValueNil(v.WarehouseType, v.WaitForCompletion, v.MaxClusterCount, v.MinClusterCount, v.ScalingPolicy, v.AutoSuspend, v.AutoResume, v.ResourceMonitor, v.Comment, v.EnableQueryAcceleration, v.QueryAccelerationMaxScaleFactor, v.ResourceConstraint, v.Generation, v.MaxConcurrencyLevel, v.StatementQueuedTimeoutInSeconds, v.StatementTimeoutInSeconds, v.QueryThroughputMultiplier) {
+		return errAtLeastOneOf("WarehouseUnset", "WarehouseType", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds", "QueryThroughputMultiplier")
 	}
 	return nil
 }
@@ -711,8 +722,8 @@ type Warehouse struct {
 	OwnerRoleType                   string
 	ResourceConstraint              *WarehouseResourceConstraint
 	Generation                      *WarehouseGeneration
-	MaxStatementSize                *MaxStatementSize
-	MaxBurstRateCredits             *int
+	MaxQueryPerformanceLevel        *MaxQueryPerformanceLevel
+	QueryThroughputMultiplier       *int
 }
 
 type warehouseDBRow struct {
@@ -750,8 +761,8 @@ type warehouseDBRow struct {
 	OwnerRoleType                   sql.NullString `db:"owner_role_type"`
 	ResourceConstraint              sql.NullString `db:"resource_constraint"`
 	Generation                      sql.NullString `db:"generation"`
-	MaxStatementSize                sql.NullString `db:"max_statement_size"`
-	MaxBurstRateCredits             sql.NullInt64  `db:"max_burst_rate_credits"`
+	MaxQueryPerformanceLevel        sql.NullString `db:"max_query_performance_level"`
+	QueryThroughputMultiplier       sql.NullInt64  `db:"query_throughput_multiplier"`
 }
 
 func (row warehouseDBRow) convert() (*Warehouse, error) {
@@ -848,8 +859,8 @@ func (row warehouseDBRow) convert() (*Warehouse, error) {
 			return nil, fmt.Errorf("invalid warehouse type: %s", wh.Type)
 		}
 	}
-	mapNullStringWithMapping(&wh.MaxStatementSize, row.MaxStatementSize, ToMaxStatementSize)
-	mapNullInt(&wh.MaxBurstRateCredits, row.MaxBurstRateCredits)
+	mapNullStringWithMapping(&wh.MaxQueryPerformanceLevel, row.MaxQueryPerformanceLevel, ToMaxQueryPerformanceLevel)
+	mapNullInt(&wh.QueryThroughputMultiplier, row.QueryThroughputMultiplier)
 	return wh, nil
 }
 

--- a/pkg/sdk/warehouses_test.go
+++ b/pkg/sdk/warehouses_test.go
@@ -85,9 +85,9 @@ func TestWarehouseCreateAdaptive(t *testing.T) {
 			OrReplace: Bool(true),
 			name:      NewAccountObjectIdentifier("myadaptivewh"),
 
-			Comment:          String("adaptive warehouse"),
-			MaxStatementSize: Pointer(MaxStatementSizeMedium),
-
+			Comment:                         String("adaptive warehouse"),
+			MaxQueryPerformanceLevel:        Pointer(MaxQueryPerformanceLevelMedium),
+			QueryThroughputMultiplier:       Int(22),
 			StatementQueuedTimeoutInSeconds: Int(30),
 			StatementTimeoutInSeconds:       Int(60),
 			Tag: []TagAssociation{
@@ -101,7 +101,7 @@ func TestWarehouseCreateAdaptive(t *testing.T) {
 				},
 			},
 		}
-		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE WAREHOUSE "myadaptivewh" WAREHOUSE_TYPE = 'ADAPTIVE' COMMENT = 'adaptive warehouse' MAX_STATEMENT_SIZE = 'MEDIUM' TAG (%s = 'v1', %s = 'v2') STATEMENT_QUEUED_TIMEOUT_IN_SECONDS = 30 STATEMENT_TIMEOUT_IN_SECONDS = 60`,
+		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE WAREHOUSE "myadaptivewh" WAREHOUSE_TYPE = 'ADAPTIVE' COMMENT = 'adaptive warehouse' MAX_QUERY_PERFORMANCE_LEVEL = 'MEDIUM' QUERY_THROUGHPUT_MULTIPLIER = 22 TAG (%s = 'v1', %s = 'v2') STATEMENT_QUEUED_TIMEOUT_IN_SECONDS = 30 STATEMENT_TIMEOUT_IN_SECONDS = 60`,
 			tagId1.FullyQualifiedName(), tagId2.FullyQualifiedName())
 	})
 
@@ -623,25 +623,25 @@ func Test_Warehouse_ToScalingPolicy(t *testing.T) {
 	}
 }
 
-func Test_Warehouse_ToMaxStatementSize(t *testing.T) {
+func Test_Warehouse_ToMaxQueryPerformanceLevel(t *testing.T) {
 	type test struct {
 		input string
-		want  MaxStatementSize
+		want  MaxQueryPerformanceLevel
 	}
 
 	valid := []test{
 		// case insensitive.
-		{input: "medium", want: MaxStatementSizeMedium},
+		{input: "medium", want: MaxQueryPerformanceLevelMedium},
 
 		// Supported Values
-		{input: "XSMALL", want: MaxStatementSizeXSmall},
-		{input: "SMALL", want: MaxStatementSizeSmall},
-		{input: "MEDIUM", want: MaxStatementSizeMedium},
-		{input: "LARGE", want: MaxStatementSizeLarge},
-		{input: "XLARGE", want: MaxStatementSizeXLarge},
-		{input: "XXLARGE", want: MaxStatementSizeXXLarge},
-		{input: "XXXLARGE", want: MaxStatementSizeXXXLarge},
-		{input: "X4LARGE", want: MaxStatementSizeX4Large},
+		{input: "XSMALL", want: MaxQueryPerformanceLevelXSmall},
+		{input: "SMALL", want: MaxQueryPerformanceLevelSmall},
+		{input: "MEDIUM", want: MaxQueryPerformanceLevelMedium},
+		{input: "LARGE", want: MaxQueryPerformanceLevelLarge},
+		{input: "XLARGE", want: MaxQueryPerformanceLevelXLarge},
+		{input: "XXLARGE", want: MaxQueryPerformanceLevelXXLarge},
+		{input: "XXXLARGE", want: MaxQueryPerformanceLevelXXXLarge},
+		{input: "X4LARGE", want: MaxQueryPerformanceLevelX4Large},
 	}
 
 	invalid := []test{
@@ -653,7 +653,7 @@ func Test_Warehouse_ToMaxStatementSize(t *testing.T) {
 
 	for _, tc := range valid {
 		t.Run(tc.input, func(t *testing.T) {
-			got, err := ToMaxStatementSize(tc.input)
+			got, err := ToMaxQueryPerformanceLevel(tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.want, got)
 		})
@@ -661,7 +661,7 @@ func Test_Warehouse_ToMaxStatementSize(t *testing.T) {
 
 	for _, tc := range invalid {
 		t.Run(tc.input, func(t *testing.T) {
-			_, err := ToMaxStatementSize(tc.input)
+			_, err := ToMaxQueryPerformanceLevel(tc.input)
 			require.Error(t, err)
 		})
 	}


### PR DESCRIPTION
## Summary

Aligns the adaptive warehouse SDK field names with the actual Snowflake field names.

- Rename `MaxStatementSize` → `MaxQueryPerformanceLevel`
- Rename `MaxBurstRateCredits` → `QueryThroughputMultiplier`
- Add `QueryThroughputMultiplier` to `CreateAdaptiveWarehouseOptions`
- Add `QueryThroughputMultiplier` to `WarehouseSet` and `WarehouseUnset`
- Update all assertion helpers (`HasMaxQueryPerformanceLevel`, `HasQueryThroughputMultiplier`, `HasNoMaxQueryPerformanceLevel`, `HasNoQueryThroughputMultiplier`) and integration/unit tests accordingly