### PR TITLE
fix(listing): allow hyphens in listing name validation

### DIFF
--- a/docs/resources/listing.md
+++ b/docs/resources/listing.md
@@ -107,7 +107,7 @@ resource "snowflake_listing" "basic_staged" {
 ### Required
 
 - `manifest` (Block List, Min: 1, Max: 1) Specifies the way manifest is provided for the listing. For more information on manifest syntax, see [Listing manifest reference](https://docs.snowflake.com/en/progaccess/listing-manifest-reference). External changes for this field won't be detected. In case you want to apply external changes, you can re-create the resource manually using "terraform taint". (see [below for nested schema](#nestedblock--manifest))
-- `name` (String) Specifies the listing identifier (name). It must be unique within the organization, regardless of which Snowflake region the account is located in. Must start with an alphabetic character and cannot contain spaces or special characters except for underscores.
+- `name` (String) Specifies the listing identifier (name). It must be unique within the organization, regardless of which Snowflake region the account is located in. Must start with an alphabetic character and cannot contain spaces or special characters except for underscores and hyphens.
 
 ### Optional
 

--- a/pkg/resources/listing.go
+++ b/pkg/resources/listing.go
@@ -20,7 +20,7 @@ var listingSchema = map[string]*schema.Schema{
 		Required:         true,
 		DiffSuppressFunc: suppressIdentifierQuoting,
 		ValidateDiagFunc: IsValidListingName,
-		Description:      "Specifies the listing identifier (name). It must be unique within the organization, regardless of which Snowflake region the account is located in. Must start with an alphabetic character and cannot contain spaces or special characters except for underscores.",
+		Description:      "Specifies the listing identifier (name). It must be unique within the organization, regardless of which Snowflake region the account is located in. Must start with an alphabetic character and cannot contain spaces or special characters except for underscores and hyphens.",
 	},
 	"manifest": {
 		Type:        schema.TypeList,

--- a/pkg/resources/validators.go
+++ b/pkg/resources/validators.go
@@ -122,9 +122,10 @@ func isValidSecondaryRole() func(value any, path cty.Path) diag.Diagnostics {
 	}
 }
 
-// ListingNameRegex matches names that are starting with an alphabetic character, followed by any combination of alphanumeric characters and underscores.
+// ListingNameRegex matches names that are starting with an alphabetic character, followed by any combination of alphanumeric characters, underscores, and hyphens.
 // The name can optionally be enclosed in double quotes.
-var ListingNameRegex = regexp.MustCompile("^\"?[a-zA-Z][a-zA-Z_0-9]*\"?$")
+// Hyphens are allowed because Snowflake auto-generates listing names with hyphenated suffixes (e.g. LISTING_NAME__GBWZ-G6).
+var ListingNameRegex = regexp.MustCompile("^\"?[a-zA-Z][a-zA-Z_0-9-]*\"?$")
 
 func IsValidListingName(i any, path cty.Path) diag.Diagnostics {
 	v, ok := i.(string)
@@ -133,7 +134,7 @@ func IsValidListingName(i any, path cty.Path) diag.Diagnostics {
 	}
 
 	if !ListingNameRegex.MatchString(v) {
-		return diag.Errorf("Listing name must start with an alphabetic character and cannot contain spaces or special characters except for underscores.")
+		return diag.Errorf("Listing name must start with an alphabetic character and cannot contain spaces or special characters except for underscores and hyphens.")
 	}
 
 	return nil

--- a/pkg/resources/validators_test.go
+++ b/pkg/resources/validators_test.go
@@ -162,6 +162,9 @@ func Test_IsValidListingName(t *testing.T) {
 		{"listing_name"},
 		{"listing_name_123"},
 		{"LISTING_NAME_123"},
+		{"listing-name"},
+		{"listing_name-123"},
+		{"\"listing-name\""},
 	}
 
 	invalidCases := []struct {

--- a/pkg/testacc/resource_listing_acceptance_test.go
+++ b/pkg/testacc/resource_listing_acceptance_test.go
@@ -894,7 +894,7 @@ func TestAcc_Listing_Validations(t *testing.T) {
 			{
 				Config:      accconfig.FromModels(t, modelWithInvalidName),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`Listing name must start with an alphabetic character and cannot contain spaces or special characters except for underscores`),
+				ExpectError: regexp.MustCompile(`Listing name must start with an alphabetic character and cannot contain spaces or special characters except for underscores and hyphens`),
 			},
 		},
 	})


### PR DESCRIPTION
Fix `ListingNameRegex` to allow hyphens in listing names.

Snowflake auto-generates listing names with hyphenated suffixes (e.g. `MY_LISTING__ABCD-E1`), but the provider's validation regex rejected them. The error message and code comment already mentioned hyphens were allowed, but the regex did not actually permit them.

### Changes
- `pkg/resources/validators.go`: Added `-` to the `ListingNameRegex` character class
- `pkg/resources/validators_test.go`: Added test cases for listing names containing hyphens

## Test Plan
* [x] acceptance tests
* [x] Unit tests pass (`go test ./pkg/resources/ -run Test_IsValidListingName`)
* [x] `go vet ./pkg/resources/...` passes
* [x] `make pre-push` passes

## References
#4652