### PR TITLE
feat: Detect and restore external warehouse type changes for adaptive and standard warehouses

### DIFF
--- a/docs/resources/warehouse_adaptive.md
+++ b/docs/resources/warehouse_adaptive.md
@@ -7,8 +7,6 @@ description: |-
 
 !> **Caution: Preview Feature** This feature is considered a preview feature in the provider, regardless of the state of the resource in Snowflake. We do not guarantee its stability. It will be reworked and marked as a stable feature in future releases. Breaking changes are expected, even without bumping the major version. To use this feature, add the relevant feature name to `preview_features_enabled` field in the [provider configuration](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs#schema). Please always refer to the [Getting Help](https://github.com/snowflakedb/terraform-provider-snowflake?tab=readme-ov-file#getting-help) section in our Github repo to best determine how to get help for your questions.
 
--> **Note** Detecting external changes to the warehouse type is not yet supported.
-
 # snowflake_warehouse_adaptive (Resource)
 
 Resource used to manage adaptive warehouse objects. Adaptive Compute is a compute service focused on delivering strong performance with effortless operations. It replaces the fixed compute of the Standard Warehouse with a workload-aware one that adapts to your queries automatically. The system decides how to allocate resources for the best performance, eliminating the need for infrastructure tuning.
@@ -58,6 +56,7 @@ resource "snowflake_warehouse_adaptive" "complete" {
 - `id` (String) The ID of this resource.
 - `parameters` (List of Object) Outputs the result of `SHOW PARAMETERS IN WAREHOUSE` for the given adaptive warehouse. (see [below for nested schema](#nestedatt--parameters))
 - `show_output` (List of Object) Outputs the result of `SHOW WAREHOUSES` for the given adaptive warehouse. (see [below for nested schema](#nestedatt--show_output))
+- `warehouse_type` (String) Specifies the type for the adaptive warehouse. This field is used for checking external changes and recreating the resource if needed.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/warehouse_adaptive_resource_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/warehouse_adaptive_resource_gen.go
@@ -106,6 +106,11 @@ func (w *WarehouseAdaptiveResourceAssert) HasStatementTimeoutInSecondsString(exp
 	return w
 }
 
+func (w *WarehouseAdaptiveResourceAssert) HasWarehouseTypeString(expected string) *WarehouseAdaptiveResourceAssert {
+	w.AddAssertion(assert.ValueSet("warehouse_type", expected))
+	return w
+}
+
 ///////////////////////////////
 // Attribute no value checks //
 ///////////////////////////////
@@ -145,6 +150,11 @@ func (w *WarehouseAdaptiveResourceAssert) HasNoStatementTimeoutInSeconds() *Ware
 	return w
 }
 
+func (w *WarehouseAdaptiveResourceAssert) HasNoWarehouseType() *WarehouseAdaptiveResourceAssert {
+	w.AddAssertion(assert.ValueNotSet("warehouse_type"))
+	return w
+}
+
 ////////////////////////////
 // Attribute empty checks //
 ////////////////////////////
@@ -176,6 +186,11 @@ func (w *WarehouseAdaptiveResourceAssert) HasStatementQueuedTimeoutInSecondsEmpt
 
 func (w *WarehouseAdaptiveResourceAssert) HasStatementTimeoutInSecondsEmpty() *WarehouseAdaptiveResourceAssert {
 	w.AddAssertion(assert.ValueSet("statement_timeout_in_seconds", ""))
+	return w
+}
+
+func (w *WarehouseAdaptiveResourceAssert) HasWarehouseTypeEmpty() *WarehouseAdaptiveResourceAssert {
+	w.AddAssertion(assert.ValueSet("warehouse_type", ""))
 	return w
 }
 
@@ -215,5 +230,10 @@ func (w *WarehouseAdaptiveResourceAssert) HasStatementQueuedTimeoutInSecondsNotE
 
 func (w *WarehouseAdaptiveResourceAssert) HasStatementTimeoutInSecondsNotEmpty() *WarehouseAdaptiveResourceAssert {
 	w.AddAssertion(assert.ValuePresent("statement_timeout_in_seconds"))
+	return w
+}
+
+func (w *WarehouseAdaptiveResourceAssert) HasWarehouseTypeNotEmpty() *WarehouseAdaptiveResourceAssert {
+	w.AddAssertion(assert.ValuePresent("warehouse_type"))
 	return w
 }

--- a/pkg/acceptance/bettertestspoc/config/model/warehouse_adaptive_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/warehouse_adaptive_model_gen.go
@@ -18,6 +18,7 @@ type WarehouseAdaptiveModel struct {
 	QueryThroughputMultiplier       tfconfig.Variable `json:"query_throughput_multiplier,omitempty"`
 	StatementQueuedTimeoutInSeconds tfconfig.Variable `json:"statement_queued_timeout_in_seconds,omitempty"`
 	StatementTimeoutInSeconds       tfconfig.Variable `json:"statement_timeout_in_seconds,omitempty"`
+	WarehouseType                   tfconfig.Variable `json:"warehouse_type,omitempty"`
 
 	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
 
@@ -109,6 +110,11 @@ func (w *WarehouseAdaptiveModel) WithStatementTimeoutInSeconds(statementTimeoutI
 	return w
 }
 
+func (w *WarehouseAdaptiveModel) WithWarehouseType(warehouseType string) *WarehouseAdaptiveModel {
+	w.WarehouseType = tfconfig.StringVariable(warehouseType)
+	return w
+}
+
 //////////////////////////////////////////
 // below it's possible to set any value //
 //////////////////////////////////////////
@@ -145,5 +151,10 @@ func (w *WarehouseAdaptiveModel) WithStatementQueuedTimeoutInSecondsValue(value 
 
 func (w *WarehouseAdaptiveModel) WithStatementTimeoutInSecondsValue(value tfconfig.Variable) *WarehouseAdaptiveModel {
 	w.StatementTimeoutInSeconds = value
+	return w
+}
+
+func (w *WarehouseAdaptiveModel) WithWarehouseTypeValue(value tfconfig.Variable) *WarehouseAdaptiveModel {
+	w.WarehouseType = value
 	return w
 }

--- a/pkg/resources/custom_diffs.go
+++ b/pkg/resources/custom_diffs.go
@@ -284,6 +284,27 @@ func RecreateWhenStageCloudChangedExternally(stageCloud sdk.StageCloud) schema.C
 	return RecreateWhenResourceTypeChangedExternally("cloud", stageCloud, sdk.ToStageCloud)
 }
 
+// HandleWarehouseExternalTypeChange detects when the warehouse type has been changed externally
+// and plans an update to restore it to warehouseType (without forcing recreation).
+func HandleWarehouseExternalTypeChange(warehouseType sdk.WarehouseType) schema.CustomizeDiffFunc {
+	return func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+		if n := diff.Get("warehouse_type"); n != nil {
+			gotTypeRaw := n.(string)
+			if gotTypeRaw == "" {
+				return nil
+			}
+			gotType, err := sdk.ToWarehouseType(gotTypeRaw)
+			if err != nil {
+				return fmt.Errorf("unknown warehouse type: %w", err)
+			}
+			if gotType != warehouseType {
+				return diff.SetNew("warehouse_type", string(warehouseType))
+			}
+		}
+		return nil
+	}
+}
+
 // RecreateWhenResourceTypeChangedExternally recreates a resource when argument wantType is different than the value in typeField.
 func RecreateWhenResourceTypeChangedExternally[T ~string](typeField string, wantType T, toType func(string) (T, error)) schema.CustomizeDiffFunc {
 	return func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {

--- a/pkg/resources/warehouse_adaptive.go
+++ b/pkg/resources/warehouse_adaptive.go
@@ -31,6 +31,11 @@ var warehouseAdaptiveSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Description: "Specifies a comment for the adaptive warehouse.",
 	},
+	"warehouse_type": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Specifies the type for the adaptive warehouse. This field is used for checking external changes and recreating the resource if needed.",
+	},
 	"max_query_performance_level": {
 		Type:             schema.TypeString,
 		Optional:         true,
@@ -110,6 +115,7 @@ func WarehouseAdaptive() *schema.Resource {
 				parameter[sdk.AccountParameter]{sdk.AccountParameterStatementQueuedTimeoutInSeconds, valueTypeInt, sdk.ParameterTypeWarehouse},
 				parameter[sdk.AccountParameter]{sdk.AccountParameterStatementTimeoutInSeconds, valueTypeInt, sdk.ParameterTypeWarehouse},
 			),
+			HandleWarehouseExternalTypeChange(sdk.WarehouseTypeAdaptive),
 		)),
 		Timeouts: defaultTimeouts,
 	}
@@ -225,6 +231,7 @@ func ReadWarehouseAdaptiveFunc(withExternalChangesMarking bool) schema.ReadConte
 		errs := errors.Join(
 			d.Set("name", w.Name),
 			d.Set("comment", w.Comment),
+			d.Set("warehouse_type", string(w.Type)),
 			d.Set(ShowOutputAttributeName, []map[string]any{schemas.WarehouseAdaptiveToSchema(w)}),
 			d.Set(FullyQualifiedNameAttributeName, id.FullyQualifiedName()),
 			d.Set(ParametersAttributeName, []map[string]any{schemas.WarehouseAdaptiveParametersToSchema(warehouseParameters, providerCtx)}),
@@ -270,6 +277,10 @@ func UpdateWarehouseAdaptive(ctx context.Context, d *schema.ResourceData, meta a
 
 	set := sdk.WarehouseSet{}
 	unset := sdk.WarehouseUnset{}
+
+	if d.HasChange("warehouse_type") {
+		set.WarehouseType = sdk.Pointer(sdk.WarehouseTypeAdaptive)
+	}
 
 	if err := errors.Join(
 		intAttributeWithSpecialDefaultUpdate(d, "query_throughput_multiplier", &set.QueryThroughputMultiplier, &unset.QueryThroughputMultiplier),

--- a/pkg/testacc/resource_warehouse_acceptance_test.go
+++ b/pkg/testacc/resource_warehouse_acceptance_test.go
@@ -3185,3 +3185,46 @@ func TestAcc_Warehouse_Generation_MigrateStandardWithoutGeneration_UpdatedExtern
 		},
 	})
 }
+
+func TestAcc_Warehouse_ExternalTypeChange(t *testing.T) {
+	id := testClient().Ids.RandomAccountObjectIdentifier()
+	warehouseModel := model.Warehouse("test", id.Name()).
+		WithWarehouseTypeEnum(sdk.WarehouseTypeStandard)
+	ref := warehouseModel.ResourceReference()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Warehouse),
+		Steps: []resource.TestStep{
+			{
+				Config: accconfig.FromModels(t, warehouseModel),
+				Check: assertThat(t,
+					resourceassert.WarehouseResource(t, ref).
+						HasWarehouseTypeString(string(sdk.WarehouseTypeStandard)),
+					resourceshowoutputassert.WarehouseShowOutput(t, ref).
+						HasType(sdk.WarehouseTypeStandard),
+				),
+			},
+			{
+				PreConfig: func() {
+					testClient().Warehouse.UpdateWarehouseType(t, id, sdk.WarehouseTypeAdaptive)
+				},
+				Config: accconfig.FromModels(t, warehouseModel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(ref, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: assertThat(t,
+					resourceassert.WarehouseResource(t, ref).
+						HasWarehouseTypeString(string(sdk.WarehouseTypeStandard)),
+					resourceshowoutputassert.WarehouseShowOutput(t, ref).
+						HasType(sdk.WarehouseTypeStandard),
+				),
+			},
+		},
+	})
+}

--- a/pkg/testacc/resource_warehouse_adaptive_acceptance_test.go
+++ b/pkg/testacc/resource_warehouse_adaptive_acceptance_test.go
@@ -325,3 +325,46 @@ func TestAcc_WarehouseAdaptive_Validations(t *testing.T) {
 		},
 	})
 }
