### PR TITLE
fix: Use HTTPS URLs in ExternalOauth security integration tests

### DIFF
--- a/pkg/acceptance/helpers/security_integration_client.go
+++ b/pkg/acceptance/helpers/security_integration_client.go
@@ -67,7 +67,7 @@ func (c *SecurityIntegrationClient) CreateExternalOauth(t *testing.T) (*sdk.Secu
 	issuer := random.String()
 	request := sdk.NewCreateExternalOauthSecurityIntegrationRequest(id, false, sdk.ExternalOauthSecurityIntegrationTypeCustom,
 		issuer, []sdk.TokenUserMappingClaim{{Claim: "foo"}}, sdk.ExternalOauthSecurityIntegrationSnowflakeUserMappingAttributeLoginName,
-	).WithExternalOauthJwsKeysUrl([]sdk.JwsKeysUrl{{JwsKeyUrl: "http://example.com"}})
+	).WithExternalOauthJwsKeysUrl([]sdk.JwsKeysUrl{{JwsKeyUrl: "https://example.com"}})
 	return c.CreateExternalOauthWithRequest(t, request)
 }
 

--- a/pkg/sdk/testint/security_integrations_gen_integration_test.go
+++ b/pkg/sdk/testint/security_integrations_gen_integration_test.go
@@ -415,12 +415,12 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 
 		integration, id, _ := createExternalOauth(t, func(r *sdk.CreateExternalOauthSecurityIntegrationRequest) {
 			r.WithExternalOauthAllowedRolesList(sdk.AllowedRolesListRequest{AllowedRolesList: []sdk.AccountObjectIdentifier{role1.ID()}}).
-				WithExternalOauthJwsKeysUrl([]sdk.JwsKeysUrl{{JwsKeyUrl: "http://example.com"}})
+				WithExternalOauthJwsKeysUrl([]sdk.JwsKeysUrl{{JwsKeyUrl: "https://example.com"}})
 		})
 		details, err := client.SecurityIntegrations.Describe(ctx, id)
 		require.NoError(t, err)
 
-		assert.Contains(t, details, sdk.SecurityIntegrationProperty{Name: "EXTERNAL_OAUTH_JWS_KEYS_URL", Type: "Object", Value: "http://example.com", Default: ""})
+		assert.Contains(t, details, sdk.SecurityIntegrationProperty{Name: "EXTERNAL_OAUTH_JWS_KEYS_URL", Type: "Object", Value: "https://example.com", Default: ""})
 		assert.Contains(t, details, sdk.SecurityIntegrationProperty{Name: "EXTERNAL_OAUTH_ALLOWED_ROLES_LIST", Type: "List", Value: role1.Name, Default: "[]"})
 
 		assertSecurityIntegration(t, integration, id, "EXTERNAL_OAUTH - CUSTOM", false, "")
@@ -1099,10 +1099,10 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 
 	t.Run("Show ExternalOauth", func(t *testing.T) {
 		si1, id1, _ := createExternalOauth(t, func(r *sdk.CreateExternalOauthSecurityIntegrationRequest) {
-			r.WithExternalOauthJwsKeysUrl([]sdk.JwsKeysUrl{{JwsKeyUrl: "http://example.com"}})
+			r.WithExternalOauthJwsKeysUrl([]sdk.JwsKeysUrl{{JwsKeyUrl: "https://example.com"}})
 		})
 		si2, _, _ := createExternalOauth(t, func(r *sdk.CreateExternalOauthSecurityIntegrationRequest) {
-			r.WithExternalOauthJwsKeysUrl([]sdk.JwsKeysUrl{{JwsKeyUrl: "http://example2.com"}})
+			r.WithExternalOauthJwsKeysUrl([]sdk.JwsKeysUrl{{JwsKeyUrl: "https://example2.com"}})
 		})
 
 		returnedIntegrations, err := client.SecurityIntegrations.Show(ctx, sdk.NewShowSecurityIntegrationRequest().WithLike(sdk.Like{


### PR DESCRIPTION
## Changes

Snowflake rejects plain HTTP URLs for the `EXTERNAL_OAUTH_JWS_KEYS_URL` parameter in External OAuth security integrations, requiring HTTPS. Test fixtures were using `http://example.com`, causing integration test failures when Snowflake validates the URL scheme.

- Update `EXTERNAL_OAUTH_JWS_KEYS_URL` test values from `http://` to `https://` in security integration helper and integration tests

The fix is purely in test fixtures — no SDK or resource logic changes were needed.

## References

- https://docs.snowflake.com/en/release-notes/bcr-bundles/2026_02/bcr-2218