### PR TITLE
feat: Extend GRANTS_SAFE_DESTROY experiment to snowflake_grant_account_role, snowflake_grant_database_role, snowflake_grant_application_role

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -47,7 +47,7 @@ A new `GRANTS_SAFE_DESTROY` experiment has been added. When enabled, resource de
 
 This is useful when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.
 
-Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`.
+Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`, `snowflake_grant_account_role`, `snowflake_grant_database_role`, `snowflake_grant_application_role`.
 
 To enable, add `GRANTS_SAFE_DESTROY` to your provider's `experimental_features_enabled` list:
 ```hcl

--- a/docs/index.md
+++ b/docs/index.md
@@ -974,7 +974,7 @@ Note: this is supported only on all stage resources (`snowflake_stage_external_s
 #### GRANTS_SAFE_DESTROY
 When enabled, grant destroy operations silently succeed when the underlying Snowflake object (or its dependencies) no longer exists.
 
-Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`.
+Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`, `snowflake_grant_account_role`, `snowflake_grant_database_role`, `snowflake_grant_application_role`.
 
 This prevents errors when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.
 

--- a/examples/additional/experimental_features.MD
+++ b/examples/additional/experimental_features.MD
@@ -61,7 +61,7 @@ Note: this is supported only on all stage resources (`snowflake_stage_external_s
 #### GRANTS_SAFE_DESTROY
 When enabled, grant destroy operations silently succeed when the underlying Snowflake object (or its dependencies) no longer exists.
 
-Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`.
+Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`, `snowflake_grant_account_role`, `snowflake_grant_database_role`, `snowflake_grant_application_role`.
 
 This prevents errors when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.
 

--- a/pkg/acceptance/helpers/application_client.go
+++ b/pkg/acceptance/helpers/application_client.go
@@ -37,6 +37,18 @@ func (c *ApplicationClient) CreateApplication(t *testing.T, packageId sdk.Accoun
 	return application, c.DropApplicationFunc(t, id)
 }
 
+func (c *ApplicationClient) CreateApplicationWithIdentifier(t *testing.T, id sdk.AccountObjectIdentifier, packageId sdk.AccountObjectIdentifier, version string) (*sdk.Application, func()) {
+	t.Helper()
+	ctx := context.Background()
+	err := c.client().Create(ctx, sdk.NewCreateApplicationRequest(id, packageId).WithVersion(*sdk.NewApplicationVersionRequest().WithVersionAndPatch(*sdk.NewVersionAndPatchRequest(version, nil))))
+	require.NoError(t, err)
+
+	application, err := c.client().ShowByID(ctx, id)
+	require.NoError(t, err)
+
+	return application, c.DropApplicationFunc(t, id)
+}
+
 func (c *ApplicationClient) DropApplicationFunc(t *testing.T, id sdk.AccountObjectIdentifier) func() {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/acceptance/planchecks/execute.go
+++ b/pkg/acceptance/planchecks/execute.go
@@ -9,6 +9,6 @@ import (
 // Execute is a function that can be used to execute any code at the given phase.
 type Execute func()
 
-func (e Execute) CheckPlan(_ context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
+func (e Execute) CheckPlan(_ context.Context, _ plancheck.CheckPlanRequest, _ *plancheck.CheckPlanResponse) {
 	e()
 }

--- a/pkg/acceptance/planchecks/execute.go
+++ b/pkg/acceptance/planchecks/execute.go
@@ -1,0 +1,14 @@
+package planchecks
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+// Execute is a function that can be used to execute any code at the given phase.
+type Execute func()
+
+func (e Execute) CheckPlan(_ context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
+	e()
+}

--- a/pkg/provider/experimentalfeatures/experimental_features.go
+++ b/pkg/provider/experimentalfeatures/experimental_features.go
@@ -122,7 +122,7 @@ var allExperiments = []Experiment{
 		ExperimentalFeatureStateActive,
 		joinWithDoubleNewline(
 			"When enabled, grant destroy operations silently succeed when the underlying Snowflake object (or its dependencies) no longer exists.",
-			"Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`.",
+			"Currently supported by: `snowflake_grant_privileges_to_account_role`, `snowflake_grant_privileges_to_database_role`, `snowflake_grant_privileges_to_share`, `snowflake_grant_account_role`, `snowflake_grant_database_role`, `snowflake_grant_application_role`.",
 			"This prevents errors when, for example, a warehouse or role is deleted externally and the corresponding grant resource is later removed from the Terraform configuration.",
 			"Without this experiment, destroying such resources fails with `does not exist or not authorized`.",
 		),

