### PR TITLE
chore: Define custom interfaces in the SDK gen

### DIFF
--- a/pkg/sdk/application_roles_gen.go
+++ b/pkg/sdk/application_roles_gen.go
@@ -17,11 +17,10 @@ import (
 type ApplicationRoles interface {
 	Grant(ctx context.Context, request *GrantApplicationRoleRequest) error
 	Revoke(ctx context.Context, request *RevokeApplicationRoleRequest) error
-	// Adjusted manually
-	RevokeSafely(ctx context.Context, request *RevokeApplicationRoleRequest) error
 	Show(ctx context.Context, request *ShowApplicationRoleRequest) ([]ApplicationRole, error)
 	ShowByID(ctx context.Context, id DatabaseObjectIdentifier) (*ApplicationRole, error)
 	ShowByIDSafely(ctx context.Context, id DatabaseObjectIdentifier) (*ApplicationRole, error)
+	RevokeSafely(ctx context.Context, request *RevokeApplicationRoleRequest) error
 }
 
 // GrantApplicationRoleOptions is based on https://docs.snowflake.com/en/sql-reference/sql/grant-application-role.

--- a/pkg/sdk/catalog_integrations_gen.go
+++ b/pkg/sdk/catalog_integrations_gen.go
@@ -17,18 +17,12 @@ type CatalogIntegrations interface {
 	ShowByID(ctx context.Context, id AccountObjectIdentifier) (*CatalogIntegration, error)
 	ShowByIDSafely(ctx context.Context, id AccountObjectIdentifier) (*CatalogIntegration, error)
 	Describe(ctx context.Context, id AccountObjectIdentifier) ([]CatalogIntegrationProperty, error)
-
-	// DescribeAwsGlueDetails is added manually
 	DescribeAwsGlueDetails(ctx context.Context, id AccountObjectIdentifier) (*CatalogIntegrationAwsGlueDetails, error)
-	// DescribeObjectStorageDetails is added manually
 	DescribeObjectStorageDetails(ctx context.Context, id AccountObjectIdentifier) (*CatalogIntegrationObjectStorageDetails, error)
-	// DescribeOpenCatalogDetails is added manually
 	DescribeOpenCatalogDetails(ctx context.Context, id AccountObjectIdentifier) (*CatalogIntegrationOpenCatalogDetails, error)
-	// DescribeIcebergRestDetails is added manually
 	DescribeIcebergRestDetails(ctx context.Context, id AccountObjectIdentifier) (*CatalogIntegrationIcebergRestDetails, error)
-	// DescribeSapBdcDetails is added manually
 	DescribeSapBdcDetails(ctx context.Context, id AccountObjectIdentifier) (*CatalogIntegrationSapBdcDetails, error)
-	// DescribeDetails is added manually; it returns combined describe output for all types of catalog integrations.
+	// DescribeDetails returns combined describe output for all types of catalog integrations.
 	DescribeDetails(ctx context.Context, id AccountObjectIdentifier) (*CatalogIntegrationAllDetails, error)
 }
 

--- a/pkg/sdk/functions_gen.go
+++ b/pkg/sdk/functions_gen.go
@@ -22,10 +22,8 @@ type Functions interface {
 	ShowByID(ctx context.Context, id SchemaObjectIdentifierWithArguments) (*Function, error)
 	ShowByIDSafely(ctx context.Context, id SchemaObjectIdentifierWithArguments) (*Function, error)
 	Describe(ctx context.Context, id SchemaObjectIdentifierWithArguments) ([]FunctionDetail, error)
-
-	// DescribeDetails is added manually; it returns aggregated describe results for the given function.
+	// DescribeDetails returns aggregated describe results for the given function.
 	DescribeDetails(ctx context.Context, id SchemaObjectIdentifierWithArguments) (*FunctionDetails, error)
-	// ShowParameters is added manually
 	ShowParameters(ctx context.Context, id SchemaObjectIdentifierWithArguments) ([]*Parameter, error)
 }
 

--- a/pkg/sdk/generator/defs/application_roles_def.go
+++ b/pkg/sdk/generator/defs/application_roles_def.go
@@ -58,4 +58,10 @@ var applicationRolesDef = g.NewInterface(
 		WithValidation(g.ValidIdentifier, "ApplicationName"),
 ).ShowByIdOperationWithFiltering(
 	g.ShowByIDApplicationNameFiltering,
-)
+).
+	WithCustomInterfaceMethod(
+		"RevokeSafely",
+		"",
+		[]*g.MethodParameter{g.NewMethodParameter("request", "*RevokeApplicationRoleRequest")},
+		"error",
+	)

