### PR TITLE
chore: Add RevokeSafely to Roles, DatabaseRoles, and ApplicationRoles SDK interfaces

### DIFF
--- a/pkg/sdk/application_roles_gen.go
+++ b/pkg/sdk/application_roles_gen.go
@@ -17,6 +17,8 @@ import (
 type ApplicationRoles interface {
 	Grant(ctx context.Context, request *GrantApplicationRoleRequest) error
 	Revoke(ctx context.Context, request *RevokeApplicationRoleRequest) error
+	// Adjusted manually
+	RevokeSafely(ctx context.Context, request *RevokeApplicationRoleRequest) error
 	Show(ctx context.Context, request *ShowApplicationRoleRequest) ([]ApplicationRole, error)
 	ShowByID(ctx context.Context, id DatabaseObjectIdentifier) (*ApplicationRole, error)
 	ShowByIDSafely(ctx context.Context, id DatabaseObjectIdentifier) (*ApplicationRole, error)

--- a/pkg/sdk/application_roles_impl_gen.go
+++ b/pkg/sdk/application_roles_impl_gen.go
@@ -26,6 +26,11 @@ func (v *applicationRoles) Revoke(ctx context.Context, request *RevokeApplicatio
 	return validateAndExec(v.client, ctx, opts)
 }
 
+// Adjusted manually
+func (v *applicationRoles) RevokeSafely(ctx context.Context, request *RevokeApplicationRoleRequest) error {
+	return SafeRevokePrivileges(func() error { return v.Revoke(ctx, request) })
+}
+
 func (v *applicationRoles) Show(ctx context.Context, request *ShowApplicationRoleRequest) ([]ApplicationRole, error) {
 	opts := request.toOpts()
 	dbRows, err := validateAndQuery[applicationRoleDbRow](v.client, ctx, opts)

--- a/pkg/sdk/database_role.go
+++ b/pkg/sdk/database_role.go
@@ -16,6 +16,7 @@ type DatabaseRoles interface {
 
 	Grant(ctx context.Context, request *GrantDatabaseRoleRequest) error
 	Revoke(ctx context.Context, request *RevokeDatabaseRoleRequest) error
+	RevokeSafely(ctx context.Context, request *RevokeDatabaseRoleRequest) error
 	GrantToShare(ctx context.Context, request *GrantDatabaseRoleToShareRequest) error
 	RevokeFromShare(ctx context.Context, request *RevokeDatabaseRoleFromShareRequest) error
 }

--- a/pkg/sdk/database_role_impl.go
+++ b/pkg/sdk/database_role_impl.go
@@ -77,6 +77,10 @@ func (v *databaseRoles) Revoke(ctx context.Context, request *RevokeDatabaseRoleR
 	return validateAndExec(v.client, ctx, opts)
 }
 
+func (v *databaseRoles) RevokeSafely(ctx context.Context, request *RevokeDatabaseRoleRequest) error {
+	return SafeRevokePrivileges(func() error { return v.Revoke(ctx, request) })
+}
+
 func (v *databaseRoles) GrantToShare(ctx context.Context, request *GrantDatabaseRoleToShareRequest) error {
 	opts := request.toOpts()
 	return validateAndExec(v.client, ctx, opts)

--- a/pkg/sdk/roles.go
+++ b/pkg/sdk/roles.go
@@ -16,6 +16,7 @@ type Roles interface {
 	ShowByIDSafely(ctx context.Context, id AccountObjectIdentifier) (*Role, error)
 	Grant(ctx context.Context, req *GrantRoleRequest) error
 	Revoke(ctx context.Context, req *RevokeRoleRequest) error
+	RevokeSafely(ctx context.Context, req *RevokeRoleRequest) error
 	Use(ctx context.Context, req *UseRoleRequest) error
 	UseSecondary(ctx context.Context, req *UseSecondaryRolesRequest) error
 }

--- a/pkg/sdk/roles_impl.go
+++ b/pkg/sdk/roles_impl.go
@@ -59,6 +59,10 @@ func (v *roles) Revoke(ctx context.Context, req *RevokeRoleRequest) error {
 	return validateAndExec(v.client, ctx, req.toOpts())
 }
 
+func (v *roles) RevokeSafely(ctx context.Context, req *RevokeRoleRequest) error {
+	return SafeRevokePrivileges(func() error { return v.Revoke(ctx, req) })
+}
+
 func (v *roles) Use(ctx context.Context, req *UseRoleRequest) error {
 	return v.client.Sessions.UseRole(ctx, req.id)
 }

--- a/pkg/sdk/testint/application_roles_gen_integration_test.go
+++ b/pkg/sdk/testint/application_roles_gen_integration_test.go
@@ -13,6 +13,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO [SNOW-1431726]: Move to helpers
+func createApp(t *testing.T) *sdk.Application {
+	t.Helper()
+
+	stage, cleanupStage := testClientHelper().Stage.CreateStage(t)
+	t.Cleanup(cleanupStage)
+
+	testClientHelper().Stage.PutOnStage(t, stage.ID(), "manifest.yml")
+	testClientHelper().Stage.PutOnStage(t, stage.ID(), "setup.sql")
+
+	applicationPackage, cleanupApplicationPackage := testClientHelper().ApplicationPackage.CreateApplicationPackage(t)
+	t.Cleanup(cleanupApplicationPackage)
+
+	testClientHelper().ApplicationPackage.RegisterVersion(t, applicationPackage.ID(), stage.ID(), "v1")
+
+	application, cleanupApplication := testClientHelper().Application.CreateApplication(t, applicationPackage.ID(), "v1")
+	t.Cleanup(cleanupApplication)
+	return application
+}
+
 // TestInt_ApplicationRoles setup is a little bit different from usual integration test, because of how native apps work.
 // I will try to explain it in a short form, but check out this article for more detailed description (https://docs.snowflake.com/en/developer-guide/native-apps/tutorials/getting-started-tutorial#introduction)
 //   - create stage - it is where we will be keeping our application files
@@ -24,26 +44,6 @@ import (
 func TestInt_ApplicationRoles(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
-
-	// TODO [SNOW-1431726]: Move to helpers
-	createApp := func(t *testing.T) *sdk.Application {
-		t.Helper()
-
-		stage, cleanupStage := testClientHelper().Stage.CreateStage(t)
-		t.Cleanup(cleanupStage)
-
-		testClientHelper().Stage.PutOnStage(t, stage.ID(), "manifest.yml")
-		testClientHelper().Stage.PutOnStage(t, stage.ID(), "setup.sql")
-
-		applicationPackage, cleanupApplicationPackage := testClientHelper().ApplicationPackage.CreateApplicationPackage(t)
-		t.Cleanup(cleanupApplicationPackage)
-
-		testClientHelper().ApplicationPackage.RegisterVersion(t, applicationPackage.ID(), stage.ID(), "v1")
-
-		application, cleanupApplication := testClientHelper().Application.CreateApplication(t, applicationPackage.ID(), "v1")
-		t.Cleanup(cleanupApplication)
-		return application
-	}
 
 	application := createApp(t)
 

--- a/pkg/sdk/testint/safe_grant_handlers_integration_test.go
+++ b/pkg/sdk/testint/safe_grant_handlers_integration_test.go
@@ -495,7 +495,7 @@ func TestInt_SafeRevokeAccountRole(t *testing.T) {
 	})
 
 	t.Run("revoke role that was never granted", func(t *testing.T) {
-		err := client.Roles.RevokeSafely(ctx, sdk.NewRevokeRoleRequest(role.ID(), sdk.RevokeRole{Role: sdk.Pointer(parentRole.ID())}))
+		err := client.Roles.RevokeSafely(ctx, sdk.NewRevokeRoleRequest(NonExistingAccountObjectIdentifier, sdk.RevokeRole{Role: sdk.Pointer(NonExistingAccountObjectIdentifier)}))
 		assert.NoError(t, err)
 	})
 }
@@ -521,7 +521,7 @@ func TestInt_SafeRevokeDatabaseRole(t *testing.T) {
 	})
 
 	t.Run("revoke database role that was never granted", func(t *testing.T) {
-		err := client.DatabaseRoles.RevokeSafely(ctx, sdk.NewRevokeDatabaseRoleRequest(databaseRole.ID()).WithAccountRole(accountRole.ID()))
+		err := client.DatabaseRoles.RevokeSafely(ctx, sdk.NewRevokeDatabaseRoleRequest(NonExistingDatabaseObjectIdentifier).WithAccountRole(NonExistingAccountObjectIdentifier))
 		assert.NoError(t, err)
 	})
 }

--- a/pkg/sdk/testint/safe_grant_handlers_integration_test.go
+++ b/pkg/sdk/testint/safe_grant_handlers_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -471,4 +472,83 @@ func TestInt_SafeRevokeFromShareOnNonExistingSchemaLevelObjects(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestInt_SafeRevokeAccountRole(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	role, roleCleanup := testClientHelper().Role.CreateRole(t)
+	t.Cleanup(roleCleanup)
+
+	parentRole, parentRoleCleanup := testClientHelper().Role.CreateRole(t)
+	t.Cleanup(parentRoleCleanup)
+
+	t.Run("revoke non-existing role", func(t *testing.T) {
+		err := client.Roles.RevokeSafely(ctx, sdk.NewRevokeRoleRequest(NonExistingAccountObjectIdentifier, sdk.RevokeRole{Role: sdk.Pointer(parentRole.ID())}))
+		assert.NoError(t, err)
+	})
+
+	t.Run("revoke from non-existing grantee role", func(t *testing.T) {
+		err := client.Roles.RevokeSafely(ctx, sdk.NewRevokeRoleRequest(role.ID(), sdk.RevokeRole{Role: &NonExistingAccountObjectIdentifier}))
+		assert.NoError(t, err)
+	})
+
+	t.Run("revoke role that was never granted", func(t *testing.T) {
+		err := client.Roles.RevokeSafely(ctx, sdk.NewRevokeRoleRequest(role.ID(), sdk.RevokeRole{Role: sdk.Pointer(parentRole.ID())}))
+		assert.NoError(t, err)
+	})
+}
+
+func TestInt_SafeRevokeDatabaseRole(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	databaseRole, databaseRoleCleanup := testClientHelper().DatabaseRole.CreateDatabaseRole(t)
+	t.Cleanup(databaseRoleCleanup)
+
+	accountRole, accountRoleCleanup := testClientHelper().Role.CreateRole(t)
+	t.Cleanup(accountRoleCleanup)
+
+	t.Run("revoke non-existing database role from account role", func(t *testing.T) {
+		err := client.DatabaseRoles.RevokeSafely(ctx, sdk.NewRevokeDatabaseRoleRequest(NonExistingDatabaseObjectIdentifier).WithAccountRole(accountRole.ID()))
+		assert.NoError(t, err)
+	})
+
+	t.Run("revoke database role from non-existing account role", func(t *testing.T) {
+		err := client.DatabaseRoles.RevokeSafely(ctx, sdk.NewRevokeDatabaseRoleRequest(databaseRole.ID()).WithAccountRole(NonExistingAccountObjectIdentifier))
+		assert.NoError(t, err)
+	})
+
+	t.Run("revoke database role that was never granted", func(t *testing.T) {
+		err := client.DatabaseRoles.RevokeSafely(ctx, sdk.NewRevokeDatabaseRoleRequest(databaseRole.ID()).WithAccountRole(accountRole.ID()))
+		assert.NoError(t, err)
+	})
+}
+
+func TestInt_SafeRevokeApplicationRole(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	app := createApp(t)
+	applicationRoleName := testvars.ApplicationRole1
+	applicationRoleId := sdk.NewDatabaseObjectIdentifier(app.Name, applicationRoleName)
+
+	accountRole, accountRoleCleanup := testClientHelper().Role.CreateRole(t)
+	t.Cleanup(accountRoleCleanup)
+
+	t.Run("revoke non-existing application role from account role", func(t *testing.T) {
+		err := client.ApplicationRoles.RevokeSafely(ctx, sdk.NewRevokeApplicationRoleRequest(NonExistingDatabaseObjectIdentifier).WithFrom(*sdk.NewKindOfRoleRequest().WithRoleName(accountRole.ID())))
+		assert.NoError(t, err)
+	})
+
+	t.Run("revoke application role from non-existing account role", func(t *testing.T) {
+		err := client.ApplicationRoles.RevokeSafely(ctx, sdk.NewRevokeApplicationRoleRequest(applicationRoleId).WithFrom(*sdk.NewKindOfRoleRequest().WithRoleName(accountRole.ID())))
+		assert.NoError(t, err)
+	})
+
+	t.Run("revoke application role that was never granted", func(t *testing.T) {
+		err := client.ApplicationRoles.RevokeSafely(ctx, sdk.NewRevokeApplicationRoleRequest(NonExistingDatabaseObjectIdentifier).WithFrom(*sdk.NewKindOfRoleRequest().WithRoleName(NonExistingAccountObjectIdentifier)))
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
## Overview

Adds `RevokeSafely` to three role-grant SDK interfaces as the SDK prerequisite for supporting the `GRANTS_SAFE_DESTROY` experiment in `snowflake_grant_account_role`, `snowflake_grant_application_role`, and `snowflake_grant_database_role` resources (resource changes are a follow-up).

## Related

Follows #4581 (`GRANTS_SAFE_DESTROY` experiment for `snowflake_grant_privileges_to_account_role`).