### PR TITLE
chore: Add ALTER support for adaptive warehouses

### DIFF
--- a/pkg/sdk/testint/warehouses_integration_test.go
+++ b/pkg/sdk/testint/warehouses_integration_test.go
@@ -490,6 +490,58 @@ func TestInt_Warehouses(t *testing.T) {
 		)
 	})
 
+	t.Run("alter adaptive: set and unset all adaptive params", func(t *testing.T) {
+		warehouse, warehouseCleanup := testClientHelper().Warehouse.CreateAdaptive(t)
+		t.Cleanup(warehouseCleanup)
+
+		assertThatObject(t, objectassert.Warehouse(t, warehouse.ID()).
+			HasMaxQueryPerformanceLevel(sdk.MaxQueryPerformanceLevelLarge).
+			HasQueryThroughputMultiplier(0),
+		)
+		assertThatObject(t, objectparametersassert.WarehouseParameters(t, warehouse.ID()).
+			HasStatementQueuedTimeoutInSeconds(0).
+			HasStatementTimeoutInSeconds(172800),
+		)
+
+		err := client.Warehouses.Alter(ctx, warehouse.ID(), &sdk.AlterWarehouseOptions{
+			Set: &sdk.WarehouseSet{
+				MaxQueryPerformanceLevel:        sdk.Pointer(sdk.MaxQueryPerformanceLevelXSmall),
+				QueryThroughputMultiplier:       sdk.Int(5),
+				StatementQueuedTimeoutInSeconds: sdk.Int(100),
+				StatementTimeoutInSeconds:       sdk.Int(200),
+			},
+		})
+		require.NoError(t, err)
+
+		assertThatObject(t, objectassert.Warehouse(t, warehouse.ID()).
+			HasMaxQueryPerformanceLevel(sdk.MaxQueryPerformanceLevelXSmall).
+			HasQueryThroughputMultiplier(5),
+		)
+		assertThatObject(t, objectparametersassert.WarehouseParameters(t, warehouse.ID()).
+			HasStatementQueuedTimeoutInSeconds(100).
+			HasStatementTimeoutInSeconds(200),
+		)
+
+		err = client.Warehouses.Alter(ctx, warehouse.ID(), &sdk.AlterWarehouseOptions{
+			Unset: &sdk.WarehouseUnset{
+				MaxQueryPerformanceLevel:        sdk.Bool(true),
+				QueryThroughputMultiplier:       sdk.Bool(true),
+				StatementQueuedTimeoutInSeconds: sdk.Bool(true),
+				StatementTimeoutInSeconds:       sdk.Bool(true),
+			},
+		})
+		require.NoError(t, err)
+
+		assertThatObject(t, objectassert.Warehouse(t, warehouse.ID()).
+			HasMaxQueryPerformanceLevel(sdk.MaxQueryPerformanceLevelLarge).
+			HasQueryThroughputMultiplier(2),
+		)
+		assertThatObject(t, objectparametersassert.WarehouseParameters(t, warehouse.ID()).
+			HasStatementQueuedTimeoutInSeconds(0).
+			HasStatementTimeoutInSeconds(172800),
+		)
+	})
+
 	t.Run("alter: set and unset parameters", func(t *testing.T) {
 		// new warehouse created on purpose
 		warehouse, warehouseCleanup := testClientHelper().Warehouse.CreateWarehouse(t)

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -305,10 +305,26 @@ var AllMaxQueryPerformanceLevels = []string{
 
 func ToMaxQueryPerformanceLevel(s string) (MaxQueryPerformanceLevel, error) {
 	s = strings.ToUpper(s)
-	if slices.Contains(AllMaxQueryPerformanceLevels, s) {
-		return MaxQueryPerformanceLevel(s), nil
+	switch s {
+	case string(MaxQueryPerformanceLevelXSmall), "X-SMALL":
+		return MaxQueryPerformanceLevelXSmall, nil
+	case string(MaxQueryPerformanceLevelSmall):
+		return MaxQueryPerformanceLevelSmall, nil
+	case string(MaxQueryPerformanceLevelMedium):
+		return MaxQueryPerformanceLevelMedium, nil
+	case string(MaxQueryPerformanceLevelLarge):
+		return MaxQueryPerformanceLevelLarge, nil
+	case string(MaxQueryPerformanceLevelXLarge), "X-LARGE":
+		return MaxQueryPerformanceLevelXLarge, nil
+	case string(MaxQueryPerformanceLevelXXLarge), "2X-LARGE":
+		return MaxQueryPerformanceLevelXXLarge, nil
+	case string(MaxQueryPerformanceLevelXXXLarge), "3X-LARGE":
+		return MaxQueryPerformanceLevelXXXLarge, nil
+	case string(MaxQueryPerformanceLevelX4Large), "4X-LARGE":
+		return MaxQueryPerformanceLevelX4Large, nil
+	default:
+		return "", fmt.Errorf("invalid max query performance level: %s", s)
 	}
-	return "", fmt.Errorf("invalid max query performance level: %s", s)
 }
 
 // CreateWarehouseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-warehouse.
@@ -498,12 +514,13 @@ type WarehouseSet struct {
 	QueryAccelerationMaxScaleFactor *int                         `ddl:"parameter" sql:"QUERY_ACCELERATION_MAX_SCALE_FACTOR"`
 	ResourceConstraint              *WarehouseResourceConstraint `ddl:"parameter,single_quotes" sql:"RESOURCE_CONSTRAINT"`
 	Generation                      *WarehouseGeneration         `ddl:"parameter,single_quotes" sql:"GENERATION"`
+	QueryThroughputMultiplier       *int                         `ddl:"parameter" sql:"QUERY_THROUGHPUT_MULTIPLIER"`
+	MaxQueryPerformanceLevel        *MaxQueryPerformanceLevel    `ddl:"parameter,single_quotes" sql:"MAX_QUERY_PERFORMANCE_LEVEL"`
 
 	// Object params
 	MaxConcurrencyLevel             *int `ddl:"parameter" sql:"MAX_CONCURRENCY_LEVEL"`
 	StatementQueuedTimeoutInSeconds *int `ddl:"parameter" sql:"STATEMENT_QUEUED_TIMEOUT_IN_SECONDS"`
 	StatementTimeoutInSeconds       *int `ddl:"parameter" sql:"STATEMENT_TIMEOUT_IN_SECONDS"`
-	QueryThroughputMultiplier       *int `ddl:"parameter" sql:"QUERY_THROUGHPUT_MULTIPLIER"`
 }
 
 func (v *WarehouseSet) validate() error {
@@ -528,8 +545,8 @@ func (v *WarehouseSet) validate() error {
 			return fmt.Errorf("QueryThroughputMultiplier must be greater than or equal to 0")
 		}
 	}
-	if everyValueNil(v.WarehouseType, v.WarehouseSize, v.WaitForCompletion, v.MaxClusterCount, v.MinClusterCount, v.ScalingPolicy, v.AutoSuspend, v.AutoResume, v.ResourceMonitor, v.Comment, v.EnableQueryAcceleration, v.QueryAccelerationMaxScaleFactor, v.ResourceConstraint, v.Generation, v.MaxConcurrencyLevel, v.StatementQueuedTimeoutInSeconds, v.StatementTimeoutInSeconds, v.QueryThroughputMultiplier) {
-		return errAtLeastOneOf("WarehouseSet", "WarehouseType", "WarehouseSize", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds", "QueryThroughputMultiplier")
+	if everyValueNil(v.WarehouseType, v.WarehouseSize, v.WaitForCompletion, v.MaxClusterCount, v.MinClusterCount, v.ScalingPolicy, v.AutoSuspend, v.AutoResume, v.ResourceMonitor, v.Comment, v.EnableQueryAcceleration, v.QueryAccelerationMaxScaleFactor, v.ResourceConstraint, v.Generation, v.MaxConcurrencyLevel, v.StatementQueuedTimeoutInSeconds, v.StatementTimeoutInSeconds, v.QueryThroughputMultiplier, v.MaxQueryPerformanceLevel) {
+		return errAtLeastOneOf("WarehouseSet", "WarehouseType", "WarehouseSize", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds", "QueryThroughputMultiplier", "MaxQueryPerformanceLevel")
 	}
 	return nil
 }
@@ -555,11 +572,12 @@ type WarehouseUnset struct {
 	StatementQueuedTimeoutInSeconds *bool `ddl:"keyword" sql:"STATEMENT_QUEUED_TIMEOUT_IN_SECONDS"`
 	StatementTimeoutInSeconds       *bool `ddl:"keyword" sql:"STATEMENT_TIMEOUT_IN_SECONDS"`
 	QueryThroughputMultiplier       *bool `ddl:"keyword" sql:"QUERY_THROUGHPUT_MULTIPLIER"`
+	MaxQueryPerformanceLevel        *bool `ddl:"keyword" sql:"MAX_QUERY_PERFORMANCE_LEVEL"`
 }
 
 func (v *WarehouseUnset) validate() error {
-	if everyValueNil(v.WarehouseType, v.WaitForCompletion, v.MaxClusterCount, v.MinClusterCount, v.ScalingPolicy, v.AutoSuspend, v.AutoResume, v.ResourceMonitor, v.Comment, v.EnableQueryAcceleration, v.QueryAccelerationMaxScaleFactor, v.ResourceConstraint, v.Generation, v.MaxConcurrencyLevel, v.StatementQueuedTimeoutInSeconds, v.StatementTimeoutInSeconds, v.QueryThroughputMultiplier) {
-		return errAtLeastOneOf("WarehouseUnset", "WarehouseType", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds", "QueryThroughputMultiplier")
+	if everyValueNil(v.WarehouseType, v.WaitForCompletion, v.MaxClusterCount, v.MinClusterCount, v.ScalingPolicy, v.AutoSuspend, v.AutoResume, v.ResourceMonitor, v.Comment, v.EnableQueryAcceleration, v.QueryAccelerationMaxScaleFactor, v.ResourceConstraint, v.Generation, v.MaxConcurrencyLevel, v.StatementQueuedTimeoutInSeconds, v.StatementTimeoutInSeconds, v.QueryThroughputMultiplier, v.MaxQueryPerformanceLevel) {
+		return errAtLeastOneOf("WarehouseUnset", "WarehouseType", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds", "QueryThroughputMultiplier", "MaxQueryPerformanceLevel")
 	}
 	return nil
 }

--- a/pkg/sdk/warehouses_test.go
+++ b/pkg/sdk/warehouses_test.go
@@ -304,6 +304,34 @@ func TestWarehouseAlter(t *testing.T) {
 	})
 }
 
+func TestWarehouseAlterAdaptive(t *testing.T) {
+	t.Run("alter adaptive: set all adaptive params", func(t *testing.T) {
+		opts := &AlterWarehouseOptions{
+			name: NewAccountObjectIdentifier("mywarehouse"),
+			Set: &WarehouseSet{
+				MaxQueryPerformanceLevel:        Pointer(MaxQueryPerformanceLevelXSmall),
+				QueryThroughputMultiplier:       Int(5),
+				StatementQueuedTimeoutInSeconds: Int(100),
+				StatementTimeoutInSeconds:       Int(200),
+			},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER WAREHOUSE "mywarehouse" SET QUERY_THROUGHPUT_MULTIPLIER = 5 MAX_QUERY_PERFORMANCE_LEVEL = 'XSMALL' STATEMENT_QUEUED_TIMEOUT_IN_SECONDS = 100 STATEMENT_TIMEOUT_IN_SECONDS = 200`)
+	})
+
+	t.Run("alter adaptive: unset all adaptive params", func(t *testing.T) {
+		opts := &AlterWarehouseOptions{
+			name: NewAccountObjectIdentifier("mywarehouse"),
+			Unset: &WarehouseUnset{
+				MaxQueryPerformanceLevel:        Bool(true),
+				QueryThroughputMultiplier:       Bool(true),
+				StatementQueuedTimeoutInSeconds: Bool(true),
+				StatementTimeoutInSeconds:       Bool(true),
+			},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER WAREHOUSE "mywarehouse" UNSET STATEMENT_QUEUED_TIMEOUT_IN_SECONDS, STATEMENT_TIMEOUT_IN_SECONDS, QUERY_THROUGHPUT_MULTIPLIER, MAX_QUERY_PERFORMANCE_LEVEL`)
+	})
+}
+
 func TestWarehouseDrop(t *testing.T) {
 	t.Run("only name", func(t *testing.T) {
 		opts := &DropWarehouseOptions{


### PR DESCRIPTION
## Changes

- Add `MaxQueryPerformanceLevel` to SET and UNSET.
- Update `validate()` methods.
- Support enum aliases.