### PR TITLE
fix: Handle prefixed region format in AccountURL()

### DIFF
--- a/pkg/sdk/context_functions.go
+++ b/pkg/sdk/context_functions.go
@@ -58,7 +58,12 @@ type CurrentSessionDetails struct {
 }
 
 func (acc *CurrentSessionDetails) AccountURL() (string, error) {
-	if regionID, ok := regionMapping[strings.ToLower(acc.Region)]; ok {
+	region := acc.Region
+	// CURRENT_REGION() may return a prefixed form like "PUBLIC.AWS_US_EAST_1"; use the last segment.
+	if idx := strings.LastIndex(region, "."); idx >= 0 {
+		region = region[idx+1:]
+	}
+	if regionID, ok := regionMapping[strings.ToLower(region)]; ok {
 		accountID := acc.Account
 		if len(regionID) > 0 {
 			accountID = fmt.Sprintf("%s.%s", accountID, regionID)

--- a/pkg/sdk/context_functions_test.go
+++ b/pkg/sdk/context_functions_test.go
@@ -69,6 +69,11 @@ func TestCurrentSessionDetails_AccountURL(t *testing.T) {
 		{region: "azure_australiaeast", expectedURL: "https://TESTACCOUNT.australia-east.azure.snowflakecomputing.com"},
 
 		{region: "AWS_US_WEST_2", expectedURL: "https://TESTACCOUNT.snowflakecomputing.com"}, // case insensitive
+
+		// prefixed forms returned by CURRENT_REGION() in newer Snowflake versions
+		{region: "PUBLIC.AWS_US_EAST_1", expectedURL: "https://TESTACCOUNT.us-east-1.snowflakecomputing.com"},
+		{region: "AWS_US_GOV_EAST_1_FHPLUS.AWS_US_GOV_EAST_1_FHPLUS", expectedURL: "https://TESTACCOUNT.fhplus.us-gov-east-1.aws.snowflakecomputing.com"},
+		{region: "PUBLIC.AZURE_EASTUS2", expectedURL: "https://TESTACCOUNT.east-us-2.azure.snowflakecomputing.com"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes #4632

The snowflake_current_account data source was returning null for the URL because newer Snowflake versions return region strings with prefixes like "PUBLIC.AWS_US_EAST_1" instead of just "AWS_US_EAST_1". The region mapping lookup was failing on these formats.

Updated AccountURL() to extract the last segment of the region string when it contains a dot. So "PUBLIC.AWS_US_EAST_1" becomes "AWS_US_EAST_1" for the lookup. Backward compatible with the old format.

## Test Plan
* [x] unit tests

Added test cases for the prefixed region formats to verify the URLs are generated correctly.

## References
* #4632