### PR TITLE
feat: support in-place session policy attachment updates

### DIFF
--- a/pkg/resources/account_session_policy_attachment.go
+++ b/pkg/resources/account_session_policy_attachment.go
@@ -17,7 +17,6 @@ var accountSessionPolicyAttachmentSchema = map[string]*schema.Schema{
 	"session_policy_name": {
 		Type:             schema.TypeString,
 		Required:         true,
-		ForceNew:         true,
 		Description:      "Fully qualified name of the session policy to apply to the current account.",
 		ValidateDiagFunc: IsValidIdentifier[sdk.SchemaObjectIdentifier](),
 	},
@@ -29,6 +28,7 @@ func AccountSessionPolicyAttachment() *schema.Resource {
 
 		CreateContext: PreviewFeatureCreateContextWrapper(string(previewfeatures.AccountSessionPolicyAttachmentResource), TrackingCreateWrapper(resources.AccountSessionPolicyAttachment, CreateAccountSessionPolicyAttachment)),
 		ReadContext:   PreviewFeatureReadContextWrapper(string(previewfeatures.AccountSessionPolicyAttachmentResource), TrackingReadWrapper(resources.AccountSessionPolicyAttachment, ReadAccountSessionPolicyAttachment)),
+		UpdateContext: PreviewFeatureUpdateContextWrapper(string(previewfeatures.AccountSessionPolicyAttachmentResource), TrackingUpdateWrapper(resources.AccountSessionPolicyAttachment, UpdateAccountSessionPolicyAttachment)),
 		DeleteContext: PreviewFeatureDeleteContextWrapper(string(previewfeatures.AccountSessionPolicyAttachmentResource), TrackingDeleteWrapper(resources.AccountSessionPolicyAttachment, DeleteAccountSessionPolicyAttachment)),
 
 		Schema: accountSessionPolicyAttachmentSchema,
@@ -39,15 +39,15 @@ func AccountSessionPolicyAttachment() *schema.Resource {
 	}
 }
 
-func CreateAccountSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateAccountSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
-	sessionPolicyId, ok := sdk.NewObjectIdentifierFromFullyQualifiedName(d.Get("session_policy_name").(string)).(sdk.SchemaObjectIdentifier)
-	if !ok {
-		return diag.FromErr(fmt.Errorf("session_policy_name %s is not a valid session policy qualified name, expected format: `\"db\".\"schema\".\"policy\"`", d.Get("session_policy_name")))
+	sessionPolicyId, err := sdk.ParseSchemaObjectIdentifier(d.Get("session_policy_name").(string))
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
-	err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{
+	err = client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{
 		Set: &sdk.AccountSet{
 			SessionPolicy: &sessionPolicyId,
 		},
@@ -61,19 +61,10 @@ func CreateAccountSessionPolicyAttachment(ctx context.Context, d *schema.Resourc
 	return ReadAccountSessionPolicyAttachment(ctx, d, meta)
 }
 
-func ReadAccountSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ReadAccountSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
-	sessionPolicyId, err := sdk.ParseSchemaObjectIdentifier(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	currentAccountName, err := client.ContextFunctions.CurrentAccount(ctx)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	currentAccountId, err := sdk.ParseAccountObjectIdentifier(currentAccountName)
+	currentAccountId, err := sdk.ParseAccountObjectIdentifier(client.GetAccountLocator())
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -86,7 +77,7 @@ func ReadAccountSessionPolicyAttachment(ctx context.Context, d *schema.ResourceD
 	sessionPolicyReferences := make([]sdk.PolicyReference, 0)
 	for _, policyReference := range policyReferences {
 		if policyReference.PolicyKind == sdk.PolicyKindSessionPolicy {
-			sessionPolicyReferences = append(sessionPolicyReferences, sdk.PolicyReference{})
+			sessionPolicyReferences = append(sessionPolicyReferences, policyReference)
 		}
 	}
 
@@ -105,14 +96,54 @@ func ReadAccountSessionPolicyAttachment(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	if err := d.Set("session_policy_name", sessionPolicyId.FullyQualifiedName()); err != nil {
+	sessionPolicyFromRef := sdk.NewSchemaObjectIdentifier(
+		*sessionPolicyReferences[0].PolicyDb,
+		*sessionPolicyReferences[0].PolicySchema,
+		sessionPolicyReferences[0].PolicyName,
+	)
+
+	if err := d.Set("session_policy_name", sessionPolicyFromRef.FullyQualifiedName()); err != nil {
 		return diag.FromErr(err)
 	}
+
+	d.SetId(helpers.EncodeResourceIdentifier(sessionPolicyFromRef))
 
 	return nil
 }
 
-func DeleteAccountSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func UpdateAccountSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	client := meta.(*provider.Context).Client
+
+	if d.HasChange("session_policy_name") {
+		newSessionPolicyName, err := sdk.ParseSchemaObjectIdentifier(d.Get("session_policy_name").(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{
+			Unset: &sdk.AccountUnset{
+				SessionPolicy: sdk.Bool(true),
+			},
+		}); err != nil {
+			d.Partial(true)
+			return diag.FromErr(fmt.Errorf("error while unsetting old session policy from account, err = %w", err))
+		}
+		if err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{
+			Set: &sdk.AccountSet{
+				SessionPolicy: &newSessionPolicyName,
+			},
+		}); err != nil {
+			d.Partial(true)
+			return diag.FromErr(fmt.Errorf("error while setting new session policy on account, err = %w", err))
+		}
+
+		d.SetId(helpers.EncodeResourceIdentifier(newSessionPolicyName))
+	}
+
+	return ReadAccountSessionPolicyAttachment(ctx, d, meta)
+}
+
+func DeleteAccountSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
 	err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{
@@ -123,6 +154,8 @@ func DeleteAccountSessionPolicyAttachment(ctx context.Context, d *schema.Resourc
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	d.SetId("")
 
 	return nil
 }

--- a/pkg/resources/user_session_policy_attachment.go
+++ b/pkg/resources/user_session_policy_attachment.go
@@ -25,7 +25,6 @@ var userSessionPolicyAttachmentSchema = map[string]*schema.Schema{
 	"session_policy_name": {
 		Type:             schema.TypeString,
 		Required:         true,
-		ForceNew:         true,
 		Description:      "Fully qualified name of the session policy.",
 		ValidateDiagFunc: IsValidIdentifier[sdk.SchemaObjectIdentifier](),
 	},
@@ -36,23 +35,43 @@ func UserSessionPolicyAttachment() *schema.Resource {
 		Description:   "Specifies the session policy to use for a certain user.",
 		CreateContext: PreviewFeatureCreateContextWrapper(string(previewfeatures.UserSessionPolicyAttachmentResource), TrackingCreateWrapper(resources.UserSessionPolicyAttachment, CreateUserSessionPolicyAttachment)),
 		ReadContext:   PreviewFeatureReadContextWrapper(string(previewfeatures.UserSessionPolicyAttachmentResource), TrackingReadWrapper(resources.UserSessionPolicyAttachment, ReadUserSessionPolicyAttachment)),
+		UpdateContext: PreviewFeatureUpdateContextWrapper(string(previewfeatures.UserSessionPolicyAttachmentResource), TrackingUpdateWrapper(resources.UserSessionPolicyAttachment, UpdateUserSessionPolicyAttachment)),
 		DeleteContext: PreviewFeatureDeleteContextWrapper(string(previewfeatures.UserSessionPolicyAttachmentResource), TrackingDeleteWrapper(resources.UserSessionPolicyAttachment, DeleteUserSessionPolicyAttachment)),
 
 		Schema: userSessionPolicyAttachmentSchema,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: TrackingImportWrapper(resources.UserSessionPolicyAttachment, ImportUserSessionPolicyAttachment),
 		},
 		Timeouts: defaultTimeouts,
 	}
 }
 
+func ImportUserSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	userName, err := getUserNameForUserSessionPolicyAttachment(d)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := d.Set("user_name", userName.Name()); err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
 func CreateUserSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
-	userName := sdk.NewAccountObjectIdentifierFromFullyQualifiedName(d.Get("user_name").(string))
-	sessionPolicy := sdk.NewSchemaObjectIdentifierFromFullyQualifiedName(d.Get("session_policy_name").(string))
+	userName, err := sdk.ParseAccountObjectIdentifier(d.Get("user_name").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	sessionPolicy, err := sdk.ParseSchemaObjectIdentifier(d.Get("session_policy_name").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	err := client.Users.Alter(ctx, userName, &sdk.AlterUserOptions{
+	err = client.Users.Alter(ctx, userName, &sdk.AlterUserOptions{
 		Set: &sdk.UserSet{
 			SessionPolicy: &sessionPolicy,
 		},
@@ -69,12 +88,7 @@ func CreateUserSessionPolicyAttachment(ctx context.Context, d *schema.ResourceDa
 func ReadUserSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
-	parts := helpers.ParseResourceIdentifier(d.Id())
-	if len(parts) != 2 {
-		return diag.FromErr(fmt.Errorf("required id format '<user_identifier>|<session_policy_fqn>', but got: '%s'", d.Id()))
-	}
-
-	userName, err := sdk.ParseAccountObjectIdentifier(parts[0])
+	userName, err := getUserNameForUserSessionPolicyAttachment(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -115,9 +129,6 @@ func ReadUserSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
-	if err := d.Set("user_name", userName.Name()); err != nil {
-		return diag.FromErr(err)
-	}
 	if err := d.Set(
 		"session_policy_name",
 		sdk.NewSchemaObjectIdentifier(
@@ -132,12 +143,54 @@ func ReadUserSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData
 	return nil
 }
 
+func UpdateUserSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	client := meta.(*provider.Context).Client
+
+	if d.HasChange("session_policy_name") {
+		userName, err := getUserNameForUserSessionPolicyAttachment(d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		newSessionPolicyName, err := sdk.ParseSchemaObjectIdentifier(d.Get("session_policy_name").(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if err := client.Users.Alter(ctx, *userName, &sdk.AlterUserOptions{
+			IfExists: sdk.Bool(true),
+			Unset: &sdk.UserUnset{
+				SessionPolicy: sdk.Bool(true),
+			},
+		}); err != nil {
+			d.Partial(true)
+			return diag.FromErr(fmt.Errorf("error while unsetting old session policy from user %v, err = %w", userName.FullyQualifiedName(), err))
+		}
+		if err := client.Users.Alter(ctx, *userName, &sdk.AlterUserOptions{
+			IfExists: sdk.Bool(true),
+			Set: &sdk.UserSet{
+				SessionPolicy: &newSessionPolicyName,
+			},
+		}); err != nil {
+			d.Partial(true)
+			return diag.FromErr(fmt.Errorf("error while setting new session policy to user %v, err = %w", userName.FullyQualifiedName(), err))
+		}
+
+		d.SetId(helpers.EncodeResourceIdentifier(userName.FullyQualifiedName(), newSessionPolicyName.FullyQualifiedName()))
+	}
+
+	return ReadUserSessionPolicyAttachment(ctx, d, meta)
+}
+
 func DeleteUserSessionPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
-	userName := sdk.NewAccountObjectIdentifierFromFullyQualifiedName(d.Get("user_name").(string))
+	userName, err := sdk.ParseAccountObjectIdentifier(d.Get("user_name").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	err := client.Users.Alter(ctx, userName, &sdk.AlterUserOptions{
+	err = client.Users.Alter(ctx, userName, &sdk.AlterUserOptions{
 		IfExists: sdk.Bool(true),
 		Unset: &sdk.UserUnset{
 			SessionPolicy: sdk.Bool(true),
@@ -150,4 +203,17 @@ func DeleteUserSessionPolicyAttachment(ctx context.Context, d *schema.ResourceDa
 	d.SetId("")
 
 	return nil
+}
+
+func getUserNameForUserSessionPolicyAttachment(d *schema.ResourceData) (*sdk.AccountObjectIdentifier, error) {
+	parts := helpers.ParseResourceIdentifier(d.Id())
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("required id format '<user_identifier>|<session_policy_fqn>', but got: '%s'", d.Id())
+	}
+
+	userName, err := sdk.ParseAccountObjectIdentifier(parts[0])
+	if err != nil {
+		return nil, err
+	}
+	return &userName, nil
 }

--- a/pkg/testacc/1_setup_provider_test.go
+++ b/pkg/testacc/1_setup_provider_test.go
@@ -47,6 +47,7 @@ var (
 	servicesProviderFactory                          = providerFactoryUsingCache("Services")
 	userPasswordPoliciesProviderFactory              = providerFactoryUsingCache("UserPasswordPolicies")
 	userAuthenticationPoliciesProviderFactory        = providerFactoryUsingCache("UserAuthenticationPolicies")
+	sessionPoliciesProviderFactory                   = providerFactoryUsingCache("SessionPolicies")
 	explicitAccountAdminRoleProviderFactory          = providerFactoryUsingCache("ExplicitAccountAdminRole")
 	strictPrivilegeManagementGrantProviderFactory    = providerFactoryUsingCache("StrictPrivilegeManagementGrantProvider")
 	grantsImportValidationProviderFactory            = providerFactoryUsingCache("GrantsImportValidationProvider")

--- a/pkg/testacc/resource_account_session_policy_attachment_acceptance_test.go
+++ b/pkg/testacc/resource_account_session_policy_attachment_acceptance_test.go
@@ -43,7 +43,7 @@ func TestAcc_AccountSessionPolicyAttachment_BasicUseCase(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: sessionPoliciesProviderFactory,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
@@ -70,7 +70,7 @@ func TestAcc_AccountSessionPolicyAttachment_BasicUseCase(t *testing.T) {
 			{
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(ref, plancheck.ResourceActionDestroyBeforeCreate),
+						plancheck.ExpectResourceAction(ref, plancheck.ResourceActionUpdate),
 					},
 				},
 				Config: config.FromModels(t, newPolicy),

--- a/pkg/testacc/resource_session_policy_acceptance_test.go
+++ b/pkg/testacc/resource_session_policy_acceptance_test.go
@@ -56,13 +56,6 @@ func TestAcc_SessionPolicy_BasicUseCase(t *testing.T) {
 		WithBlockedSecondaryRolesAll().
 		WithComment(comment)
 
-	altered2 := model.SessionPolicy("t", newId.DatabaseName(), newId.SchemaName(), newId.Name()).
-		WithSessionIdleTimeoutMins(sessionIdleTimeoutMins).
-		WithSessionUiIdleTimeoutMins(sessionUiIdleTimeoutMins).
-		WithAllowedSecondaryRolesAll().
-		WithBlockedSecondaryRolesNone().
-		WithComment(comment)
-
 	allAttributes := model.SessionPolicy("t", id.DatabaseName(), id.SchemaName(), id.Name()).
 		WithSessionIdleTimeoutMins(sessionIdleTimeoutMins).
 		WithSessionUiIdleTimeoutMins(sessionUiIdleTimeoutMins).
@@ -142,35 +135,6 @@ func TestAcc_SessionPolicy_BasicUseCase(t *testing.T) {
 			HasBlockedSecondaryRoles("ALL"),
 	}
 
-	alteredAssertions2 := []assert.TestCheckFuncProvider{
-		resourceassert.SessionPolicyResource(t, ref).
-			HasName(newId.Name()).
-			HasSchema(newId.SchemaName()).
-			HasDatabase(newId.DatabaseName()).
-			HasSessionIdleTimeoutMins(sessionIdleTimeoutMins).
-			HasSessionUiIdleTimeoutMins(sessionUiIdleTimeoutMins).
-			HasAllAllowedSecondaryRoles().
-			HasNoBlockedSecondaryRoles().
-			HasComment(comment),
-		resourceshowoutputassert.SessionPolicyShowOutput(t, ref).
-			HasName(newId.Name()).
-			HasDatabaseName(newId.DatabaseName()).
-			HasSchemaName(newId.SchemaName()).
-			HasKind("SESSION_POLICY").
-			HasOwner(snowflakeroles.Accountadmin.Name()).
-			HasComment(comment).
-			HasOwnerRoleType("ROLE").
-			HasOptions(""),
-		resourceshowoutputassert.SessionPolicyDescribeOutput(t, ref).
-			HasOwner(snowflakeroles.Accountadmin.Name()).
-			HasOwnerRoleType("ROLE").
-			HasComment(comment).
-			HasSessionIdleTimeoutMins(sessionIdleTimeoutMins).
-			HasSessionUiIdleTimeoutMins(sessionUiIdleTimeoutMins).
-			HasAllowedSecondaryRoles("ALL").
-			HasNoBlockedSecondaryRoles(),
-	}
-
 	completeAssertions := []assert.TestCheckFuncProvider{
 		resourceassert.SessionPolicyResource(t, ref).
 			HasName(id.Name()).
@@ -234,15 +198,65 @@ func TestAcc_SessionPolicy_BasicUseCase(t *testing.T) {
 				Config: config.FromModels(t, altered),
 				Check:  assertThat(t, alteredAssertions...),
 			},
-			// Change all secondary roles to none and vice versa
+			// Change secondary roles externally (All -> None, None -> All)
 			{
+				PreConfig: func() {
+					alterRequest := sdk.NewAlterSessionPolicyRequest(newId).WithSet(*sdk.NewSessionPolicySetRequest().
+						WithAllowedSecondaryRoles(*sdk.NewSessionPolicySecondaryRolesRequest().WithAll(true)).
+						WithBlockedSecondaryRoles(*sdk.NewSessionPolicySecondaryRolesRequest().WithNone(true)),
+					)
+					testClient().SessionPolicy.Alter(t, alterRequest)
+				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(ref, plancheck.ResourceActionUpdate),
+						// allowed_secondary_roles
+						planchecks.ExpectDrift(ref, "allowed_secondary_roles.0.none", sdk.String("true"), sdk.String("false")),
+						planchecks.ExpectChange(ref, "allowed_secondary_roles.0.none", tfjson.ActionUpdate, sdk.String("false"), sdk.String("true")),
+						planchecks.ExpectDrift(ref, "allowed_secondary_roles.0.all", sdk.String("false"), sdk.String("true")),
+						planchecks.ExpectChange(ref, "allowed_secondary_roles.0.all", tfjson.ActionUpdate, sdk.String("true"), nil),
+						// blocked_secondary_roles
+						planchecks.ExpectDrift(ref, "blocked_secondary_roles.0.none", sdk.String("false"), sdk.String("true")),
+						planchecks.ExpectChange(ref, "blocked_secondary_roles.0.none", tfjson.ActionUpdate, sdk.String("true"), nil),
+						planchecks.ExpectDrift(ref, "blocked_secondary_roles.0.all", sdk.String("true"), sdk.String("false")),
+						planchecks.ExpectChange(ref, "blocked_secondary_roles.0.all", tfjson.ActionUpdate, sdk.String("false"), sdk.String("true")),
 					},
 				},
-				Config: config.FromModels(t, altered2),
-				Check:  assertThat(t, alteredAssertions2...),
+				Config: config.FromModels(t, altered),
+				Check:  assertThat(t, alteredAssertions...),
+			},
+			// Change secondary roles externally (All -> Roles, None -> Roles)
+			{
+				PreConfig: func() {
+					alterRequest := sdk.NewAlterSessionPolicyRequest(newId).WithSet(*sdk.NewSessionPolicySetRequest().
+						WithAllowedSecondaryRoles(*sdk.NewSessionPolicySecondaryRolesRequest().WithRoles([]sdk.AccountObjectIdentifier{role1.ID()})).
+						WithBlockedSecondaryRoles(*sdk.NewSessionPolicySecondaryRolesRequest().WithRoles([]sdk.AccountObjectIdentifier{role2.ID()})),
+					)
+					testClient().SessionPolicy.Alter(t, alterRequest)
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: func() []plancheck.PlanCheck {
+						allowedSecondaryRoles := sdk.String(fmt.Sprintf("[%s]", role1.Name))
+						blockedSecondaryRoles := sdk.String(fmt.Sprintf("[%s]", role2.Name))
+						return []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(ref, plancheck.ResourceActionUpdate),
+							// allowed_secondary_roles
+							planchecks.ExpectDrift(ref, "allowed_secondary_roles.0.none", sdk.String("true"), sdk.String("false")),
+							planchecks.ExpectChange(ref, "allowed_secondary_roles.0.none", tfjson.ActionUpdate, sdk.String("false"), sdk.String("true")),
+							planchecks.ExpectNoChangeOnField(ref, "allowed_secondary_roles.0.all"),
+							planchecks.ExpectDrift(ref, "allowed_secondary_roles.0.roles", sdk.String("[]"), allowedSecondaryRoles),
+							planchecks.ExpectChange(ref, "allowed_secondary_roles.0.roles", tfjson.ActionUpdate, allowedSecondaryRoles, sdk.String("[]")),
+							// blocked_secondary_roles
+							planchecks.ExpectNoChangeOnField(ref, "blocked_secondary_roles.0.none"),
+							planchecks.ExpectDrift(ref, "blocked_secondary_roles.0.all", sdk.String("true"), sdk.String("false")),
+							planchecks.ExpectChange(ref, "blocked_secondary_roles.0.all", tfjson.ActionUpdate, sdk.String("false"), sdk.String("true")),
+							planchecks.ExpectDrift(ref, "blocked_secondary_roles.0.roles", sdk.String("[]"), blockedSecondaryRoles),
+							planchecks.ExpectChange(ref, "blocked_secondary_roles.0.roles", tfjson.ActionUpdate, blockedSecondaryRoles, sdk.String("[]")),
+						}
+					}(),
+				},
+				Config: config.FromModels(t, altered),
+				Check:  assertThat(t, alteredAssertions...),
 			},
 			// Unset
 			{
@@ -287,7 +301,7 @@ func TestAcc_SessionPolicy_BasicUseCase(t *testing.T) {
 					"blocked_secondary_roles",
 				},
 			},
-			// Change props externally
+			// Change all props externally
 			{
 				PreConfig: func() {
 					alterRequest := sdk.NewAlterSessionPolicyRequest(id).WithSet(*sdk.NewSessionPolicySetRequest().

--- a/pkg/testacc/resource_user_session_policy_attachment_acceptance_test.go
+++ b/pkg/testacc/resource_user_session_policy_attachment_acceptance_test.go
@@ -59,7 +59,7 @@ func TestAcc_UserSessionPolicyAttachment_BasicUseCase(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: sessionPoliciesProviderFactory,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
@@ -96,7 +96,7 @@ func TestAcc_UserSessionPolicyAttachment_BasicUseCase(t *testing.T) {
 			{
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(ref, plancheck.ResourceActionDestroyBeforeCreate),
+						plancheck.ExpectResourceAction(ref, plancheck.ResourceActionUpdate),
 					},
 				},
 				Config: config.FromModels(t, newPolicy),


### PR DESCRIPTION
## Changes

- Remove `ForceNew` from `session_policy_name` on user and account session policy attachment resources.
- Parse fully qualified names with `sdk.Parse*Identifier` helpers instead of `New*FromFullyQualifiedName`-style parsing.
- Add `ImportUserSessionPolicyAttachment` and register it on the user session policy attachment importer.
- Resolve the Snowflake account for account session policy attachment reads with `client.GetAccountLocator()` instead of `SELECT CURRENT_ACCOUNT()`.
- Improve `session_policy` acceptance tests for externally changed secondary roles.
- Add `sessionPoliciesProviderFactory` and use it in `user_session_policy_attachment` acceptance tests to avoid "No active warehouse selected in the current session" test failures.