--- a/pkg/sdk/generator/defs/application_roles_def.go
+++ b/pkg/sdk/generator/defs/application_roles_def.go
@@ -58,10 +58,9 @@ var applicationRolesDef = g.NewInterface(
 		WithValidation(g.ValidIdentifier, "ApplicationName"),
 ).ShowByIdOperationWithFiltering(
 	g.ShowByIDApplicationNameFiltering,
-).
-	WithCustomInterfaceMethod(
-		"RevokeSafely",
-		"",
-		[]*g.MethodParameter{g.NewMethodParameter("request", "*RevokeApplicationRoleRequest")},
-		"error",
-	)
+).WithCustomInterfaceMethod(
+	"RevokeSafely",
+	"",
+	[]*g.MethodParameter{g.NewMethodParameter("request", "*RevokeApplicationRoleRequest")},
+	"error",
+)

--- a/pkg/sdk/generator/defs/catalog_integrations_def.go
+++ b/pkg/sdk/generator/defs/catalog_integrations_def.go
@@ -351,4 +351,3 @@ var catalogIntegrationsDef = g.NewInterface(
 		CatalogIntegrationAccessDelegationModeEnumDef,
 		CatalogIntegrationCatalogApiTypeEnumDef,
 	)
-

--- a/pkg/sdk/generator/defs/catalog_integrations_def.go
+++ b/pkg/sdk/generator/defs/catalog_integrations_def.go
@@ -308,6 +308,42 @@ var catalogIntegrationsDef = g.NewInterface(
 			Text("Sigv4SigningRegion").
 			Text("Sigv4ExternalId"),
 	).
+	WithCustomInterfaceMethod(
+		"DescribeAwsGlueDetails",
+		"",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.AccountObjectIdentifier]())},
+		"*CatalogIntegrationAwsGlueDetails", "error",
+	).
+	WithCustomInterfaceMethod(
+		"DescribeObjectStorageDetails",
+		"",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.AccountObjectIdentifier]())},
+		"*CatalogIntegrationObjectStorageDetails", "error",
+	).
+	WithCustomInterfaceMethod(
+		"DescribeOpenCatalogDetails",
+		"",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.AccountObjectIdentifier]())},
+		"*CatalogIntegrationOpenCatalogDetails", "error",
+	).
+	WithCustomInterfaceMethod(
+		"DescribeIcebergRestDetails",
+		"",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.AccountObjectIdentifier]())},
+		"*CatalogIntegrationIcebergRestDetails", "error",
+	).
+	WithCustomInterfaceMethod(
+		"DescribeSapBdcDetails",
+		"",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.AccountObjectIdentifier]())},
+		"*CatalogIntegrationSapBdcDetails", "error",
+	).
+	WithCustomInterfaceMethod(
+		"DescribeDetails",
+		"DescribeDetails returns combined describe output for all types of catalog integrations.",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.AccountObjectIdentifier]())},
+		"*CatalogIntegrationAllDetails", "error",
+	).
 	WithEnums(
 		CatalogIntegrationCatalogSourceTypeEnumDef,
 		CatalogIntegrationTableFormatEnumDef,
@@ -315,3 +351,4 @@ var catalogIntegrationsDef = g.NewInterface(
 		CatalogIntegrationAccessDelegationModeEnumDef,
 		CatalogIntegrationCatalogApiTypeEnumDef,
 	)
+

--- a/pkg/sdk/generator/defs/functions_def.go
+++ b/pkg/sdk/generator/defs/functions_def.go
@@ -378,4 +378,16 @@ var functionsDef = g.NewInterface(
 		SQL("FUNCTION").
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-)
+).
+	WithCustomInterfaceMethod(
+		"DescribeDetails",
+		"DescribeDetails returns aggregated describe results for the given function.",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifierWithArguments]())},
+		"*FunctionDetails", "error",
+	).
+	WithCustomInterfaceMethod(
+		"ShowParameters",
+		"",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifierWithArguments]())},
+		"[]*Parameter", "error",
+	)