--- a/pkg/resources/grant_account_role.go
+++ b/pkg/resources/grant_account_role.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
@@ -155,7 +156,8 @@ func ReadGrantAccountRole(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func DeleteGrantAccountRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.Context).Client
+	providerCtx := meta.(*provider.Context)
+	client := providerCtx.Client
 	parts := strings.Split(d.Id(), helpers.IDDelimiter)
 	if len(parts) != 3 {
 		return diag.FromErr(fmt.Errorf("invalid ID specified: %v, expected <role_name>|<grantee_object_type>|<grantee_identifier>", d.Id()))
@@ -164,17 +166,21 @@ func DeleteGrantAccountRole(ctx context.Context, d *schema.ResourceData, meta in
 	objectType := parts[1]
 	granteeName := parts[2]
 	granteeIdentifier := sdk.NewAccountObjectIdentifierFromFullyQualifiedName(granteeName)
+	revokeFunc := client.Roles.Revoke
+	if experimentalfeatures.IsExperimentEnabled(experimentalfeatures.GrantsSafeDestroy, providerCtx.EnabledExperiments) {
+		revokeFunc = client.Roles.RevokeSafely
+	}
+	var err error
 	switch objectType {
 	case "ROLE":
-		if err := client.Roles.Revoke(ctx, sdk.NewRevokeRoleRequest(id, sdk.RevokeRole{Role: &granteeIdentifier})); err != nil {
-			return diag.FromErr(err)
-		}
+		err = revokeFunc(ctx, sdk.NewRevokeRoleRequest(id, sdk.RevokeRole{Role: &granteeIdentifier}))
 	case "USER":
-		if err := client.Roles.Revoke(ctx, sdk.NewRevokeRoleRequest(id, sdk.RevokeRole{User: &granteeIdentifier})); err != nil {
-			return diag.FromErr(err)
-		}
+		err = revokeFunc(ctx, sdk.NewRevokeRoleRequest(id, sdk.RevokeRole{User: &granteeIdentifier}))
 	default:
 		return diag.FromErr(fmt.Errorf("invalid object type specified: %v, expected ROLE or USER", objectType))
+	}
+	if err != nil {
+		return diag.FromErr(err)
 	}
 	d.SetId("")
 	return nil

--- a/pkg/resources/grant_application_role.go
+++ b/pkg/resources/grant_application_role.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
@@ -256,7 +257,8 @@ func ReadContextGrantApplicationRole(ctx context.Context, d *schema.ResourceData
 }
 
 func DeleteContextGrantApplicationRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.Context).Client
+	providerCtx := meta.(*provider.Context)
+	client := providerCtx.Client
 
 	parts := helpers.ParseResourceIdentifier(d.Id())
 	id, err := sdk.ParseDatabaseObjectIdentifier(parts[0])
@@ -265,26 +267,28 @@ func DeleteContextGrantApplicationRole(ctx context.Context, d *schema.ResourceDa
 	}
 	objectType := parts[1]
 	granteeName := parts[2]
+	revokeFunc := client.ApplicationRoles.Revoke
+	if experimentalfeatures.IsExperimentEnabled(experimentalfeatures.GrantsSafeDestroy, providerCtx.EnabledExperiments) {
+		revokeFunc = client.ApplicationRoles.RevokeSafely
+	}
 	switch objectType {
 	case "ACCOUNT_ROLE":
 		applicationRoleName, err := sdk.ParseAccountObjectIdentifier(granteeName)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		if err := client.ApplicationRoles.Revoke(ctx, sdk.NewRevokeApplicationRoleRequest(id).WithFrom(*sdk.NewKindOfRoleRequest().WithRoleName(applicationRoleName))); err != nil {
-			if errors.Is(err, sdk.ErrObjectNotExistOrAuthorized) {
-				return diag.FromErr(err)
-			}
+		err = revokeFunc(ctx, sdk.NewRevokeApplicationRoleRequest(id).WithFrom(*sdk.NewKindOfRoleRequest().WithRoleName(applicationRoleName)))
+		if err != nil {
+			return diag.FromErr(err)
 		}
 	case "APPLICATION":
 		applicationName, err := sdk.ParseAccountObjectIdentifier(granteeName)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		if err := client.ApplicationRoles.Revoke(ctx, sdk.NewRevokeApplicationRoleRequest(id).WithFrom(*sdk.NewKindOfRoleRequest().WithApplicationName(applicationName))); err != nil {
-			if errors.Is(err, sdk.ErrObjectNotExistOrAuthorized) {
-				return diag.FromErr(err)
-			}
+		err = revokeFunc(ctx, sdk.NewRevokeApplicationRoleRequest(id).WithFrom(*sdk.NewKindOfRoleRequest().WithApplicationName(applicationName)))
+		if err != nil {
+			return diag.FromErr(err)
 		}
 	}
 	d.SetId("")

--- a/pkg/resources/grant_database_role.go
+++ b/pkg/resources/grant_database_role.go
@@ -223,9 +223,7 @@ func DeleteGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta i
 	revokeFromShareFunc := client.DatabaseRoles.RevokeFromShare
 	if experimentalfeatures.IsExperimentEnabled(experimentalfeatures.GrantsSafeDestroy, providerCtx.EnabledExperiments) {
 		revokeFunc = client.DatabaseRoles.RevokeSafely
-		revokeFromShareFunc = func(ctx context.Context, req *sdk.RevokeDatabaseRoleFromShareRequest) error {
-			return sdk.SafeRevokePrivileges(func() error { return client.DatabaseRoles.RevokeFromShare(ctx, req) })
-		}
+		revokeFromShareFunc = client.DatabaseRoles.RevokeFromShareSafely
 	}
 	switch objectType {
 	case "ROLE":

--- a/pkg/resources/grant_database_role.go
+++ b/pkg/resources/grant_database_role.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
@@ -208,7 +209,8 @@ func ReadGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta int
 
 // DeleteGrantDatabaseRole implements schema.DeleteFunc.
 func DeleteGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.Context).Client
+	providerCtx := meta.(*provider.Context)
+	client := providerCtx.Client
 
 	parts := helpers.ParseResourceIdentifier(d.Id())
 	id, err := sdk.ParseDatabaseObjectIdentifier(parts[0])
@@ -217,13 +219,21 @@ func DeleteGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta i
 	}
 	objectType := parts[1]
 	granteeName := parts[2]
+	revokeFunc := client.DatabaseRoles.Revoke
+	revokeFromShareFunc := client.DatabaseRoles.RevokeFromShare
+	if experimentalfeatures.IsExperimentEnabled(experimentalfeatures.GrantsSafeDestroy, providerCtx.EnabledExperiments) {
+		revokeFunc = client.DatabaseRoles.RevokeSafely
+		revokeFromShareFunc = func(ctx context.Context, req *sdk.RevokeDatabaseRoleFromShareRequest) error {
+			return sdk.SafeRevokePrivileges(func() error { return client.DatabaseRoles.RevokeFromShare(ctx, req) })
+		}
+	}
 	switch objectType {
 	case "ROLE":
 		accountRoleId, err := sdk.ParseAccountObjectIdentifier(granteeName)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		if err := client.DatabaseRoles.Revoke(ctx, sdk.NewRevokeDatabaseRoleRequest(id).WithAccountRole(accountRoleId)); err != nil {
+		if err = revokeFunc(ctx, sdk.NewRevokeDatabaseRoleRequest(id).WithAccountRole(accountRoleId)); err != nil {
 			return diag.FromErr(err)
 		}
 	case "DATABASE ROLE":
@@ -231,7 +241,7 @@ func DeleteGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta i
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		if err := client.DatabaseRoles.Revoke(ctx, sdk.NewRevokeDatabaseRoleRequest(id).WithDatabaseRole(databaseRoleId)); err != nil {
+		if err = revokeFunc(ctx, sdk.NewRevokeDatabaseRoleRequest(id).WithDatabaseRole(databaseRoleId)); err != nil {
 			return diag.FromErr(err)
 		}
 	case "SHARE":
@@ -239,7 +249,7 @@ func DeleteGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta i
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		if err := client.DatabaseRoles.RevokeFromShare(ctx, sdk.NewRevokeDatabaseRoleFromShareRequest(id, sharedId)); err != nil {
+		if err = revokeFromShareFunc(ctx, sdk.NewRevokeDatabaseRoleFromShareRequest(id, sharedId)); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/pkg/sdk/database_role.go
+++ b/pkg/sdk/database_role.go
@@ -19,6 +19,7 @@ type DatabaseRoles interface {
 	RevokeSafely(ctx context.Context, request *RevokeDatabaseRoleRequest) error
 	GrantToShare(ctx context.Context, request *GrantDatabaseRoleToShareRequest) error
 	RevokeFromShare(ctx context.Context, request *RevokeDatabaseRoleFromShareRequest) error
+	RevokeFromShareSafely(ctx context.Context, request *RevokeDatabaseRoleFromShareRequest) error
 }
 
 // createDatabaseRoleOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-database-role.

--- a/pkg/sdk/database_role_impl.go
+++ b/pkg/sdk/database_role_impl.go
@@ -91,6 +91,10 @@ func (v *databaseRoles) RevokeFromShare(ctx context.Context, request *RevokeData
 	return validateAndExec(v.client, ctx, opts)
 }
 
+func (v *databaseRoles) RevokeFromShareSafely(ctx context.Context, request *RevokeDatabaseRoleFromShareRequest) error {
+	return SafeRevokePrivileges(func() error { return v.RevokeFromShare(ctx, request) })
+}
+
 func (s *CreateDatabaseRoleRequest) toOpts() *createDatabaseRoleOptions {
 	return &createDatabaseRoleOptions{
 		OrReplace:   Bool(s.orReplace),

--- a/pkg/sdk/testint/safe_grant_handlers_integration_test.go
+++ b/pkg/sdk/testint/safe_grant_handlers_integration_test.go
@@ -526,6 +526,32 @@ func TestInt_SafeRevokeDatabaseRole(t *testing.T) {
 	})
 }
 
+func TestInt_SafeRevokeDatabaseRoleFromShare(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	databaseRole, databaseRoleCleanup := testClientHelper().DatabaseRole.CreateDatabaseRole(t)
+	t.Cleanup(databaseRoleCleanup)
+
+	share, shareCleanup := testClientHelper().Share.CreateShare(t)
+	t.Cleanup(shareCleanup)
+
+	t.Run("revoke non-existing database role from share", func(t *testing.T) {
+		err := client.DatabaseRoles.RevokeFromShareSafely(ctx, sdk.NewRevokeDatabaseRoleFromShareRequest(NonExistingDatabaseObjectIdentifier, share.ID()))
+		assert.NoError(t, err)
+	})
+
+	t.Run("revoke database role from non-existing share", func(t *testing.T) {
+		err := client.DatabaseRoles.RevokeFromShareSafely(ctx, sdk.NewRevokeDatabaseRoleFromShareRequest(databaseRole.ID(), NonExistingAccountObjectIdentifier))
+		assert.NoError(t, err)
+	})
+
+	t.Run("revoke non-existing database role from non-existing share", func(t *testing.T) {
+		err := client.DatabaseRoles.RevokeFromShareSafely(ctx, sdk.NewRevokeDatabaseRoleFromShareRequest(NonExistingDatabaseObjectIdentifier, NonExistingAccountObjectIdentifier))
+		assert.NoError(t, err)
+	})
+}
+
 func TestInt_SafeRevokeApplicationRole(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()

--- a/pkg/testacc/resource_grant_application_role_acceptance_test.go
+++ b/pkg/testacc/resource_grant_application_role_acceptance_test.go
@@ -20,6 +20,14 @@ import (
 func createApp(t *testing.T) *sdk.Application {
 	t.Helper()
 
+	application, _ := createAppReturnApplicationPackage(t)
+	return application
+}
+
+// TODO [SNOW-1431726]: Move to helpers
+func createAppReturnApplicationPackage(t *testing.T) (*sdk.Application, *sdk.ApplicationPackage) {
+	t.Helper()
+
 	stage, cleanupStage := testClient().Stage.CreateStage(t)
 	t.Cleanup(cleanupStage)
 
@@ -33,7 +41,7 @@ func createApp(t *testing.T) *sdk.Application {
 
 	application, cleanupApplication := testClient().Application.CreateApplication(t, applicationPackage.ID(), "v1")
 	t.Cleanup(cleanupApplication)
-	return application
+	return application, applicationPackage
 }
 
 func TestAcc_GrantApplicationRole_accountRole(t *testing.T) {

--- a/pkg/testacc/resource_grant_role_safe_destroy_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_grant_role_safe_destroy_experimental_features_acceptance_test.go
@@ -1,4 +1,4 @@
-//go:build account_level_tests
+//go:build non_account_level_tests
 
 package testacc
 
@@ -36,7 +36,6 @@ func TestAcc_Experimental_GrantAccountRole_SafeDestroy_MissingParentRole(t *test
 
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
-	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantRole_SafeDestroy")
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -62,7 +61,7 @@ func TestAcc_Experimental_GrantAccountRole_SafeDestroy_MissingParentRole(t *test
 			},
 			// Recreate the parent role, drop it again in PreApply, then destroy with GRANTS_SAFE_DESTROY — succeeds.
 			{
-				ProtoV6ProviderFactories: experimentFactory,
+				ProtoV6ProviderFactories: grantsSafeDestroyProviderFactory,
 				PreConfig: func() {
 					testClient().Role.CreateRoleWithIdentifier(t, parentRole.ID())
 				},
@@ -93,7 +92,6 @@ func TestAcc_Experimental_GrantAccountRole_SafeDestroy_MissingRole(t *testing.T)
 
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
-	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantRole_SafeDestroy")
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -119,7 +117,7 @@ func TestAcc_Experimental_GrantAccountRole_SafeDestroy_MissingRole(t *testing.T)
 			},
 			// Recreate the granted role, drop it again in PreApply, then destroy with GRANTS_SAFE_DESTROY — succeeds.
 			{
-				ProtoV6ProviderFactories: experimentFactory,
+				ProtoV6ProviderFactories: grantsSafeDestroyProviderFactory,
 				PreConfig: func() {
 					testClient().Role.CreateRoleWithIdentifier(t, role.ID())
 				},
@@ -150,7 +148,6 @@ func TestAcc_Experimental_GrantDatabaseRole_SafeDestroy_MissingParentRole(t *tes
 
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
-	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantRole_SafeDestroy")
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -176,7 +173,7 @@ func TestAcc_Experimental_GrantDatabaseRole_SafeDestroy_MissingParentRole(t *tes
 			},
 			// Recreate the parent account role, drop it again in PreApply, then destroy with GRANTS_SAFE_DESTROY — succeeds.
 			{
-				ProtoV6ProviderFactories: experimentFactory,
+				ProtoV6ProviderFactories: grantsSafeDestroyProviderFactory,
 				PreConfig: func() {
 					testClient().Role.CreateRoleWithIdentifier(t, parentRole.ID())
 				},
@@ -207,7 +204,6 @@ func TestAcc_Experimental_GrantDatabaseRole_SafeDestroy_MissingDatabaseRole(t *t
 
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
-	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantRole_SafeDestroy")
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -233,7 +229,7 @@ func TestAcc_Experimental_GrantDatabaseRole_SafeDestroy_MissingDatabaseRole(t *t
 			},
 			// Recreate the database role, drop it again in PreApply, then destroy with GRANTS_SAFE_DESTROY — succeeds.
 			{
-				ProtoV6ProviderFactories: experimentFactory,
+				ProtoV6ProviderFactories: grantsSafeDestroyProviderFactory,
 				PreConfig: func() {
 					testClient().DatabaseRole.CreateDatabaseRoleInDatabaseWithName(t, dbRole.ID().DatabaseId(), dbRole.ID().Name())
 				},
@@ -269,7 +265,6 @@ func TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingParentAccountR
 
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
-	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantApplicationRole_SafeDestroy")
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -295,7 +290,7 @@ func TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingParentAccountR
 			},
 			// Recreate the parent account role, drop it again in PreApply, then destroy with GRANTS_SAFE_DESTROY — succeeds.
 			{
-				ProtoV6ProviderFactories: experimentFactory,
+				ProtoV6ProviderFactories: grantsSafeDestroyProviderFactory,
 				PreConfig: func() {
 					testClient().Role.CreateRoleWithIdentifier(t, parentRole.ID())
 				},
@@ -332,7 +327,6 @@ func TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingApplication(t 
 
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
-	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantApplicationRole_SafeDestroy")
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -358,7 +352,7 @@ func TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingApplication(t 
 			},
 			// Recreate the grantee application, drop it again in PreApply, then destroy with GRANTS_SAFE_DESTROY — succeeds.
 			{
-				ProtoV6ProviderFactories: experimentFactory,
+				ProtoV6ProviderFactories: grantsSafeDestroyProviderFactory,
 				PreConfig: func() {
 					testClient().Application.CreateApplicationWithIdentifier(t, app.ID(), appPackage.ID(), "v1")
 				},

--- a/pkg/testacc/resource_grant_role_safe_destroy_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_grant_role_safe_destroy_experimental_features_acceptance_test.go
@@ -3,15 +3,18 @@
 package testacc
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/planchecks"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
@@ -42,11 +45,31 @@ func TestAcc_Experimental_GrantAccountRole_SafeDestroy_MissingParentRole(t *test
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				Config:                   config.FromModels(t, grantModel),
 			},
-			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
+			// Drop the parent role externally and destroy WITHOUT experiment — must error.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.Execute(testClient().Role.DropRoleFunc(t, parentRole.ID())),
+					},
+				},
+				Destroy:     true,
+				ExpectError: regexp.MustCompile("does not exist or not authorized"),
+			},
+			// Recreate the parent role, drop it again in PreApply, then destroy with GRANTS_SAFE_DESTROY — succeeds.
 			{
 				ProtoV6ProviderFactories: experimentFactory,
-				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
-				Destroy:                  true,
+				PreConfig: func() {
+					testClient().Role.CreateRoleWithIdentifier(t, parentRole.ID())
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.Execute(testClient().Role.DropRoleFunc(t, parentRole.ID())),
+					},
+				},
+				Config:  config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy: true,
 			},
 		},
 	})
@@ -79,11 +102,31 @@ func TestAcc_Experimental_GrantAccountRole_SafeDestroy_MissingRole(t *testing.T)
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				Config:                   config.FromModels(t, grantModel),
 			},
-			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
+			// Drop the granted role externally WITHOUT experiment — must error.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.Execute(testClient().Role.DropRoleFunc(t, role.ID())),
+					},
+				},
+				Destroy:     true,
+				ExpectError: regexp.MustCompile("does not exist or not authorized"),
+			},
+			// Recreate the granted role, drop it again in PreApply, then destroy with GRANTS_SAFE_DESTROY — succeeds.
 			{
 				ProtoV6ProviderFactories: experimentFactory,
-				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
-				Destroy:                  true,
+				PreConfig: func() {
+					testClient().Role.CreateRoleWithIdentifier(t, role.ID())
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.Execute(testClient().Role.DropRoleFunc(t, role.ID())),
+					},
+				},
+				Config:  config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy: true,
 			},
 		},
 	})
@@ -116,11 +159,31 @@ func TestAcc_Experimental_GrantDatabaseRole_SafeDestroy_MissingParentRole(t *tes
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				Config:                   config.FromModels(t, grantModel),
 			},
-			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
+			// Drop the parent account role externally WITHOUT experiment — must error.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.Execute(testClient().Role.DropRoleFunc(t, parentRole.ID())),
+					},
+				},
+				Destroy:     true,
+				ExpectError: regexp.MustCompile("does not exist or not authorized"),
+			},
+			// Recreate the parent account role, drop it again in PreApply, then destroy with GRANTS_SAFE_DESTROY — succeeds.
 			{
 				ProtoV6ProviderFactories: experimentFactory,
-				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
-				Destroy:                  true,
+				PreConfig: func() {
+					testClient().Role.CreateRoleWithIdentifier(t, parentRole.ID())
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.Execute(testClient().Role.DropRoleFunc(t, parentRole.ID())),
+					},
+				},
+				Config:  config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy: true,
 			},
 		},
 	})
