### PR TITLE
fix: tag propagation field

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -46,6 +46,8 @@ The `propagate` field is now treated as nullable: when the column is absent from
 
 No changes in configuration are required. Users on standard accounts who experienced a crash on plan or apply should be able to use the `snowflake_tag` resource normally after upgrading.
 
+References: [#4651](https://github.com/snowflakedb/terraform-provider-snowflake/issues/4651)
+
 ## v2.14.x ➞ v2.15.0
 
 ### **IMPORTANT** *(improvement)* Go driver bumped to v2

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -36,13 +36,13 @@ No changes are required for existing configurations unless you want to manage se
 
 ### *(bugfix)* Fixed `snowflake_tag` crash on Standard accounts
 
-In v2.15.0 we added the `propagate` field to the `snowflake_tag` resource. On [Standard accounts](https://docs.snowflake.com/en/user-guide/intro-editions#standard-edition), Snowflake does not return a `propagate` column in `SHOW TAGS`. The provider attempted to scan a SQL `NULL` into a non-nullable Go string, resulting in a fatal error whenever any `snowflake_tag` resource was refreshed on such accounts:
+In v2.15.0 we added the `propagate` field to the `snowflake_tag` resource. On [Standard accounts](https://docs.snowflake.com/en/user-guide/intro-editions#standard-edition), Snowflake always returns the `propagate` column in `SHOW TAGS` with `null` value. The provider attempted to scan a SQL `NULL` into a non-nullable Go string, resulting in a fatal error whenever any `snowflake_tag` resource was refreshed on such accounts:
 
 ```text
 │ Error: sql: Scan error on column index 8, name "propagate": converting NULL to string is unsupported
 ```
 
-The `propagate` field is now treated as nullable: when the column is absent from `SHOW TAGS`, the field is `nil` and the state attribute is left unchanged.
+The `propagate` field is now treated as nullable.
 
 No changes in configuration are required. Users on standard accounts who experienced a crash on plan or apply should be able to use the `snowflake_tag` resource normally after upgrading.
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -34,6 +34,18 @@ This feature will be marked as stable in future releases. To use it, add `snowfl
 
 No changes are required for existing configurations unless you want to manage session policies with Terraform.
 
+### *(bugfix)* Fixed `snowflake_tag` crash on Standard accounts
+
+In v2.15.0 we added the `propagate` field to the `snowflake_tag` resource. On [Standard accounts](https://docs.snowflake.com/en/user-guide/intro-editions#standard-edition), Snowflake does not return a `propagate` column in `SHOW TAGS`. The provider attempted to scan a SQL `NULL` into a non-nullable Go string, resulting in a fatal error whenever any `snowflake_tag` resource was refreshed on such accounts:
+
+```text
+│ Error: sql: Scan error on column index 8, name "propagate": converting NULL to string is unsupported
+```
+
+The `propagate` field is now treated as nullable: when the column is absent from `SHOW TAGS`, the field is `nil` and the state attribute is left unchanged.
+
+No changes in configuration are required. Users on standard accounts who experienced a crash on plan or apply should be able to use the `snowflake_tag` resource normally after upgrading.
+
 ## v2.14.x ➞ v2.15.0
 
 ### **IMPORTANT** *(improvement)* Go driver bumped to v2

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/tag_snowflake_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/tag_snowflake_ext.go
@@ -52,7 +52,3 @@ func (t *TagAssert) HasAllowedValuesEmpty() *TagAssert {
 	})
 	return t
 }
-
-func (t *TagAssert) HasPropagateEnum(expected sdk.TagPropagation) *TagAssert {
-	return t.HasPropagate(string(expected))
-}

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/tag_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/tag_snowflake_gen.go
@@ -124,11 +124,14 @@ func (t *TagAssert) HasOwnerRoleType(expected string) *TagAssert {
 	return t
 }
 
-func (t *TagAssert) HasPropagate(expected string) *TagAssert {
+func (t *TagAssert) HasPropagate(expected sdk.TagPropagation) *TagAssert {
 	t.AddAssertion(func(t *testing.T, o *sdk.Tag) error {
 		t.Helper()
-		if string(o.Propagate) != expected {
-			return fmt.Errorf("expected propagate: %v; got: %v", expected, o.Propagate)
+		if o.Propagate == nil {
+			return fmt.Errorf("expected propagate to have value; got: nil")
+		}
+		if *o.Propagate != expected {
+			return fmt.Errorf("expected propagate: %v; got: %v", expected, *o.Propagate)
 		}
 		return nil
 	})

--- a/pkg/resources/tag.go
+++ b/pkg/resources/tag.go
@@ -314,11 +314,16 @@ func ReadContextTag(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 	}
 
+	var propagate *string
+	if tag.Propagate != nil {
+		propagate = sdk.Pointer(string(*tag.Propagate))
+	}
+
 	errs := errors.Join(
 		d.Set(FullyQualifiedNameAttributeName, id.FullyQualifiedName()),
 		d.Set(ShowOutputAttributeName, []map[string]any{schemas.TagToSchema(tag)}),
 		d.Set("comment", tag.Comment),
-		d.Set("propagate", tag.Propagate),
+		d.Set("propagate", propagate),
 		func() error {
 			// Use ordered_allowed_values by default (including import where rawConfig is null).
 			// Determine the usage by checking config values, but if not provided by Terraform,

--- a/pkg/schemas/tag_gen.go
+++ b/pkg/schemas/tag_gen.go
@@ -61,7 +61,9 @@ func TagToSchema(tag *sdk.Tag) map[string]any {
 	tagSchema["comment"] = tag.Comment
 	tagSchema["allowed_values"] = tag.AllowedValues
 	tagSchema["owner_role_type"] = tag.OwnerRoleType
-	tagSchema["propagate"] = string(tag.Propagate)
+	if tag.Propagate != nil {
+		tagSchema["propagate"] = string((*tag.Propagate))
+	}
 	return tagSchema
 }
 

--- a/pkg/sdk/tags.go
+++ b/pkg/sdk/tags.go
@@ -109,7 +109,7 @@ type Tag struct {
 	Comment       string
 	AllowedValues []string
 	OwnerRoleType string
-	Propagate     TagPropagation
+	Propagate     *TagPropagation
 }
 
 func (v *Tag) ID() SchemaObjectIdentifier {
@@ -125,7 +125,7 @@ type tagRow struct {
 	Comment       string         `db:"comment"`
 	AllowedValues sql.NullString `db:"allowed_values"`
 	OwnerRoleType string         `db:"owner_role_type"`
-	Propagate     string         `db:"propagate"`
+	Propagate     sql.NullString `db:"propagate"`
 }
 
 func (tr tagRow) convert() (*Tag, error) {
@@ -141,7 +141,7 @@ func (tr tagRow) convert() (*Tag, error) {
 	if tr.AllowedValues.Valid {
 		t.AllowedValues = ParseCommaSeparatedStringArray(tr.AllowedValues.String, true)
 	}
-	mapStringWithMapping(&t.Propagate, tr.Propagate, ToTagPropagation)
+	mapNullStringWithMapping(&t.Propagate, tr.Propagate, ToTagPropagation)
 	return t, nil
 }
 

--- a/pkg/sdk/testint/tags_integration_test.go
+++ b/pkg/sdk/testint/tags_integration_test.go
@@ -32,7 +32,7 @@ func TestInt_Tags(t *testing.T) {
 			HasComment(expectedComment).
 			HasAllowedValuesUnordered(expectedAllowedValues...).
 			HasOwnerRoleType("ROLE").
-			HasPropagate(string(expectedPropagate)),
+			HasPropagate(expectedPropagate),
 		)
 	}
 
@@ -263,7 +263,8 @@ func TestInt_Tags(t *testing.T) {
 
 		tag, err = client.Tags.ShowByID(ctx, id)
 		require.NoError(t, err)
-		assert.Equal(t, sdk.TagPropagationOnDependency, tag.Propagate)
+		require.NotNil(t, tag.Propagate)
+		assert.Equal(t, sdk.TagPropagationOnDependency, *tag.Propagate)
 
 		unset := sdk.NewTagUnsetRequest().WithPropagate(true)
 		err = client.Tags.Alter(ctx, sdk.NewAlterTagRequest(id).WithUnset(*unset))
@@ -271,7 +272,8 @@ func TestInt_Tags(t *testing.T) {
 
 		tag, err = client.Tags.ShowByID(ctx, id)
 		require.NoError(t, err)
-		assert.Equal(t, sdk.TagPropagationNone, tag.Propagate)
+		require.NotNil(t, tag.Propagate)
+		assert.Equal(t, sdk.TagPropagationNone, *tag.Propagate)
 	})
 
 	t.Run("show tag: without like", func(t *testing.T) {

--- a/pkg/testacc/resource_tag_acceptance_test.go
+++ b/pkg/testacc/resource_tag_acceptance_test.go
@@ -52,7 +52,7 @@ func TestAcc_Tag_BasicUseCase(t *testing.T) {
 			HasOwner(testClient().Context.CurrentRole(t).Name()).
 			HasComment("").
 			HasAllowedValues().
-			HasPropagateEnum(sdk.TagPropagationNone),
+			HasPropagate(sdk.TagPropagationNone),
 
 		resourceassert.TagResource(t, basic.ResourceReference()).
 			HasNameString(id.Name()).
@@ -84,7 +84,7 @@ func TestAcc_Tag_BasicUseCase(t *testing.T) {
 			HasOwner(testClient().Context.CurrentRole(t).Name()).
 			HasComment(comment).
 			HasAllowedValuesUnordered("value1", "value2", "FAIL").
-			HasPropagateEnum(sdk.TagPropagationOnDependency),
+			HasPropagate(sdk.TagPropagationOnDependency),
 
 		resourceassert.TagResource(t, complete.ResourceReference()).
 			HasNameString(newId.Name()).
@@ -1056,7 +1056,7 @@ func TestAcc_Tag_PropagateWithAllowedValuesSequence(t *testing.T) {
 				Config: config.FromModels(t, withSeqInitial),
 				Check: assertThat(t,
 					objectassert.Tag(t, tagId).
-						HasPropagateEnum(sdk.TagPropagationOnDependency).
+						HasPropagate(sdk.TagPropagationOnDependency).
 						HasAllowedValuesUnordered("confidential", "internal", "public"),
 					resourceassert.TagResource(t, withSeqInitial.ResourceReference()).
 						HasOnConflictAllowedValuesSequence().
@@ -1136,7 +1136,7 @@ func TestAcc_Tag_PropagateWithAllowedValuesSequence(t *testing.T) {
 				Config: config.FromModels(t, basic),
 				Check: assertThat(t,
 					objectassert.Tag(t, tagId).
-						HasPropagateEnum(sdk.TagPropagationNone),
+						HasPropagate(sdk.TagPropagationNone),
 					resourceassert.TagResource(t, basic.ResourceReference()).
 						HasPropagateEnum(sdk.TagPropagationNone).
 						HasOnConflictEmpty(),


### PR DESCRIPTION
## Changes
- Changes `propagate` column type from non-null to nullable, as with lower Snowflake editions, it can be missing, which makes the tag resource fail. Update all places that use this field (assertions, tag resources, show_schema, etc.)

## References
<!-- issues documentation links, etc  -->
* https://github.com/snowflakedb/terraform-provider-snowflake/issues/4651