--- a/pkg/sdk/generator/defs/functions_def.go
+++ b/pkg/sdk/generator/defs/functions_def.go
@@ -378,16 +378,14 @@ var functionsDef = g.NewInterface(
 		SQL("FUNCTION").
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).
-	WithCustomInterfaceMethod(
-		"DescribeDetails",
-		"DescribeDetails returns aggregated describe results for the given function.",
-		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifierWithArguments]())},
-		"*FunctionDetails", "error",
-	).
-	WithCustomInterfaceMethod(
-		"ShowParameters",
-		"",
-		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifierWithArguments]())},
-		"[]*Parameter", "error",
-	)
+).WithCustomInterfaceMethod(
+	"DescribeDetails",
+	"DescribeDetails returns aggregated describe results for the given function.",
+	[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifierWithArguments]())},
+	"*FunctionDetails", "error",
+).WithCustomInterfaceMethod(
+	"ShowParameters",
+	"",
+	[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifierWithArguments]())},
+	"[]*Parameter", "error",
+)

--- a/pkg/sdk/generator/defs/organization_accounts_def.go
+++ b/pkg/sdk/generator/defs/organization_accounts_def.go
@@ -113,6 +113,24 @@ var organizationAccountsDef = g.NewInterface(
 			OptionalLike(),
 	).
 	ShowByIdOperationWithFiltering(g.ShowByIDLikeFiltering).
+	WithCustomInterfaceMethod("ShowParameters", "", nil, "[]*Parameter", "error").
+	WithCustomInterfaceMethod("UnsetAllParameters", "", nil, "error").
+	WithCustomInterfaceMethod(
+		"UnsetPolicySafely",
+		"UnsetPolicySafely unsets a policy on the current account by a given supported kind.\nIt ignores an error that occurs on the Snowflake side whenever you try to unset policy which is already unset.",
+		[]*g.MethodParameter{g.NewMethodParameter("kind", "PolicyKind")},
+		"error",
+	).
+	WithCustomInterfaceMethod(
+		"SetPolicySafely",
+		"SetPolicySafely sets a policy on the current account by a given supported kind.\nIt firstly tries to unset the policy with UnsetPolicySafely method to make sure that the policy is not set,\nthen proceeds by setting the passed policy on the organization account.",
+		[]*g.MethodParameter{
+			g.NewMethodParameter("kind", "PolicyKind"),
+			g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifier]()),
+		},
+		"error",
+	).
+	WithCustomInterfaceMethod("UnsetAll", "", nil, "error").
 	WithEnums(
 		OrganizationAccountEditionEnumDef,
 	)

--- a/pkg/sdk/generator/defs/password_policies_def.go
+++ b/pkg/sdk/generator/defs/password_policies_def.go
@@ -140,4 +140,5 @@ var passwordPoliciesDef = g.NewInterface(
 			Number("PasswordMaxRetries").
 			Number("PasswordLockoutTimeMins").
 			Number("PasswordHistory"),
-	)
+	).
+	WithCustomInterfaceMethod("DescribeDetails", "", []*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifier]())}, "*PasswordPolicyDetails", "error")

--- a/pkg/sdk/generator/defs/procedures_def.go
+++ b/pkg/sdk/generator/defs/procedures_def.go
@@ -590,16 +590,14 @@ var proceduresDef = g.NewInterface(
 		WithValidation(g.ValidateValueSet, "ProcedureDefinition").
 		WithValidation(g.ValidIdentifier, "ProcedureName").
 		WithValidation(g.ValidIdentifier, "Name"),
-).
-	WithCustomInterfaceMethod(
-		"DescribeDetails",
-		"DescribeDetails returns aggregated describe results for the given procedure.",
-		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifierWithArguments]())},
-		"*ProcedureDetails", "error",
-	).
-	WithCustomInterfaceMethod(
-		"ShowParameters",
-		"",
-		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifierWithArguments]())},
-		"[]*Parameter", "error",
-	)
+).WithCustomInterfaceMethod(
+	"DescribeDetails",
+	"DescribeDetails returns aggregated describe results for the given procedure.",
+	[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifierWithArguments]())},
+	"*ProcedureDetails", "error",
+).WithCustomInterfaceMethod(
+	"ShowParameters",
+	"",
+	[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifierWithArguments]())},
+	"[]*Parameter", "error",
+)