@@ -153,11 +216,31 @@ func TestAcc_Experimental_GrantDatabaseRole_SafeDestroy_MissingDatabaseRole(t *t
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				Config:                   config.FromModels(t, grantModel),
 			},
-			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
+			// Drop the database role externally WITHOUT experiment — must error.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.Execute(testClient().DatabaseRole.CleanupDatabaseRoleFunc(t, dbRole.ID())),
+					},
+				},
+				Destroy:     true,
+				ExpectError: regexp.MustCompile("does not exist or not authorized"),
+			},
+			// Recreate the database role, drop it again in PreApply, then destroy with GRANTS_SAFE_DESTROY — succeeds.
 			{
 				ProtoV6ProviderFactories: experimentFactory,
-				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
-				Destroy:                  true,
+				PreConfig: func() {
+					testClient().DatabaseRole.CreateDatabaseRoleInDatabaseWithName(t, dbRole.ID().DatabaseId(), dbRole.ID().Name())
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.Execute(testClient().DatabaseRole.CleanupDatabaseRoleFunc(t, dbRole.ID())),
+					},
+				},
+				Config:  config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy: true,
 			},
 		},
 	})
@@ -169,7 +252,7 @@ func TestAcc_Experimental_GrantDatabaseRole_SafeDestroy_MissingDatabaseRole(t *t
 //
 // Note: unlike grant_privileges_to_* resources, grant_application_role Read already handles missing
 // objects gracefully by clearing state. This test verifies the full lifecycle succeeds end-to-end
-// (either via Read clearing state or RevokeSafely handling the error in a race condition scenario).
+// via RevokeSafely handling the error in a race condition scenario.
 func TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingParentAccountRole(t *testing.T) {
 	app := createApp(t)
 	applicationRoleName := testvars.ApplicationRole1
@@ -197,10 +280,29 @@ func TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingParentAccountR
 			},
 			// Drop the parent account role externally and destroy with GRANTS_SAFE_DESTROY — succeeds.
 			{
-				ProtoV6ProviderFactories: experimentFactory,
-				PreConfig:                testClient().Role.DropRoleFunc(t, parentRole.ID()),
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
-				Destroy:                  true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.Execute(testClient().Role.DropRoleFunc(t, parentRole.ID())),
+					},
+				},
+				Destroy:     true,
+				ExpectError: regexp.MustCompile("does not exist or not authorized"),
+			},
+			// Recreate the parent account role, drop it again in PreApply, then destroy with GRANTS_SAFE_DESTROY — succeeds.
+			{
+				ProtoV6ProviderFactories: experimentFactory,
+				PreConfig: func() {
+					testClient().Role.CreateRoleWithIdentifier(t, parentRole.ID())
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.Execute(testClient().Role.DropRoleFunc(t, parentRole.ID())),
+					},
+				},
+				Config:  config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy: true,
 			},
 		},
 	})
