### PR TITLE
feat: Extend GRANTS_SAFE_DESTROY experiment to snowflake_grant_privileges_to_database_role

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -32,7 +32,7 @@ A new `GRANTS_SAFE_DESTROY` experiment has been added. When enabled, resource de
 
 This is useful when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.
 
-Currently supported by: `snowflake_grant_privileges_to_account_role`. This experiment is designed to be extended to other resources in the future.
+Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`.
 
 To enable, add `GRANTS_SAFE_DESTROY` to your provider's `experimental_features_enabled` list:
 ```hcl

--- a/docs/index.md
+++ b/docs/index.md
@@ -973,7 +973,7 @@ Note: this is supported only on all stage resources (`snowflake_stage_external_s
 #### GRANTS_SAFE_DESTROY
 When enabled, grant destroy operations silently succeed when the underlying Snowflake object (or its dependencies) no longer exists.
 
-Currently supported by: `snowflake_grant_privileges_to_account_role`. This experiment is designed to be extended to other grant resources in the future.
+Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`.
 
 This prevents errors when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.
 

--- a/examples/additional/experimental_features.MD
+++ b/examples/additional/experimental_features.MD
@@ -61,7 +61,7 @@ Note: this is supported only on all stage resources (`snowflake_stage_external_s
 #### GRANTS_SAFE_DESTROY
 When enabled, grant destroy operations silently succeed when the underlying Snowflake object (or its dependencies) no longer exists.
 
-Currently supported by: `snowflake_grant_privileges_to_account_role`. This experiment is designed to be extended to other grant resources in the future.
+Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`.
 
 This prevents errors when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.
 

--- a/pkg/provider/experimentalfeatures/experimental_features.go
+++ b/pkg/provider/experimentalfeatures/experimental_features.go
@@ -122,7 +122,7 @@ var allExperiments = []Experiment{
 		ExperimentalFeatureStateActive,
 		joinWithDoubleNewline(
 			"When enabled, grant destroy operations silently succeed when the underlying Snowflake object (or its dependencies) no longer exists.",
-			"Currently supported by: `snowflake_grant_privileges_to_account_role`. This experiment is designed to be extended to other grant resources in the future.",
+			"Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`.",
 			"This prevents errors when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.",
 			"Without this experiment, destroying such resources fails with `does not exist or not authorized`.",
 		),

--- a/pkg/resources/grant_privileges_to_database_role.go
+++ b/pkg/resources/grant_privileges_to_database_role.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
@@ -598,7 +599,8 @@ func UpdateGrantPrivilegesToDatabaseRole(ctx context.Context, d *schema.Resource
 }
 
 func DeleteGrantPrivilegesToDatabaseRole(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*provider.Context).Client
+	providerCtx := meta.(*provider.Context)
+	client := providerCtx.Client
 	id, err := ParseGrantPrivilegesToDatabaseRoleId(d.Id())
 	if err != nil {
 		return diag.Diagnostics{
@@ -614,13 +616,11 @@ func DeleteGrantPrivilegesToDatabaseRole(ctx context.Context, d *schema.Resource
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = client.Grants.RevokePrivilegesFromDatabaseRole(
-		ctx,
-		getDatabaseRolePrivilegesFromSchema(d),
-		grantOn,
-		id.DatabaseRoleName,
-		&sdk.RevokePrivilegesFromDatabaseRoleOptions{},
-	)
+	if experimentalfeatures.IsExperimentEnabled(experimentalfeatures.GrantsSafeDestroy, providerCtx.EnabledExperiments) {
+		err = client.Grants.RevokePrivilegesFromDatabaseRoleSafely(ctx, getDatabaseRolePrivilegesFromSchema(d), grantOn, id.DatabaseRoleName, &sdk.RevokePrivilegesFromDatabaseRoleOptions{})
+	} else {
+		err = client.Grants.RevokePrivilegesFromDatabaseRole(ctx, getDatabaseRolePrivilegesFromSchema(d), grantOn, id.DatabaseRoleName, &sdk.RevokePrivilegesFromDatabaseRoleOptions{})
+	}
 	if err != nil {
 		return diag.Diagnostics{
 			diag.Diagnostic{

--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -13,6 +13,7 @@ type Grants interface {
 	RevokePrivilegesFromAccountRoleSafely(ctx context.Context, privileges *AccountRoleGrantPrivileges, on *AccountRoleGrantOn, role AccountObjectIdentifier, opts *RevokePrivilegesFromAccountRoleOptions) error
 	GrantPrivilegesToDatabaseRole(ctx context.Context, privileges *DatabaseRoleGrantPrivileges, on *DatabaseRoleGrantOn, role DatabaseObjectIdentifier, opts *GrantPrivilegesToDatabaseRoleOptions) error
 	RevokePrivilegesFromDatabaseRole(ctx context.Context, privileges *DatabaseRoleGrantPrivileges, on *DatabaseRoleGrantOn, role DatabaseObjectIdentifier, opts *RevokePrivilegesFromDatabaseRoleOptions) error
+	RevokePrivilegesFromDatabaseRoleSafely(ctx context.Context, privileges *DatabaseRoleGrantPrivileges, on *DatabaseRoleGrantOn, role DatabaseObjectIdentifier, opts *RevokePrivilegesFromDatabaseRoleOptions) error
 	GrantPrivilegeToShare(ctx context.Context, privileges []ObjectPrivilege, on *ShareGrantOn, to AccountObjectIdentifier) error
 	RevokePrivilegeFromShare(ctx context.Context, privileges []ObjectPrivilege, on *ShareGrantOn, from AccountObjectIdentifier) error
 	RevokePrivilegeFromShareSafely(ctx context.Context, privileges []ObjectPrivilege, on *ShareGrantOn, from AccountObjectIdentifier) error

--- a/pkg/sdk/grants_impl.go
+++ b/pkg/sdk/grants_impl.go
@@ -166,6 +166,21 @@ func (v *grants) GrantPrivilegesToDatabaseRole(ctx context.Context, privileges *
 }
 
 func (v *grants) RevokePrivilegesFromDatabaseRole(ctx context.Context, privileges *DatabaseRoleGrantPrivileges, on *DatabaseRoleGrantOn, role DatabaseObjectIdentifier, opts *RevokePrivilegesFromDatabaseRoleOptions) error {
+	return v.revokePrivilegesFromDatabaseRole(ctx, privileges, on, role, opts, noopExecWrapper)
+}
+
+func (v *grants) RevokePrivilegesFromDatabaseRoleSafely(ctx context.Context, privileges *DatabaseRoleGrantPrivileges, on *DatabaseRoleGrantOn, role DatabaseObjectIdentifier, opts *RevokePrivilegesFromDatabaseRoleOptions) error {
+	return v.revokePrivilegesFromDatabaseRole(ctx, privileges, on, role, opts, SafeRevokePrivileges)
+}
+
+func (v *grants) revokePrivilegesFromDatabaseRole(
+	ctx context.Context,
+	privileges *DatabaseRoleGrantPrivileges,
+	on *DatabaseRoleGrantOn,
+	role DatabaseObjectIdentifier,
+	opts *RevokePrivilegesFromDatabaseRoleOptions,
+	execWrapper func(func() error) error,
+) error {
 	if opts == nil {
 		opts = &RevokePrivilegesFromDatabaseRoleOptions{}
 	}
@@ -185,7 +200,7 @@ func (v *grants) RevokePrivilegesFromDatabaseRole(ctx context.Context, privilege
 			on.SchemaObject.All.InDatabase,
 			on.SchemaObject.All.InSchema,
 			func(pipe Pipe) error {
-				return v.client.Grants.RevokePrivilegesFromDatabaseRole(
+				return v.revokePrivilegesFromDatabaseRole(
 					ctx,
 					privileges,
 					&DatabaseRoleGrantOn{
@@ -198,12 +213,15 @@ func (v *grants) RevokePrivilegesFromDatabaseRole(ctx context.Context, privilege
 					},
 					role,
 					opts,
+					execWrapper,
 				)
 			},
 		)
 	}
 
-	return validateAndExec(v.client, ctx, opts)
+	return execWrapper(func() error {
+		return validateAndExec(v.client, ctx, opts)
+	})
 }
 
 func (v *grants) GrantPrivilegeToShare(ctx context.Context, privileges []ObjectPrivilege, on *ShareGrantOn, to AccountObjectIdentifier) error {

--- a/pkg/sdk/testint/safe_grant_handlers_integration_test.go
+++ b/pkg/sdk/testint/safe_grant_handlers_integration_test.go
@@ -552,3 +552,112 @@ func TestInt_SafeRevokeApplicationRole(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestInt_SafeRevokePrivilegesFromDatabaseRole(t *testing.T) {
+	client := testClient(t)
+
+	dbRole, dbRoleCleanup := testClientHelper().DatabaseRole.CreateDatabaseRole(t)
+	t.Cleanup(dbRoleCleanup)
+
+	table, tableCleanup := testClientHelper().Table.Create(t)
+	t.Cleanup(tableCleanup)
+
+	ctx := context.Background()
+
+	tablePrivileges := &sdk.DatabaseRoleGrantPrivileges{
+		SchemaObjectPrivileges: []sdk.SchemaObjectPrivilege{sdk.SchemaObjectPrivilegeSelect},
+	}
+	tableOn := func(id sdk.SchemaObjectIdentifier) *sdk.DatabaseRoleGrantOn {
+		return &sdk.DatabaseRoleGrantOn{
+			SchemaObject: &sdk.GrantOnSchemaObject{
+				SchemaObject: &sdk.Object{
+					ObjectType: sdk.ObjectTypeTable,
+					Name:       id,
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		Name string
+		On   *sdk.DatabaseRoleGrantOn
+		Role sdk.DatabaseObjectIdentifier
+	}{
+		{Name: "missing database role", On: tableOn(table.ID()), Role: NonExistingDatabaseObjectIdentifier},
+		{Name: "missing database", On: tableOn(NonExistingSchemaObjectIdentifierWithNonExistingDatabaseAndSchema), Role: dbRole.ID()},
+		{Name: "missing schema", On: tableOn(NonExistingSchemaObjectIdentifierWithNonExistingSchema), Role: dbRole.ID()},
+		{Name: "missing schema object", On: tableOn(NonExistingSchemaObjectIdentifier), Role: dbRole.ID()},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.Name, func(t *testing.T) {
+			err := client.Grants.RevokePrivilegesFromDatabaseRoleSafely(ctx, tablePrivileges, tt.On, tt.Role, nil)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestInt_SafeRevokePrivilegesFromDatabaseRole_AllPipesWithMissingRole(t *testing.T) {
+	client := testClient(t)
+
+	table, tableCleanup := testClientHelper().Table.Create(t)
+	t.Cleanup(tableCleanup)
+
+	stage, stageCleanup := testClientHelper().Stage.CreateStage(t)
+	t.Cleanup(stageCleanup)
+
+	copyStatement := createPipeCopyStatement(t, table, stage)
+
+	_, pipeCleanup := testClientHelper().Pipe.CreatePipe(t, copyStatement)
+	t.Cleanup(pipeCleanup)
+
+	_, secondPipeCleanup := testClientHelper().Pipe.CreatePipe(t, copyStatement)
+	t.Cleanup(secondPipeCleanup)
+
+	dbRole, dbRoleCleanup := testClientHelper().DatabaseRole.CreateDatabaseRole(t)
+	t.Cleanup(dbRoleCleanup)
+
+	ctx := context.Background()
+
+	// Grant MONITOR on all pipes in schema to the database role.
+	err := client.Grants.GrantPrivilegesToDatabaseRole(
+		ctx,
+		&sdk.DatabaseRoleGrantPrivileges{
+			SchemaObjectPrivileges: []sdk.SchemaObjectPrivilege{sdk.SchemaObjectPrivilegeMonitor},
+		},
+		&sdk.DatabaseRoleGrantOn{
+			SchemaObject: &sdk.GrantOnSchemaObject{
+				All: &sdk.GrantOnSchemaObjectIn{
+					PluralObjectType: sdk.PluralObjectTypePipes,
+					InSchema:         sdk.Pointer(testClientHelper().Ids.SchemaId()),
+				},
+			},
+		},
+		dbRole.ID(),
+		&sdk.GrantPrivilegesToDatabaseRoleOptions{},
+	)
+	require.NoError(t, err)
+
+	// Drop the database role — pipes still exist, so Pipes.Show succeeds,
+	// but each per-pipe REVOKE will fail with ErrObjectNotExistOrAuthorized.
+	dbRoleCleanup()
+
+	// RevokePrivilegesFromDatabaseRoleSafely must suppress the per-pipe errors individually.
+	err = client.Grants.RevokePrivilegesFromDatabaseRoleSafely(
+		ctx,
+		&sdk.DatabaseRoleGrantPrivileges{
+			SchemaObjectPrivileges: []sdk.SchemaObjectPrivilege{sdk.SchemaObjectPrivilegeMonitor},
+		},
+		&sdk.DatabaseRoleGrantOn{
+			SchemaObject: &sdk.GrantOnSchemaObject{
+				All: &sdk.GrantOnSchemaObjectIn{
+					PluralObjectType: sdk.PluralObjectTypePipes,
+					InSchema:         sdk.Pointer(testClientHelper().Ids.SchemaId()),
+				},
+			},
+		},
+		dbRole.ID(),
+		nil,
+	)
+	assert.NoError(t, err)
+}

--- a/pkg/testacc/resource_grant_privileges_safe_destroy_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_safe_destroy_experimental_features_acceptance_test.go
@@ -32,7 +32,7 @@ func TestAcc_Experimental_GrantPrivilegesToAccountRole_SafeDestroy_MissingWareho
 
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
-	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantPrivilegesToAccountRole_SafeDestroy_MissingWarehouse")
+	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantPrivileges_SafeDestroy")
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -79,7 +79,7 @@ func TestAcc_Experimental_GrantPrivilegesToAccountRole_SafeDestroy_MissingRole(t
 
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
-	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantPrivilegesToAccountRole_SafeDestroy_MissingRole")
+	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantPrivileges_SafeDestroy")
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -95,6 +95,98 @@ func TestAcc_Experimental_GrantPrivilegesToAccountRole_SafeDestroy_MissingRole(t
 			{
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				PreConfig:                testClient().Role.DropRoleFunc(t, role.ID()),
+				Config:                   config.FromModels(t, grantModel),
+				Destroy:                  true,
+				ExpectError:              regexp.MustCompile("does not exist or not authorized"),
+			},
+			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
+			{
+				ProtoV6ProviderFactories: experimentFactory,
+				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy:                  true,
+			},
+		},
+	})
+}
+
+// TestAcc_Experimental_GrantPrivilegesToDatabaseRole_SafeDestroy_MissingDatabase verifies that destroying
+// a database role grant resource fails when the target database is deleted externally (default behavior),
+// and succeeds when the GRANTS_SAFE_DESTROY experiment is enabled.
+// Uses all_privileges = true so that Read skips existence checks and Delete is actually called.
+func TestAcc_Experimental_GrantPrivilegesToDatabaseRole_SafeDestroy_MissingDatabase(t *testing.T) {
+	// Create a separate database to grant on so we can drop it independently of the role.
+	db, dbCleanup := testClient().Database.CreateDatabase(t)
+	t.Cleanup(dbCleanup)
+
+	dbRole, dbRoleCleanup := testClient().DatabaseRole.CreateDatabaseRoleInDatabase(t, db.ID())
+	t.Cleanup(dbRoleCleanup)
+
+	grantModel := model.GrantPrivilegesToDatabaseRole("test", dbRole.ID().FullyQualifiedName()).
+		WithAllPrivileges(true).
+		WithOnDatabase(db.ID().Name())
+
+	experimentProviderModel := providermodel.SnowflakeProvider().
+		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
+	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantPrivileges_SafeDestroy")
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			// Create the grant with default provider.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+			},
+			// Drop the target database externally, then try to destroy without experiment — expect failure.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				PreConfig:                testClient().Database.DropDatabaseFunc(t, db.ID()),
+				Config:                   config.FromModels(t, grantModel),
+				Destroy:                  true,
+				ExpectError:              regexp.MustCompile("does not exist or not authorized"),
+			},
+			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
+			{
+				ProtoV6ProviderFactories: experimentFactory,
+				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy:                  true,
+			},
+		},
+	})
+}
+
+// TestAcc_Experimental_GrantPrivilegesToDatabaseRole_SafeDestroy_MissingDatabaseRole verifies that destroying
+// a database role grant resource fails when the grantee database role is deleted externally (default behavior),
+// and succeeds when the GRANTS_SAFE_DESTROY experiment is enabled.
+// Uses all_privileges = true so that Read skips existence checks and Delete is actually called.
+func TestAcc_Experimental_GrantPrivilegesToDatabaseRole_SafeDestroy_MissingDatabaseRole(t *testing.T) {
+	dbRole, dbRoleCleanup := testClient().DatabaseRole.CreateDatabaseRole(t)
+	t.Cleanup(dbRoleCleanup)
+
+	grantModel := model.GrantPrivilegesToDatabaseRole("test", dbRole.ID().FullyQualifiedName()).
+		WithAllPrivileges(true).
+		WithOnDatabase(testClient().Ids.DatabaseId().Name())
+
+	experimentProviderModel := providermodel.SnowflakeProvider().
+		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
+	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantPrivileges_SafeDestroy")
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			// Create the grant with default provider.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+			},
+			// Drop the database role externally, then try to destroy without experiment — expect failure.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				PreConfig:                testClient().DatabaseRole.CleanupDatabaseRoleFunc(t, dbRole.ID()),
 				Config:                   config.FromModels(t, grantModel),
 				Destroy:                  true,
 				ExpectError:              regexp.MustCompile("does not exist or not authorized"),


### PR DESCRIPTION
## Changes

Extends the existing `GRANTS_SAFE_DESTROY` experiment (introduced in #4581) to the `snowflake_grant_privileges_to_database_role` resource. Also, reuse the cached provider between the related grants tests.