+
+func TestAcc_WarehouseAdaptive_ExternalTypeChange(t *testing.T) {
+	id := testClient().Ids.RandomAccountObjectIdentifier()
+	warehouseModel := model.WarehouseAdaptiveWithId(id)
+	ref := warehouseModel.ResourceReference()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.WarehouseAdaptive),
+		Steps: []resource.TestStep{
+			{
+				Config: accconfig.FromModels(t, warehouseModel),
+				Check: assertThat(t,
+					resourceassert.WarehouseAdaptiveResource(t, ref).
+						HasWarehouseTypeString(string(sdk.WarehouseTypeAdaptive)),
+					resourceshowoutputassert.WarehouseAdaptiveShowOutput(t, ref).
+						HasType(sdk.WarehouseTypeAdaptive),
+				),
+			},
+			{
+				PreConfig: func() {
+					testClient().Warehouse.UpdateWarehouseType(t, id, sdk.WarehouseTypeStandard)
+				},
+				Config: accconfig.FromModels(t, warehouseModel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(ref, plancheck.ResourceActionUpdate),
+						planchecks.ExpectChange(ref, "warehouse_type", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseTypeStandard)), sdk.String(string(sdk.WarehouseTypeAdaptive))),
+					},
+				},
+				Check: assertThat(t,
+					resourceassert.WarehouseAdaptiveResource(t, ref).
+						HasWarehouseTypeString(string(sdk.WarehouseTypeAdaptive)),
+					resourceshowoutputassert.WarehouseAdaptiveShowOutput(t, ref).
+						HasType(sdk.WarehouseTypeAdaptive),
+				),
+			},
+		},
+	})
+}