@@ -212,16 +314,18 @@ func TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingParentAccountR
 //
 // Note: unlike grant_privileges_to_* resources, grant_application_role Read already handles missing
 // objects gracefully by clearing state. This test verifies the full lifecycle succeeds end-to-end
-// (either via Read clearing state or RevokeSafely handling the error in a race condition scenario).
+// via RevokeSafely handling the error in a race condition scenario.
 func TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingApplication(t *testing.T) {
-	app := createApp(t)
-	granteeApp := createApp(t)
+	app, appPackage := createAppReturnApplicationPackage(t)
 
 	applicationRoleName := testvars.ApplicationRole1
 	appRoleFullName := sdk.NewDatabaseObjectIdentifier(app.ID().Name(), applicationRoleName).FullyQualifiedName()
 
+	parentRole, parentRoleCleanup := testClient().Role.CreateRole(t)
+	t.Cleanup(parentRoleCleanup)
+
 	grantModel := model.GrantApplicationRole("test", appRoleFullName).
-		WithApplicationName(granteeApp.ID().Name())
+		WithParentAccountRoleName(parentRole.ID().Name())
 
 	experimentProviderModel := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
@@ -237,12 +341,31 @@ func TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingApplication(t 
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				Config:                   config.FromModels(t, grantModel),
 			},
-			// Drop the grantee application externally and destroy with GRANTS_SAFE_DESTROY — succeeds.
+			// Drop the grantee application externally WITHOUT experiment — must error.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.Execute(testClient().Application.DropApplicationFunc(t, app.ID())),
+					},
+				},
+				Destroy:     true,
+				ExpectError: regexp.MustCompile("does not exist or not authorized"),
+			},
+			// Recreate the grantee application, drop it again in PreApply, then destroy with GRANTS_SAFE_DESTROY — succeeds.
 			{
 				ProtoV6ProviderFactories: experimentFactory,
-				PreConfig:                testClient().Application.DropApplicationFunc(t, granteeApp.ID()),
-				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
-				Destroy:                  true,
+				PreConfig: func() {
+					testClient().Application.CreateApplicationWithIdentifier(t, app.ID(), appPackage.ID(), "v1")
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.Execute(testClient().Application.DropApplicationFunc(t, app.ID())),
+					},
+				},
+				Config:  config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy: true,
 			},
 		},
 	})

