### PR TITLE
chore: update hybrid table grant error expectations

### DIFF
--- a/pkg/testacc/resource_grant_ownership_acceptance_test.go
+++ b/pkg/testacc/resource_grant_ownership_acceptance_test.go
@@ -1656,7 +1656,7 @@ func TestAcc_GrantOwnership_OnObject_HybridTable_ToAccountRole_Fails(t *testing.
 			{
 				ConfigDirectory: ConfigurationDirectory("TestAcc_GrantOwnership/OnObject_HybridTable_ToAccountRole"),
 				ConfigVariables: configVariables(sdk.ObjectTypeHybridTable),
-				ExpectError:     regexp.MustCompile("syntax error line 1 at position 26 unexpected 'TABLE"),
+				ExpectError:     regexp.MustCompile("Unsupported feature"),
 			},
 			{
 				ConfigDirectory: ConfigurationDirectory("TestAcc_GrantOwnership/OnObject_HybridTable_ToAccountRole"),

--- a/pkg/testacc/resource_grant_privileges_to_account_role_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_account_role_acceptance_test.go
@@ -2287,7 +2287,7 @@ func TestAcc_GrantPrivileges_OnObject_HybridTable_ToAccountRole_Fails(t *testing
 			{
 				ConfigDirectory: ConfigurationDirectory("TestAcc_GrantPrivilegesToAccountRole/OnSchemaObject_OnObject_HybridTable"),
 				ConfigVariables: configVariables(sdk.ObjectTypeHybridTable),
-				ExpectError:     regexp.MustCompile("syntax error line 1 at position 28 unexpected 'TABLE"),
+				ExpectError:     regexp.MustCompile("Unsupported feature"),
 			},
 			{
 				ConfigDirectory: ConfigurationDirectory("TestAcc_GrantPrivilegesToAccountRole/OnSchemaObject_OnObject_HybridTable"),

--- a/pkg/testacc/resource_grant_privileges_to_database_role_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_database_role_acceptance_test.go
@@ -1452,7 +1452,7 @@ func TestAcc_GrantPrivileges_OnObject_HybridTable_ToDatabaseRole_Fails(t *testin
 			{
 				ConfigDirectory: ConfigurationDirectory("TestAcc_GrantPrivilegesToDatabaseRole/OnSchemaObject_OnObject_HybridTable"),
 				ConfigVariables: configVariables(sdk.ObjectTypeHybridTable),
-				ExpectError:     regexp.MustCompile("syntax error line 1 at position 28 unexpected 'TABLE"),
+				ExpectError:     regexp.MustCompile("Unsupported feature"),
 			},
 			{
 				ConfigDirectory: ConfigurationDirectory("TestAcc_GrantPrivilegesToDatabaseRole/OnSchemaObject_OnObject_HybridTable"),


### PR DESCRIPTION
Snowflake now returns "Unsupported feature 'UNKNOWN'" error message when trying to manage grants on the HYBRID TABLE object type. Update expected error to match "Unsupported feature" so acceptance tests pass.