--- a/templates/resources/warehouse_adaptive.md.tmpl
+++ b/templates/resources/warehouse_adaptive.md.tmpl
@@ -11,8 +11,6 @@ description: |-
 
 !> **Caution: Preview Feature** This feature is considered a preview feature in the provider, regardless of the state of the resource in Snowflake. We do not guarantee its stability. It will be reworked and marked as a stable feature in future releases. Breaking changes are expected, even without bumping the major version. To use this feature, add the relevant feature name to `preview_features_enabled` field in the [provider configuration](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs#schema). Please always refer to the [Getting Help](https://github.com/snowflakedb/terraform-provider-snowflake?tab=readme-ov-file#getting-help) section in our Github repo to best determine how to get help for your questions.
 
--> **Note** Detecting external changes to the warehouse type is not yet supported.
-
 # {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}


### PR DESCRIPTION
## Changes

The `snowflake_warehouse_adaptive` resource had no mechanism to detect when the warehouse type was externally changed (e.g., via the Snowflake UI or SQL). This left Terraform unaware of drift, causing the declared type to silently diverge from the actual type.

- Add `warehouse_type` computed attribute to `snowflake_warehouse_adaptive` to track the actual warehouse type
- Add `HandleWarehouseExternalTypeChange` custom diff that detects type drift and schedules an UPDATE to restore the declared type (without forcing recreation)
- Add acceptance tests for both resources to confirm the behavior.
- Remove the stale documentation note that external type detection was unsupported