### PR TITLE
fix: Remove file_format from ComputedIfAnyAttributeChanged on stage resources

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -277,6 +277,16 @@ This was caused by a missing early-exit check in the internal SQL parser used to
 
 No changes in configuration are required. If this error happened during object creation, the state of this resource may be empty. In this case, just reimport the object.
 
+### *(bug fix)* Fixed `describe_output` permadiff on stage resources
+
+The `describe_output` computed attribute on all stage resources (`snowflake_stage_external_s3`, `snowflake_stage_external_azure`, `snowflake_stage_external_gcs`, `snowflake_stage_external_s3_compatible`, `snowflake_stage_internal`) was incorrectly tracking `file_format` as a trigger for recomputation. The provider normalizes selected file format subfields (e.g. resolves identifier quoting), but it's not applied in the recomputation logic, which could lead to permadiffs.
+
+Now, changes on `file_format` do not trigger marking `describe_output` as computed in all stage resources.
+
+No changes in configuration are required.
+
+Reference: [#4514](https://github.com/snowflakedb/terraform-provider-snowflake/issues/4514)
+
 ## v2.14.0 ➞ v2.14.1
 
 ### *(breaking change)* Adjustments in `snowflake_authentication_policy` and `snowflake_authentication_policies` due to `DESC AUTHENTICATION POLICY` output change

--- a/pkg/resources/external_azure_stage.go
+++ b/pkg/resources/external_azure_stage.go
@@ -158,7 +158,7 @@ func ExternalAzureStage() *schema.Resource {
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.ExternalAzureStage, customdiff.All(
 			ComputedIfAnyAttributeChanged(externalAzureStageSchema, ShowOutputAttributeName, "name", "comment", "url", "storage_integration", "encryption"),
-			ComputedIfAnyAttributeChanged(externalAzureStageSchema, DescribeOutputAttributeName, "directory.0.enable", "directory.0.auto_refresh", "url", "use_privatelink_endpoint", "file_format"),
+			ComputedIfAnyAttributeChanged(externalAzureStageSchema, DescribeOutputAttributeName, "directory.0.enable", "directory.0.auto_refresh", "url", "use_privatelink_endpoint"),
 			ComputedIfAnyAttributeChanged(externalAzureStageSchema, FullyQualifiedNameAttributeName, "name"),
 			ForceNewIfChangeToEmptySlice[any]("directory"),
 			ForceNewIfChangeToEmptySlice[any]("credentials"),

--- a/pkg/resources/external_gcs_stage.go
+++ b/pkg/resources/external_gcs_stage.go
@@ -130,7 +130,7 @@ func ExternalGcsStage() *schema.Resource {
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.ExternalGcsStage, customdiff.All(
 			ComputedIfAnyAttributeChanged(externalGcsStageSchema, ShowOutputAttributeName, "name", "comment", "url", "storage_integration", "encryption"),
-			ComputedIfAnyAttributeChanged(externalGcsStageSchema, DescribeOutputAttributeName, "directory.0.enable", "directory.0.auto_refresh", "url", "file_format"),
+			ComputedIfAnyAttributeChanged(externalGcsStageSchema, DescribeOutputAttributeName, "directory.0.enable", "directory.0.auto_refresh", "url"),
 			ComputedIfAnyAttributeChanged(externalGcsStageSchema, FullyQualifiedNameAttributeName, "name"),
 			ForceNewIfChangeToEmptySlice[any]("directory"),
 			ForceNewIfChangeToEmptySlice[any]("encryption"),

--- a/pkg/resources/external_s3_compatible_stage.go
+++ b/pkg/resources/external_s3_compatible_stage.go
@@ -109,7 +109,7 @@ func ExternalS3CompatibleStage() *schema.Resource {
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.ExternalS3CompatibleStage, customdiff.All(
 			ComputedIfAnyAttributeChanged(externalS3CompatStageSchema, ShowOutputAttributeName, "name", "comment", "url", "endpoint"),
-			ComputedIfAnyAttributeChanged(externalS3CompatStageSchema, DescribeOutputAttributeName, "directory.0.enable", "directory.0.auto_refresh", "url", "file_format"),
+			ComputedIfAnyAttributeChanged(externalS3CompatStageSchema, DescribeOutputAttributeName, "directory.0.enable", "directory.0.auto_refresh", "url"),
 			ComputedIfAnyAttributeChanged(externalS3CompatStageSchema, FullyQualifiedNameAttributeName, "name"),
 			ForceNewIfChangeToEmptySlice[any]("directory"),
 			ForceNewIfChangeToEmptySlice[any]("credentials"),

--- a/pkg/resources/external_s3_stage.go
+++ b/pkg/resources/external_s3_stage.go
@@ -203,7 +203,7 @@ func ExternalS3Stage() *schema.Resource {
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.ExternalS3Stage, customdiff.All(
 			ComputedIfAnyAttributeChanged(externalS3StageSchema, ShowOutputAttributeName, "name", "comment", "url", "storage_integration", "encryption"),
-			ComputedIfAnyAttributeChanged(externalS3StageSchema, DescribeOutputAttributeName, "directory.0.enable", "directory.0.auto_refresh", "url", "use_privatelink_endpoint", "aws_access_point_arn", "file_format"),
+			ComputedIfAnyAttributeChanged(externalS3StageSchema, DescribeOutputAttributeName, "directory.0.enable", "directory.0.auto_refresh", "url", "use_privatelink_endpoint", "aws_access_point_arn"),
 			ComputedIfAnyAttributeChanged(externalS3StageSchema, FullyQualifiedNameAttributeName, "name"),
 			ForceNewIfChangeToEmptySlice[any]("directory"),
 			ForceNewIfChangeToEmptySlice[any]("credentials"),

--- a/pkg/resources/internal_stage.go
+++ b/pkg/resources/internal_stage.go
@@ -94,7 +94,7 @@ func InternalStage() *schema.Resource {
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.InternalStage, customdiff.All(
 			ComputedIfAnyAttributeChanged(internalStageSchema, ShowOutputAttributeName, "name", "comment"),
-			ComputedIfAnyAttributeChanged(internalStageSchema, DescribeOutputAttributeName, "directory.0.enable", "directory.0.auto_refresh", "file_format"),
+			ComputedIfAnyAttributeChanged(internalStageSchema, DescribeOutputAttributeName, "directory.0.enable", "directory.0.auto_refresh"),
 			ComputedIfAnyAttributeChanged(internalStageSchema, FullyQualifiedNameAttributeName, "name"),
 			ForceNewIfChangeToEmptySlice[any]("directory"),
 			ForceNewIfNotDefault("directory.0.auto_refresh"),

--- a/pkg/testacc/resource_external_s3_stage_acceptance_test.go
+++ b/pkg/testacc/resource_external_s3_stage_acceptance_test.go
@@ -967,6 +967,7 @@ func TestAcc_ExternalS3Stage_DescribeOutputPermadiff(t *testing.T) {
 			{
 				ExternalProviders:  ExternalProviderWithExactVersion("2.14.1"),
 				Config:             accconfig.FromModels(t, providerModel, stageModelQuotedFileFormatId),
+				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
 			// Step 3: Upgrade to current version — plan must be empty (proves the fix).

--- a/pkg/testacc/resource_external_s3_stage_acceptance_test.go
+++ b/pkg/testacc/resource_external_s3_stage_acceptance_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert"
 	accconfig "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/ids"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/importchecks"
@@ -19,6 +20,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 	resourcehelpers "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeroles"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/previewfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	r "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -916,6 +918,62 @@ func TestAcc_ExternalS3Stage_Validations(t *testing.T) {
 				Config:      accconfig.FromModels(t, modelStorageIntegrationWithPrivatelink),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`storage_integration": conflicts with use_privatelink_endpoint`),
+			},
+		},
+	})
+}
+
+// TestAcc_ExternalS3Stage_DescribeOutputPermadiff verifies that the describe_output
+// permadiff caused by identifier quoting on file_format.0.format_name is fixed.
+// In v2.14.1, ComputedIfAnyAttributeChanged was triggered on file_format changes,
+// causing describe_output to be marked
+// as (known after apply) on every plan when a nested field had changes which were suppressed.
+// See: https://github.com/snowflakedb/terraform-provider-snowflake/issues/4514
+func TestAcc_ExternalS3Stage_DescribeOutputPermadiff(t *testing.T) {
+	id := testClient().Ids.RandomSchemaObjectIdentifier()
+	awsUrl := testenvs.GetOrSkipTest(t, testenvs.AwsExternalBucketUrl)
+
+	fileFormat, fileFormatCleanup := testClient().FileFormat.CreateFileFormat(t)
+	t.Cleanup(fileFormatCleanup)
+
+	providerModel := providermodel.SnowflakeProvider().
+		WithPreviewFeaturesEnabled(string(previewfeatures.ExternalS3StageResource))
+	currentProviderFactory := providerFactoryUsingCache("TestAcc_ExternalS3Stage_DescribeOutputPermadiff_GH4514")
+
+	// Use unquoted identifier form (e.g., "DB.SCHEMA.FMT") instead of the FQN form
+	// (e.g., "\"DB\".\"SCHEMA\".\"FMT\"") to reproduce the mismatch that causes the permadiff.
+	unquotedFormatName := fileFormat.ID().DatabaseName() + "." + fileFormat.ID().SchemaName() + "." + fileFormat.ID().Name()
+	quotedFormatName := fileFormat.ID().FullyQualifiedName()
+
+	stageModelUnquotedFileFormatId := model.ExternalS3StageWithId(id, awsUrl).
+		WithFileFormatName(unquotedFormatName)
+
+	stageModelQuotedFileFormatId := model.ExternalS3StageWithId(id, awsUrl).
+		WithFileFormatName(quotedFormatName)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.ExternalS3Stage),
+		Steps: []resource.TestStep{
+			// Step 1: Create with v2.14.1 — the version where the bug exists.
+			{
+				ExternalProviders: ExternalProviderWithExactVersion("2.14.1"),
+				Config:            accconfig.FromModels(t, providerModel, stageModelUnquotedFileFormatId),
+			},
+			// Step 2: Plan-only on v2.14.1 — proves the bug: after changing the file_format.0.format_name to quoted notation,
+			// the plan is not empty and describe_output is marked as (known after apply).
+			{
+				ExternalProviders:  ExternalProviderWithExactVersion("2.14.1"),
+				Config:             accconfig.FromModels(t, providerModel, stageModelQuotedFileFormatId),
+				ExpectNonEmptyPlan: true,
+			},
+			// Step 3: Upgrade to current version — plan must be empty (proves the fix).
+			{
+				ProtoV6ProviderFactories: currentProviderFactory,
+				Config:                   accconfig.FromModels(t, providerModel, stageModelQuotedFileFormatId),
+				PlanOnly:                 true,
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

- Fixes `describe_output` permadiff on `snowflake_stage_external_s3` (and all other stage resources) when `file_format.0.format_name` uses unquoted identifier notation.
- Removes `"file_format"` from the `ComputedIfAnyAttributeChanged` calls for `describe_output` on all five stage resources. The `ComputedIfAnyAttributeChanged` function cannot respect `DiffSuppressFunc` on nested attributes (documented at `custom_diffs.go:119`), so `diff.HasChange("file_format")` returns `true` when `format_name` differs only in quoting, eagerly marking `describe_output` as `(known after apply)`.
- Adds a regression test that reproduces the bug on v2.14.1 and verifies a clean plan on the current version.

Ref. https://github.com/snowflakedb/terraform-provider-snowflake/issues/4514