--- a/pkg/sdk/generator/defs/procedures_def.go
+++ b/pkg/sdk/generator/defs/procedures_def.go
@@ -590,4 +590,16 @@ var proceduresDef = g.NewInterface(
 		WithValidation(g.ValidateValueSet, "ProcedureDefinition").
 		WithValidation(g.ValidIdentifier, "ProcedureName").
 		WithValidation(g.ValidIdentifier, "Name"),
-)
+).
+	WithCustomInterfaceMethod(
+		"DescribeDetails",
+		"DescribeDetails returns aggregated describe results for the given procedure.",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifierWithArguments]())},
+		"*ProcedureDetails", "error",
+	).
+	WithCustomInterfaceMethod(
+		"ShowParameters",
+		"",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifierWithArguments]())},
+		"[]*Parameter", "error",
+	)

--- a/pkg/sdk/generator/defs/semantic_views_def.go
+++ b/pkg/sdk/generator/defs/semantic_views_def.go
@@ -97,7 +97,13 @@ var semanticViewsDef = g.NewInterface(
 			OptionalStartsWith().
 			OptionalLimitFrom(),
 	).
-	ShowByIdOperationWithFiltering(g.ShowByIDInFiltering, g.ShowByIDLikeFiltering)
+	ShowByIdOperationWithFiltering(g.ShowByIDInFiltering, g.ShowByIDLikeFiltering).
+	WithCustomInterfaceMethod(
+		"DescribeSemanticViewDetails",
+		"DescribeSemanticViewDetails returns converted describe output for semantic views.",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifier]())},
+		"*SemanticViewDescribeDetails", "error",
+	)
 
 var primaryKey = g.NewQueryStruct("PrimaryKeys").
 	ListAssignment("PRIMARY KEY", "SemanticViewColumn", g.ParameterOptions().Parentheses().NoEquals().Required())

--- a/pkg/sdk/generator/defs/session_policies_def.go
+++ b/pkg/sdk/generator/defs/session_policies_def.go
@@ -125,4 +125,10 @@ var sessionPoliciesDef = g.NewInterface(
 			Number("SessionUiIdleTimeoutMins").
 			StringList("AllowedSecondaryRoles").
 			StringList("BlockedSecondaryRoles"),
+	).
+	WithCustomInterfaceMethod(
+		"DescribeDetails",
+		"",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifier]())},
+		"*SessionPolicyDetails", "error",
 	)

--- a/pkg/sdk/generator/defs/storage_integrations_def.go
+++ b/pkg/sdk/generator/defs/storage_integrations_def.go
@@ -213,4 +213,28 @@ var storageIntegrationsDef = g.NewInterface(
 			Text("ConsentUrl").
 			Text("MultiTenantAppName").
 			Text("ServiceAccount"),
+	).
+	WithCustomInterfaceMethod(
+		"DescribeAwsDetails",
+		"DescribeAwsDetails returns converted describe output for AWS storage integrations.",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.AccountObjectIdentifier]())},
+		"*StorageIntegrationAwsDetails", "error",
+	).
+	WithCustomInterfaceMethod(
+		"DescribeAzureDetails",
+		"DescribeAzureDetails returns converted describe output for Azure storage integrations.",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.AccountObjectIdentifier]())},
+		"*StorageIntegrationAzureDetails", "error",
+	).
+	WithCustomInterfaceMethod(
+		"DescribeGcsDetails",
+		"DescribeGcsDetails returns converted describe output for GCS storage integrations.",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.AccountObjectIdentifier]())},
+		"*StorageIntegrationGcsDetails", "error",
+	).
+	WithCustomInterfaceMethod(
+		"DescribeDetails",
+		"DescribeDetails returns combined describe output for all types of storage integrations.",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.AccountObjectIdentifier]())},
+		"*StorageIntegrationAllDetails", "error",
 	)

--- a/pkg/sdk/generator/defs/tasks_def.go
+++ b/pkg/sdk/generator/defs/tasks_def.go
@@ -223,4 +223,25 @@ var tasksDef = g.NewInterface(
 			Name().
 			OptionalSQL("RETRY LAST").
 			WithValidation(g.ValidIdentifier, "name"),
+	).
+	WithCustomInterfaceMethod(
+		"ShowParameters",
+		"",
+		[]*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifier]())},
+		"[]*Parameter", "error",
+	).
+	WithCustomInterfaceMethod(
+		"SuspendRootTasks",
+		"",
+		[]*g.MethodParameter{
+			g.NewMethodParameter("taskId", g.KindOfT[sdkcommons.SchemaObjectIdentifier]()),
+			g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifier]()),
+		},
+		"[]SchemaObjectIdentifier", "error",
+	).
+	WithCustomInterfaceMethod(
+		"ResumeTasks",
+		"",
+		[]*g.MethodParameter{g.NewMethodParameter("ids", "[]SchemaObjectIdentifier")},
+		"error",
 	)