--- a/pkg/testacc/resource_grant_role_safe_destroy_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_grant_role_safe_destroy_experimental_features_acceptance_test.go
@@ -284,7 +284,7 @@ func TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingParentAccountR
 			// Drop the parent account role externally WITHOUT experiment — must error.
 			{
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
+				Config:                   config.FromModels(t, grantModel),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						planchecks.Execute(testClient().Role.DropRoleFunc(t, parentRole.ID())),

--- a/pkg/testacc/resource_grant_role_safe_destroy_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_grant_role_safe_destroy_experimental_features_acceptance_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
+// NOTE: In most cases, we call DROP inside PreApply check.
+// This is to force destroying the resource after the plan is computed.
+
 // TestAcc_Experimental_GrantAccountRole_SafeDestroy_MissingParentRole verifies that destroying
 // a grant_account_role resource fails when the grantee (parent) role is deleted externally (default behavior),
 // and succeeds when the GRANTS_SAFE_DESTROY experiment is enabled.

--- a/pkg/testacc/resource_grant_role_safe_destroy_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_grant_role_safe_destroy_experimental_features_acceptance_test.go
@@ -281,7 +281,7 @@ func TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingParentAccountR
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				Config:                   config.FromModels(t, grantModel),
 			},
-			// Drop the parent account role externally and destroy with GRANTS_SAFE_DESTROY — succeeds.
+			// Drop the parent account role externally WITHOUT experiment — must error.
 			{
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				Config:                   config.FromModels(t, experimentProviderModel, grantModel),

--- a/pkg/testacc/resource_grant_role_safe_destroy_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_grant_role_safe_destroy_experimental_features_acceptance_test.go
@@ -1,0 +1,249 @@
+//go:build account_level_tests
+
+package testacc
+
+import (
+	"testing"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+// TestAcc_Experimental_GrantAccountRole_SafeDestroy_MissingParentRole verifies that destroying
+// a grant_account_role resource fails when the grantee (parent) role is deleted externally (default behavior),
+// and succeeds when the GRANTS_SAFE_DESTROY experiment is enabled.
+func TestAcc_Experimental_GrantAccountRole_SafeDestroy_MissingParentRole(t *testing.T) {
+	role, roleCleanup := testClient().Role.CreateRole(t)
+	t.Cleanup(roleCleanup)
+
+	parentRole, parentRoleCleanup := testClient().Role.CreateRole(t)
+	t.Cleanup(parentRoleCleanup)
+
+	grantModel := model.GrantAccountRole("test", role.ID().Name()).
+		WithParentRoleName(parentRole.ID().Name())
+
+	experimentProviderModel := providermodel.SnowflakeProvider().
+		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
+	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantRole_SafeDestroy")
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			// Create the grant with default provider.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+			},
+			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
+			{
+				ProtoV6ProviderFactories: experimentFactory,
+				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy:                  true,
+			},
+		},
+	})
+}
+
+// TestAcc_Experimental_GrantAccountRole_SafeDestroy_MissingRole verifies that destroying
+// a grant_account_role resource fails when the granted role itself is deleted externally (default behavior),
+// and succeeds when the GRANTS_SAFE_DESTROY experiment is enabled.
+func TestAcc_Experimental_GrantAccountRole_SafeDestroy_MissingRole(t *testing.T) {
+	role, roleCleanup := testClient().Role.CreateRole(t)
+	t.Cleanup(roleCleanup)
+
+	parentRole, parentRoleCleanup := testClient().Role.CreateRole(t)
+	t.Cleanup(parentRoleCleanup)
+
+	grantModel := model.GrantAccountRole("test", role.ID().Name()).
+		WithParentRoleName(parentRole.ID().Name())
+
+	experimentProviderModel := providermodel.SnowflakeProvider().
+		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
+	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantRole_SafeDestroy")
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			// Create the grant with default provider.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+			},
+			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
+			{
+				ProtoV6ProviderFactories: experimentFactory,
+				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy:                  true,
+			},
+		},
+	})
+}
+
+// TestAcc_Experimental_GrantDatabaseRole_SafeDestroy_MissingParentRole verifies that destroying
+// a grant_database_role resource fails when the grantee (parent) account role is deleted externally
+// (default behavior), and succeeds when the GRANTS_SAFE_DESTROY experiment is enabled.
+func TestAcc_Experimental_GrantDatabaseRole_SafeDestroy_MissingParentRole(t *testing.T) {
+	dbRole, dbRoleCleanup := testClient().DatabaseRole.CreateDatabaseRole(t)
+	t.Cleanup(dbRoleCleanup)
+
+	parentRole, parentRoleCleanup := testClient().Role.CreateRole(t)
+	t.Cleanup(parentRoleCleanup)
+
+	grantModel := model.GrantDatabaseRole("test", dbRole.ID().FullyQualifiedName()).
+		WithParentRoleName(parentRole.ID().Name())
+
+	experimentProviderModel := providermodel.SnowflakeProvider().
+		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
+	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantRole_SafeDestroy")
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			// Create the grant with default provider.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+			},
+			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
+			{
+				ProtoV6ProviderFactories: experimentFactory,
+				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy:                  true,
+			},
+		},
+	})
+}
+
+// TestAcc_Experimental_GrantDatabaseRole_SafeDestroy_MissingDatabaseRole verifies that destroying
+// a grant_database_role resource fails when the database role itself is deleted externally
+// (default behavior), and succeeds when the GRANTS_SAFE_DESTROY experiment is enabled.
+func TestAcc_Experimental_GrantDatabaseRole_SafeDestroy_MissingDatabaseRole(t *testing.T) {
+	dbRole, dbRoleCleanup := testClient().DatabaseRole.CreateDatabaseRole(t)
+	t.Cleanup(dbRoleCleanup)
+
+	parentRole, parentRoleCleanup := testClient().Role.CreateRole(t)
+	t.Cleanup(parentRoleCleanup)
+
+	grantModel := model.GrantDatabaseRole("test", dbRole.ID().FullyQualifiedName()).
+		WithParentRoleName(parentRole.ID().Name())
+
+	experimentProviderModel := providermodel.SnowflakeProvider().
+		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
+	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantRole_SafeDestroy")
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			// Create the grant with default provider.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+			},
+			// Destroy with GRANTS_SAFE_DESTROY experiment — succeeds.
+			{
+				ProtoV6ProviderFactories: experimentFactory,
+				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy:                  true,
+			},
+		},
+	})
+}
+
+// TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingParentAccountRole verifies that destroying
+// a grant_application_role resource (ACCOUNT_ROLE grantee type) succeeds when the grantee account role is
+// deleted externally and the GRANTS_SAFE_DESTROY experiment is enabled.
+//
+// Note: unlike grant_privileges_to_* resources, grant_application_role Read already handles missing
+// objects gracefully by clearing state. This test verifies the full lifecycle succeeds end-to-end
+// (either via Read clearing state or RevokeSafely handling the error in a race condition scenario).
+func TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingParentAccountRole(t *testing.T) {
+	app := createApp(t)
+	applicationRoleName := testvars.ApplicationRole1
+	appRoleFullName := sdk.NewDatabaseObjectIdentifier(app.ID().Name(), applicationRoleName).FullyQualifiedName()
+
+	parentRole, parentRoleCleanup := testClient().Role.CreateRole(t)
+	t.Cleanup(parentRoleCleanup)
+
+	grantModel := model.GrantApplicationRole("test", appRoleFullName).
+		WithParentAccountRoleName(parentRole.ID().Name())
+
+	experimentProviderModel := providermodel.SnowflakeProvider().
+		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
+	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantApplicationRole_SafeDestroy")
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			// Create the grant with default provider.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+			},
+			// Drop the parent account role externally and destroy with GRANTS_SAFE_DESTROY — succeeds.
+			{
+				ProtoV6ProviderFactories: experimentFactory,
+				PreConfig:                testClient().Role.DropRoleFunc(t, parentRole.ID()),
+				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy:                  true,
+			},
+		},
+	})
+}
+
+// TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingApplication verifies that destroying
+// a grant_application_role resource (APPLICATION grantee type) succeeds when the grantee application is
+// deleted externally and the GRANTS_SAFE_DESTROY experiment is enabled.
+//
+// Note: unlike grant_privileges_to_* resources, grant_application_role Read already handles missing
+// objects gracefully by clearing state. This test verifies the full lifecycle succeeds end-to-end
+// (either via Read clearing state or RevokeSafely handling the error in a race condition scenario).
+func TestAcc_Experimental_GrantApplicationRole_SafeDestroy_MissingApplication(t *testing.T) {
+	app := createApp(t)
+	granteeApp := createApp(t)
+
+	applicationRoleName := testvars.ApplicationRole1
+	appRoleFullName := sdk.NewDatabaseObjectIdentifier(app.ID().Name(), applicationRoleName).FullyQualifiedName()
+
+	grantModel := model.GrantApplicationRole("test", appRoleFullName).
+		WithApplicationName(granteeApp.ID().Name())
+
+	experimentProviderModel := providermodel.SnowflakeProvider().
+		WithExperimentalFeaturesEnabled(experimentalfeatures.GrantsSafeDestroy)
+	experimentFactory := providerFactoryUsingCache("TestAcc_Experimental_GrantApplicationRole_SafeDestroy")
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			// Create the grant with default provider.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, grantModel),
+			},
+			// Drop the grantee application externally and destroy with GRANTS_SAFE_DESTROY — succeeds.
+			{
+				ProtoV6ProviderFactories: experimentFactory,
+				PreConfig:                testClient().Application.DropApplicationFunc(t, granteeApp.ID()),
+				Config:                   config.FromModels(t, experimentProviderModel, grantModel),
+				Destroy:                  true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- Extends the `GRANTS_SAFE_DESTROY` experimental feature to three additional role-grant resources: `snowflake_grant_account_role`, `snowflake_grant_database_role`, and `snowflake_grant_application_role`
- When enabled, destroy operations silently succeed if the underlying Snowflake object (or its grantee) no longer exists, preventing `does not exist or not authorized` errors
- Fix inverted logic in `grant_application_role` — it only returned an error for ErrObjectNotExistOrAuthorized and silently swallowed all other errors.