### PR TITLE
fix: Address failing CI step

### DIFF
--- a/.github/workflows/tests-account-level.yml
+++ b/.github/workflows/tests-account-level.yml
@@ -165,13 +165,19 @@ jobs:
           body: |
             Account-level tests ${{ job.status }} for [${{ github.event.client_payload.slash_command.args.named.sha || github.event.pull_request.head.sha }}](https://github.com/snowflakedb/terraform-provider-snowflake/actions/runs/${{ github.run_id }})
 
+      # For fork PRs, tests run via repository_dispatch (triggered by /ok-to-test),
+      # but the resulting check runs are tied to the default branch, not the fork PR.
+      # This step updates the (skipped) check run on the fork PR's head SHA so the
+      # PR status reflects the actual test outcome. It resolves the job's display name
+      # via job.check_run_id (since github.job returns the job_id, not the display name)
+      # and uses it to find the matching check run on the fork PR's commit.
       - name: Set fork job status
         uses: actions/github-script@v6
         if: ${{ always() }}
         id: update_check_run
         env:
           number: ${{ github.event.client_payload.pull_request.number }}
-          job: ${{ github.job }}
+          check_run_id: ${{ job.check_run_id }}
           # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
           conclusion: ${{ job.status }}
           sha: ${{ github.event.client_payload.slash_command.args.named.sha }}
@@ -183,12 +189,18 @@ jobs:
               console.log("Not repository_dispatch... nothing to do!");
               return process.env.event_name;
             }
+            const { data: currentCheck } = await github.rest.checks.get({
+              ...context.repo,
+              check_run_id: parseInt(process.env.check_run_id)
+            });
+            const jobName = currentCheck.name;
+            console.log(`Current job check run name: ${jobName}`);
             const ref = process.env.sha;
             const { data: checks } = await github.rest.checks.listForRef({
               ...context.repo,
               ref
             });
-            const check = checks.check_runs.filter(c => c.name === process.env.job);
+            const check = checks.check_runs.filter(c => c.name === jobName);
             console.log(check);
             const { data: result } = await github.rest.checks.update({
               ...context.repo,

--- a/.github/workflows/tests-account-level.yml
+++ b/.github/workflows/tests-account-level.yml
@@ -202,6 +202,10 @@ jobs:
             });
             const check = checks.check_runs.filter(c => c.name === jobName);
             console.log(check);
+            if (check.length === 0) {
+              console.log(`No matching check run found for "${jobName}" on ${ref}`);
+              return;
+            }
             const { data: result } = await github.rest.checks.update({
               ...context.repo,
               check_run_id: check[0].id,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -178,13 +178,19 @@ jobs:
           body: |
             Integration tests ${{ job.status }} for [${{ github.event.client_payload.slash_command.args.named.sha || github.event.pull_request.head.sha }}](https://github.com/snowflakedb/terraform-provider-snowflake/actions/runs/${{ github.run_id }})
 
+      # For fork PRs, tests run via repository_dispatch (triggered by /ok-to-test),
+      # but the resulting check runs are tied to the default branch, not the fork PR.
+      # This step updates the (skipped) check run on the fork PR's head SHA so the
+      # PR status reflects the actual test outcome. It resolves the job's display name
+      # via job.check_run_id (since github.job returns the job_id, not the display name)
+      # and uses it to find the matching check run on the fork PR's commit.
       - name: Set fork job status
         uses: actions/github-script@v6
         if: ${{ always() }}
         id: update_check_run
         env:
           number: ${{ github.event.client_payload.pull_request.number }}
-          job: ${{ github.job }}
+          check_run_id: ${{ job.check_run_id }}
           # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
           conclusion: ${{ job.status }}
           sha: ${{ github.event.client_payload.slash_command.args.named.sha }}
@@ -196,12 +202,18 @@ jobs:
               console.log("Not repository_dispatch... nothing to do!");
               return process.env.event_name;
             }
+            const { data: currentCheck } = await github.rest.checks.get({
+              ...context.repo,
+              check_run_id: parseInt(process.env.check_run_id)
+            });
+            const jobName = currentCheck.name;
+            console.log(`Current job check run name: ${jobName}`);
             const ref = process.env.sha;
             const { data: checks } = await github.rest.checks.listForRef({
               ...context.repo,
               ref
             });
-            const check = checks.check_runs.filter(c => c.name === process.env.job);
+            const check = checks.check_runs.filter(c => c.name === jobName);
             console.log(check);
             const { data: result } = await github.rest.checks.update({
               ...context.repo,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -215,6 +215,10 @@ jobs:
             });
             const check = checks.check_runs.filter(c => c.name === jobName);
             console.log(check);
+            if (check.length === 0) {
+              console.log(`No matching check run found for "${jobName}" on ${ref}`);
+              return;
+            }
             const { data: result } = await github.rest.checks.update({
               ...context.repo,
               check_run_id: check[0].id,


### PR DESCRIPTION
Update the GitHub Actions workflows to improve how test results are reported for pull requests originating from forks. It ensures that the status of test jobs is correctly reflected on the fork PR's head commit, addressing issues where check runs were previously tied to the default branch instead of the fork PR.

Addresses error messages such as in: https://github.com/snowflakedb/terraform-provider-snowflake/actions/runs/23607972309