--- a/pkg/sdk/generator/defs/user_programmatic_access_tokens_def.go
+++ b/pkg/sdk/generator/defs/user_programmatic_access_tokens_def.go
@@ -121,10 +121,10 @@ var userProgrammaticAccessTokensDef = g.NewInterface(
 		SQL("USER PROGRAMMATIC ACCESS TOKENS").
 		OptionalIdentifier("UserName", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("FOR USER")),
 ).ShowByIdOperationWithNoFiltering().
-	WithEnums(ProgrammaticAccessTokenStatusDef).
 	WithCustomInterfaceMethod(
 		"RemoveByIDSafely",
 		"",
 		[]*g.MethodParameter{g.NewMethodParameter("request", "*RemoveUserProgrammaticAccessTokenRequest")},
 		"error",
-	)
+	).
+	WithEnums(ProgrammaticAccessTokenStatusDef)

--- a/pkg/sdk/generator/defs/user_programmatic_access_tokens_def.go
+++ b/pkg/sdk/generator/defs/user_programmatic_access_tokens_def.go
@@ -121,4 +121,10 @@ var userProgrammaticAccessTokensDef = g.NewInterface(
 		SQL("USER PROGRAMMATIC ACCESS TOKENS").
 		OptionalIdentifier("UserName", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("FOR USER")),
 ).ShowByIdOperationWithNoFiltering().
-	WithEnums(ProgrammaticAccessTokenStatusDef)
+	WithEnums(ProgrammaticAccessTokenStatusDef).
+	WithCustomInterfaceMethod(
+		"RemoveByIDSafely",
+		"",
+		[]*g.MethodParameter{g.NewMethodParameter("request", "*RemoveUserProgrammaticAccessTokenRequest")},
+		"error",
+	)

--- a/pkg/sdk/generator/example/paired_struct_examples_gen.go
+++ b/pkg/sdk/generator/example/paired_struct_examples_gen.go
@@ -41,10 +41,10 @@ type pairedStructExampleRow struct {
 	SecondAccountId              string         `db:"second_account_id"`
 	OptionalAccountId            sql.NullString `db:"optional_account_id"`
 	OptionalSecondAccountId      sql.NullString `db:"optional_second_account_id"`
-	SchemaObjectId               sql.NullString `db:"schema_object_id"`
-	SecondSchemaObjectId         sql.NullString `db:"second_schema_object_id"`
-	OptionalSchemaObjectId       string         `db:"optional_schema_object_id"`
-	OptionalSecondSchemaObjectId string         `db:"optional_second_schema_object_id"`
+	SchemaObjectId               string         `db:"schema_object_id"`
+	SecondSchemaObjectId         string         `db:"second_schema_object_id"`
+	OptionalSchemaObjectId       sql.NullString `db:"optional_schema_object_id"`
+	OptionalSecondSchemaObjectId sql.NullString `db:"optional_second_schema_object_id"`
 	DatabaseObjectId             string         `db:"database_object_id"`
 	SecondDatabaseObjectId       string         `db:"second_database_object_id"`
 }
@@ -110,10 +110,10 @@ type pairedStructExampleDetailRow struct {
 	SecondAccountId              string         `db:"second_account_id"`
 	OptionalAccountId            sql.NullString `db:"optional_account_id"`
 	OptionalSecondAccountId      sql.NullString `db:"optional_second_account_id"`
-	SchemaObjectId               sql.NullString `db:"schema_object_id"`
-	SecondSchemaObjectId         sql.NullString `db:"second_schema_object_id"`
-	OptionalSchemaObjectId       string         `db:"optional_schema_object_id"`
-	OptionalSecondSchemaObjectId string         `db:"optional_second_schema_object_id"`
+	SchemaObjectId               string         `db:"schema_object_id"`
+	SecondSchemaObjectId         string         `db:"second_schema_object_id"`
+	OptionalSchemaObjectId       sql.NullString `db:"optional_schema_object_id"`
+	OptionalSecondSchemaObjectId sql.NullString `db:"optional_second_schema_object_id"`
 	DatabaseObjectId             string         `db:"database_object_id"`
 	SecondDatabaseObjectId       string         `db:"second_database_object_id"`
 }

