### PR TITLE
chore: Add Identifier First Login validation

### DIFF
--- a/pkg/acceptance/helpers/1_prerequisites.go
+++ b/pkg/acceptance/helpers/1_prerequisites.go
@@ -23,6 +23,18 @@ func (c *TestClient) EnsureQuotedIdentifiersIgnoreCaseIsSetToFalse(ctx context.C
 	return nil
 }
 
+func (c *TestClient) EnsureEnableIdentifierFirstLoginIsSetToTrue(ctx context.Context) error {
+	log.Printf("[DEBUG] Making sure ENABLE_IDENTIFIER_FIRST_LOGIN parameter is set correctly")
+	param, err := c.context.client.Parameters.ShowAccountParameter(ctx, sdk.AccountParameterEnableIdentifierFirstLogin)
+	if err != nil {
+		return fmt.Errorf("checking ENABLE_IDENTIFIER_FIRST_LOGIN resulted in error: %w", err)
+	}
+	if param.Value != "true" {
+		return fmt.Errorf("parameter ENABLE_IDENTIFIER_FIRST_LOGIN has value %s, expected: true", param.Value)
+	}
+	return nil
+}
+
 func (c *TestClient) EnsureEssentialRolesExist(ctx context.Context) error {
 	log.Printf("[DEBUG] Making sure essential roles exist")
 	type RoleGrant struct {

--- a/pkg/sdk/testint/setup_test.go
+++ b/pkg/sdk/testint/setup_test.go
@@ -223,11 +223,12 @@ func (itc *integrationTestContext) initialize() error {
 		}
 		itc.secondaryWarehouse = secondaryWarehouse
 
-		err = testClientHelper().EnsureQuotedIdentifiersIgnoreCaseIsSetToFalse(itc.ctx)
-		if err != nil {
-			return err
-		}
-		err = secondaryTestClientHelper().EnsureQuotedIdentifiersIgnoreCaseIsSetToFalse(itc.secondaryCtx)
+		err = errors.Join(
+			testClientHelper().EnsureQuotedIdentifiersIgnoreCaseIsSetToFalse(itc.ctx),
+			testClientHelper().EnsureEnableIdentifierFirstLoginIsSetToTrue(itc.ctx),
+			secondaryTestClientHelper().EnsureQuotedIdentifiersIgnoreCaseIsSetToFalse(itc.secondaryCtx),
+			secondaryTestClientHelper().EnsureEnableIdentifierFirstLoginIsSetToTrue(itc.secondaryCtx),
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/testacc/0_setup_test.go
+++ b/pkg/testacc/0_setup_test.go
@@ -178,7 +178,9 @@ func (atc *acceptanceTestContext) initialize() error {
 
 		errs := errors.Join(
 			testClient().EnsureQuotedIdentifiersIgnoreCaseIsSetToFalse(ctx),
+			testClient().EnsureEnableIdentifierFirstLoginIsSetToTrue(ctx),
 			secondaryTestClient().EnsureQuotedIdentifiersIgnoreCaseIsSetToFalse(ctx),
+			secondaryTestClient().EnsureEnableIdentifierFirstLoginIsSetToTrue(ctx),
 			testClient().EnsureEssentialRolesExist(ctx),
 			secondaryTestClient().EnsureEssentialRolesExist(ctx),
 		)


### PR DESCRIPTION
## Changes
- Add a validation step for the ENABLE_IDENTIFIER_FIRST_LOGIN parameter in the integration and acceptance tests