### PR TITLE
feat: nested none/all/roles for allowed and blocked secondary roles

### DIFF
--- a/docs/resources/session_policy.md
+++ b/docs/resources/session_policy.md
@@ -25,15 +25,33 @@ resource "snowflake_session_policy" "basic" {
 }
 
 ## Complete (with every optional set)
-resource "snowflake_session_policy" "timeouts" {
+resource "snowflake_session_policy" "complete" {
   database                     = "database_name"
   schema                       = "schema_name"
-  name                         = "session_policy_timeouts"
+  name                         = "session_policy_name"
   session_idle_timeout_mins    = 60
   session_ui_idle_timeout_mins = 60
-  allowed_secondary_roles      = ["ROLE_A", "ROLE_B"]
-  blocked_secondary_roles      = ["ROLE_C", "ROLE_D"]
-  comment                      = "My session policy"
+  allowed_secondary_roles {
+    roles = ["ROLE_A", "ROLE_B"]
+  }
+  blocked_secondary_roles {
+    roles = ["ROLE_C", "ROLE_D"]
+  }
+  comment = "My session policy"
+}
+
+## Secondary roles using all / none
+resource "snowflake_session_policy" "secondary_roles_all_none" {
+  database = "database_name"
+  schema   = "schema_name"
+  name     = "session_policy_name"
+
+  allowed_secondary_roles {
+    all = true
+  }
+  blocked_secondary_roles {
+    none = true
+  }
 }
 ```
 
@@ -50,8 +68,8 @@ resource "snowflake_session_policy" "timeouts" {
 
 ### Optional
 
-- `allowed_secondary_roles` (Set of String) Specifies the allowed secondary roles for a session policy, if any. Use a single-element set whose only value is `all` (case-insensitive) to allow all secondary roles, equivalent to `('ALL')` in Snowflake.
-- `blocked_secondary_roles` (Set of String) Specifies the blocked secondary roles for a session policy, if any. Blocked secondary roles take precedence over allowed secondary roles. Use a single-element set whose only value is `all` (case-insensitive) to disallow all secondary roles, equivalent to `('ALL')` in Snowflake.
+- `allowed_secondary_roles` (Block List, Max: 1) Specifies the allowed secondary roles for a session policy, if any. (see [below for nested schema](#nestedblock--allowed_secondary_roles))
+- `blocked_secondary_roles` (Block List, Max: 1) Specifies the blocked secondary roles for a session policy, if any. Blocked secondary roles take precedence over allowed secondary roles. (see [below for nested schema](#nestedblock--blocked_secondary_roles))
 - `comment` (String) Specifies a comment for the session policy.
 - `session_idle_timeout_mins` (Number) For Snowflake clients and programmatic clients, specifies the number of minutes in which a session can be idle before users must authenticate to Snowflake again.
 - `session_ui_idle_timeout_mins` (Number) For Snowsight, specifies the number of minutes in which a session can be idle before users must authenticate to Snowflake again.
@@ -63,6 +81,26 @@ resource "snowflake_session_policy" "timeouts" {
 - `fully_qualified_name` (String) Fully qualified name of the resource. For more information, see [object name resolution](https://docs.snowflake.com/en/sql-reference/name-resolution).
 - `id` (String) The ID of this resource.
 - `show_output` (List of Object) Outputs the result of `SHOW SESSION POLICIES` for this session policy. (see [below for nested schema](#nestedatt--show_output))
+
+<a id="nestedblock--allowed_secondary_roles"></a>
+### Nested Schema for `allowed_secondary_roles`
+
+Optional:
+
+- `all` (Boolean) When true, allows all secondary roles.
+- `none` (Boolean) When true, disallows all secondary roles.
+- `roles` (Set of String) Specifies roles to be allowed as secondary roles.
+
+
+<a id="nestedblock--blocked_secondary_roles"></a>
+### Nested Schema for `blocked_secondary_roles`
+
+Optional:
+
+- `all` (Boolean) When true, disallows all secondary roles.
+- `none` (Boolean) When true, allows all secondary roles.
+- `roles` (Set of String) Specifies roles to be blocked as secondary roles.
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/examples/resources/snowflake_session_policy/resource.tf
+++ b/examples/resources/snowflake_session_policy/resource.tf
@@ -6,13 +6,31 @@ resource "snowflake_session_policy" "basic" {
 }
 
 ## Complete (with every optional set)
-resource "snowflake_session_policy" "timeouts" {
+resource "snowflake_session_policy" "complete" {
   database                     = "database_name"
   schema                       = "schema_name"
-  name                         = "session_policy_timeouts"
+  name                         = "session_policy_name"
   session_idle_timeout_mins    = 60
   session_ui_idle_timeout_mins = 60
-  allowed_secondary_roles      = ["ROLE_A", "ROLE_B"]
-  blocked_secondary_roles      = ["ROLE_C", "ROLE_D"]
-  comment                      = "My session policy"
+  allowed_secondary_roles {
+    roles = ["ROLE_A", "ROLE_B"]
+  }
+  blocked_secondary_roles {
+    roles = ["ROLE_C", "ROLE_D"]
+  }
+  comment = "My session policy"
+}
+
+## Secondary roles using all / none
+resource "snowflake_session_policy" "secondary_roles_all_none" {
+  database = "database_name"
+  schema   = "schema_name"
+  name     = "session_policy_name"
+
+  allowed_secondary_roles {
+    all = true
+  }
+  blocked_secondary_roles {
+    none = true
+  }
 }

--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/session_policy_resource_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/session_policy_resource_ext.go
@@ -1,0 +1,47 @@
+package resourceassert
+
+import (
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
+)
+
+func (s *SessionPolicyResourceAssert) HasNoAllowedSecondaryRoles() *SessionPolicyResourceAssert {
+	s.AddAssertion(assert.ValueSet("allowed_secondary_roles.#", "1"))
+	s.AddAssertion(assert.ValueSet("allowed_secondary_roles.0.none", "true"))
+	return s
+}
+
+func (s *SessionPolicyResourceAssert) HasAllowedSecondaryRoles(expected ...string) *SessionPolicyResourceAssert {
+	if len(expected) == 0 {
+		return s.HasNoAllowedSecondaryRoles()
+	}
+	s.AddAssertion(assert.ValueSet("allowed_secondary_roles.#", "1"))
+	s.SetContainsExactlyStringValues("allowed_secondary_roles.0.roles", expected...)
+	return s
+}
+
+func (s *SessionPolicyResourceAssert) HasAllAllowedSecondaryRoles() *SessionPolicyResourceAssert {
+	s.AddAssertion(assert.ValueSet("allowed_secondary_roles.#", "1"))
+	s.AddAssertion(assert.ValueSet("allowed_secondary_roles.0.all", "true"))
+	return s
+}
+
+func (s *SessionPolicyResourceAssert) HasNoBlockedSecondaryRoles() *SessionPolicyResourceAssert {
+	s.AddAssertion(assert.ValueSet("blocked_secondary_roles.#", "1"))
+	s.AddAssertion(assert.ValueSet("blocked_secondary_roles.0.none", "true"))
+	return s
+}
+
+func (s *SessionPolicyResourceAssert) HasBlockedSecondaryRoles(expected ...string) *SessionPolicyResourceAssert {
+	if len(expected) == 0 {
+		return s.HasNoBlockedSecondaryRoles()
+	}
+	s.AddAssertion(assert.ValueSet("blocked_secondary_roles.#", "1"))
+	s.SetContainsExactlyStringValues("blocked_secondary_roles.0.roles", expected...)
+	return s
+}
+
+func (s *SessionPolicyResourceAssert) HasAllBlockedSecondaryRoles() *SessionPolicyResourceAssert {
+	s.AddAssertion(assert.ValueSet("blocked_secondary_roles.#", "1"))
+	s.AddAssertion(assert.ValueSet("blocked_secondary_roles.0.all", "true"))
+	return s
+}

--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/session_policy_resource_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/session_policy_resource_gen.go
@@ -47,15 +47,9 @@ func (s *SessionPolicyResourceAssert) HasName(expected string) *SessionPolicyRes
 	return s
 }
 
-func (s *SessionPolicyResourceAssert) HasAllowedSecondaryRoles(expected ...string) *SessionPolicyResourceAssert {
-	s.SetContainsExactlyStringValues("allowed_secondary_roles", expected...)
-	return s
-}
+// typed assert for "allowed_secondary_roles" (type: List, subtype: Map) is not currently supported
 
-func (s *SessionPolicyResourceAssert) HasBlockedSecondaryRoles(expected ...string) *SessionPolicyResourceAssert {
-	s.SetContainsExactlyStringValues("blocked_secondary_roles", expected...)
-	return s
-}
+// typed assert for "blocked_secondary_roles" (type: List, subtype: Map) is not currently supported
 
 func (s *SessionPolicyResourceAssert) HasComment(expected string) *SessionPolicyResourceAssert {
 	s.StringValueSet("comment", expected)

--- a/pkg/acceptance/bettertestspoc/config/model/session_policy_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/session_policy_model_ext.go
@@ -5,20 +5,42 @@ import (
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 )
 
+func (s *SessionPolicyModel) WithAllowedSecondaryRolesNone() *SessionPolicyModel {
+	return s.WithAllowedSecondaryRolesValue(tfconfig.ListVariable(tfconfig.ObjectVariable(map[string]tfconfig.Variable{
+		"none": tfconfig.BoolVariable(true),
+	})))
+}
+
+func (s *SessionPolicyModel) WithAllowedSecondaryRolesAll() *SessionPolicyModel {
+	return s.WithAllowedSecondaryRolesValue(tfconfig.ListVariable(tfconfig.ObjectVariable(map[string]tfconfig.Variable{
+		"all": tfconfig.BoolVariable(true),
+	})))
+}
+
 func (s *SessionPolicyModel) WithAllowedSecondaryRoles(roles ...string) *SessionPolicyModel {
-	return s.WithAllowedSecondaryRolesValue(
-		tfconfig.SetVariable(
-			collections.Map(roles, func(role string) tfconfig.Variable {
-				return tfconfig.StringVariable(role)
-			})...,
-		))
+	return s.WithAllowedSecondaryRolesValue(tfconfig.ListVariable(tfconfig.ObjectVariable(map[string]tfconfig.Variable{
+		"roles": tfconfig.SetVariable(collections.Map(roles, func(role string) tfconfig.Variable {
+			return tfconfig.StringVariable(role)
+		})...),
+	})))
+}
+
+func (s *SessionPolicyModel) WithBlockedSecondaryRolesNone() *SessionPolicyModel {
+	return s.WithBlockedSecondaryRolesValue(tfconfig.ListVariable(tfconfig.ObjectVariable(map[string]tfconfig.Variable{
+		"none": tfconfig.BoolVariable(true),
+	})))
+}
+
+func (s *SessionPolicyModel) WithBlockedSecondaryRolesAll() *SessionPolicyModel {
+	return s.WithBlockedSecondaryRolesValue(tfconfig.ListVariable(tfconfig.ObjectVariable(map[string]tfconfig.Variable{
+		"all": tfconfig.BoolVariable(true),
+	})))
 }
 
 func (s *SessionPolicyModel) WithBlockedSecondaryRoles(roles ...string) *SessionPolicyModel {
-	return s.WithBlockedSecondaryRolesValue(
-		tfconfig.SetVariable(
-			collections.Map(roles, func(role string) tfconfig.Variable {
-				return tfconfig.StringVariable(role)
-			})...,
-		))
+	return s.WithBlockedSecondaryRolesValue(tfconfig.ListVariable(tfconfig.ObjectVariable(map[string]tfconfig.Variable{
+		"roles": tfconfig.SetVariable(collections.Map(roles, func(role string) tfconfig.Variable {
+			return tfconfig.StringVariable(role)
+		})...),
+	})))
 }

--- a/pkg/resources/session_policy.go
+++ b/pkg/resources/session_policy.go
@@ -54,35 +54,22 @@ var sessionPolicySchema = map[string]*schema.Schema{
 		ValidateFunc:     validation.IntAtLeast(1),
 	},
 	"allowed_secondary_roles": {
-		Type:     schema.TypeSet,
-		Optional: true,
-		Description: joinWithSpace("Specifies the allowed secondary roles for a session policy, if any.",
-			"Use a single-element set whose only value is `all` (case-insensitive) to allow all secondary roles, equivalent to `('ALL')` in Snowflake."),
-		DiffSuppressFunc: SuppressIfAny(
-			IgnoreChangeToCurrentSnowflakeValueInDescribe("allowed_secondary_roles"),
-			NormalizeAndCompareIdentifiersInSet("allowed_secondary_roles"),
-		),
-		Elem: &schema.Schema{
-			Type:             schema.TypeString,
-			ValidateDiagFunc: IsValidIdentifier[sdk.AccountObjectIdentifier](),
-			DiffSuppressFunc: suppressIdentifierQuoting,
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "Specifies the allowed secondary roles for a session policy, if any.",
+		Elem: &schema.Resource{
+			Schema: sessionPolicySecondaryRolesSchema("allowed_secondary_roles"),
 		},
 	},
 	"blocked_secondary_roles": {
-		Type:     schema.TypeSet,
+		Type:     schema.TypeList,
 		Optional: true,
+		MaxItems: 1,
 		Description: joinWithSpace("Specifies the blocked secondary roles for a session policy, if any.",
-			"Blocked secondary roles take precedence over allowed secondary roles.",
-			"Use a single-element set whose only value is `all` (case-insensitive) to disallow all secondary roles, equivalent to `('ALL')` in Snowflake.",
-		),
-		DiffSuppressFunc: SuppressIfAny(
-			IgnoreChangeToCurrentSnowflakeValueInDescribe("blocked_secondary_roles"),
-			NormalizeAndCompareIdentifiersInSet("blocked_secondary_roles"),
-		),
-		Elem: &schema.Schema{
-			Type:             schema.TypeString,
-			ValidateDiagFunc: IsValidIdentifier[sdk.AccountObjectIdentifier](),
-			DiffSuppressFunc: suppressIdentifierQuoting,
+			"Blocked secondary roles take precedence over allowed secondary roles."),
+		Elem: &schema.Resource{
+			Schema: sessionPolicySecondaryRolesSchema("blocked_secondary_roles"),
 		},
 	},
 	"comment": {
@@ -109,6 +96,46 @@ var sessionPolicySchema = map[string]*schema.Schema{
 	FullyQualifiedNameAttributeName: schemas.FullyQualifiedNameSchema,
 }
 
+func sessionPolicySecondaryRolesSchema(attrName string) map[string]*schema.Schema {
+	allDescription, noneDescription := "When true, allows all secondary roles.", "When true, disallows all secondary roles."
+	action := "allowed"
+	if attrName == "blocked_secondary_roles" {
+		allDescription, noneDescription = noneDescription, allDescription
+		action = "blocked"
+	}
+
+	exactlyOneOf := func(attrName string) []string {
+		return collections.Map([]string{"none", "all", "roles"}, func(elem string) string {
+			return fmt.Sprintf("%s.0.%s", attrName, elem)
+		})
+	}
+
+	return map[string]*schema.Schema{
+		"none": {
+			Type:         schema.TypeBool,
+			Optional:     true,
+			Description:  noneDescription,
+			ExactlyOneOf: exactlyOneOf(attrName),
+		},
+		"all": {
+			Type:         schema.TypeBool,
+			Optional:     true,
+			Description:  allDescription,
+			ExactlyOneOf: exactlyOneOf(attrName),
+		},
+		"roles": {
+			Type:         schema.TypeSet,
+			Optional:     true,
+			Description:  fmt.Sprintf("Specifies roles to be %s as secondary roles.", action),
+			ExactlyOneOf: exactlyOneOf(attrName),
+			Elem: &schema.Schema{
+				Type:             schema.TypeString,
+				ValidateDiagFunc: IsValidIdentifier[sdk.AccountObjectIdentifier](),
+			},
+		},
+	}
+}
+
 func SessionPolicy() *schema.Resource {
 	deleteFunc := ResourceDeleteContextFunc(
 		sdk.ParseSchemaObjectIdentifier,
@@ -131,7 +158,9 @@ func SessionPolicy() *schema.Resource {
 		Timeouts: defaultTimeouts,
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.SessionPolicy, customdiff.All(
 			ComputedIfAnyAttributeChanged(sessionPolicySchema, ShowOutputAttributeName, "name", "schema", "database", "comment"),
-			ComputedIfAnyAttributeChanged(sessionPolicySchema, DescribeOutputAttributeName, "name", "schema", "database", "session_idle_timeout_mins", "session_ui_idle_timeout_mins", "allowed_secondary_roles", "blocked_secondary_roles", "comment"),
+			// For now, the set/list fields have to be excluded.
+			// TODO [SNOW-1648997]: address the above comment
+			ComputedIfAnyAttributeChanged(sessionPolicySchema, DescribeOutputAttributeName, "name", "schema", "database", "session_idle_timeout_mins", "session_ui_idle_timeout_mins", "comment"),
 			ComputedIfAnyAttributeChanged(sessionPolicySchema, FullyQualifiedNameAttributeName, "name", "schema", "database"),
 		)),
 	}
@@ -148,8 +177,8 @@ func CreateSessionPolicy(ctx context.Context, d *schema.ResourceData, meta any) 
 	errs := errors.Join(
 		intAttributeCreateBuilder(d, "session_idle_timeout_mins", request.WithSessionIdleTimeoutMins),
 		intAttributeCreateBuilder(d, "session_ui_idle_timeout_mins", request.WithSessionUiIdleTimeoutMins),
-		secondaryRolesAttributeCreateBuilder(d, "allowed_secondary_roles", request.WithAllowedSecondaryRoles),
-		secondaryRolesAttributeCreateBuilder(d, "blocked_secondary_roles", request.WithBlockedSecondaryRoles),
+		attributeMappedValueCreateBuilder(d, "allowed_secondary_roles", request.WithAllowedSecondaryRoles, buildSessionPolicySecondaryRolesRequest),
+		attributeMappedValueCreateBuilder(d, "blocked_secondary_roles", request.WithBlockedSecondaryRoles, buildSessionPolicySecondaryRolesRequest),
 		stringAttributeCreateBuilder(d, "comment", request.WithComment),
 	)
 	if errs != nil {
@@ -197,14 +226,14 @@ func ReadSessionPolicyFunc(withExternalChangesMarking bool) schema.ReadContextFu
 				return diag.FromErr(err)
 			}
 			normalizeStringList := func(v any) any {
-				if list, ok := v.([]interface{}); ok {
+				if list, ok := v.([]any); ok {
 					return expandStringList(list)
 				}
 				return v
 			}
 			if err = handleExternalChangesToObjectInFlatDescribeDeepEqual(d,
-				outputMapping{"allowed_secondary_roles", "allowed_secondary_roles", details.AllowedSecondaryRoles, details.AllowedSecondaryRoles, normalizeStringList},
-				outputMapping{"blocked_secondary_roles", "blocked_secondary_roles", details.BlockedSecondaryRoles, details.BlockedSecondaryRoles, normalizeStringList},
+				outputMapping{"allowed_secondary_roles", "allowed_secondary_roles", details.AllowedSecondaryRoles, secondaryRolesResourceStateFromDescribeOutput(details.AllowedSecondaryRoles), normalizeStringList},
+				outputMapping{"blocked_secondary_roles", "blocked_secondary_roles", details.BlockedSecondaryRoles, secondaryRolesResourceStateFromDescribeOutput(details.BlockedSecondaryRoles), normalizeStringList},
 			); err != nil {
 				return diag.FromErr(err)
 			}
@@ -245,8 +274,8 @@ func UpdateSessionPolicy(ctx context.Context, d *schema.ResourceData, meta any) 
 	if err := errors.Join(
 		intAttributeUpdate(d, "session_idle_timeout_mins", &setRequest.SessionIdleTimeoutMins, &unsetRequest.SessionIdleTimeoutMins),
 		intAttributeUpdate(d, "session_ui_idle_timeout_mins", &setRequest.SessionUiIdleTimeoutMins, &unsetRequest.SessionUiIdleTimeoutMins),
-		secondaryRolesAttributeUpdate(d, "allowed_secondary_roles", &setRequest.AllowedSecondaryRoles, &unsetRequest.AllowedSecondaryRoles),
-		secondaryRolesAttributeUpdate(d, "blocked_secondary_roles", &setRequest.BlockedSecondaryRoles, &unsetRequest.BlockedSecondaryRoles),
+		attributeMappedValueUpdate(d, "allowed_secondary_roles", &setRequest.AllowedSecondaryRoles, &unsetRequest.AllowedSecondaryRoles, buildSessionPolicySecondaryRolesRequest),
+		attributeMappedValueUpdate(d, "blocked_secondary_roles", &setRequest.BlockedSecondaryRoles, &unsetRequest.BlockedSecondaryRoles, buildSessionPolicySecondaryRolesRequest),
 		stringAttributeUpdate(d, "comment", &setRequest.Comment, &unsetRequest.Comment),
 	); err != nil {
 		return diag.FromErr(err)
@@ -266,47 +295,48 @@ func UpdateSessionPolicy(ctx context.Context, d *schema.ResourceData, meta any) 
 	return ReadSessionPolicyFunc(false)(ctx, d, meta)
 }
 
-func secondaryRolesAttributeCreateBuilder[T any](d *schema.ResourceData, key string, setValue func(request sdk.SessionPolicySecondaryRolesRequest) *T) error {
-	if v, ok := d.GetOk(key); ok {
-		secondaryRolesRaw := v.(*schema.Set).List()
-		request, err := buildSessionPolicySecondaryRolesRequest(secondaryRolesRaw)
-		if err != nil {
-			return err
-		}
-		setValue(*request)
+func buildSessionPolicySecondaryRolesRequest(v any) (sdk.SessionPolicySecondaryRolesRequest, error) {
+	list := v.([]any)
+	if len(list) == 0 {
+		return sdk.SessionPolicySecondaryRolesRequest{}, fmt.Errorf("session policy secondary roles block is empty")
 	}
-	return nil
-}
-
-func secondaryRolesAttributeUpdate(d *schema.ResourceData, key string, setField **sdk.SessionPolicySecondaryRolesRequest, unsetField **bool) error {
-	if d.HasChange(key) {
-		if v, ok := d.GetOk(key); ok {
-			request, err := buildSessionPolicySecondaryRolesRequest(v.(*schema.Set).List())
-			if err != nil {
-				return err
-			}
-			*setField = request
-		} else {
-			*unsetField = sdk.Bool(true)
-		}
-	}
-	return nil
-}
-
-func buildSessionPolicySecondaryRolesRequest(rawRoles []any) (*sdk.SessionPolicySecondaryRolesRequest, error) {
-	roles := expandStringList(rawRoles)
+	block := list[0].(map[string]any)
 	request := sdk.NewSessionPolicySecondaryRolesRequest()
-	switch {
-	case len(roles) == 0:
-		request.WithNone(true)
-	case len(roles) == 1 && strings.EqualFold("ALL", roles[0]):
-		request.WithAll(true)
-	default:
-		mapped, err := collections.MapErr(roles, sdk.ParseAccountObjectIdentifier)
-		if err != nil {
-			return nil, err
-		}
-		request.WithRoles(mapped)
+	if block["none"].(bool) {
+		return *request.WithNone(true), nil
 	}
-	return request, nil
+	if block["all"].(bool) {
+		return *request.WithAll(true), nil
+	}
+	rawRoles := block["roles"].(*schema.Set).List()
+	roles := expandStringList(rawRoles)
+	ids, err := collections.MapErr(roles, sdk.ParseAccountObjectIdentifier)
+	if err != nil {
+		return sdk.SessionPolicySecondaryRolesRequest{}, err
+	}
+	return *request.WithRoles(ids), nil
+}
+
+// secondaryRolesResourceStateFromDescribeOutput converts DESCRIBE output (list of role names, empty list,
+// or a single ALL sentinel) into the nested block shape used by allowed_secondary_roles / blocked_secondary_roles.
+func secondaryRolesResourceStateFromDescribeOutput(roles []string) []any {
+	if len(roles) == 0 {
+		return []any{
+			map[string]any{"none": true},
+		}
+	}
+	if len(roles) == 1 && strings.EqualFold(roles[0], "ALL") {
+		return []any{
+			map[string]any{"all": true},
+		}
+	}
+	elems := make([]any, len(roles))
+	for i, r := range roles {
+		elems[i] = r
+	}
+	return []any{
+		map[string]any{
+			"roles": schema.NewSet(schema.HashString, elems),
+		},
+	}
 }

--- a/pkg/testacc/resource_session_policy_acceptance_test.go
+++ b/pkg/testacc/resource_session_policy_acceptance_test.go
@@ -52,9 +52,8 @@ func TestAcc_SessionPolicy_BasicUseCase(t *testing.T) {
 	altered := model.SessionPolicy("t", newId.DatabaseName(), newId.SchemaName(), newId.Name()).
 		WithSessionIdleTimeoutMins(sessionIdleTimeoutMins).
 		WithSessionUiIdleTimeoutMins(sessionUiIdleTimeoutMins).
-		// TODO: make it possible to provide an empty list
-		// WithAllowedSecondaryRoles().
-		WithBlockedSecondaryRoles("all").
+		WithAllowedSecondaryRolesNone().
+		WithBlockedSecondaryRolesAll().
 		WithComment(comment)
 
 	allAttributes := model.SessionPolicy("t", id.DatabaseName(), id.SchemaName(), id.Name()).
@@ -114,8 +113,8 @@ func TestAcc_SessionPolicy_BasicUseCase(t *testing.T) {
 			HasDatabase(newId.DatabaseName()).
 			HasSessionIdleTimeoutMins(sessionIdleTimeoutMins).
 			HasSessionUiIdleTimeoutMins(sessionUiIdleTimeoutMins).
-			HasAllowedSecondaryRolesEmpty().
-			HasBlockedSecondaryRoles("all").
+			HasNoAllowedSecondaryRoles().
+			HasAllBlockedSecondaryRoles().
 			HasComment(comment),
 		resourceshowoutputassert.SessionPolicyShowOutput(t, ref).
 			HasName(newId.Name()).
@@ -132,9 +131,7 @@ func TestAcc_SessionPolicy_BasicUseCase(t *testing.T) {
 			HasComment(comment).
 			HasSessionIdleTimeoutMins(sessionIdleTimeoutMins).
 			HasSessionUiIdleTimeoutMins(sessionUiIdleTimeoutMins).
-			// TODO: uncomment the line below
-			// HasNoAllowedSecondaryRoles().
-			HasAllowedSecondaryRoles("ALL").
+			HasNoAllowedSecondaryRoles().
 			HasBlockedSecondaryRoles("ALL"),
 	}
 
@@ -267,12 +264,16 @@ func TestAcc_SessionPolicy_BasicUseCase(t *testing.T) {
 							plancheck.ExpectResourceAction(ref, plancheck.ResourceActionUpdate),
 							planchecks.ExpectDrift(ref, "session_idle_timeout_mins", sessionIdle, externalSessionIdle),
 							planchecks.ExpectDrift(ref, "session_ui_idle_timeout_mins", sessionUiIdle, externalSessionUiIdle),
-							// Don't check allowed_secondary_roles, as the order of elements is unpredictable
-							planchecks.ExpectDrift(ref, "blocked_secondary_roles", blockedSecondaryRoles, sdk.String("[ALL]")),
+							// Don't check allowed_secondary_roles.0.roles, as the order of elements is unpredictable
+							planchecks.ExpectDrift(ref, "allowed_secondary_roles.0.none", sdk.String("false"), sdk.String("true")),
+							planchecks.ExpectDrift(ref, "blocked_secondary_roles.0.roles", blockedSecondaryRoles, sdk.String("[]")),
+							planchecks.ExpectDrift(ref, "blocked_secondary_roles.0.all", sdk.String("false"), sdk.String("true")),
 							planchecks.ExpectDrift(ref, "comment", sdk.String(comment), sdk.String(externalComment)),
 							planchecks.ExpectChange(ref, "session_idle_timeout_mins", tfjson.ActionUpdate, externalSessionIdle, sessionIdle),
 							planchecks.ExpectChange(ref, "session_ui_idle_timeout_mins", tfjson.ActionUpdate, externalSessionUiIdle, sessionUiIdle),
-							planchecks.ExpectChange(ref, "blocked_secondary_roles", tfjson.ActionUpdate, sdk.String("[ALL]"), blockedSecondaryRoles),
+							planchecks.ExpectChange(ref, "allowed_secondary_roles.0.none", tfjson.ActionUpdate, sdk.String("true"), nil),
+							planchecks.ExpectChange(ref, "blocked_secondary_roles.0.roles", tfjson.ActionUpdate, sdk.String("[]"), blockedSecondaryRoles),
+							planchecks.ExpectChange(ref, "blocked_secondary_roles.0.all", tfjson.ActionUpdate, sdk.String("true"), nil),
 							planchecks.ExpectChange(ref, "comment", tfjson.ActionUpdate, sdk.String(externalComment), sdk.String(comment)),
 						}
 					}(),

--- a/pkg/testacc/resource_session_policy_acceptance_test.go
+++ b/pkg/testacc/resource_session_policy_acceptance_test.go
@@ -56,6 +56,13 @@ func TestAcc_SessionPolicy_BasicUseCase(t *testing.T) {
 		WithBlockedSecondaryRolesAll().
 		WithComment(comment)
 
+	altered2 := model.SessionPolicy("t", newId.DatabaseName(), newId.SchemaName(), newId.Name()).
+		WithSessionIdleTimeoutMins(sessionIdleTimeoutMins).
+		WithSessionUiIdleTimeoutMins(sessionUiIdleTimeoutMins).
+		WithAllowedSecondaryRolesAll().
+		WithBlockedSecondaryRolesNone().
+		WithComment(comment)
+
 	allAttributes := model.SessionPolicy("t", id.DatabaseName(), id.SchemaName(), id.Name()).
 		WithSessionIdleTimeoutMins(sessionIdleTimeoutMins).
 		WithSessionUiIdleTimeoutMins(sessionUiIdleTimeoutMins).
@@ -135,6 +142,35 @@ func TestAcc_SessionPolicy_BasicUseCase(t *testing.T) {
 			HasBlockedSecondaryRoles("ALL"),
 	}
 
+	alteredAssertions2 := []assert.TestCheckFuncProvider{
+		resourceassert.SessionPolicyResource(t, ref).
+			HasName(newId.Name()).
+			HasSchema(newId.SchemaName()).
+			HasDatabase(newId.DatabaseName()).
+			HasSessionIdleTimeoutMins(sessionIdleTimeoutMins).
+			HasSessionUiIdleTimeoutMins(sessionUiIdleTimeoutMins).
+			HasAllAllowedSecondaryRoles().
+			HasNoBlockedSecondaryRoles().
+			HasComment(comment),
+		resourceshowoutputassert.SessionPolicyShowOutput(t, ref).
+			HasName(newId.Name()).
+			HasDatabaseName(newId.DatabaseName()).
+			HasSchemaName(newId.SchemaName()).
+			HasKind("SESSION_POLICY").
+			HasOwner(snowflakeroles.Accountadmin.Name()).
+			HasComment(comment).
+			HasOwnerRoleType("ROLE").
+			HasOptions(""),
+		resourceshowoutputassert.SessionPolicyDescribeOutput(t, ref).
+			HasOwner(snowflakeroles.Accountadmin.Name()).
+			HasOwnerRoleType("ROLE").
+			HasComment(comment).
+			HasSessionIdleTimeoutMins(sessionIdleTimeoutMins).
+			HasSessionUiIdleTimeoutMins(sessionUiIdleTimeoutMins).
+			HasAllowedSecondaryRoles("ALL").
+			HasNoBlockedSecondaryRoles(),
+	}
+
 	completeAssertions := []assert.TestCheckFuncProvider{
 		resourceassert.SessionPolicyResource(t, ref).
 			HasName(id.Name()).
@@ -197,6 +233,16 @@ func TestAcc_SessionPolicy_BasicUseCase(t *testing.T) {
 				},
 				Config: config.FromModels(t, altered),
 				Check:  assertThat(t, alteredAssertions...),
+			},
+			// Change all secondary roles to none and vice versa
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(ref, plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: config.FromModels(t, altered2),
+				Check:  assertThat(t, alteredAssertions2...),
 			},
 			// Unset
 			{
@@ -266,6 +312,8 @@ func TestAcc_SessionPolicy_BasicUseCase(t *testing.T) {
 							planchecks.ExpectDrift(ref, "session_ui_idle_timeout_mins", sessionUiIdle, externalSessionUiIdle),
 							// Don't check allowed_secondary_roles.0.roles, as the order of elements is unpredictable
 							planchecks.ExpectDrift(ref, "allowed_secondary_roles.0.none", sdk.String("false"), sdk.String("true")),
+							planchecks.ExpectNoChangeOnField(ref, "allowed_secondary_roles.0.all"),
+							planchecks.ExpectNoChangeOnField(ref, "blocked_secondary_roles.0.none"),
 							planchecks.ExpectDrift(ref, "blocked_secondary_roles.0.roles", blockedSecondaryRoles, sdk.String("[]")),
 							planchecks.ExpectDrift(ref, "blocked_secondary_roles.0.all", sdk.String("false"), sdk.String("true")),
 							planchecks.ExpectDrift(ref, "comment", sdk.String(comment), sdk.String(externalComment)),


### PR DESCRIPTION
Follow-up to 0f0ca926. Removes the TODO about session_policy resource limits: an empty allowed_secondary_roles set could not express “disallow all” secondary roles.

Model each side as a single nested block with exactly one of none, all, or roles set; update docs and examples accordingly.