### PR TITLE
chore: Migrate majority of db and plain struct definitions to paired structs approach

### DIFF
--- a/pkg/sdk/generator/defs/api_integrations_def.go
+++ b/pkg/sdk/generator/defs/api_integrations_def.go
@@ -123,22 +123,15 @@ var apiIntegrationsDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-integrations",
-		g.DbStruct("showApiIntegrationsDbRow").
+		g.StructPair("showApiIntegrationsDbRow", "ApiIntegration").
 			Text("name").
-			Text("type").
+			Text("type", g.WithPlainFieldName("ApiType")).
 			Text("category").
 			Bool("enabled").
-			OptionalText("comment").
+			OptionalText("comment", g.WithRequiredInPlain()).
 			Time("created_on"),
-		g.PlainStruct("ApiIntegration").
-			Text("Name").
-			Text("ApiType").
-			Text("Category").
-			Bool("Enabled").
-			Text("Comment").
-			Time("CreatedOn"),
 		g.NewQueryStruct("ShowApiIntegrations").
 			Show().
 			SQL("API INTEGRATIONS").
@@ -147,19 +140,14 @@ var apiIntegrationsDef = g.NewInterface(
 	ShowByIdOperationWithFiltering(
 		g.ShowByIDLikeFiltering,
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-integration",
-		g.DbStruct("descApiIntegrationsDbRow").
-			Text("property").
-			Text("property_type").
-			Text("property_value").
-			Text("property_default"),
-		g.PlainStruct("ApiIntegrationProperty").
-			Text("Name").
-			Text("Type").
-			Text("Value").
-			Text("Default"),
+		g.StructPair("descApiIntegrationsDbRow", "ApiIntegrationProperty").
+			Text("property", g.WithPlainFieldName("Name")).
+			Text("property_type", g.WithPlainFieldName("Type")).
+			Text("property_value", g.WithPlainFieldName("Value")).
+			Text("property_default", g.WithPlainFieldName("Default")),
 		g.NewQueryStruct("DescribeApiIntegration").
 			Describe().
 			SQL("API INTEGRATION").

--- a/pkg/sdk/generator/defs/application_packages_def.go
+++ b/pkg/sdk/generator/defs/application_packages_def.go
@@ -134,32 +134,20 @@ var applicationPackagesDef = g.NewInterface(
 		IfExists().
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-application-packages",
-	g.DbStruct("applicationPackageRow").
-		Field("created_on", "string").
-		Field("name", "string").
-		Field("is_default", "string").
-		Field("is_current", "string").
-		Field("distribution", "string").
-		Field("owner", "string").
-		Field("comment", "string").
-		Field("retention_time", "int").
-		Field("options", "string").
-		Field("dropped_on", "sql.NullString").
-		Field("application_class", "sql.NullString"),
-	g.PlainStruct("ApplicationPackage").
-		Field("CreatedOn", "string").
-		Field("Name", "string").
-		Field("IsDefault", "bool").
-		Field("IsCurrent", "bool").
-		Field("Distribution", "string").
-		Field("Owner", "string").
-		Field("Comment", "string").
-		Field("RetentionTime", "int").
-		Field("Options", "string").
-		Field("DroppedOn", "string").
-		Field("ApplicationClass", "string"),
+	g.StructPair("applicationPackageRow", "ApplicationPackage").
+		Text("created_on").
+		Text("name").
+		Field("is_default", "string", "bool").
+		Field("is_current", "string", "bool").
+		Text("distribution").
+		Text("owner").
+		Text("comment").
+		Number("retention_time").
+		Text("options").
+		OptionalText("dropped_on", g.WithRequiredInPlain()).
+		OptionalText("application_class", g.WithRequiredInPlain()),
 	g.NewQueryStruct("ShowApplicationPackages").
 		Show().
 		SQL("APPLICATION PACKAGES").

--- a/pkg/sdk/generator/defs/application_roles_def.go
+++ b/pkg/sdk/generator/defs/application_roles_def.go
@@ -42,20 +42,14 @@ var applicationRolesDef = g.NewInterface(
 			g.KeywordOptions().SQL("FROM"),
 		).
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-application-roles",
-	g.DbStruct("applicationRoleDbRow").
-		Field("created_on", "time.Time").
-		Field("name", "string").
-		Field("owner", "string").
-		Field("comment", "string").
-		Field("owner_role_type", "string"),
-	g.PlainStruct("ApplicationRole").
-		Field("CreatedOn", "time.Time").
-		Field("Name", "string").
-		Field("Owner", "string").
-		Field("Comment", "string").
-		Field("OwnerRoleType", "string"),
+	g.StructPair("applicationRoleDbRow", "ApplicationRole").
+		Time("created_on").
+		Text("name").
+		Text("owner").
+		Text("comment").
+		Text("owner_role_type"),
 	g.NewQueryStruct("ShowApplicationRoles").
 		Show().
 		SQL("APPLICATION ROLES IN APPLICATION").

--- a/pkg/sdk/generator/defs/applications_def.go
+++ b/pkg/sdk/generator/defs/applications_def.go
@@ -100,36 +100,22 @@ var applicationsDef = g.NewInterface(
 		OptionalUnsetTags().
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ExactlyOneValueSet, "Set", "Unset", "Upgrade", "UpgradeVersion", "UnsetReferences", "SetTags", "UnsetTags"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-applications",
-	g.DbStruct("applicationRow").
-		Field("created_on", "string").
-		Field("name", "string").
-		Field("is_default", "string").
-		Field("is_current", "string").
-		Field("source_type", "string").
-		Field("source", "string").
-		Field("owner", "string").
-		Field("comment", "string").
-		Field("version", "string").
-		Field("label", "string").
-		Field("patch", "int").
-		Field("options", "string").
-		Field("retention_time", "int"),
-	g.PlainStruct("Application").
-		Field("CreatedOn", "string").
-		Field("Name", "string").
-		Field("IsDefault", "bool").
-		Field("IsCurrent", "bool").
-		Field("SourceType", "string").
-		Field("Source", "string").
-		Field("Owner", "string").
-		Field("Comment", "string").
-		Field("Version", "string").
-		Field("Label", "string").
-		Field("Patch", "int").
-		Field("Options", "string").
-		Field("RetentionTime", "int"),
+	g.StructPair("applicationRow", "Application").
+		Text("created_on").
+		Text("name").
+		Field("is_default", "string", "bool").
+		Field("is_current", "string", "bool").
+		Text("source_type").
+		Text("source").
+		Text("owner").
+		Text("comment").
+		Text("version").
+		Text("label").
+		Number("patch").
+		Text("options").
+		Number("retention_time"),
 	g.NewQueryStruct("ShowApplications").
 		Show().
 		SQL("APPLICATIONS").
@@ -138,15 +124,12 @@ var applicationsDef = g.NewInterface(
 		OptionalLimit(),
 ).ShowByIdOperationWithFiltering(
 	g.ShowByIDLikeFiltering,
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSlice,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-application",
-	g.DbStruct("applicationPropertyRow").
-		Field("property", "string").
-		Field("value", "sql.NullString"),
-	g.PlainStruct("ApplicationProperty").
-		Field("Property", "string").
-		Field("Value", "string"),
+	g.StructPair("applicationPropertyRow", "ApplicationProperty").
+		Text("property").
+		OptionalText("value", g.WithRequiredInPlain()),
 	g.NewQueryStruct("DescribeApplication").
 		Describe().
 		SQL("APPLICATION").

--- a/pkg/sdk/generator/defs/authentication_policies_def.go
+++ b/pkg/sdk/generator/defs/authentication_policies_def.go
@@ -175,28 +175,18 @@ var authenticationPoliciesDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-authentication-policies",
-		g.DbStruct("showAuthenticationPolicyDBRow").
-			OptionalTime("created_on").
+		g.StructPair("showAuthenticationPolicyDBRow", "AuthenticationPolicy").
+			OptionalTime("created_on", g.WithRequiredInPlain()).
 			Text("name").
 			Text("comment").
-			OptionalText("database_name").
-			OptionalText("schema_name").
+			OptionalText("database_name", g.WithRequiredInPlain()).
+			OptionalText("schema_name", g.WithRequiredInPlain()).
 			Text("kind").
-			OptionalText("owner").
-			OptionalText("owner_role_type").
+			OptionalText("owner", g.WithRequiredInPlain()).
+			OptionalText("owner_role_type", g.WithRequiredInPlain()).
 			Text("options"),
-		g.PlainStruct("AuthenticationPolicy").
-			Time("CreatedOn").
-			Text("Name").
-			Text("Comment").
-			Text("DatabaseName").
-			Text("SchemaName").
-			Text("Kind").
-			Text("Owner").
-			Text("OwnerRoleType").
-			Text("Options"),
 		g.NewQueryStruct("ShowAuthenticationPolicies").
 			Show().
 			SQL("AUTHENTICATION POLICIES").
@@ -210,19 +200,14 @@ var authenticationPoliciesDef = g.NewInterface(
 		g.ShowByIDLikeFiltering,
 		g.ShowByIDExtendedInFiltering,
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-authentication-policy",
-		g.DbStruct("describeAuthenticationPolicyDBRow").
+		g.StructPair("describeAuthenticationPolicyDBRow", "AuthenticationPolicyDescription").
 			Text("property").
 			Text("value").
 			Text("default").
 			Text("description"),
-		g.PlainStruct("AuthenticationPolicyDescription").
-			Text("Property").
-			Text("Value").
-			Text("Default").
-			Text("Description"),
 		g.NewQueryStruct("DescribeAuthenticationPolicy").
 			Describe().
 			SQL("AUTHENTICATION POLICY").

--- a/pkg/sdk/generator/defs/catalog_integrations_def.go
+++ b/pkg/sdk/generator/defs/catalog_integrations_def.go
@@ -169,22 +169,15 @@ var catalogIntegrationsDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-catalog-integrations",
-		g.DbStruct("showCatalogIntegrationsDbRow").
+		g.StructPair("showCatalogIntegrationsDbRow", "CatalogIntegration").
 			Text("name").
 			Bool("enabled").
 			Text("type").
 			Text("category").
-			OptionalText("comment").
+			OptionalText("comment", g.WithRequiredInPlain()).
 			Time("created_on"),
-		g.PlainStruct("CatalogIntegration").
-			Text("Name").
-			Bool("Enabled").
-			Text("Type").
-			Text("Category").
-			Text("Comment").
-			Time("CreatedOn"),
 		g.NewQueryStruct("ShowCatalogIntegration").
 			Show().
 			SQL("CATALOG INTEGRATIONS").
@@ -193,19 +186,14 @@ var catalogIntegrationsDef = g.NewInterface(
 	ShowByIdOperationWithFiltering(
 		g.ShowByIDLikeFiltering,
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-catalog-integration",
-		g.DbStruct("descCatalogIntegrationsDbRow").
-			Text("property").
-			Text("property_type").
-			Text("property_value").
-			Text("property_default"),
-		g.PlainStruct("CatalogIntegrationProperty").
-			Text("Name").
-			Text("Type").
-			Text("Value").
-			Text("Default"),
+		g.StructPair("descCatalogIntegrationsDbRow", "CatalogIntegrationProperty").
+			Text("property", g.WithPlainFieldName("Name")).
+			Text("property_type", g.WithPlainFieldName("Type")).
+			Text("property_value", g.WithPlainFieldName("Value")).
+			Text("property_default", g.WithPlainFieldName("Default")),
 		g.NewQueryStruct("DescribeCatalogIntegration").
 			Describe().
 			SQL("CATALOG INTEGRATION").

--- a/pkg/sdk/generator/defs/compute_pools_def.go
+++ b/pkg/sdk/generator/defs/compute_pools_def.go
@@ -74,14 +74,14 @@ var computePoolsDef = g.NewInterface(
 		IfExists().
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-compute-pools",
-	g.DbStruct("computePoolsRow").
+	g.StructPair("computePoolsRow", "ComputePool").
 		Text("name").
-		Text("state").
+		PlainField("state", "ComputePoolState").
 		Number("min_nodes").
 		Number("max_nodes").
-		Text("instance_family").
+		PlainField("instance_family", "ComputePoolInstanceFamily").
 		Number("num_services").
 		Number("num_jobs").
 		Number("auto_suspend_secs").
@@ -95,27 +95,7 @@ var computePoolsDef = g.NewInterface(
 		Text("owner").
 		OptionalText("comment").
 		Bool("is_exclusive").
-		OptionalText("application"),
-	g.PlainStruct("ComputePool").
-		Text("Name").
-		Field("State", "ComputePoolState").
-		Number("MinNodes").
-		Number("MaxNodes").
-		Field("InstanceFamily", "ComputePoolInstanceFamily").
-		Number("NumServices").
-		Number("NumJobs").
-		Number("AutoSuspendSecs").
-		Bool("AutoResume").
-		Number("ActiveNodes").
-		Number("IdleNodes").
-		Number("TargetNodes").
-		Time("CreatedOn").
-		Time("ResumedOn").
-		Time("UpdatedOn").
-		Text("Owner").
-		OptionalText("Comment").
-		Bool("IsExclusive").
-		Field("Application", "*AccountObjectIdentifier"),
+		Field("application", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("Application")),
 	g.NewQueryStruct("ShowComputePools").
 		Show().
 		SQL("COMPUTE POOLS").
@@ -124,15 +104,15 @@ var computePoolsDef = g.NewInterface(
 		OptionalLimitFrom(),
 ).ShowByIdOperationWithFiltering(
 	g.ShowByIDLikeFiltering,
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSingleValue,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-compute-pool",
-	g.DbStruct("computePoolDescRow").
+	g.StructPair("computePoolDescRow", "ComputePoolDetails").
 		Text("name").
-		Text("state").
+		PlainField("state", "ComputePoolState").
 		Number("min_nodes").
 		Number("max_nodes").
-		Text("instance_family").
+		PlainField("instance_family", "ComputePoolInstanceFamily").
 		Number("num_services").
 		Number("num_jobs").
 		Number("auto_suspend_secs").
@@ -146,31 +126,9 @@ var computePoolsDef = g.NewInterface(
 		Text("owner").
 		OptionalText("comment").
 		Bool("is_exclusive").
-		OptionalText("application").
+		Field("application", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("Application")).
 		Text("error_code").
 		Text("status_message"),
-	g.PlainStruct("ComputePoolDetails").
-		Text("Name").
-		Field("State", "ComputePoolState").
-		Number("MinNodes").
-		Number("MaxNodes").
-		Field("InstanceFamily", "ComputePoolInstanceFamily").
-		Number("NumServices").
-		Number("NumJobs").
-		Number("AutoSuspendSecs").
-		Bool("AutoResume").
-		Number("ActiveNodes").
-		Number("IdleNodes").
-		Number("TargetNodes").
-		Time("CreatedOn").
-		Time("ResumedOn").
-		Time("UpdatedOn").
-		Text("Owner").
-		OptionalText("Comment").
-		Bool("IsExclusive").
-		Field("Application", "*AccountObjectIdentifier").
-		Text("ErrorCode").
-		Text("StatusMessage"),
 	g.NewQueryStruct("DescComputePool").
 		Describe().
 		SQL("COMPUTE POOL").

--- a/pkg/sdk/generator/defs/connections_def.go
+++ b/pkg/sdk/generator/defs/connections_def.go
@@ -73,34 +73,21 @@ var connectionsDef = g.NewInterface(
 		IfExists().
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-connections",
-	g.DbStruct("connectionRow").
+	g.StructPair("connectionRow", "Connection").
 		OptionalText("region_group").
 		Text("snowflake_region").
-		Field("created_on", "time.Time").
+		Time("created_on").
 		Text("account_name").
 		Text("name").
-		Field("comment", "sql.NullString").
-		Text("is_primary").
-		Text("primary").
-		Text("failover_allowed_to_accounts").
+		OptionalText("comment").
+		Field("is_primary", "string", "bool").
+		Field("primary", "string", "ExternalObjectIdentifier").
+		Field("failover_allowed_to_accounts", "string", "[]AccountIdentifier").
 		Text("connection_url").
 		Text("organization_name").
 		Text("account_locator"),
-	g.PlainStruct("Connection").
-		OptionalText("RegionGroup").
-		Text("SnowflakeRegion").
-		Field("CreatedOn", "time.Time").
-		Text("AccountName").
-		Text("Name").
-		OptionalText("Comment").
-		Bool("IsPrimary").
-		Field("Primary", "ExternalObjectIdentifier").
-		Field("FailoverAllowedToAccounts", "[]AccountIdentifier").
-		Text("ConnectionUrl").
-		Text("OrganizationName").
-		Text("AccountLocator"),
 	g.NewQueryStruct("ShowConnections").
 		Show().
 		SQL("CONNECTIONS").

--- a/pkg/sdk/generator/defs/cortex_search_services_def.go
+++ b/pkg/sdk/generator/defs/cortex_search_services_def.go
@@ -56,21 +56,14 @@ var cortexSearchServicesDef = g.NewInterface(
 		// Validations
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ExactlyOneValueSet, "Set"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/LIMITEDACCESS/cortex-search/sql/show-cortex-search",
-	// Fields
-	g.DbStruct("cortexSearchServiceRow").
-		Field("created_on", "time.Time").
-		Field("name", "string").
-		Field("database_name", "string").
-		Field("schema_name", "string").
-		OptionalText("comment"),
-	g.PlainStruct("CortexSearchService").
-		Field("CreatedOn", "time.Time").
-		Field("Name", "string").
-		Field("DatabaseName", "string").
-		Field("SchemaName", "string").
-		Field("Comment", "string"),
+	g.StructPair("cortexSearchServiceRow", "CortexSearchService").
+		Time("created_on").
+		Text("name").
+		Text("database_name").
+		Text("schema_name").
+		OptionalText("comment", g.WithRequiredInPlain()),
 	g.NewQueryStruct("ShowCortexSearchService").
 		Show().
 		SQL("CORTEX SEARCH SERVICES").
@@ -81,10 +74,10 @@ var cortexSearchServicesDef = g.NewInterface(
 ).ShowByIdOperationWithFiltering(
 	g.ShowByIDLikeFiltering,
 	g.ShowByIDInFiltering,
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSingleValue,
 	"https://docs.snowflake.com/LIMITEDACCESS/cortex-search/sql/desc-cortex-search",
-	g.DbStruct("cortexSearchServiceDetailsRow").
+	g.StructPair("cortexSearchServiceDetailsRow", "CortexSearchServiceDetails").
 		Text("created_on").
 		Text("name").
 		Text("database_name").
@@ -92,8 +85,8 @@ var cortexSearchServicesDef = g.NewInterface(
 		Text("target_lag").
 		Text("warehouse").
 		OptionalText("search_column").
-		OptionalText("attribute_columns").
-		OptionalText("columns").
+		Field("attribute_columns", "sql.NullString", "[]string").
+		Field("columns", "sql.NullString", "[]string").
 		OptionalText("definition").
 		OptionalText("comment").
 		Text("service_query_url").
@@ -102,24 +95,6 @@ var cortexSearchServicesDef = g.NewInterface(
 		Text("indexing_state").
 		OptionalText("indexing_error").
 		OptionalText("embedding_model"),
-	g.PlainStruct("CortexSearchServiceDetails").
-		Text("CreatedOn").
-		Text("Name").
-		Text("DatabaseName").
-		Text("SchemaName").
-		Text("TargetLag").
-		Text("Warehouse").
-		OptionalText("SearchColumn").
-		Field("AttributeColumns", "[]string").
-		Field("Columns", "[]string").
-		OptionalText("Definition").
-		OptionalText("Comment").
-		Text("ServiceQueryUrl").
-		Text("DataTimestamp").
-		Number("SourceDataNumRows").
-		Text("IndexingState").
-		OptionalText("IndexingError").
-		OptionalText("EmbeddingModel"),
 	g.NewQueryStruct("DescribeCortexSearchService").
 		Describe().
 		SQL("CORTEX SEARCH SERVICE").

--- a/pkg/sdk/generator/defs/event_tables_def.go
+++ b/pkg/sdk/generator/defs/event_tables_def.go
@@ -78,24 +78,16 @@ var eventTablesDef = g.NewInterface(
 		OptionalTags().
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-event-tables",
-	g.DbStruct("eventTableRow").
-		Field("created_on", "time.Time").
-		Field("name", "string").
-		Field("database_name", "string").
-		Field("schema_name", "string").
-		Field("owner", "sql.NullString").
-		Field("comment", "sql.NullString").
-		Field("owner_role_type", "sql.NullString"),
-	g.PlainStruct("EventTable").
-		Field("CreatedOn", "time.Time").
-		Field("Name", "string").
-		Field("DatabaseName", "string").
-		Field("SchemaName", "string").
-		Field("Owner", "string").
-		Field("Comment", "string").
-		Field("OwnerRoleType", "string"),
+	g.StructPair("eventTableRow", "EventTable").
+		Time("created_on").
+		Text("name").
+		Text("database_name").
+		Text("schema_name").
+		OptionalText("owner", g.WithRequiredInPlain()).
+		OptionalText("comment", g.WithRequiredInPlain()).
+		OptionalText("owner_role_type", g.WithRequiredInPlain()),
 	g.NewQueryStruct("ShowEventTables").
 		Show().
 		Terse().
@@ -107,17 +99,13 @@ var eventTablesDef = g.NewInterface(
 ).ShowByIdOperationWithFiltering(
 	g.ShowByIDInFiltering,
 	g.ShowByIDLikeFiltering,
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSingleValue,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-event-table",
-	g.DbStruct("eventTableDetailsRow").
-		Field("name", "string").
-		Field("kind", "string").
-		Field("comment", "string"),
-	g.PlainStruct("EventTableDetails").
-		Field("Name", "string").
-		Field("Kind", "string").
-		Field("Comment", "string"),
+	g.StructPair("eventTableDetailsRow", "EventTableDetails").
+		Text("name").
+		Text("kind").
+		Text("comment"),
 	g.NewQueryStruct("DescribeEventTable").
 		Describe().
 		SQL("EVENT TABLE").

--- a/pkg/sdk/generator/defs/external_volumes_def.go
+++ b/pkg/sdk/generator/defs/external_volumes_def.go
@@ -150,37 +150,27 @@ var externalVolumesDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-external-volume",
-		g.DbStruct("externalVolumeDescRow").
-			Text("parent_property").
-			Text("property").
-			Text("property_type").
-			Text("property_value").
-			Text("property_default"),
-		g.PlainStruct("ExternalVolumeProperty").
-			Text("Parent").
-			Text("Name").
-			Text("Type").
-			Text("Value").
-			Text("Default"),
+		g.StructPair("externalVolumeDescRow", "ExternalVolumeProperty").
+			Text("parent_property", g.WithPlainFieldName("Parent")).
+			Text("property", g.WithPlainFieldName("Name")).
+			Text("property_type", g.WithPlainFieldName("Type")).
+			Text("property_value", g.WithPlainFieldName("Value")).
+			Text("property_default", g.WithPlainFieldName("Default")),
 		g.NewQueryStruct("DescExternalVolume").
 			Describe().
 			SQL("EXTERNAL VOLUME").
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-external-volumes",
-		g.DbStruct("externalVolumeShowRow").
+		g.StructPair("externalVolumeShowRow", "ExternalVolume").
 			Text("name").
 			Bool("allow_writes").
-			OptionalText("comment"),
-		g.PlainStruct("ExternalVolume").
-			Text("Name").
-			Bool("AllowWrites").
-			Text("Comment"),
+			OptionalText("comment", g.WithRequiredInPlain()),
 		g.NewQueryStruct("ShowExternalVolumes").
 			Show().
 			SQL("EXTERNAL VOLUMES").

--- a/pkg/sdk/generator/defs/git_repositories_def.go
+++ b/pkg/sdk/generator/defs/git_repositories_def.go
@@ -6,31 +6,18 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/generator/gen/sdkcommons"
 )
 
-var gitRepositoryDbRow = g.DbStruct("gitRepositoriesRow").
+var gitRepositoryPairs = g.StructPair("gitRepositoriesRow", "GitRepository").
 	Time("created_on").
 	Text("name").
 	Text("database_name").
 	Text("schema_name").
 	Text("origin").
-	Text("api_integration").
-	OptionalText("git_credentials").
+	OptionalAccountObjectIdentifier("api_integration", g.WithPlainFieldName("ApiIntegration")).
+	Field("git_credentials", "sql.NullString", "*SchemaObjectIdentifier", g.WithPlainFieldName("GitCredentials")).
 	Text("owner").
 	Text("owner_role_type").
 	OptionalText("comment").
 	OptionalTime("last_fetched_at")
-
-var gitRepository = g.PlainStruct("GitRepository").
-	Time("CreatedOn").
-	Text("Name").
-	Text("DatabaseName").
-	Text("SchemaName").
-	Text("Origin").
-	Field("ApiIntegration", "*AccountObjectIdentifier").
-	Field("GitCredentials", "*SchemaObjectIdentifier").
-	Text("Owner").
-	Text("OwnerRoleType").
-	OptionalText("Comment").
-	OptionalTime("LastFetchedAt")
 
 var gitRepositoriesDef = g.NewInterface(
 	"GitRepositories",
@@ -90,20 +77,18 @@ var gitRepositoriesDef = g.NewInterface(
 		IfExists().
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSingleValue,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-git-repository",
-	gitRepositoryDbRow,
-	gitRepository,
+	gitRepositoryPairs,
 	g.NewQueryStruct("DescribeGitRepository").
 		Describe().
 		SQL("GIT REPOSITORY").
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-git-repositories",
-	gitRepositoryDbRow,
-	gitRepository,
+	gitRepositoryPairs,
 	g.NewQueryStruct("ShowGitRepositories").
 		Show().
 		SQL("GIT REPOSITORIES").

--- a/pkg/sdk/generator/defs/hybrid_tables_def.go
+++ b/pkg/sdk/generator/defs/hybrid_tables_def.go
@@ -235,28 +235,18 @@ var hybridTablesDef = g.NewInterface(
 		OptionalSQL("RESTRICT").
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ConflictingFields, "Cascade", "Restrict"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-hybrid-tables",
-	g.DbStruct("hybridTableRow").
+	g.StructPair("hybridTableRow", "HybridTable").
 		Time("created_on").
 		Text("name").
 		Text("database_name").
 		Text("schema_name").
-		OptionalText("owner").
+		OptionalText("owner", g.WithRequiredInPlain()).
 		OptionalNumber("rows").
 		OptionalNumber("bytes").
-		OptionalText("comment").
-		OptionalText("owner_role_type"),
-	g.PlainStruct("HybridTable").
-		Time("CreatedOn").
-		Text("Name").
-		Text("DatabaseName").
-		Text("SchemaName").
-		Text("Owner").
-		OptionalNumber("Rows").
-		OptionalNumber("Bytes").
-		Text("Comment").
-		Text("OwnerRoleType"),
+		OptionalText("comment", g.WithRequiredInPlain()).
+		OptionalText("owner_role_type", g.WithRequiredInPlain()),
 	g.NewQueryStruct("ShowHybridTables").
 		Show().
 		Terse().
@@ -268,37 +258,23 @@ var hybridTablesDef = g.NewInterface(
 ).ShowByIdOperationWithFiltering(
 	g.ShowByIDInFiltering,
 	g.ShowByIDLikeFiltering,
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSlice,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-table",
-	g.DbStruct("hybridTableDetailsRow").
+	g.StructPair("hybridTableDetailsRow", "HybridTableDetails").
 		Text("name").
 		Text("type").
 		Text("kind").
-		Text("null").
-		OptionalText("default").
-		Text("primary key").
-		Text("unique key").
-		OptionalText("check").
-		OptionalText("expression").
-		OptionalText("comment").
-		OptionalText("policy name").
-		OptionalText("privacy domain").
-		OptionalText("schema_evolution_record"),
-	g.PlainStruct("HybridTableDetails").
-		Text("Name").
-		Text("Type").
-		Text("Kind").
-		Text("IsNullable").
-		Text("Default").
-		Text("PrimaryKey").
-		Text("UniqueKey").
-		Text("Check").
-		Text("Expression").
-		Text("Comment").
-		Text("PolicyName").
-		Text("PrivacyDomain").
-		Text("SchemaEvolutionRecord"),
+		Text("null", g.WithPlainFieldName("IsNullable")).
+		OptionalText("default", g.WithRequiredInPlain()).
+		Text("primary key", g.WithPlainFieldName("PrimaryKey")).
+		Text("unique key", g.WithPlainFieldName("UniqueKey")).
+		OptionalText("check", g.WithRequiredInPlain()).
+		OptionalText("expression", g.WithRequiredInPlain()).
+		OptionalText("comment", g.WithRequiredInPlain()).
+		OptionalText("policy name", g.WithPlainFieldName("PolicyName"), g.WithRequiredInPlain()).
+		OptionalText("privacy domain", g.WithPlainFieldName("PrivacyDomain"), g.WithRequiredInPlain()).
+		OptionalText("schema_evolution_record", g.WithRequiredInPlain()),
 	g.NewQueryStruct("DescribeHybridTable").
 		Describe().
 		SQL("TABLE").

--- a/pkg/sdk/generator/defs/image_repositories_def.go
+++ b/pkg/sdk/generator/defs/image_repositories_def.go
@@ -57,9 +57,9 @@ var imageRepositoriesDef = g.NewInterface(
 		IfExists().
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-image-repositories",
-	g.DbStruct("imageRepositoriesRow").
+	g.StructPair("imageRepositoriesRow", "ImageRepository").
 		Time("created_on").
 		Text("name").
 		Text("database_name").
@@ -68,19 +68,8 @@ var imageRepositoriesDef = g.NewInterface(
 		Text("owner").
 		Text("owner_role_type").
 		Text("comment").
-		Text("encryption").
+		PlainField("encryption", "ImageRepositoryEncryptionType").
 		Text("privatelink_repository_url"),
-	g.PlainStruct("ImageRepository").
-		Time("CreatedOn").
-		Text("Name").
-		Text("DatabaseName").
-		Text("SchemaName").
-		Text("RepositoryUrl").
-		Text("Owner").
-		Text("OwnerRoleType").
-		Text("Comment").
-		Field("Encryption", g.KindOfT[sdkcommons.ImageRepositoryEncryptionType]()).
-		Text("PrivatelinkRepositoryUrl"),
 	g.NewQueryStruct("ShowImageRepositories").
 		Show().
 		SQL("IMAGE REPOSITORIES").

--- a/pkg/sdk/generator/defs/listings_def.go
+++ b/pkg/sdk/generator/defs/listings_def.go
@@ -13,7 +13,7 @@ var listingWithDef = g.NewQueryStruct("ListingWith").
 
 // There are more fields listed than in https://docs.snowflake.com/en/sql-reference/sql/show-listings.
 // They are mapped straight from the SHOW LISTINGS output.
-var listingDbRow = g.DbStruct("listingDBRow").
+var listingPairs = g.StructPair("listingDBRow", "Listing").
 	Text("global_name").
 	Text("name").
 	Text("title").
@@ -22,7 +22,7 @@ var listingDbRow = g.DbStruct("listingDBRow").
 	Text("created_on").
 	Text("updated_on").
 	OptionalText("published_on").
-	Text("state").
+	PlainField("state", "ListingState").
 	OptionalText("review_state").
 	OptionalText("comment").
 	Text("owner").
@@ -40,34 +40,6 @@ var listingDbRow = g.DbStruct("listingDBRow").
 	OptionalText("organization_profile_name").
 	OptionalText("uniform_listing_locator").
 	OptionalText("detailed_target_accounts")
-
-var listing = g.PlainStruct("Listing").
-	Text("GlobalName").
-	Text("Name").
-	Text("Title").
-	OptionalText("Subtitle").
-	Text("Profile").
-	Text("CreatedOn").
-	Text("UpdatedOn").
-	OptionalText("PublishedOn").
-	Field("State", g.KindOfT[sdkcommons.ListingState]()).
-	OptionalText("ReviewState").
-	OptionalText("Comment").
-	Text("Owner").
-	Text("OwnerRoleType").
-	OptionalText("Regions").
-	Text("TargetAccounts").
-	Bool("IsMonetized").
-	Bool("IsApplication").
-	Bool("IsTargeted").
-	OptionalBool("IsLimitedTrial").
-	OptionalBool("IsByRequest").
-	OptionalText("Distribution").
-	OptionalBool("IsMountlessQueryable").
-	OptionalText("RejectedOn").
-	OptionalText("OrganizationProfileName").
-	OptionalText("UniformListingLocator").
-	OptionalText("DetailedTargetAccounts")
 
 // There are more fields listed than in https://docs.snowflake.com/en/sql-reference/sql/desc-listing
 // They are mapped straight from the DESC LISTING output.
@@ -294,10 +266,9 @@ var listingsDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-listings",
-		listingDbRow,
-		listing,
+		listingPairs,
 		g.NewQueryStruct("ShowListings").
 			Show().
 			SQL("LISTINGS").

--- a/pkg/sdk/generator/defs/managed_accounts_def.go
+++ b/pkg/sdk/generator/defs/managed_accounts_def.go
@@ -6,27 +6,16 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/generator/gen/sdkcommons"
 )
 
-var managedAccountDbRow = g.DbStruct("managedAccountDBRow").
-	OptionalText("account_name").
+var managedAccountPairs = g.StructPair("managedAccountDBRow", "ManagedAccount").
+	OptionalText("account_name", g.WithPlainFieldName("Name"), g.WithRequiredInPlain()).
 	Text("cloud").
 	Text("region").
-	OptionalText("account_locator").
+	OptionalText("account_locator", g.WithPlainFieldName("Locator"), g.WithRequiredInPlain()).
 	Text("created_on").
-	OptionalText("account_url").
-	Text("account_locator_url").
+	OptionalText("account_url", g.WithPlainFieldName("URL"), g.WithRequiredInPlain()).
+	Text("account_locator_url", g.WithPlainFieldName("AccountLocatorURL")).
 	Bool("is_reader").
 	OptionalText("comment")
-
-var managedAccount = g.PlainStruct("ManagedAccount").
-	Text("Name").
-	Text("Cloud").
-	Text("Region").
-	Text("Locator").
-	Text("CreatedOn").
-	Text("URL").
-	Text("AccountLocatorURL").
-	Bool("IsReader").
-	OptionalText("Comment")
 
 var managedAccountsDef = g.NewInterface(
 	"ManagedAccounts",
@@ -61,10 +50,9 @@ var managedAccountsDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-managed-accounts",
-		managedAccountDbRow,
-		managedAccount,
+		managedAccountPairs,
 		g.NewQueryStruct("ShowManagedAccounts").
 			Show().
 			SQL("MANAGED ACCOUNTS").

--- a/pkg/sdk/generator/defs/materialized_views_def.go
+++ b/pkg/sdk/generator/defs/materialized_views_def.go
@@ -42,13 +42,13 @@ var materializedViewUnset = g.NewQueryStruct("MaterializedViewUnset").
 	OptionalSQL("COMMENT").
 	WithValidation(g.ExactlyOneValueSet, "Secure", "Comment")
 
-var materializedViewDbRow = g.DbStruct("materializedViewDBRow").
+var materializedViewPairs = g.StructPair("materializedViewDBRow", "MaterializedView").
 	Text("created_on").
 	Text("name").
 	OptionalText("reserved").
 	Text("database_name").
 	Text("schema_name").
-	OptionalText("cluster_by").
+	OptionalText("cluster_by", g.WithRequiredInPlain()).
 	Number("rows").
 	Number("bytes").
 	Text("source_database_name").
@@ -58,63 +58,26 @@ var materializedViewDbRow = g.DbStruct("materializedViewDBRow").
 	Time("compacted_on").
 	Text("owner").
 	Bool("invalid").
-	OptionalText("invalid_reason").
+	OptionalText("invalid_reason", g.WithRequiredInPlain()).
 	Text("behind_by").
-	OptionalText("comment").
+	OptionalText("comment", g.WithRequiredInPlain()).
 	Text("text").
 	Bool("is_secure").
-	Text("automatic_clustering").
-	OptionalText("owner_role_type").
-	OptionalText("budget")
+	Field("automatic_clustering", "string", "bool").
+	OptionalText("owner_role_type", g.WithRequiredInPlain()).
+	OptionalText("budget", g.WithRequiredInPlain())
 
-var materializedView = g.PlainStruct("MaterializedView").
-	Text("CreatedOn").
-	Text("Name").
-	OptionalText("Reserved").
-	Text("DatabaseName").
-	Text("SchemaName").
-	Text("ClusterBy").
-	Number("Rows").
-	Number("Bytes").
-	Text("SourceDatabaseName").
-	Text("SourceSchemaName").
-	Text("SourceTableName").
-	Time("RefreshedOn").
-	Time("CompactedOn").
-	Text("Owner").
-	Bool("Invalid").
-	Text("InvalidReason").
-	Text("BehindBy").
-	Text("Comment").
-	Text("Text").
-	Bool("IsSecure").
-	Bool("AutomaticClustering").
-	Text("OwnerRoleType").
-	Text("Budget")
-
-var materializedViewDetailsDbRow = g.DbStruct("materializedViewDetailsRow").
+var materializedViewDetailsPairs = g.StructPair("materializedViewDetailsRow", "MaterializedViewDetails").
 	Text("name").
-	Field("type", "DataType").
+	Field("type", "DataType", "DataType").
 	Text("kind").
-	Text("null").
+	Field("null?", "string", "bool", g.WithDbFieldName("Null"), g.WithPlainFieldName("IsNullable")).
 	OptionalText("default").
-	Text("primary key").
-	Text("unique key").
-	OptionalText("check").
+	Field("primary key", "string", "bool", g.WithPlainFieldName("IsPrimary")).
+	Field("unique key", "string", "bool", g.WithPlainFieldName("IsUnique")).
+	Field("check", "sql.NullString", "*bool").
 	OptionalText("expression").
 	OptionalText("comment")
-
-var materializedViewDetails = g.PlainStruct("MaterializedViewDetails").
-	Text("Name").
-	Field("Type", "DataType").
-	Text("Kind").
-	Bool("IsNullable").
-	OptionalText("Default").
-	Bool("IsPrimary").
-	Bool("IsUnique").
-	OptionalBool("Check").
-	OptionalText("Expression").
-	OptionalText("Comment")
 
 var materializedViewsDef = g.NewInterface(
 	"MaterializedViews",
@@ -169,10 +132,9 @@ var materializedViewsDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-materialized-views",
-		materializedViewDbRow,
-		materializedView,
+		materializedViewPairs,
 		g.NewQueryStruct("ShowMaterializedViews").
 			Show().
 			SQL("MATERIALIZED VIEWS").
@@ -183,11 +145,10 @@ var materializedViewsDef = g.NewInterface(
 		g.ShowByIDInFiltering,
 		g.ShowByIDLikeFiltering,
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-materialized-view",
-		materializedViewDetailsDbRow,
-		materializedViewDetails,
+		materializedViewDetailsPairs,
 		g.NewQueryStruct("DescribeMaterializedView").
 			Describe().
 			SQL("MATERIALIZED VIEW").

--- a/pkg/sdk/generator/defs/network_policies_def.go
+++ b/pkg/sdk/generator/defs/network_policies_def.go
@@ -104,24 +104,16 @@ var (
 				Name().
 				WithValidation(g.ValidIdentifier, "name"),
 		).
-		ShowOperation(
+		ShowOperationWithPairedStructs(
 			"https://docs.snowflake.com/en/sql-reference/sql/show-network-policies",
-			g.DbStruct("showNetworkPolicyDBRow").
-				Field("created_on", "string").
-				Field("name", "string").
-				Field("comment", "string").
-				Field("entries_in_allowed_ip_list", "int").
-				Field("entries_in_blocked_ip_list", "int").
-				Field("entries_in_allowed_network_rules", "int").
-				Field("entries_in_blocked_network_rules", "int"),
-			g.PlainStruct("NetworkPolicy").
-				Field("CreatedOn", "string").
-				Field("Name", "string").
-				Field("Comment", "string").
-				Field("EntriesInAllowedIpList", "int").
-				Field("EntriesInBlockedIpList", "int").
-				Field("EntriesInAllowedNetworkRules", "int").
-				Field("EntriesInBlockedNetworkRules", "int"),
+			g.StructPair("showNetworkPolicyDBRow", "NetworkPolicy").
+				Text("created_on").
+				Text("name").
+				Text("comment").
+				Number("entries_in_allowed_ip_list").
+				Number("entries_in_blocked_ip_list").
+				Number("entries_in_allowed_network_rules").
+				Number("entries_in_blocked_network_rules"),
 			g.NewQueryStruct("ShowNetworkPolicies").
 				Show().
 				SQL("NETWORK POLICIES").
@@ -130,15 +122,12 @@ var (
 		ShowByIdOperationWithFiltering(
 			g.ShowByIDLikeFiltering,
 		).
-		DescribeOperation(
+		DescribeOperationWithPairedStructs(
 			g.DescriptionMappingKindSlice,
 			"https://docs.snowflake.com/en/sql-reference/sql/desc-network-policy",
-			g.DbStruct("describeNetworkPolicyDBRow").
-				Field("name", "string").
-				Field("value", "string"),
-			g.PlainStruct("NetworkPolicyProperty").
-				Field("Name", "string").
-				Field("Value", "string"),
+			g.StructPair("describeNetworkPolicyDBRow", "NetworkPolicyProperty").
+				Text("name").
+				Text("value"),
 			g.NewQueryStruct("DescribeNetworkPolicy").
 				Describe().
 				SQL("NETWORK POLICY").

--- a/pkg/sdk/generator/defs/network_rules_def.go
+++ b/pkg/sdk/generator/defs/network_rules_def.go
@@ -61,30 +61,19 @@ var networkRulesDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-network-rules",
-		g.DbStruct("ShowNetworkRulesRow").
+		g.StructPair("ShowNetworkRulesRow", "NetworkRule").
 			Time("created_on").
 			Text("name").
 			Text("database_name").
 			Text("schema_name").
 			Text("owner").
 			Text("comment").
-			Text("type").
-			Text("mode").
-			Number("entries_in_valuelist").
+			PlainField("type", "NetworkRuleType").
+			PlainField("mode", "NetworkRuleMode").
+			Number("entries_in_valuelist", g.WithPlainFieldName("EntriesInValueList")).
 			Text("owner_role_type"),
-		g.PlainStruct("NetworkRule").
-			Time("CreatedOn").
-			Text("Name").
-			Text("DatabaseName").
-			Text("SchemaName").
-			Text("Owner").
-			Text("Comment").
-			Field("Type", "NetworkRuleType").
-			Field("Mode", "NetworkRuleMode").
-			Number("EntriesInValueList").
-			Text("OwnerRoleType"),
 		g.NewQueryStruct("ShowNetworkRules").
 			Show().
 			SQL("NETWORK RULES").
@@ -97,29 +86,19 @@ var networkRulesDef = g.NewInterface(
 		g.ShowByIDInFiltering,
 		g.ShowByIDLikeFiltering,
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSingleValue,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-network-rule",
-		g.DbStruct("DescNetworkRulesRow").
+		g.StructPair("DescNetworkRulesRow", "NetworkRuleDetails").
 			Time("created_on").
 			Text("name").
 			Text("database_name").
 			Text("schema_name").
 			Text("owner").
 			Text("comment").
-			Text("type").
-			Text("mode").
-			Text("value_list"),
-		g.PlainStruct("NetworkRuleDetails").
-			Time("CreatedOn").
-			Text("Name").
-			Text("DatabaseName").
-			Text("SchemaName").
-			Text("Owner").
-			Text("Comment").
-			Field("Type", "NetworkRuleType").
-			Field("Mode", "NetworkRuleMode").
-			Field("ValueList", "[]string"),
+			PlainField("type", "NetworkRuleType").
+			PlainField("mode", "NetworkRuleMode").
+			StringList("value_list"),
 		g.NewQueryStruct("ShowNetworkRules").
 			Describe().
 			SQL("NETWORK RULE").

--- a/pkg/sdk/generator/defs/notebooks_def.go
+++ b/pkg/sdk/generator/defs/notebooks_def.go
@@ -6,39 +6,27 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/generator/gen/sdkcommons"
 )
 
-var notebookDbRow = g.DbStruct("notebookRow").
+var notebookPairs = g.StructPair("notebookRow", "Notebook").
 	Time("created_on").
 	Text("name").
 	Text("database_name").
 	Text("schema_name").
 	OptionalText("comment").
 	Text("owner").
-	OptionalText("query_warehouse").
+	Field("query_warehouse", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("QueryWarehouse")).
 	Text("url_id").
 	Text("owner_role_type").
-	Text("code_warehouse")
+	Field("code_warehouse", "string", "AccountObjectIdentifier", g.WithPlainFieldName("CodeWarehouse"))
 
-var notebook = g.PlainStruct("Notebook").
-	Time("CreatedOn").
-	Text("Name").
-	Text("DatabaseName").
-	Text("SchemaName").
-	OptionalText("Comment").
-	Text("Owner").
-	Field("QueryWarehouse", "*AccountObjectIdentifier").
-	Text("UrlId").
-	Text("OwnerRoleType").
-	Field("CodeWarehouse", "AccountObjectIdentifier")
-
-var notebookDetailsDbRow = g.DbStruct("NotebookDetailsRow").
+var notebookDetailsPairs = g.StructPair("NotebookDetailsRow", "NotebookDetails").
 	OptionalText("title").
 	Text("main_file").
-	OptionalText("query_warehouse").
+	Field("query_warehouse", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("QueryWarehouse")).
 	Text("url_id").
 	Text("default_packages").
 	OptionalText("user_packages").
 	OptionalText("runtime_name").
-	OptionalText("compute_pool").
+	Field("compute_pool", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("ComputePool")).
 	Text("owner").
 	Text("import_urls").
 	Text("external_access_integrations").
@@ -60,37 +48,6 @@ var notebookDetailsDbRow = g.DbStruct("NotebookDetailsRow").
 	OptionalText("last_version_source_location_uri").
 	OptionalText("last_version_git_commit_hash").
 	OptionalText("live_version_location_uri")
-
-var notebookDetails = g.PlainStruct("NotebookDetails").
-	OptionalText("Title").
-	Text("MainFile").
-	Field("QueryWarehouse", "*AccountObjectIdentifier").
-	Text("UrlId").
-	Text("DefaultPackages").
-	OptionalText("UserPackages").
-	OptionalText("RuntimeName").
-	Field("ComputePool", "*AccountObjectIdentifier").
-	Text("Owner").
-	Text("ImportUrls").
-	Text("ExternalAccessIntegrations").
-	Text("ExternalAccessSecrets").
-	Text("CodeWarehouse").
-	Number("IdleAutoShutdownTimeSeconds").
-	Text("RuntimeEnvironmentVersion").
-	Text("Name").
-	OptionalText("Comment").
-	Text("DefaultVersion").
-	Text("DefaultVersionName").
-	OptionalText("DefaultVersionAlias").
-	Text("DefaultVersionLocationUri").
-	OptionalText("DefaultVersionSourceLocationUri").
-	OptionalText("DefaultVersionGitCommitHash").
-	Text("LastVersionName").
-	OptionalText("LastVersionAlias").
-	Text("LastVersionLocationUri").
-	OptionalText("LastVersionSourceLocationUri").
-	OptionalText("LastVersionGitCommitHash").
-	OptionalText("LiveVersionLocationUri")
 
 var notebooksDef = g.NewInterface(
 	"Notebooks",
@@ -176,20 +133,18 @@ var notebooksDef = g.NewInterface(
 		IfExists().
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSingleValue,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-notebook",
-	notebookDetailsDbRow,
-	notebookDetails,
+	notebookDetailsPairs,
 	g.NewQueryStruct("DescribeNotebook").
 		Describe().
 		SQL("NOTEBOOK").
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-notebooks",
-	notebookDbRow,
-	notebook,
+	notebookPairs,
 	g.NewQueryStruct("ShowNotebooks").
 		Show().
 		SQL("NOTEBOOKS").

--- a/pkg/sdk/generator/defs/notification_integrations_def.go
+++ b/pkg/sdk/generator/defs/notification_integrations_def.go
@@ -197,22 +197,15 @@ var notificationIntegrationsDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-integrations",
-		g.DbStruct("showNotificationIntegrationsDbRow").
+		g.StructPair("showNotificationIntegrationsDbRow", "NotificationIntegration").
 			Text("name").
-			Text("type").
+			Text("type", g.WithPlainFieldName("NotificationType")).
 			Text("category").
 			Bool("enabled").
-			OptionalText("comment").
+			OptionalText("comment", g.WithRequiredInPlain()).
 			Time("created_on"),
-		g.PlainStruct("NotificationIntegration").
-			Text("Name").
-			Text("NotificationType").
-			Text("Category").
-			Bool("Enabled").
-			Text("Comment").
-			Time("CreatedOn"),
 		g.NewQueryStruct("ShowNotificationIntegrations").
 			Show().
 			SQL("NOTIFICATION INTEGRATIONS").
@@ -221,19 +214,14 @@ var notificationIntegrationsDef = g.NewInterface(
 	ShowByIdOperationWithFiltering(
 		g.ShowByIDLikeFiltering,
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-integration",
-		g.DbStruct("descNotificationIntegrationsDbRow").
-			Text("property").
-			Text("property_type").
-			Text("property_value").
-			Text("property_default"),
-		g.PlainStruct("NotificationIntegrationProperty").
-			Text("Name").
-			Text("Type").
-			Text("Value").
-			Text("Default"),
+		g.StructPair("descNotificationIntegrationsDbRow", "NotificationIntegrationProperty").
+			Text("property", g.WithPlainFieldName("Name")).
+			Text("property_type", g.WithPlainFieldName("Type")).
+			Text("property_value", g.WithPlainFieldName("Value")).
+			Text("property_default", g.WithPlainFieldName("Default")),
 		g.NewQueryStruct("DescribeNotificationIntegration").
 			Describe().
 			SQL("NOTIFICATION INTEGRATION").

--- a/pkg/sdk/generator/defs/organization_accounts_def.go
+++ b/pkg/sdk/generator/defs/organization_accounts_def.go
@@ -77,13 +77,13 @@ var organizationAccountsDef = g.NewInterface(
 			WithValidation(g.ConflictingFields, "Name", "UnsetTags").
 			WithValidation(g.ExactlyOneValueSet, "Set", "Unset", "SetTags", "UnsetTags", "RenameTo", "DropOldUrl"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-organization-accounts",
-		g.DbStruct("organizationAccountDbRow").
+		g.StructPair("organizationAccountDbRow", "OrganizationAccount").
 			Text("organization_name").
 			Text("account_name").
 			Text("snowflake_region").
-			Text("edition").
+			PlainField("edition", "OrganizationAccountEdition").
 			Text("account_url").
 			Text("created_on").
 			OptionalText("comment").
@@ -102,29 +102,6 @@ var organizationAccountsDef = g.NewInterface(
 			OptionalText("organization_old_url_last_used").
 			Bool("is_events_account").
 			Bool("is_organization_account"),
-		g.PlainStruct("OrganizationAccount").
-			Text("OrganizationName").
-			Text("AccountName").
-			Text("SnowflakeRegion").
-			Field("Edition", g.KindOfT[sdkcommons.OrganizationAccountEdition]()).
-			Text("AccountUrl").
-			Text("CreatedOn").
-			OptionalText("Comment").
-			Text("AccountLocator").
-			Text("AccountLocatorUrl").
-			Number("ManagedAccounts").
-			Text("ConsumptionBillingEntityName").
-			OptionalText("MarketplaceConsumerBillingEntityName").
-			OptionalText("MarketplaceProviderBillingEntityName").
-			OptionalText("OldAccountUrl").
-			Bool("IsOrgAdmin").
-			OptionalText("AccountOldUrlSavedOn").
-			OptionalText("AccountOldUrlLastUsed").
-			OptionalText("OrganizationOldUrl").
-			OptionalText("OrganizationOldUrlSavedOn").
-			OptionalText("OrganizationOldUrlLastUsed").
-			Bool("IsEventsAccount").
-			Bool("IsOrganizationAccount"),
 		g.NewQueryStruct("ShowOrganizationAccounts").
 			Show().
 			SQL("ORGANIZATION ACCOUNTS").

--- a/pkg/sdk/generator/defs/row_access_policies_def.go
+++ b/pkg/sdk/generator/defs/row_access_policies_def.go
@@ -6,28 +6,6 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/generator/gen/sdkcommons"
 )
 
-var rowAccessPolicyDbRow = g.DbStruct("rowAccessPolicyDBRow").
-	Text("created_on").
-	Text("name").
-	Text("database_name").
-	Text("schema_name").
-	Text("kind").
-	Text("owner").
-	OptionalText("comment").
-	Text("options").
-	Text("owner_role_type")
-
-var rowAccessPolicy = g.PlainStruct("RowAccessPolicy").
-	Text("CreatedOn").
-	Text("Name").
-	Text("DatabaseName").
-	Text("SchemaName").
-	Text("Kind").
-	Text("Owner").
-	Text("Comment").
-	Text("Options").
-	Text("OwnerRoleType")
-
 var rowAccessPoliciesDef = g.NewInterface(
 	"RowAccessPolicies",
 	"RowAccessPolicy",
@@ -81,10 +59,18 @@ var rowAccessPoliciesDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-row-access-policies",
-		rowAccessPolicyDbRow,
-		rowAccessPolicy,
+		g.StructPair("rowAccessPolicyDBRow", "RowAccessPolicy").
+			Text("created_on").
+			Text("name").
+			Text("database_name").
+			Text("schema_name").
+			Text("kind").
+			Text("owner").
+			OptionalText("comment", g.WithRequiredInPlain()).
+			Text("options").
+			Text("owner_role_type"),
 		g.NewQueryStruct("ShowRowAccessPolicies").
 			Show().
 			SQL("ROW ACCESS POLICIES").
@@ -96,19 +82,14 @@ var rowAccessPoliciesDef = g.NewInterface(
 		g.ShowByIDExtendedInFiltering,
 		g.ShowByIDLikeFiltering,
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSingleValue,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-row-access-policy",
-		g.DbStruct("describeRowAccessPolicyDBRow").
-			Field("name", "string").
-			Field("signature", "string").
-			Field("return_type", "string").
-			Field("body", "string"),
-		g.PlainStruct("RowAccessPolicyDescription").
-			Field("Name", "string").
-			Field("Signature", "[]TableColumnSignature").
-			Field("ReturnType", "string").
-			Field("Body", "string"),
+		g.StructPair("describeRowAccessPolicyDBRow", "RowAccessPolicyDescription").
+			Text("name").
+			Field("signature", "string", "[]TableColumnSignature").
+			Text("return_type").
+			Text("body"),
 		g.NewQueryStruct("DescribeRowAccessPolicy").
 			Describe().
 			SQL("ROW ACCESS POLICY").

--- a/pkg/sdk/generator/defs/secrets_def.go
+++ b/pkg/sdk/generator/defs/secrets_def.go
@@ -8,55 +8,30 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/generator/gen/sdkcommons"
 )
 
-var secretDbRow = g.DbStruct("secretDBRow").
-	Field("created_on", "time.Time").
-	Field("name", "string").
-	Field("schema_name", "string").
-	Field("database_name", "string").
-	Field("owner", "string").
-	Field("comment", "sql.NullString").
-	Field("secret_type", "string").
-	Field("oauth_scopes", "sql.NullString").
-	Field("owner_role_type", "string")
+var secretPairs = g.StructPair("secretDBRow", "Secret").
+	Time("created_on").
+	Text("name").
+	Text("schema_name").
+	Text("database_name").
+	Text("owner").
+	OptionalText("comment").
+	Text("secret_type").
+	Field("oauth_scopes", "sql.NullString", "[]string").
+	Text("owner_role_type")
 
-var secret = g.PlainStruct("Secret").
-	Field("CreatedOn", "time.Time").
-	Field("Name", "string").
-	Field("SchemaName", "string").
-	Field("DatabaseName", "string").
-	Field("Owner", "string").
-	Field("Comment", "*string").
-	Field("SecretType", "string").
-	Field("OauthScopes", "[]string").
-	Field("OwnerRoleType", "string")
-
-var secretDetailsDbRow = g.DbStruct("secretDetailsDBRow").
-	Field("created_on", "time.Time").
-	Field("name", "string").
-	Field("schema_name", "string").
-	Field("database_name", "string").
-	Field("owner", "string").
-	Field("comment", "sql.NullString").
-	Field("secret_type", "string").
-	Field("username", "sql.NullString").
-	Field("oauth_access_token_expiry_time", "*time.Time").
-	Field("oauth_refresh_token_expiry_time", "*time.Time").
-	Field("oauth_scopes", "sql.NullString").
-	Field("integration_name", "sql.NullString")
-
-var secretDetails = g.PlainStruct("SecretDetails").
-	Field("CreatedOn", "time.Time").
-	Field("Name", "string").
-	Field("SchemaName", "string").
-	Field("DatabaseName", "string").
-	Field("Owner", "string").
-	Field("Comment", "*string").
-	Field("SecretType", "string").
-	Field("Username", "*string").
-	Field("OauthAccessTokenExpiryTime", "*time.Time").
-	Field("OauthRefreshTokenExpiryTime", "*time.Time").
-	Field("OauthScopes", "[]string").
-	Field("IntegrationName", "*string")
+var secretDetailsPairs = g.StructPair("secretDetailsDBRow", "SecretDetails").
+	Time("created_on").
+	Text("name").
+	Text("schema_name").
+	Text("database_name").
+	Text("owner").
+	OptionalText("comment").
+	Text("secret_type").
+	OptionalText("username").
+	Field("oauth_access_token_expiry_time", "*time.Time", "*time.Time").
+	Field("oauth_refresh_token_expiry_time", "*time.Time", "*time.Time").
+	Field("oauth_scopes", "sql.NullString", "[]string").
+	OptionalText("integration_name")
 
 var secretsApiIntegrationScopeDef = g.NewQueryStruct("ApiIntegrationScope").
 	Text("Scope", g.KeywordOptions().SingleQuotes().Required())
@@ -194,10 +169,9 @@ var secretsDef = g.NewInterface(
 		IfExists().
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-secrets",
-	secretDbRow,
-	secret,
+	secretPairs,
 	g.NewQueryStruct("ShowSecret").
 		Show().
 		SQL("SECRETS").
@@ -206,11 +180,10 @@ var secretsDef = g.NewInterface(
 ).ShowByIdOperationWithFiltering(
 	g.ShowByIDLikeFiltering,
 	g.ShowByIDExtendedInFiltering,
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSingleValue,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-secret",
-	secretDetailsDbRow,
-	secretDetails,
+	secretDetailsPairs,
 	g.NewQueryStruct("DescribeSecret").
 		Describe().
 		SQL("SECRET").

--- a/pkg/sdk/generator/defs/security_integrations_def.go
+++ b/pkg/sdk/generator/defs/security_integrations_def.go
@@ -663,41 +663,29 @@ var securityIntegrationsDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-integration",
-		g.DbStruct("securityIntegrationDescRow").
-			Field("property", "string").
-			Field("property_type", "string").
-			Field("property_value", "string").
-			Field("property_default", "string"),
-		g.PlainStruct("SecurityIntegrationProperty").
-			Field("Name", "string").
-			Field("Type", "string").
-			Field("Value", "string").
-			Field("Default", "string"),
+		g.StructPair("securityIntegrationDescRow", "SecurityIntegrationProperty").
+			Text("property", g.WithPlainFieldName("Name")).
+			Text("property_type", g.WithPlainFieldName("Type")).
+			Text("property_value", g.WithPlainFieldName("Value")).
+			Text("property_default", g.WithPlainFieldName("Default")),
 		g.NewQueryStruct("DescSecurityIntegration").
 			Describe().
 			SQL("SECURITY INTEGRATION").
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-integrations",
-		g.DbStruct("securityIntegrationShowRow").
+		g.StructPair("securityIntegrationShowRow", "SecurityIntegration").
 			Text("name").
-			Text("type").
+			Text("type", g.WithPlainFieldName("IntegrationType")).
 			Text("category").
 			Bool("enabled").
-			OptionalText("comment").
+			OptionalText("comment", g.WithRequiredInPlain()).
 			Time("created_on"),
-		g.PlainStruct("SecurityIntegration").
-			Text("Name").
-			Text("IntegrationType").
-			Text("Category").
-			Bool("Enabled").
-			Text("Comment").
-			Time("CreatedOn"),
 		g.NewQueryStruct("ShowSecurityIntegrations").
 			Show().
 			SQL("SECURITY INTEGRATIONS").

--- a/pkg/sdk/generator/defs/semantic_views_def.go
+++ b/pkg/sdk/generator/defs/semantic_views_def.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/generator/gen/sdkcommons"
 )
 
-var semanticViewDbRow = g.DbStruct("semanticViewDBRow").
+var semanticViewPairs = g.StructPair("semanticViewDBRow", "SemanticView").
 	Time("created_on").
 	Text("name").
 	Text("database_name").
@@ -16,29 +16,12 @@ var semanticViewDbRow = g.DbStruct("semanticViewDBRow").
 	Text("owner_role_type").
 	OptionalText("extension")
 
-var semanticView = g.PlainStruct("SemanticView").
-	Time("CreatedOn").
-	Text("Name").
-	Text("DatabaseName").
-	Text("SchemaName").
-	OptionalText("Comment").
-	Text("Owner").
-	Text("OwnerRoleType").
-	OptionalText("Extension")
-
-var semanticViewDetailsDbRow = g.DbStruct("semanticViewDetailsRow").
+var semanticViewDetailsPairs = g.StructPair("semanticViewDetailsRow", "SemanticViewDetails").
 	OptionalText("object_kind").
 	OptionalText("object_name").
 	OptionalText("parent_entity").
 	Text("property").
 	Text("property_value")
-
-var semanticViewDetails = g.PlainStruct("SemanticViewDetails").
-	OptionalText("ObjectKind").
-	OptionalText("ObjectName").
-	OptionalText("ParentEntity").
-	Text("Property").
-	Text("PropertyValue")
 
 var semanticViewsDef = g.NewInterface(
 	"SemanticViews",
@@ -92,21 +75,19 @@ var semanticViewsDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-semantic-view",
-		semanticViewDetailsDbRow,
-		semanticViewDetails,
+		semanticViewDetailsPairs,
 		g.NewQueryStruct("DescribeSemanticView").
 			Describe().
 			SQL("SEMANTIC VIEW").
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-semantic-views",
-		semanticViewDbRow,
-		semanticView,
+		semanticViewPairs,
 		g.NewQueryStruct("ShowSemanticViews").
 			Show().
 			Terse().

--- a/pkg/sdk/generator/defs/sequences_def.go
+++ b/pkg/sdk/generator/defs/sequences_def.go
@@ -51,30 +51,19 @@ var sequencesDef = g.NewInterface(
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ValidIdentifierIfSet, "RenameTo").
 		WithValidation(g.ExactlyOneValueSet, "RenameTo", "SetIncrement", "Set", "UnsetComment"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-sequences",
-	g.DbStruct("sequenceRow").
-		Field("created_on", "string").
-		Field("name", "string").
-		Field("schema_name", "string").
-		Field("database_name", "string").
-		Field("next_value", "int").
-		Field("interval", "int").
-		Field("owner", "string").
-		Field("owner_role_type", "string").
-		Field("comment", "string").
-		Field("ordered", "string"),
-	g.PlainStruct("Sequence").
-		Field("CreatedOn", "string").
-		Field("Name", "string").
-		Field("SchemaName", "string").
-		Field("DatabaseName", "string").
-		Field("NextValue", "int").
-		Field("Interval", "int").
-		Field("Owner", "string").
-		Field("OwnerRoleType", "string").
-		Field("Comment", "string").
-		Field("Ordered", "bool"),
+	g.StructPair("sequenceRow", "Sequence").
+		Text("created_on").
+		Text("name").
+		Text("schema_name").
+		Text("database_name").
+		Number("next_value").
+		Number("interval").
+		Text("owner").
+		Text("owner_role_type").
+		Text("comment").
+		Field("ordered", "string", "bool"),
 	g.NewQueryStruct("ShowSequences").
 		Show().
 		SQL("SEQUENCES").
@@ -83,31 +72,20 @@ var sequencesDef = g.NewInterface(
 ).ShowByIdOperationWithFiltering(
 	g.ShowByIDInFiltering,
 	g.ShowByIDLikeFiltering,
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSingleValue,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-sequence",
-	g.DbStruct("sequenceDetailRow").
-		Field("created_on", "string").
-		Field("name", "string").
-		Field("schema_name", "string").
-		Field("database_name", "string").
-		Field("next_value", "int").
-		Field("interval", "int").
-		Field("owner", "string").
-		Field("owner_role_type", "string").
-		Field("comment", "string").
-		Field("ordered", "string"),
-	g.PlainStruct("SequenceDetail").
-		Field("CreatedOn", "string").
-		Field("Name", "string").
-		Field("SchemaName", "string").
-		Field("DatabaseName", "string").
-		Field("NextValue", "int").
-		Field("Interval", "int").
-		Field("Owner", "string").
-		Field("OwnerRoleType", "string").
-		Field("Comment", "string").
-		Field("Ordered", "bool"),
+	g.StructPair("sequenceDetailRow", "SequenceDetail").
+		Text("created_on").
+		Text("name").
+		Text("schema_name").
+		Text("database_name").
+		Number("next_value").
+		Number("interval").
+		Text("owner").
+		Text("owner_role_type").
+		Text("comment").
+		Field("ordered", "string", "bool"),
 	g.NewQueryStruct("DescribeSequence").
 		Describe().
 		SQL("SEQUENCE").

--- a/pkg/sdk/generator/defs/services_def.go
+++ b/pkg/sdk/generator/defs/services_def.go
@@ -141,15 +141,15 @@ var servicesDef = g.NewInterface(
 		Name().
 		OptionalSQL("FORCE").
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-services",
-	g.DbStruct("servicesRow").
+	g.StructPair("servicesRow", "Service").
 		Text("name").
-		Text("status").
+		PlainField("status", "ServiceStatus").
 		Text("database_name").
 		Text("schema_name").
 		Text("owner").
-		Text("compute_pool").
+		AccountObjectIdentifier("compute_pool", g.WithPlainFieldName("ComputePool")).
 		Text("dns_name").
 		Number("current_instances").
 		Number("target_instances").
@@ -157,7 +157,7 @@ var servicesDef = g.NewInterface(
 		Number("min_instances").
 		Number("max_instances").
 		Bool("auto_resume").
-		OptionalText("external_access_integrations").
+		Field("external_access_integrations", "sql.NullString", "[]AccountObjectIdentifier").
 		Time("created_on").
 		Time("updated_on").
 		OptionalTime("resumed_on").
@@ -165,42 +165,13 @@ var servicesDef = g.NewInterface(
 		Number("auto_suspend_secs").
 		OptionalText("comment").
 		Text("owner_role_type").
-		OptionalText("query_warehouse").
+		Field("query_warehouse", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("QueryWarehouse")).
 		Bool("is_job").
 		Bool("is_async_job").
 		Text("spec_digest").
 		Bool("is_upgrading").
 		OptionalText("managing_object_domain").
 		OptionalText("managing_object_name"),
-	g.PlainStruct("Service").
-		Text("Name").
-		Field("Status", "ServiceStatus").
-		Text("DatabaseName").
-		Text("SchemaName").
-		Text("Owner").
-		Field("ComputePool", "AccountObjectIdentifier").
-		Text("DnsName").
-		Number("CurrentInstances").
-		Number("TargetInstances").
-		Number("MinReadyInstances").
-		Number("MinInstances").
-		Number("MaxInstances").
-		Bool("AutoResume").
-		Field("ExternalAccessIntegrations", "[]AccountObjectIdentifier").
-		Time("CreatedOn").
-		Time("UpdatedOn").
-		OptionalTime("ResumedOn").
-		OptionalTime("SuspendedOn").
-		Number("AutoSuspendSecs").
-		OptionalText("Comment").
-		Text("OwnerRoleType").
-		Field("QueryWarehouse", "*AccountObjectIdentifier").
-		Bool("IsJob").
-		Bool("IsAsyncJob").
-		Text("SpecDigest").
-		Bool("IsUpgrading").
-		OptionalText("ManagingObjectDomain").
-		OptionalText("ManagingObjectName"),
 	g.NewQueryStruct("ShowServices").
 		Show().
 		OptionalSQL("JOB").
@@ -214,16 +185,16 @@ var servicesDef = g.NewInterface(
 ).ShowByIdOperationWithFiltering(
 	g.ShowByIDLikeFiltering,
 	g.ShowByIDServiceInFiltering,
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSingleValue,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-service",
-	g.DbStruct("serviceDescRow").
+	g.StructPair("serviceDescRow", "ServiceDetails").
 		Text("name").
-		Text("status").
+		PlainField("status", "ServiceStatus").
 		Text("database_name").
 		Text("schema_name").
 		Text("owner").
-		Text("compute_pool").
+		AccountObjectIdentifier("compute_pool", g.WithPlainFieldName("ComputePool")).
 		Text("spec").
 		Text("dns_name").
 		Number("current_instances").
@@ -232,7 +203,7 @@ var servicesDef = g.NewInterface(
 		Number("min_instances").
 		Number("max_instances").
 		Bool("auto_resume").
-		OptionalText("external_access_integrations").
+		Field("external_access_integrations", "sql.NullString", "[]AccountObjectIdentifier").
 		Time("created_on").
 		Time("updated_on").
 		OptionalTime("resumed_on").
@@ -240,43 +211,13 @@ var servicesDef = g.NewInterface(
 		Number("auto_suspend_secs").
 		OptionalText("comment").
 		Text("owner_role_type").
-		OptionalText("query_warehouse").
+		Field("query_warehouse", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("QueryWarehouse")).
 		Bool("is_job").
 		Bool("is_async_job").
 		Text("spec_digest").
 		Bool("is_upgrading").
 		OptionalText("managing_object_domain").
 		OptionalText("managing_object_name"),
-	g.PlainStruct("ServiceDetails").
-		Text("Name").
-		Field("Status", "ServiceStatus").
-		Text("DatabaseName").
-		Text("SchemaName").
-		Text("Owner").
-		Field("ComputePool", "AccountObjectIdentifier").
-		Text("Spec").
-		Text("DnsName").
-		Number("CurrentInstances").
-		Number("TargetInstances").
-		Number("MinReadyInstances").
-		Number("MinInstances").
-		Number("MaxInstances").
-		Bool("AutoResume").
-		Field("ExternalAccessIntegrations", "[]AccountObjectIdentifier").
-		Time("CreatedOn").
-		Time("UpdatedOn").
-		OptionalTime("ResumedOn").
-		OptionalTime("SuspendedOn").
-		Number("AutoSuspendSecs").
-		OptionalText("Comment").
-		Text("OwnerRoleType").
-		Field("QueryWarehouse", "*AccountObjectIdentifier").
-		Bool("IsJob").
-		Bool("IsAsyncJob").
-		Text("SpecDigest").
-		Bool("IsUpgrading").
-		OptionalText("ManagingObjectDomain").
-		OptionalText("ManagingObjectName"),
 	g.NewQueryStruct("DescService").
 		Describe().
 		SQL("SERVICE").

--- a/pkg/sdk/generator/defs/session_policies_def.go
+++ b/pkg/sdk/generator/defs/session_policies_def.go
@@ -81,28 +81,18 @@ var sessionPoliciesDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-session-policies",
-		g.DbStruct("showSessionPolicyDBRow").
-			Field("created_on", "string").
-			Field("name", "string").
-			Field("database_name", "string").
-			Field("schema_name", "string").
-			Field("kind", "string").
-			Field("owner", "string").
-			Field("comment", "string").
-			Field("owner_role_type", "string").
-			Field("options", "string"),
-		g.PlainStruct("SessionPolicy").
-			Field("CreatedOn", "string").
-			Field("Name", "string").
-			Field("DatabaseName", "string").
-			Field("SchemaName", "string").
-			Field("Kind", "string").
-			Field("Owner", "string").
-			Field("Comment", "string").
-			Field("OwnerRoleType", "string").
-			Field("Options", "string"),
+		g.StructPair("showSessionPolicyDBRow", "SessionPolicy").
+			Text("created_on").
+			Text("name").
+			Text("database_name").
+			Text("schema_name").
+			Text("kind").
+			Text("owner").
+			Text("comment").
+			Text("owner_role_type").
+			Text("options"),
 		g.NewQueryStruct("ShowSessionPolicies").
 			Show().
 			SQL("SESSION POLICIES").
@@ -113,19 +103,14 @@ var sessionPoliciesDef = g.NewInterface(
 			OptionalLimit(),
 	).
 	ShowByIdOperationWithFiltering(g.ShowByIDLikeFiltering, g.ShowByIDExtendedInFiltering).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-session-policy",
-		g.DbStruct("describeSessionPolicyDBRow").
+		g.StructPair("describeSessionPolicyDBRow", "SessionPolicyProperty").
 			Text("property").
 			Text("value").
 			Text("default").
 			Text("description"),
-		g.PlainStruct("SessionPolicyProperty").
-			Text("Property").
-			Text("Value").
-			Text("Default").
-			Text("Description"),
 		g.NewQueryStruct("DescribeSessionPolicy").
 			Describe().
 			SQL("SESSION POLICY").

--- a/pkg/sdk/generator/defs/stages_def.go
+++ b/pkg/sdk/generator/defs/stages_def.go
@@ -349,65 +349,41 @@ var stagesDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-stage",
-		g.DbStruct("stageDescRow").
-			Field("parent_property", "string").
-			Field("property", "string").
-			Field("property_type", "string").
-			Field("property_value", "string").
-			Field("property_default", "string"),
-		g.PlainStruct("StageProperty").
-			Field("Parent", "string").
-			Field("Name", "string").
-			Field("Type", "string").
-			Field("Value", "string").
-			Field("Default", "string"),
+		g.StructPair("stageDescRow", "StageProperty").
+			Text("parent_property", g.WithPlainFieldName("Parent")).
+			Text("property", g.WithPlainFieldName("Name")).
+			Text("property_type", g.WithPlainFieldName("Type")).
+			Text("property_value", g.WithPlainFieldName("Value")).
+			Text("property_default", g.WithPlainFieldName("Default")),
 		g.NewQueryStruct("DescStage").
 			Describe().
 			SQL("STAGE").
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-stages",
-		g.DbStruct("stageShowRow").
-			Field("created_on", "time.Time").
-			Field("name", "string").
-			Field("database_name", "string").
-			Field("schema_name", "string").
-			Field("url", "string").
-			Field("has_credentials", "string").
-			Field("has_encryption_key", "string").
-			Field("owner", "string").
-			Field("comment", "string").
-			Field("region", "sql.NullString").
-			Field("type", "string").
-			Field("cloud", "sql.NullString").
+		g.StructPair("stageShowRow", "Stage").
+			Time("created_on").
+			Text("name").
+			Text("database_name").
+			Text("schema_name").
+			Text("url").
+			Field("has_credentials", "string", "bool").
+			Field("has_encryption_key", "string", "bool").
+			Text("owner").
+			Text("comment").
+			OptionalText("region").
+			PlainField("type", "StageType").
+			Field("cloud", "sql.NullString", "*StageCloud").
 			// notification_channel is deprecated in Snowflake.
-			Field("storage_integration", "sql.NullString").
-			Field("endpoint", "sql.NullString").
-			Field("owner_role_type", "sql.NullString").
-			Field("directory_enabled", "string"),
-		g.PlainStruct("Stage").
-			Field("CreatedOn", "time.Time").
-			Field("Name", "string").
-			Field("DatabaseName", "string").
-			Field("SchemaName", "string").
-			Field("Url", "string").
-			Field("HasCredentials", "bool").
-			Field("HasEncryptionKey", "bool").
-			Field("Owner", "string").
-			Field("Comment", "string").
-			Field("Region", "*string").
-			Field("Type", "StageType").
-			Field("Cloud", "*StageCloud").
-			// notification_channel is deprecated in Snowflake.
-			Field("StorageIntegration", "*AccountObjectIdentifier").
-			Field("Endpoint", "*string").
-			Field("OwnerRoleType", "*string").
-			Field("DirectoryEnabled", "bool"),
+			Field("storage_integration", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("StorageIntegration")).
+			OptionalText("endpoint").
+			Field("owner_role_type", "sql.NullString", "*string").
+			Field("directory_enabled", "string", "bool"),
 		g.NewQueryStruct("ShowStages").
 			Show().
 			SQL("STAGES").

--- a/pkg/sdk/generator/defs/storage_integrations_def.go
+++ b/pkg/sdk/generator/defs/storage_integrations_def.go
@@ -134,22 +134,15 @@ var storageIntegrationsDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-integrations",
-		g.DbStruct("showStorageIntegrationsDbRow").
+		g.StructPair("showStorageIntegrationsDbRow", "StorageIntegration").
 			Text("name").
-			Text("type").
+			Text("type", g.WithPlainFieldName("StorageType")).
 			Text("category").
 			Bool("enabled").
-			OptionalText("comment").
+			OptionalText("comment", g.WithRequiredInPlain()).
 			Time("created_on"),
-		g.PlainStruct("StorageIntegration").
-			Text("Name").
-			Text("StorageType").
-			Text("Category").
-			Bool("Enabled").
-			Text("Comment").
-			Time("CreatedOn"),
 		g.NewQueryStruct("ShowStorageIntegrations").
 			Show().
 			SQL("STORAGE INTEGRATIONS").
@@ -158,19 +151,14 @@ var storageIntegrationsDef = g.NewInterface(
 	ShowByIdOperationWithFiltering(
 		g.ShowByIDLikeFiltering,
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-integration",
-		g.DbStruct("descStorageIntegrationsDbRow").
-			Text("property").
-			Text("property_type").
-			Text("property_value").
-			Text("property_default"),
-		g.PlainStruct("StorageIntegrationProperty").
-			Text("Name").
-			Text("Type").
-			Text("Value").
-			Text("Default"),
+		g.StructPair("descStorageIntegrationsDbRow", "StorageIntegrationProperty").
+			Text("property", g.WithPlainFieldName("Name")).
+			Text("property_type", g.WithPlainFieldName("Type")).
+			Text("property_value", g.WithPlainFieldName("Value")).
+			Text("property_default", g.WithPlainFieldName("Default")),
 		g.NewQueryStruct("DescribeStorageIntegration").
 			Describe().
 			SQL("STORAGE INTEGRATION").

--- a/pkg/sdk/generator/defs/streamlits_def.go
+++ b/pkg/sdk/generator/defs/streamlits_def.go
@@ -75,30 +75,19 @@ var streamlitsDef = g.NewInterface(
 		IfExists().
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-streamlits",
-	g.DbStruct("streamlitsRow").
-		Field("created_on", "string").
-		Field("name", "string").
-		Field("database_name", "string").
-		Field("schema_name", "string").
-		Field("title", "sql.NullString").
-		Field("owner", "string").
-		Field("comment", "sql.NullString").
-		Field("query_warehouse", "sql.NullString").
-		Field("url_id", "string").
-		Field("owner_role_type", "string"),
-	g.PlainStruct("Streamlit").
-		Field("CreatedOn", "string").
-		Field("Name", "string").
-		Field("DatabaseName", "string").
-		Field("SchemaName", "string").
-		Field("Title", "string").
-		Field("Owner", "string").
-		Field("Comment", "string").
-		Field("QueryWarehouse", "string").
-		Field("UrlId", "string").
-		Field("OwnerRoleType", "string"),
+	g.StructPair("streamlitsRow", "Streamlit").
+		Text("created_on").
+		Text("name").
+		Text("database_name").
+		Text("schema_name").
+		OptionalText("title", g.WithRequiredInPlain()).
+		Text("owner").
+		OptionalText("comment", g.WithRequiredInPlain()).
+		OptionalText("query_warehouse", g.WithRequiredInPlain()).
+		Text("url_id").
+		Text("owner_role_type"),
 	g.NewQueryStruct("ShowStreamlits").
 		Show().
 		Terse().
@@ -109,33 +98,21 @@ var streamlitsDef = g.NewInterface(
 ).ShowByIdOperationWithFiltering(
 	g.ShowByIDLikeFiltering,
 	g.ShowByIDInFiltering,
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSingleValue,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-streamlit",
-	g.DbStruct("streamlitsDetailRow").
-		Field("name", "string").
-		Field("title", "sql.NullString").
-		Field("root_location", "string").
-		Field("main_file", "string").
-		Field("query_warehouse", "sql.NullString").
-		Field("url_id", "string").
-		Field("default_packages", "string").
-		Field("user_packages", "string").
-		Field("import_urls", "string").
-		Field("external_access_integrations", "string").
-		Field("external_access_secrets", "string"),
-	g.PlainStruct("StreamlitDetail").
-		Field("Name", "string").
-		Field("Title", "string").
-		Field("RootLocation", "string").
-		Field("MainFile", "string").
-		Field("QueryWarehouse", "string").
-		Field("UrlId", "string").
-		Field("DefaultPackages", "string").
-		Field("UserPackages", "[]string").
-		Field("ImportUrls", "[]string").
-		Field("ExternalAccessIntegrations", "[]string").
-		Field("ExternalAccessSecrets", "string"),
+	g.StructPair("streamlitsDetailRow", "StreamlitDetail").
+		Text("name").
+		OptionalText("title", g.WithRequiredInPlain()).
+		Text("root_location").
+		Text("main_file").
+		OptionalText("query_warehouse", g.WithRequiredInPlain()).
+		Text("url_id").
+		Text("default_packages").
+		StringList("user_packages").
+		StringList("import_urls").
+		StringList("external_access_integrations").
+		Text("external_access_secrets"),
 	g.NewQueryStruct("DescribeStreamlit").
 		Describe().
 		SQL("STREAMLIT").

--- a/pkg/sdk/generator/defs/streams_def.go
+++ b/pkg/sdk/generator/defs/streams_def.go
@@ -24,39 +24,22 @@ var (
 			WithValidation(g.ExactlyOneValueSet, "At", "Before")
 	}
 
-	showStreamDbRowDef = g.DbStruct("showStreamsDbRow").
-				Field("created_on", "time.Time").
-				Field("name", "string").
-				Field("database_name", "string").
-				Field("schema_name", "string").
-				Field("owner", "sql.NullString").
-				Field("comment", "sql.NullString").
-				Field("table_name", "sql.NullString").
-				Field("source_type", "sql.NullString").
-				Field("base_tables", "sql.NullString").
-				Field("type", "sql.NullString").
-				Field("stale", "string").
-				Field("mode", "sql.NullString").
-				Field("stale_after", "sql.NullTime").
-				Field("invalid_reason", "sql.NullString").
-				Field("owner_role_type", "sql.NullString")
-
-	streamPlainStructDef = g.PlainStruct("Stream").
-				Field("CreatedOn", "time.Time").
-				Field("Name", "string").
-				Field("DatabaseName", "string").
-				Field("SchemaName", "string").
-				Field("Owner", "*string").
-				Field("Comment", "*string").
-				Field("TableName", "*string").
-				Field("SourceType", "*StreamSourceType").
-				Field("BaseTables", "[]string").
-				Field("Type", "*string").
-				Field("Stale", "bool").
-				Field("Mode", "*StreamMode").
-				Field("StaleAfter", "*time.Time").
-				Field("InvalidReason", "*string").
-				Field("OwnerRoleType", "*string")
+	streamPairs = g.StructPair("showStreamsDbRow", "Stream").
+			Time("created_on").
+			Text("name").
+			Text("database_name").
+			Text("schema_name").
+			OptionalText("owner").
+			OptionalText("comment").
+			OptionalText("table_name").
+			Field("source_type", "sql.NullString", "*StreamSourceType").
+			Field("base_tables", "sql.NullString", "[]string").
+			OptionalText("type").
+			Field("stale", "string", "bool").
+			Field("mode", "sql.NullString", "*StreamMode").
+			OptionalTime("stale_after").
+			OptionalText("invalid_reason").
+			OptionalText("owner_role_type")
 
 	streamsDef = g.NewInterface(
 		"Streams",
@@ -179,10 +162,9 @@ var (
 				Name().
 				WithValidation(g.ValidIdentifier, "name"),
 		).
-		ShowOperation(
+		ShowOperationWithPairedStructs(
 			"https://docs.snowflake.com/en/sql-reference/sql/show-streams",
-			showStreamDbRowDef,
-			streamPlainStructDef,
+			streamPairs,
 			g.NewQueryStruct("ShowStreams").
 				Show().
 				Terse().
@@ -196,11 +178,10 @@ var (
 			g.ShowByIDExtendedInFiltering,
 			g.ShowByIDLikeFiltering,
 		).
-		DescribeOperation(
+		DescribeOperationWithPairedStructs(
 			g.DescriptionMappingKindSingleValue,
 			"https://docs.snowflake.com/en/sql-reference/sql/desc-stream",
-			showStreamDbRowDef,
-			streamPlainStructDef,
+			streamPairs,
 			g.NewQueryStruct("DescribeStream").
 				Describe().
 				SQL("STREAM").

--- a/pkg/sdk/generator/defs/tasks_def.go
+++ b/pkg/sdk/generator/defs/tasks_def.go
@@ -6,55 +6,30 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/generator/gen/sdkcommons"
 )
 
-var taskDbRow = g.DbStruct("taskDBRow").
+var taskPairs = g.StructPair("taskDBRow", "Task").
 	Text("created_on").
 	Text("name").
 	Text("id").
 	Text("database_name").
 	Text("schema_name").
 	Text("owner").
-	OptionalText("comment").
-	OptionalText("warehouse").
-	OptionalText("schedule").
-	Text("predecessors").
-	Text("state").
+	OptionalText("comment", g.WithRequiredInPlain()).
+	Field("warehouse", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("Warehouse")).
+	OptionalText("schedule", g.WithRequiredInPlain()).
+	Field("predecessors", "string", "[]SchemaObjectIdentifier").
+	PlainField("state", "TaskState").
 	Text("definition").
-	OptionalText("condition").
-	Text("allow_overlapping_execution").
-	OptionalText("error_integration").
-	OptionalText("last_committed_on").
-	OptionalText("last_suspended_on").
+	OptionalText("condition", g.WithRequiredInPlain()).
+	Field("allow_overlapping_execution", "string", "bool").
+	Field("error_integration", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("ErrorIntegration")).
+	OptionalText("last_committed_on", g.WithRequiredInPlain()).
+	OptionalText("last_suspended_on", g.WithRequiredInPlain()).
 	Text("owner_role_type").
-	OptionalText("config").
-	OptionalText("budget").
-	Text("task_relations").
-	OptionalText("last_suspended_reason").
-	OptionalText("target_completion_interval")
-
-var task = g.PlainStruct("Task").
-	Text("CreatedOn").
-	Text("Name").
-	Text("Id").
-	Text("DatabaseName").
-	Text("SchemaName").
-	Text("Owner").
-	Text("Comment").
-	Field("Warehouse", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier]()).
-	Text("Schedule").
-	Field("Predecessors", g.KindOfTSlice[sdkcommons.SchemaObjectIdentifier]()).
-	Field("State", g.KindOfT[sdkcommons.TaskState]()).
-	Text("Definition").
-	Text("Condition").
-	Bool("AllowOverlappingExecution").
-	Field("ErrorIntegration", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier]()).
-	Text("LastCommittedOn").
-	Text("LastSuspendedOn").
-	Text("OwnerRoleType").
-	Text("Config").
-	Text("Budget").
-	Field("TaskRelations", "TaskRelations").
-	Text("LastSuspendedReason").
-	Field("TargetCompletionInterval", "*TaskTargetCompletionInterval")
+	OptionalText("config", g.WithRequiredInPlain()).
+	OptionalText("budget", g.WithRequiredInPlain()).
+	PlainField("task_relations", "TaskRelations").
+	OptionalText("last_suspended_reason", g.WithRequiredInPlain()).
+	Field("target_completion_interval", "sql.NullString", "*TaskTargetCompletionInterval", g.WithPlainFieldName("TargetCompletionInterval"))
 
 var taskCreateWarehouse = g.NewQueryStruct("CreateTaskWarehouse").
 	OptionalIdentifier("Warehouse", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().Equals().SQL("WAREHOUSE")).
@@ -212,10 +187,9 @@ var tasksDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-tasks",
-		taskDbRow,
-		task,
+		taskPairs,
 		g.NewQueryStruct("ShowTasks").
 			Show().
 			Terse().
@@ -230,11 +204,10 @@ var tasksDef = g.NewInterface(
 		g.ShowByIDExtendedInFiltering,
 		g.ShowByIDLikeFiltering,
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSingleValue,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-task",
-		taskDbRow,
-		task,
+		taskPairs,
 		g.NewQueryStruct("DescribeTask").
 			Describe().
 			SQL("TASK").

--- a/pkg/sdk/generator/defs/user_programmatic_access_tokens_def.go
+++ b/pkg/sdk/generator/defs/user_programmatic_access_tokens_def.go
@@ -8,29 +8,17 @@ import (
 
 var ProgrammaticAccessTokenStatusDef = g.NewEnum("ProgrammaticAccessTokenStatus", "ProgrammaticAccessTokenStatuses", "ACTIVE", "EXPIRED", "DISABLED")
 
-var programmaticAccessTokenResultDBRowDef = g.DbStruct("programmaticAccessTokenResultDBRow").
+var programmaticAccessTokenPairs = g.StructPair("programmaticAccessTokenResultDBRow", "ProgrammaticAccessToken").
 	Text("name").
-	Text("user_name").
-	Text("role_restriction").
+	AccountObjectIdentifier("user_name", g.WithPlainFieldName("UserName")).
+	OptionalAccountObjectIdentifier("role_restriction", g.WithPlainFieldName("RoleRestriction")).
 	Time("expires_at").
-	Text("status").
+	PlainField("status", "ProgrammaticAccessTokenStatus").
 	OptionalText("comment").
 	Time("created_on").
 	Text("created_by").
 	OptionalNumber("mins_to_bypass_network_policy_requirement").
 	OptionalText("rotated_to")
-
-var programmaticAccessTokenDef = g.PlainStruct("ProgrammaticAccessToken").
-	Text("Name").
-	Field("UserName", "AccountObjectIdentifier").
-	Field("RoleRestriction", "*AccountObjectIdentifier").
-	Time("ExpiresAt").
-	Field("Status", "ProgrammaticAccessTokenStatus").
-	OptionalText("Comment").
-	Time("CreatedOn").
-	Text("CreatedBy").
-	OptionalNumber("MinsToBypassNetworkPolicyRequirement").
-	OptionalText("RotatedTo")
 
 var addProgrammaticAccessTokenResultDBRowDef = g.DbStruct("addProgrammaticAccessTokenResultDBRow").
 	Text("token_name").
@@ -136,10 +124,9 @@ var userProgrammaticAccessTokensDef = g.NewInterface(
 		Name().
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ValidIdentifier, "UserName"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-user-programmatic-access-tokens",
-	programmaticAccessTokenResultDBRowDef,
-	programmaticAccessTokenDef,
+	programmaticAccessTokenPairs,
 	g.NewQueryStruct("ShowUserProgrammaticAccessTokens").
 		Show().
 		SQL("USER PROGRAMMATIC ACCESS TOKENS").

--- a/pkg/sdk/generator/defs/views_def.go
+++ b/pkg/sdk/generator/defs/views_def.go
@@ -6,64 +6,35 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/generator/gen/sdkcommons"
 )
 
-var viewDbRow = g.DbStruct("viewDBRow").
+var viewPairs = g.StructPair("viewDBRow", "View").
 	Text("created_on").
 	Text("name").
-	OptionalText("kind").
-	OptionalText("reserved").
+	OptionalText("kind", g.WithRequiredInPlain()).
+	OptionalText("reserved", g.WithRequiredInPlain()).
 	Text("database_name").
 	Text("schema_name").
-	OptionalText("owner").
-	OptionalText("comment").
-	OptionalText("text").
-	OptionalBool("is_secure").
-	OptionalBool("is_materialized").
-	OptionalText("owner_role_type").
-	OptionalText("change_tracking")
-
-var view = g.PlainStruct("View").
-	Text("CreatedOn").
-	Text("Name").
-	Text("Kind").
-	Text("Reserved").
-	Text("DatabaseName").
-	Text("SchemaName").
-	Text("Owner").
-	Text("Comment").
-	Text("Text").
-	Bool("IsSecure").
-	Bool("IsMaterialized").
-	Text("OwnerRoleType").
-	Text("ChangeTracking")
+	OptionalText("owner", g.WithRequiredInPlain()).
+	OptionalText("comment", g.WithRequiredInPlain()).
+	OptionalText("text", g.WithRequiredInPlain()).
+	OptionalBool("is_secure", g.WithRequiredInPlain()).
+	OptionalBool("is_materialized", g.WithRequiredInPlain()).
+	OptionalText("owner_role_type", g.WithRequiredInPlain()).
+	OptionalText("change_tracking", g.WithRequiredInPlain())
 
 // TODO [SNOW-965322]: extract common type for describe
-var viewDetailsDbRow = g.DbStruct("viewDetailsRow").
+var viewDetailsPairs = g.StructPair("viewDetailsRow", "ViewDetails").
 	Text("name").
-	Field("type", "DataType").
+	Field("type", "DataType", "DataType").
 	Text("kind").
-	Text("null").
+	Field("null?", "string", "bool", g.WithDbFieldName("Null"), g.WithPlainFieldName("IsNullable")).
 	OptionalText("default").
-	Text("primary key").
-	Text("unique key").
-	OptionalText("check").
+	Field("primary key", "string", "bool", g.WithPlainFieldName("IsPrimary")).
+	Field("unique key", "string", "bool", g.WithPlainFieldName("IsUnique")).
+	Field("check", "sql.NullString", "*bool").
 	OptionalText("expression").
 	OptionalText("comment").
-	OptionalText("policy name").
-	OptionalText("privacy domain")
-
-var viewDetails = g.PlainStruct("ViewDetails").
-	Text("Name").
-	Field("Type", "DataType").
-	Text("Kind").
-	Bool("IsNullable").
-	OptionalText("Default").
-	Bool("IsPrimary").
-	Bool("IsUnique").
-	OptionalBool("Check").
-	OptionalText("Expression").
-	OptionalText("Comment").
-	OptionalText("PolicyName").
-	OptionalText("PrivacyDomain")
+	OptionalText("policy name", g.WithPlainFieldName("PolicyName")).
+	OptionalText("privacy domain", g.WithPlainFieldName("PrivacyDomain"))
 
 var columnDef = g.NewQueryStruct("Column").
 	Text("Value", g.KeywordOptions().Required().DoubleQuotes())
@@ -294,10 +265,9 @@ var viewsDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
-	ShowOperation(
+	ShowOperationWithPairedStructs(
 		"https://docs.snowflake.com/en/sql-reference/sql/show-views",
-		viewDbRow,
-		view,
+		viewPairs,
 		g.NewQueryStruct("ShowViews").
 			Show().
 			Terse().
@@ -311,11 +281,10 @@ var viewsDef = g.NewInterface(
 		g.ShowByIDExtendedInFiltering,
 		g.ShowByIDLikeFiltering,
 	).
-	DescribeOperation(
+	DescribeOperationWithPairedStructs(
 		g.DescriptionMappingKindSlice,
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-view",
-		viewDetailsDbRow,
-		viewDetails,
+		viewDetailsPairs,
 		g.NewQueryStruct("DescribeView").
 			Describe().
 			SQL("VIEW").

--- a/pkg/sdk/generator/example/defs/paired_struct_def.go
+++ b/pkg/sdk/generator/example/defs/paired_struct_def.go
@@ -43,7 +43,23 @@ func pairedStructExampleAllOptions(dbName, plainName string) *g.PairedStructs {
 		// db string, plain AccountObjectIdentifier; plain name defaults to "Id"
 		AccountObjectIdentifier("account_id").
 		// db string, plain AccountObjectIdentifier; plain name overridden
-		AccountObjectIdentifier("second_account_id", g.WithPlainFieldName("OverriddenSecondAccountId"))
+		AccountObjectIdentifier("second_account_id", g.WithPlainFieldName("OverriddenSecondAccountId")).
+		// db string, plain *AccountObjectIdentifier; plain name overridden (default would be "Id")
+		OptionalAccountObjectIdentifier("optional_account_id", g.WithPlainFieldName("OptionalAccountId")).
+		// db string, plain *AccountObjectIdentifier; plain name overridden
+		OptionalAccountObjectIdentifier("optional_second_account_id", g.WithPlainFieldName("OverriddenOptionalAccountId")).
+		// db string, plain SchemaObjectIdentifier; plain name overridden (default would be "Id")
+		SchemaObjectIdentifier("schema_object_id", g.WithPlainFieldName("SchemaObjectId")).
+		// db string, plain SchemaObjectIdentifier; plain name overridden
+		SchemaObjectIdentifier("second_schema_object_id", g.WithPlainFieldName("OverriddenSchemaObjectId")).
+		// db string, plain *SchemaObjectIdentifier; plain name overridden (default would be "Id")
+		OptionalSchemaObjectIdentifier("optional_schema_object_id", g.WithPlainFieldName("OptionalSchemaObjectId")).
+		// db string, plain *SchemaObjectIdentifier; plain name overridden
+		OptionalSchemaObjectIdentifier("optional_second_schema_object_id", g.WithPlainFieldName("OverriddenOptionalSchemaObjectId")).
+		// db string, plain DatabaseObjectIdentifier; plain name overridden (default would be "Id")
+		DatabaseObjectIdentifier("database_object_id", g.WithPlainFieldName("DatabaseObjectId")).
+		// db string, plain DatabaseObjectIdentifier; plain name overridden
+		DatabaseObjectIdentifier("second_database_object_id", g.WithPlainFieldName("OverriddenDatabaseObjectId"))
 }
 
 // PairedStructExample demonstrates the PairedStructs single-definition approach.

--- a/pkg/sdk/generator/example/paired_struct_examples_gen.go
+++ b/pkg/sdk/generator/example/paired_struct_examples_gen.go
@@ -21,24 +21,32 @@ type ShowPairedStructExampleOptions struct {
 }
 
 type pairedStructExampleRow struct {
-	ObjectName                string         `db:"object_name"`
-	BothNonNullableStrings    string         `db:"both_non_nullable_strings"`
-	StorageTypeDb             string         `db:"type"`
-	BothNullableStrings       sql.NullString `db:"both_nullable_strings"`
-	OrganizationName          sql.NullString `db:"organization_name"`
-	IsPrimary                 bool           `db:"is_primary"`
-	IsDefault                 sql.NullBool   `db:"is_default"`
-	Enabled                   sql.NullBool   `db:"enabled"`
-	NextValue                 int            `db:"next_value"`
-	Port                      sql.NullInt64  `db:"port"`
-	RetryLimit                sql.NullInt64  `db:"retry_limit"`
-	CreatedOn                 time.Time      `db:"created_on"`
-	UpdatedAt                 sql.NullTime   `db:"updated_at"`
-	Primary                   string         `db:"primary"`
-	FailoverAllowedToAccounts string         `db:"failover_allowed_to_accounts"`
-	Tags                      string         `db:"tags"`
-	AccountId                 string         `db:"account_id"`
-	SecondAccountId           string         `db:"second_account_id"`
+	ObjectName                   string         `db:"object_name"`
+	BothNonNullableStrings       string         `db:"both_non_nullable_strings"`
+	StorageTypeDb                string         `db:"type"`
+	BothNullableStrings          sql.NullString `db:"both_nullable_strings"`
+	OrganizationName             sql.NullString `db:"organization_name"`
+	IsPrimary                    bool           `db:"is_primary"`
+	IsDefault                    sql.NullBool   `db:"is_default"`
+	Enabled                      sql.NullBool   `db:"enabled"`
+	NextValue                    int            `db:"next_value"`
+	Port                         sql.NullInt64  `db:"port"`
+	RetryLimit                   sql.NullInt64  `db:"retry_limit"`
+	CreatedOn                    time.Time      `db:"created_on"`
+	UpdatedAt                    sql.NullTime   `db:"updated_at"`
+	Primary                      string         `db:"primary"`
+	FailoverAllowedToAccounts    string         `db:"failover_allowed_to_accounts"`
+	Tags                         string         `db:"tags"`
+	AccountId                    string         `db:"account_id"`
+	SecondAccountId              string         `db:"second_account_id"`
+	OptionalAccountId            string         `db:"optional_account_id"`
+	OptionalSecondAccountId      string         `db:"optional_second_account_id"`
+	SchemaObjectId               string         `db:"schema_object_id"`
+	SecondSchemaObjectId         string         `db:"second_schema_object_id"`
+	OptionalSchemaObjectId       string         `db:"optional_schema_object_id"`
+	OptionalSecondSchemaObjectId string         `db:"optional_second_schema_object_id"`
+	DatabaseObjectId             string         `db:"database_object_id"`
+	SecondDatabaseObjectId       string         `db:"second_database_object_id"`
 }
 
 type PairedStructExample struct {
@@ -60,6 +68,14 @@ type PairedStructExample struct {
 	Tags                                 []string
 	Id                                   AccountObjectIdentifier
 	OverriddenSecondAccountId            AccountObjectIdentifier
+	OptionalAccountId                    *AccountObjectIdentifier
+	OverriddenOptionalAccountId          *AccountObjectIdentifier
+	SchemaObjectId                       SchemaObjectIdentifier
+	OverriddenSchemaObjectId             SchemaObjectIdentifier
+	OptionalSchemaObjectId               *SchemaObjectIdentifier
+	OverriddenOptionalSchemaObjectId     *SchemaObjectIdentifier
+	DatabaseObjectId                     DatabaseObjectIdentifier
+	OverriddenDatabaseObjectId           DatabaseObjectIdentifier
 }
 
 func (v *PairedStructExample) ObjectType() ObjectType {
@@ -74,24 +90,32 @@ type DescribePairedStructExampleOptions struct {
 }
 
 type pairedStructExampleDetailRow struct {
-	ObjectName                string         `db:"object_name"`
-	BothNonNullableStrings    string         `db:"both_non_nullable_strings"`
-	StorageTypeDb             string         `db:"type"`
-	BothNullableStrings       sql.NullString `db:"both_nullable_strings"`
-	OrganizationName          sql.NullString `db:"organization_name"`
-	IsPrimary                 bool           `db:"is_primary"`
-	IsDefault                 sql.NullBool   `db:"is_default"`
-	Enabled                   sql.NullBool   `db:"enabled"`
-	NextValue                 int            `db:"next_value"`
-	Port                      sql.NullInt64  `db:"port"`
-	RetryLimit                sql.NullInt64  `db:"retry_limit"`
-	CreatedOn                 time.Time      `db:"created_on"`
-	UpdatedAt                 sql.NullTime   `db:"updated_at"`
-	Primary                   string         `db:"primary"`
-	FailoverAllowedToAccounts string         `db:"failover_allowed_to_accounts"`
-	Tags                      string         `db:"tags"`
-	AccountId                 string         `db:"account_id"`
-	SecondAccountId           string         `db:"second_account_id"`
+	ObjectName                   string         `db:"object_name"`
+	BothNonNullableStrings       string         `db:"both_non_nullable_strings"`
+	StorageTypeDb                string         `db:"type"`
+	BothNullableStrings          sql.NullString `db:"both_nullable_strings"`
+	OrganizationName             sql.NullString `db:"organization_name"`
+	IsPrimary                    bool           `db:"is_primary"`
+	IsDefault                    sql.NullBool   `db:"is_default"`
+	Enabled                      sql.NullBool   `db:"enabled"`
+	NextValue                    int            `db:"next_value"`
+	Port                         sql.NullInt64  `db:"port"`
+	RetryLimit                   sql.NullInt64  `db:"retry_limit"`
+	CreatedOn                    time.Time      `db:"created_on"`
+	UpdatedAt                    sql.NullTime   `db:"updated_at"`
+	Primary                      string         `db:"primary"`
+	FailoverAllowedToAccounts    string         `db:"failover_allowed_to_accounts"`
+	Tags                         string         `db:"tags"`
+	AccountId                    string         `db:"account_id"`
+	SecondAccountId              string         `db:"second_account_id"`
+	OptionalAccountId            string         `db:"optional_account_id"`
+	OptionalSecondAccountId      string         `db:"optional_second_account_id"`
+	SchemaObjectId               string         `db:"schema_object_id"`
+	SecondSchemaObjectId         string         `db:"second_schema_object_id"`
+	OptionalSchemaObjectId       string         `db:"optional_schema_object_id"`
+	OptionalSecondSchemaObjectId string         `db:"optional_second_schema_object_id"`
+	DatabaseObjectId             string         `db:"database_object_id"`
+	SecondDatabaseObjectId       string         `db:"second_database_object_id"`
 }
 
 type PairedStructExampleDetail struct {
@@ -113,4 +137,12 @@ type PairedStructExampleDetail struct {
 	Tags                                 []string
 	Id                                   AccountObjectIdentifier
 	OverriddenSecondAccountId            AccountObjectIdentifier
+	OptionalAccountId                    *AccountObjectIdentifier
+	OverriddenOptionalAccountId          *AccountObjectIdentifier
+	SchemaObjectId                       SchemaObjectIdentifier
+	OverriddenSchemaObjectId             SchemaObjectIdentifier
+	OptionalSchemaObjectId               *SchemaObjectIdentifier
+	OverriddenOptionalSchemaObjectId     *SchemaObjectIdentifier
+	DatabaseObjectId                     DatabaseObjectIdentifier
+	OverriddenDatabaseObjectId           DatabaseObjectIdentifier
 }

--- a/pkg/sdk/generator/gen/paired_struct.go
+++ b/pkg/sdk/generator/gen/paired_struct.go
@@ -212,6 +212,48 @@ func (p *PairedStructs) AccountObjectIdentifier(dbColumnName string, opts ...Pai
 	return p.addField(dbColumnName, "string", "AccountObjectIdentifier", allOpts)
 }
 
+// OptionalAccountObjectIdentifier adds a nullable AccountObjectIdentifier field. The db kind is string
+// and the plain kind is *AccountObjectIdentifier. The plain field name defaults to "Id", but can be
+// overridden with WithPlainFieldName.
+//
+//	db:    <FieldName> string `db:"<dbColumnName>"`
+//	plain: Id *AccountObjectIdentifier
+func (p *PairedStructs) OptionalAccountObjectIdentifier(dbColumnName string, opts ...PairedFieldOption) *PairedStructs {
+	allOpts := append([]PairedFieldOption{WithPlainFieldName("Id")}, opts...)
+	return p.addField(dbColumnName, "string", "*AccountObjectIdentifier", allOpts)
+}
+
+// SchemaObjectIdentifier adds a SchemaObjectIdentifier field. The db kind is string and the plain kind
+// is SchemaObjectIdentifier. The plain field name defaults to "Id", but can be overridden with WithPlainFieldName.
+//
+//	db:    <FieldName> string `db:"<dbColumnName>"`
+//	plain: Id SchemaObjectIdentifier
+func (p *PairedStructs) SchemaObjectIdentifier(dbColumnName string, opts ...PairedFieldOption) *PairedStructs {
+	allOpts := append([]PairedFieldOption{WithPlainFieldName("Id")}, opts...)
+	return p.addField(dbColumnName, "string", "SchemaObjectIdentifier", allOpts)
+}
+
+// OptionalSchemaObjectIdentifier adds a nullable SchemaObjectIdentifier field. The db kind is string
+// and the plain kind is *SchemaObjectIdentifier. The plain field name defaults to "Id", but can be
+// overridden with WithPlainFieldName.
+//
+//	db:    <FieldName> string `db:"<dbColumnName>"`
+//	plain: Id *SchemaObjectIdentifier
+func (p *PairedStructs) OptionalSchemaObjectIdentifier(dbColumnName string, opts ...PairedFieldOption) *PairedStructs {
+	allOpts := append([]PairedFieldOption{WithPlainFieldName("Id")}, opts...)
+	return p.addField(dbColumnName, "string", "*SchemaObjectIdentifier", allOpts)
+}
+
+// DatabaseObjectIdentifier adds a DatabaseObjectIdentifier field. The db kind is string and the plain kind
+// is DatabaseObjectIdentifier. The plain field name defaults to "Id", but can be overridden with WithPlainFieldName.
+//
+//	db:    <FieldName> string `db:"<dbColumnName>"`
+//	plain: Id DatabaseObjectIdentifier
+func (p *PairedStructs) DatabaseObjectIdentifier(dbColumnName string, opts ...PairedFieldOption) *PairedStructs {
+	allOpts := append([]PairedFieldOption{WithPlainFieldName("Id")}, opts...)
+	return p.addField(dbColumnName, "string", "DatabaseObjectIdentifier", allOpts)
+}
+
 // asDbStruct materializes the definition as a *dbStruct following the old implementation.
 func (p *PairedStructs) asDbStruct() *dbStruct {
 	s := DbStruct(p.dbName)

--- a/pkg/sdk/hybrid_tables_gen.go
+++ b/pkg/sdk/hybrid_tables_gen.go
@@ -50,7 +50,7 @@ type HybridTableColumn struct {
 }
 
 type HybridTableOutOfLineConstraint struct {
-	Name               *string              `ddl:"parameter,no_equals,double_quotes" sql:"CONSTRAINT"`
+	Name               *string              `ddl:"parameter,double_quotes,no_equals" sql:"CONSTRAINT"`
 	Type               ColumnConstraintType `ddl:"keyword"`
 	Columns            []string             `ddl:"keyword,parentheses"`
 	ForeignKey         *OutOfLineForeignKey `ddl:"keyword"`
@@ -118,12 +118,12 @@ type HybridTableConstraintActionAdd struct {
 type HybridTableConstraintActionRename struct {
 	renameConstraint bool   `ddl:"static" sql:"RENAME CONSTRAINT"`
 	OldName          string `ddl:"keyword,double_quotes"`
-	NewName          string `ddl:"parameter,no_equals,double_quotes" sql:"TO"`
+	NewName          string `ddl:"parameter,double_quotes,no_equals" sql:"TO"`
 }
 
 type HybridTableConstraintActionDrop struct {
 	drop           bool     `ddl:"static" sql:"DROP"`
-	ConstraintName *string  `ddl:"parameter,no_equals,double_quotes" sql:"CONSTRAINT"`
+	ConstraintName *string  `ddl:"parameter,double_quotes,no_equals" sql:"CONSTRAINT"`
 	PrimaryKey     *bool    `ddl:"keyword" sql:"PRIMARY KEY"`
 	Unique         *bool    `ddl:"keyword" sql:"UNIQUE"`
 	ForeignKey     *bool    `ddl:"keyword" sql:"FOREIGN KEY"`
@@ -212,13 +212,14 @@ type DropHybridTableOptions struct {
 
 // ShowHybridTableOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-hybrid-tables.
 type ShowHybridTableOptions struct {
-	show         bool       `ddl:"static" sql:"SHOW"`
-	Terse        *bool      `ddl:"keyword" sql:"TERSE"`
-	hybridTables bool       `ddl:"static" sql:"HYBRID TABLES"`
-	Like         *Like      `ddl:"keyword" sql:"LIKE"`
-	In           *TableIn   `ddl:"keyword" sql:"IN"`
-	StartsWith   *string    `ddl:"parameter,single_quotes,no_equals" sql:"STARTS WITH"`
-	Limit        *LimitFrom `ddl:"keyword" sql:"LIMIT"`
+	show         bool  `ddl:"static" sql:"SHOW"`
+	Terse        *bool `ddl:"keyword" sql:"TERSE"`
+	hybridTables bool  `ddl:"static" sql:"HYBRID TABLES"`
+	Like         *Like `ddl:"keyword" sql:"LIKE"`
+	// adjusted manually
+	In         *TableIn   `ddl:"keyword" sql:"IN"`
+	StartsWith *string    `ddl:"parameter,single_quotes,no_equals" sql:"STARTS WITH"`
+	Limit      *LimitFrom `ddl:"keyword" sql:"LIMIT"`
 }
 
 type hybridTableRow struct {
@@ -315,9 +316,10 @@ type DropIndexHybridTableOptions struct {
 
 // ShowIndexesHybridTableOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-indexes.
 type ShowIndexesHybridTableOptions struct {
-	show       bool       `ddl:"static" sql:"SHOW"`
-	indexes    bool       `ddl:"static" sql:"INDEXES"`
-	Like       *Like      `ddl:"keyword" sql:"LIKE"`
+	show    bool  `ddl:"static" sql:"SHOW"`
+	indexes bool  `ddl:"static" sql:"INDEXES"`
+	Like    *Like `ddl:"keyword" sql:"LIKE"`
+	// adjusted manually
 	In         *TableIn   `ddl:"keyword" sql:"IN"`
 	StartsWith *string    `ddl:"parameter,single_quotes,no_equals" sql:"STARTS WITH"`
 	Limit      *LimitFrom `ddl:"keyword" sql:"LIMIT"`

--- a/pkg/sdk/materialized_views_gen.go
+++ b/pkg/sdk/materialized_views_gen.go
@@ -174,10 +174,9 @@ type DescribeMaterializedViewOptions struct {
 }
 
 type materializedViewDetailsRow struct {
-	Name string   `db:"name"`
-	Type DataType `db:"type"`
-	Kind string   `db:"kind"`
-	// manually adjusted name
+	Name       string         `db:"name"`
+	Type       DataType       `db:"type"`
+	Kind       string         `db:"kind"`
 	Null       string         `db:"null?"`
 	Default    sql.NullString `db:"default"`
 	PrimaryKey string         `db:"primary key"`

--- a/pkg/sdk/semantic_views_gen.go
+++ b/pkg/sdk/semantic_views_gen.go
@@ -108,6 +108,7 @@ type SemanticSqlExpression struct {
 }
 
 type FactDefinition struct {
+	// adjusted manually
 	isPrivate          *bool               `ddl:"keyword" sql:"PRIVATE"`
 	semanticExpression *SemanticExpression `ddl:"keyword"`
 }
@@ -117,6 +118,7 @@ type DimensionDefinition struct {
 }
 
 type MetricDefinition struct {
+	// adjusted manually
 	isPrivate                      *bool                           `ddl:"keyword" sql:"PRIVATE"`
 	semanticExpression             *SemanticExpression             `ddl:"keyword"`
 	windowFunctionMetricDefinition *WindowFunctionMetricDefinition `ddl:"keyword"`

--- a/pkg/sdk/views_gen.go
+++ b/pkg/sdk/views_gen.go
@@ -282,10 +282,9 @@ type DescribeViewOptions struct {
 }
 
 type viewDetailsRow struct {
-	Name string   `db:"name"`
-	Type DataType `db:"type"`
-	Kind string   `db:"kind"`
-	// adjusted manually
+	Name          string         `db:"name"`
+	Type          DataType       `db:"type"`
+	Kind          string         `db:"kind"`
 	Null          string         `db:"null?"`
 	Default       sql.NullString `db:"default"`
 	PrimaryKey    string         `db:"primary key"`


### PR DESCRIPTION
Migrate the majority db/plain struct definitions to the paired struct approach, which is essential before the `convert` generation
- SDK was regenerated to validate no changes in these structs
- new helpers were introduced
- add missing comments (`manually adjusted`)
- notably the columns with `?` are now natively supported without problems

Follow-ups:
- migrate the structs used in custom operations
- decide what about the db/plain structs that have the varying attributes length (e.g. functions, procedures)