--- a/pkg/sdk/generator/example/paired_struct_examples_gen.go
+++ b/pkg/sdk/generator/example/paired_struct_examples_gen.go
@@ -39,10 +39,10 @@ type pairedStructExampleRow struct {
 	Tags                         string         `db:"tags"`
 	AccountId                    string         `db:"account_id"`
 	SecondAccountId              string         `db:"second_account_id"`
-	OptionalAccountId            string         `db:"optional_account_id"`
-	OptionalSecondAccountId      string         `db:"optional_second_account_id"`
-	SchemaObjectId               string         `db:"schema_object_id"`
-	SecondSchemaObjectId         string         `db:"second_schema_object_id"`
+	OptionalAccountId            sql.NullString `db:"optional_account_id"`
+	OptionalSecondAccountId      sql.NullString `db:"optional_second_account_id"`
+	SchemaObjectId               sql.NullString `db:"schema_object_id"`
+	SecondSchemaObjectId         sql.NullString `db:"second_schema_object_id"`
 	OptionalSchemaObjectId       string         `db:"optional_schema_object_id"`
 	OptionalSecondSchemaObjectId string         `db:"optional_second_schema_object_id"`
 	DatabaseObjectId             string         `db:"database_object_id"`
@@ -108,10 +108,10 @@ type pairedStructExampleDetailRow struct {
 	Tags                         string         `db:"tags"`
 	AccountId                    string         `db:"account_id"`
 	SecondAccountId              string         `db:"second_account_id"`
-	OptionalAccountId            string         `db:"optional_account_id"`
-	OptionalSecondAccountId      string         `db:"optional_second_account_id"`
-	SchemaObjectId               string         `db:"schema_object_id"`
-	SecondSchemaObjectId         string         `db:"second_schema_object_id"`
+	OptionalAccountId            sql.NullString `db:"optional_account_id"`
+	OptionalSecondAccountId      sql.NullString `db:"optional_second_account_id"`
+	SchemaObjectId               sql.NullString `db:"schema_object_id"`
+	SecondSchemaObjectId         sql.NullString `db:"second_schema_object_id"`
 	OptionalSchemaObjectId       string         `db:"optional_schema_object_id"`
 	OptionalSecondSchemaObjectId string         `db:"optional_second_schema_object_id"`
 	DatabaseObjectId             string         `db:"database_object_id"`

--- a/pkg/sdk/generator/gen/paired_struct.go
+++ b/pkg/sdk/generator/gen/paired_struct.go
@@ -240,7 +240,7 @@ func (p *PairedStructs) DatabaseObjectIdentifier(dbColumnName string, opts ...Pa
 //	plain: Id SchemaObjectIdentifier
 func (p *PairedStructs) SchemaObjectIdentifier(dbColumnName string, opts ...PairedFieldOption) *PairedStructs {
 	allOpts := append([]PairedFieldOption{WithPlainFieldName("Id")}, opts...)
-	return p.addField(dbColumnName, "sql.NullString", "SchemaObjectIdentifier", allOpts)
+	return p.addField(dbColumnName, "string", "SchemaObjectIdentifier", allOpts)
 }
 
 // OptionalSchemaObjectIdentifier adds a nullable SchemaObjectIdentifier field. The db kind is string
@@ -251,7 +251,7 @@ func (p *PairedStructs) SchemaObjectIdentifier(dbColumnName string, opts ...Pair
 //	plain: Id *SchemaObjectIdentifier
 func (p *PairedStructs) OptionalSchemaObjectIdentifier(dbColumnName string, opts ...PairedFieldOption) *PairedStructs {
 	allOpts := append([]PairedFieldOption{WithPlainFieldName("Id")}, opts...)
-	return p.addField(dbColumnName, "string", "*SchemaObjectIdentifier", allOpts)
+	return p.addField(dbColumnName, "sql.NullString", "*SchemaObjectIdentifier", allOpts)
 }
 
 // asDbStruct materializes the definition as a *dbStruct following the old implementation.

--- a/pkg/sdk/generator/gen/templates/interface.tmpl
+++ b/pkg/sdk/generator/gen/templates/interface.tmpl
@@ -36,6 +36,6 @@ type {{ .Name }} interface {
 			// {{ . }}
 			{{- end }}
 		{{- end }}
-		{{ .Name }}(ctx context.Context{{ range .Parameters }}, {{ .Name }} {{ .Kind }}{{ end }}){{ if eq (len .ReturnTypes) 0 }}{{ else if eq (len .ReturnTypes) 1 }} {{ index .ReturnTypes 0 }}{{ else }} ({{ join .ReturnTypes ", " }}){{ end }}
+		{{ .Name }}(ctx context.Context{{ range .Parameters }}, {{ .Name }} {{ .Kind }}{{ end }}){{ if eq (len .ReturnTypes) 1 }} {{ index .ReturnTypes 0 }}{{ else if gt (len .ReturnTypes) 1 }} ({{ join .ReturnTypes ", " }}){{ end }}
 	{{- end }}
 }

--- a/pkg/sdk/organization_accounts_gen.go
+++ b/pkg/sdk/organization_accounts_gen.go
@@ -13,20 +13,15 @@ type OrganizationAccounts interface {
 	Show(ctx context.Context, request *ShowOrganizationAccountRequest) ([]OrganizationAccount, error)
 	ShowByID(ctx context.Context, id AccountObjectIdentifier) (*OrganizationAccount, error)
 	ShowByIDSafely(ctx context.Context, id AccountObjectIdentifier) (*OrganizationAccount, error)
-	// ShowParameters added manually
 	ShowParameters(ctx context.Context) ([]*Parameter, error)
-	// UnsetAllParameters added manually
 	UnsetAllParameters(ctx context.Context) error
-	// UnsetPolicySafely added manually
-	// Unsets a policy on the current account by a given supported kind.
+	// UnsetPolicySafely unsets a policy on the current account by a given supported kind.
 	// It ignores an error that occurs on the Snowflake side whenever you try to unset policy which is already unset.
 	UnsetPolicySafely(ctx context.Context, kind PolicyKind) error
-	// SetPolicySafely added manually
-	// Sets a policy on the current account by a given supported kind.
+	// SetPolicySafely sets a policy on the current account by a given supported kind.
 	// It firstly tries to unset the policy with UnsetPolicySafely method to make sure that the policy is not set,
 	// then proceeds by setting the passed policy on the organization account.
 	SetPolicySafely(ctx context.Context, kind PolicyKind, id SchemaObjectIdentifier) error
-	// UnsetAll added manually
 	UnsetAll(ctx context.Context) error
 }
 

--- a/pkg/sdk/password_policies_gen.go
+++ b/pkg/sdk/password_policies_gen.go
@@ -16,7 +16,6 @@ type PasswordPolicies interface {
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*PasswordPolicy, error)
 	ShowByIDSafely(ctx context.Context, id SchemaObjectIdentifier) (*PasswordPolicy, error)
 	Describe(ctx context.Context, id SchemaObjectIdentifier) ([]PasswordPolicyProperty, error)
-	// DescribeDetails is added manually
 	DescribeDetails(ctx context.Context, id SchemaObjectIdentifier) (*PasswordPolicyDetails, error)
 }
 

--- a/pkg/sdk/procedures_gen.go
+++ b/pkg/sdk/procedures_gen.go
@@ -28,10 +28,8 @@ type Procedures interface {
 	CreateAndCallForJavaScript(ctx context.Context, request *CreateAndCallForJavaScriptProcedureRequest) error
 	CreateAndCallForPython(ctx context.Context, request *CreateAndCallForPythonProcedureRequest) error
 	CreateAndCallForSQL(ctx context.Context, request *CreateAndCallForSQLProcedureRequest) error
-
-	// DescribeDetails is added manually; it returns aggregated describe results for the given procedure.
+	// DescribeDetails returns aggregated describe results for the given procedure.
 	DescribeDetails(ctx context.Context, id SchemaObjectIdentifierWithArguments) (*ProcedureDetails, error)
-	// ShowParameters is added manually
 	ShowParameters(ctx context.Context, id SchemaObjectIdentifierWithArguments) ([]*Parameter, error)
 }
 

--- a/pkg/sdk/semantic_views_gen.go
+++ b/pkg/sdk/semantic_views_gen.go
@@ -17,8 +17,7 @@ type SemanticViews interface {
 	Show(ctx context.Context, request *ShowSemanticViewRequest) ([]SemanticView, error)
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*SemanticView, error)
 	ShowByIDSafely(ctx context.Context, id SchemaObjectIdentifier) (*SemanticView, error)
-
-	// DescribeSemanticViewDetails is added manually; it returns converted describe output for semantic views
+	// DescribeSemanticViewDetails returns converted describe output for semantic views.
 	DescribeSemanticViewDetails(ctx context.Context, id SchemaObjectIdentifier) (*SemanticViewDescribeDetails, error)
 }
 

--- a/pkg/sdk/session_policies_gen.go
+++ b/pkg/sdk/session_policies_gen.go
@@ -15,8 +15,6 @@ type SessionPolicies interface {
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*SessionPolicy, error)
 	ShowByIDSafely(ctx context.Context, id SchemaObjectIdentifier) (*SessionPolicy, error)
 	Describe(ctx context.Context, id SchemaObjectIdentifier) ([]SessionPolicyProperty, error)
-
-	// DescribeDetails is added manually
 	DescribeDetails(ctx context.Context, id SchemaObjectIdentifier) (*SessionPolicyDetails, error)
 }
 

--- a/pkg/sdk/storage_integrations_gen.go
+++ b/pkg/sdk/storage_integrations_gen.go
@@ -17,14 +17,13 @@ type StorageIntegrations interface {
 	ShowByID(ctx context.Context, id AccountObjectIdentifier) (*StorageIntegration, error)
 	ShowByIDSafely(ctx context.Context, id AccountObjectIdentifier) (*StorageIntegration, error)
 	Describe(ctx context.Context, id AccountObjectIdentifier) ([]StorageIntegrationProperty, error)
-
-	// DescribeAwsDetails is added manually; it returns converted describe output for AWS storage integrations.
+	// DescribeAwsDetails returns converted describe output for AWS storage integrations.
 	DescribeAwsDetails(ctx context.Context, id AccountObjectIdentifier) (*StorageIntegrationAwsDetails, error)
-	// DescribeAwsDetails is added manually; it returns converted describe output for Azure storage integrations.
+	// DescribeAzureDetails returns converted describe output for Azure storage integrations.
 	DescribeAzureDetails(ctx context.Context, id AccountObjectIdentifier) (*StorageIntegrationAzureDetails, error)
-	// DescribeAwsDetails is added manually; it returns converted describe output for GCS storage integrations.
+	// DescribeGcsDetails returns converted describe output for GCS storage integrations.
 	DescribeGcsDetails(ctx context.Context, id AccountObjectIdentifier) (*StorageIntegrationGcsDetails, error)
-	// DescribeDetails is added manually; it returns combined describe output for all types of storage integrations.
+	// DescribeDetails returns combined describe output for all types of storage integrations.
 	DescribeDetails(ctx context.Context, id AccountObjectIdentifier) (*StorageIntegrationAllDetails, error)
 }
 

--- a/pkg/sdk/tasks_gen.go
+++ b/pkg/sdk/tasks_gen.go
@@ -19,12 +19,8 @@ type Tasks interface {
 	ShowByIDSafely(ctx context.Context, id SchemaObjectIdentifier) (*Task, error)
 	Describe(ctx context.Context, id SchemaObjectIdentifier) (*Task, error)
 	Execute(ctx context.Context, request *ExecuteTaskRequest) error
-
-	// ShowParameters added manually
 	ShowParameters(ctx context.Context, id SchemaObjectIdentifier) ([]*Parameter, error)
-	// SuspendRootTasks added manually
 	SuspendRootTasks(ctx context.Context, taskId SchemaObjectIdentifier, id SchemaObjectIdentifier) ([]SchemaObjectIdentifier, error)
-	// ResumeTasks added manually
 	ResumeTasks(ctx context.Context, ids []SchemaObjectIdentifier) error
 }
 

--- a/pkg/sdk/user_programmatic_access_tokens_gen.go
+++ b/pkg/sdk/user_programmatic_access_tokens_gen.go
@@ -18,8 +18,6 @@ type UserProgrammaticAccessTokens interface {
 	ShowByID(ctx context.Context, userId, id AccountObjectIdentifier) (*ProgrammaticAccessToken, error)
 	// adjusted manually
 	ShowByIDSafely(ctx context.Context, userId, id AccountObjectIdentifier) (*ProgrammaticAccessToken, error)
-
-	// added manually
 	RemoveByIDSafely(ctx context.Context, request *RemoveUserProgrammaticAccessTokenRequest) error
 }
 


### PR DESCRIPTION
Move the custom methods to SDK generator definitions (after https://github.com/snowflakedb/terraform-provider-snowflake/pull/4661)

This change brings us another step closer to a manual-changes-free SDK