### PR TITLE
feat: Extend GRANTS_SAFE_DESTROY experiment to snowflake_grant_privileges_to_share

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -32,7 +32,7 @@ A new `GRANTS_SAFE_DESTROY` experiment has been added. When enabled, resource de
 
 This is useful when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.
 
-Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`.
+Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`.
 
 To enable, add `GRANTS_SAFE_DESTROY` to your provider's `experimental_features_enabled` list:
 ```hcl

--- a/docs/index.md
+++ b/docs/index.md
@@ -973,7 +973,7 @@ Note: this is supported only on all stage resources (`snowflake_stage_external_s
 #### GRANTS_SAFE_DESTROY
 When enabled, grant destroy operations silently succeed when the underlying Snowflake object (or its dependencies) no longer exists.
 
-Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`.
+Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`. This experiment is designed to be extended to other grant resources in the future.
 
 This prevents errors when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -973,7 +973,7 @@ Note: this is supported only on all stage resources (`snowflake_stage_external_s
 #### GRANTS_SAFE_DESTROY
 When enabled, grant destroy operations silently succeed when the underlying Snowflake object (or its dependencies) no longer exists.
 
-Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`. This experiment is designed to be extended to other grant resources in the future.
+Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`.
 
 This prevents errors when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.
 

--- a/examples/additional/experimental_features.MD
+++ b/examples/additional/experimental_features.MD
@@ -61,7 +61,7 @@ Note: this is supported only on all stage resources (`snowflake_stage_external_s
 #### GRANTS_SAFE_DESTROY
 When enabled, grant destroy operations silently succeed when the underlying Snowflake object (or its dependencies) no longer exists.
 
-Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`. This experiment is designed to be extended to other grant resources in the future.
+Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`.
 
 This prevents errors when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.
 

--- a/examples/additional/experimental_features.MD
+++ b/examples/additional/experimental_features.MD
@@ -61,7 +61,7 @@ Note: this is supported only on all stage resources (`snowflake_stage_external_s
 #### GRANTS_SAFE_DESTROY
 When enabled, grant destroy operations silently succeed when the underlying Snowflake object (or its dependencies) no longer exists.
 
-Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`.
+Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`. This experiment is designed to be extended to other grant resources in the future.
 
 This prevents errors when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.
 

--- a/pkg/provider/experimentalfeatures/experimental_features.go
+++ b/pkg/provider/experimentalfeatures/experimental_features.go
@@ -122,7 +122,7 @@ var allExperiments = []Experiment{
 		ExperimentalFeatureStateActive,
 		joinWithDoubleNewline(
 			"When enabled, grant destroy operations silently succeed when the underlying Snowflake object (or its dependencies) no longer exists.",
-			"Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`.",
+			"Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`. This experiment is designed to be extended to other grant resources in the future.",
 			"This prevents errors when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.",
 			"Without this experiment, destroying such resources fails with `does not exist or not authorized`.",
 		),

--- a/pkg/provider/experimentalfeatures/experimental_features.go
+++ b/pkg/provider/experimentalfeatures/experimental_features.go
@@ -122,7 +122,7 @@ var allExperiments = []Experiment{
 		ExperimentalFeatureStateActive,
 		joinWithDoubleNewline(
 			"When enabled, grant destroy operations silently succeed when the underlying Snowflake object (or its dependencies) no longer exists.",
-			"Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`. This experiment is designed to be extended to other grant resources in the future.",
+			"Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`.",
 			"This prevents errors when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.",
 			"Without this experiment, destroying such resources fails with `does not exist or not authorized`.",
 		),

--- a/pkg/resources/grant_privileges_to_share.go
+++ b/pkg/resources/grant_privileges_to_share.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"slices"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
@@ -280,7 +281,8 @@ func UpdateGrantPrivilegesToShare(ctx context.Context, d *schema.ResourceData, m
 }
 
 func DeleteGrantPrivilegesToShare(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*provider.Context).Client
+	providerCtx := meta.(*provider.Context)
+	client := providerCtx.Client
 
 	id, err := ParseGrantPrivilegesToShareId(d.Id())
 	if err != nil {
@@ -298,7 +300,11 @@ func DeleteGrantPrivilegesToShare(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	err = client.Grants.RevokePrivilegeFromShare(ctx, getObjectPrivilegesFromSchema(d), grantOn, id.ShareName)
+	if experimentalfeatures.IsExperimentEnabled(experimentalfeatures.GrantsSafeDestroy, providerCtx.EnabledExperiments) {
+		err = client.Grants.RevokePrivilegeFromShareSafely(ctx, getObjectPrivilegesFromSchema(d), grantOn, id.ShareName)
+	} else {
+		err = client.Grants.RevokePrivilegeFromShare(ctx, getObjectPrivilegesFromSchema(d), grantOn, id.ShareName)
+	}
 	if err != nil {
 		return diag.Diagnostics{
 			diag.Diagnostic{

--- a/pkg/resources/grant_privileges_to_share.go
+++ b/pkg/resources/grant_privileges_to_share.go
@@ -338,7 +338,7 @@ func ReadGrantPrivilegesToShare(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	client := meta.(*provider.Context).Client
-	if _, err := client.Shares.ShowByID(ctx, id.ShareName); err != nil && errors.Is(err, sdk.ErrObjectNotExistOrAuthorized) {
+	if _, err := client.Shares.ShowByID(ctx, id.ShareName); err != nil && errors.Is(err, sdk.ErrObjectNotFound) {
 		d.SetId("")
 		return diag.Diagnostics{
 			diag.Diagnostic{

--- a/pkg/testacc/1_setup_provider_test.go
+++ b/pkg/testacc/1_setup_provider_test.go
@@ -53,6 +53,7 @@ var (
 	grantsImportValidationAndStrictProviderFactory   = providerFactoryUsingCache("GrantsImportValidationAndStrictProvider")
 	userEnableDefaultWorkloadIdentityProviderFactory = providerFactoryUsingCache("UserEnableDefaultWorkloadIdentity")
 	s3StageProviderFactory                           = providerFactoryUsingCache("StageExternalS3")
+	grantsSafeDestroyProviderFactory                 = providerFactoryUsingCache("GrantsSafeDestroy")
 )
 
 // TODO [SNOW-2661409]: secondary account can have also a different configuration, so for now we need to be careful; let's add some hash check for the config or something else to mitigate

--- a/pkg/testacc/resource_grant_privileges_safe_destroy_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_safe_destroy_experimental_features_acceptance_test.go
@@ -203,14 +203,15 @@ func TestAcc_Experimental_GrantPrivilegesToDatabaseRole_SafeDestroy_MissingDatab
 // ReadGrantPrivilegesToShare itself: it always checks share existence via ShowByID first, removes
 // the resource from state, and returns before Delete is ever called — so no experiment is needed.
 func TestAcc_Experimental_GrantPrivilegesToShare_SafeDestroy_MissingShare(t *testing.T) {
-	database, databaseCleanup := testClient().Database.CreateDatabaseWithParametersSet(t)
-	t.Cleanup(databaseCleanup)
-
 	share, shareCleanup := testClient().Share.CreateShare(t)
 	t.Cleanup(shareCleanup)
 
+	database, databaseCleanup := testClient().Database.CreateDatabaseWithParametersSet(t)
+	t.Cleanup(databaseCleanup)
+
+	testClient().Grant.GrantPrivilegeOnDatabaseToShare(t, database.ID(), share.ID(), []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage})
 	grantModel := model.GrantPrivilegesToShare("test", []string{sdk.ObjectPrivilegeUsage.String()}, share.ID().Name()).
-		WithOnDatabase(database.ID().Name())
+		WithOnDatabase(database.ID().FullyQualifiedName())
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -219,15 +220,21 @@ func TestAcc_Experimental_GrantPrivilegesToShare_SafeDestroy_MissingShare(t *tes
 		Steps: []resource.TestStep{
 			// Create the grant with default provider.
 			{
-				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-				Config:                   config.FromModels(t, grantModel),
+				ExternalProviders: ExternalProviderWithExactVersion("2.14.1"),
+				Config:            config.FromModels(t, grantModel),
 			},
-			// Drop the share externally, then destroy — succeeds without the experiment because
+			// Drop the share externally, then try to destroy without experiment — expect failure.
+			{
+				ExternalProviders: ExternalProviderWithExactVersion("2.14.1"),
+				PreConfig:         testClient().Share.DropShareFunc(t, share.ID()),
+				Config:            config.FromModels(t, grantModel),
+				Destroy:           true,
+				ExpectError:       regexp.MustCompile(`revokePrivilegeFromShareOptions fields`),
+			},
 			// Read detects the missing share via ShowByID and clears the resource from state
 			// before Delete is called.
 			{
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-				PreConfig:                testClient().Share.DropShareFunc(t, share.ID()),
 				Config:                   config.FromModels(t, grantModel),
 				Destroy:                  true,
 			},
@@ -251,14 +258,10 @@ func TestAcc_Experimental_GrantPrivilegesToShare_SafeDestroy_MissingSchema(t *te
 	t.Cleanup(shareCleanup)
 
 	// setup grants USAGE on database to share — required by Snowflake before granting schema objects.
-	// setupGrantModel := model.GrantPrivilegesToShare("setup", []string{sdk.ObjectPrivilegeUsage.String()}, share.ID().Name()).
-	// 	WithOnDatabase(database.ID().Name())
-	// testClient().Grant.GrantPriv
+	testClient().Grant.GrantPrivilegeOnDatabaseToShare(t, database.ID(), share.ID(), []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage})
 
 	grantModel := model.GrantPrivilegesToShare("test", []string{sdk.ObjectPrivilegeSelect.String()}, share.ID().Name()).
-		WithOnAllTablesInSchema(schema.ID().FullyQualifiedName()).
-		WithDependsOn("snowflake_grant_privileges_to_share.setup")
-
+		WithOnAllTablesInSchema(schema.ID().FullyQualifiedName())
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
 

--- a/pkg/testacc/resource_grant_privileges_safe_destroy_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_safe_destroy_experimental_features_acceptance_test.go
@@ -32,7 +32,6 @@ func TestAcc_Experimental_GrantPrivilegesToAccountRole_SafeDestroy_MissingWareho
 
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
-	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantPrivileges_SafeDestroy")
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -54,7 +53,7 @@ func TestAcc_Experimental_GrantPrivilegesToAccountRole_SafeDestroy_MissingWareho
 			},
 			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
 			{
-				ProtoV6ProviderFactories: experimentFactory,
+				ProtoV6ProviderFactories: grantsSafeDestroyProviderFactory,
 				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
 				Destroy:                  true,
 			},
@@ -79,7 +78,6 @@ func TestAcc_Experimental_GrantPrivilegesToAccountRole_SafeDestroy_MissingRole(t
 
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
-	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantPrivileges_SafeDestroy")
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -101,7 +99,7 @@ func TestAcc_Experimental_GrantPrivilegesToAccountRole_SafeDestroy_MissingRole(t
 			},
 			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
 			{
-				ProtoV6ProviderFactories: experimentFactory,
+				ProtoV6ProviderFactories: grantsSafeDestroyProviderFactory,
 				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
 				Destroy:                  true,
 			},
@@ -127,7 +125,6 @@ func TestAcc_Experimental_GrantPrivilegesToDatabaseRole_SafeDestroy_MissingDatab
 
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
-	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantPrivileges_SafeDestroy")
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -149,7 +146,7 @@ func TestAcc_Experimental_GrantPrivilegesToDatabaseRole_SafeDestroy_MissingDatab
 			},
 			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
 			{
-				ProtoV6ProviderFactories: experimentFactory,
+				ProtoV6ProviderFactories: grantsSafeDestroyProviderFactory,
 				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
 				Destroy:                  true,
 			},
@@ -171,7 +168,6 @@ func TestAcc_Experimental_GrantPrivilegesToDatabaseRole_SafeDestroy_MissingDatab
 
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
-	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantPrivileges_SafeDestroy")
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -193,7 +189,100 @@ func TestAcc_Experimental_GrantPrivilegesToDatabaseRole_SafeDestroy_MissingDatab
 			},
 			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
 			{
-				ProtoV6ProviderFactories: experimentFactory,
+				ProtoV6ProviderFactories: grantsSafeDestroyProviderFactory,
+				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy:                  true,
+			},
+		},
+	})
+}
+
+// TestAcc_Experimental_GrantPrivilegesToShare_SafeDestroy_MissingShare verifies that destroying
+// a grant resource succeeds when the share (grantee) is deleted externally, even without
+// the GRANTS_SAFE_DESTROY experiment. Unlike MissingSchema, this case is handled gracefully by
+// ReadGrantPrivilegesToShare itself: it always checks share existence via ShowByID first, removes
+// the resource from state, and returns before Delete is ever called — so no experiment is needed.
+func TestAcc_Experimental_GrantPrivilegesToShare_SafeDestroy_MissingShare(t *testing.T) {
+	database, databaseCleanup := testClient().Database.CreateDatabaseWithParametersSet(t)
+	t.Cleanup(databaseCleanup)
+
+	share, shareCleanup := testClient().Share.CreateShare(t)
+	t.Cleanup(shareCleanup)
+
+	grantModel := model.GrantPrivilegesToShare("test", []string{sdk.ObjectPrivilegeUsage.String()}, share.ID().Name()).
+		WithOnDatabase(database.ID().Name())
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			// Create the grant with default provider.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+			},
+			// Drop the share externally, then destroy — succeeds without the experiment because
+			// Read detects the missing share via ShowByID and clears the resource from state
+			// before Delete is called.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				PreConfig:                testClient().Share.DropShareFunc(t, share.ID()),
+				Config:                   config.FromModels(t, grantModel),
+				Destroy:                  true,
+			},
+		},
+	})
+}
+
+// TestAcc_Experimental_GrantPrivilegesToShare_SafeDestroy_MissingSchema verifies that destroying
+// a grant resource fails when the target schema is deleted externally (default behavior), and succeeds
+// when the GRANTS_SAFE_DESTROY experiment is enabled.
+// Uses on_all_tables_in_schema so that Read skips existence checks (returns nil when opts == nil)
+// and Delete is actually called even when the schema no longer exists.
+func TestAcc_Experimental_GrantPrivilegesToShare_SafeDestroy_MissingSchema(t *testing.T) {
+	database, databaseCleanup := testClient().Database.CreateDatabaseWithParametersSet(t)
+	t.Cleanup(databaseCleanup)
+
+	schema, schemaCleanup := testClient().Schema.CreateSchemaInDatabase(t, database.ID())
+	t.Cleanup(schemaCleanup)
+
+	share, shareCleanup := testClient().Share.CreateShare(t)
+	t.Cleanup(shareCleanup)
+
+	// setup grants USAGE on database to share — required by Snowflake before granting schema objects.
+	// setupGrantModel := model.GrantPrivilegesToShare("setup", []string{sdk.ObjectPrivilegeUsage.String()}, share.ID().Name()).
+	// 	WithOnDatabase(database.ID().Name())
+	// testClient().Grant.GrantPriv
+
+	grantModel := model.GrantPrivilegesToShare("test", []string{sdk.ObjectPrivilegeSelect.String()}, share.ID().Name()).
+		WithOnAllTablesInSchema(schema.ID().FullyQualifiedName()).
+		WithDependsOn("snowflake_grant_privileges_to_share.setup")
+
+	experimentProviderModel := providermodel.SnowflakeProvider().
+		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			// Create both grants with default provider.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+			},
+			// Drop the schema externally, then try to destroy without experiment — expect failure.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				PreConfig:                testClient().Schema.DropSchemaFunc(t, schema.ID()),
+				Config:                   config.FromModels(t, grantModel),
+				Destroy:                  true,
+				ExpectError:              regexp.MustCompile("does not exist or not authorized"),
+			},
+			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
+			{
+				ProtoV6ProviderFactories: grantsSafeDestroyProviderFactory,
 				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
 				Destroy:                  true,
 			},


### PR DESCRIPTION
## Changes

The `GRANTS_SAFE_DESTROY` experiment was already supported by `snowflake_grant_privileges_to_account_role` and `snowflake_grant_privileges_to_database_role`. This PR extends it to `snowflake_grant_privileges_to_share` so that destroying a share grant silently succeeds when the underlying Snowflake object no longer exists, instead of failing with `does not exist or not authorized`.

The root cause of the linked issue was actually an incorrect error assertion. This caused the resource NOT to be marked as absent, which led to an empty `privileges` field, which caused SDK validation failure during destroy.

Ref. https://github.com/snowflakedb/terraform-provider-snowflake/issues/4136
