### PR TITLE
feat: integration tests for webhook notification integration

### DIFF
--- a/pkg/acceptance/helpers/notification_integration_client.go
+++ b/pkg/acceptance/helpers/notification_integration_client.go
@@ -36,6 +36,13 @@ func (c *NotificationIntegrationClient) CreateWithGcpPubSub(t *testing.T) (*sdk.
 	)
 }
 
+func (c *NotificationIntegrationClient) CreateWebhook(t *testing.T, webhookUrl string) (*sdk.NotificationIntegration, func()) {
+	t.Helper()
+	return c.CreateWithRequest(t, sdk.NewCreateNotificationIntegrationRequest(c.ids.RandomAccountObjectIdentifier(), true).
+		WithWebhookParams(*sdk.NewWebhookParamsRequest(webhookUrl)),
+	)
+}
+
 func (c *NotificationIntegrationClient) Create(t *testing.T) (*sdk.NotificationIntegration, func()) {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/sdk/testint/notification_integrations_gen_integration_test.go
+++ b/pkg/sdk/testint/notification_integrations_gen_integration_test.go
@@ -117,7 +117,10 @@ func TestInt_NotificationIntegrations(t *testing.T) {
 				*sdk.NewWebhookParamsRequest(webhookUrl).
 					WithWebhookSecret(secretId).
 					WithWebhookBodyTemplate(webhookBodyTemplate).
-					WithWebhookHeaders([]sdk.WebhookHeaderRequest{{Header: "Content-Type", Value: "application/json"}}),
+					WithWebhookHeaders([]sdk.WebhookHeaderRequest{
+						{Header: "Content-Type", Value: "application/json"},
+						{Header: "Custom-Header", Value: "custom-value"},
+					}),
 			).
 			WithComment("slack webhook")
 	}
@@ -348,8 +351,8 @@ func TestInt_NotificationIntegrations(t *testing.T) {
 			return property.Name == "WEBHOOK_HEADERS"
 		})
 		require.NoError(t, err)
-		assert.Contains(t, headersProp.Value, "Content-Type")
-		assert.Contains(t, headersProp.Value, "application/json")
+		assert.Contains(t, headersProp.Value, "Content-Type=application/json")
+		assert.Contains(t, headersProp.Value, "Custom-Header=custom-value")
 	})
 
 	t.Run("alter notification integration: auto", func(t *testing.T) {
@@ -460,7 +463,10 @@ func TestInt_NotificationIntegrations(t *testing.T) {
 							WithWebhookUrl(webhookOtherUrl).
 							WithWebhookSecret(secretId).
 							WithWebhookBodyTemplate(webhookOtherBodyTemplate).
-							WithWebhookHeaders([]sdk.WebhookHeaderRequest{{Header: "Content-Type", Value: "application/json"}}),
+							WithWebhookHeaders([]sdk.WebhookHeaderRequest{
+								{Header: "Content-Type", Value: "application/json"},
+								{Header: "Custom-Header", Value: "custom-value"},
+							}),
 					).
 					WithComment("changed comment"),
 			)
@@ -474,6 +480,13 @@ func TestInt_NotificationIntegrations(t *testing.T) {
 		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "WEBHOOK_URL", Type: "String", Value: webhookOtherUrl, Default: ""})
 		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "WEBHOOK_BODY_TEMPLATE", Type: "String", Value: webhookOtherBodyTemplate, Default: ""})
 		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "COMMENT", Type: "String", Value: "changed comment", Default: ""})
+
+		headersProp, err := collections.FindFirst(details, func(property sdk.NotificationIntegrationProperty) bool {
+			return property.Name == "WEBHOOK_HEADERS"
+		})
+		require.NoError(t, err)
+		assert.Contains(t, headersProp.Value, "Content-Type=application/json")
+		assert.Contains(t, headersProp.Value, "Custom-Header=custom-value")
 
 		secretProp, err := collections.FindFirst(details, func(property sdk.NotificationIntegrationProperty) bool {
 			return property.Name == "WEBHOOK_SECRET"
@@ -498,6 +511,7 @@ func TestInt_NotificationIntegrations(t *testing.T) {
 		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "ENABLED", Type: "Boolean", Value: "false", Default: "true"})
 		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "WEBHOOK_URL", Type: "String", Value: webhookOtherUrl, Default: ""})
 		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "WEBHOOK_BODY_TEMPLATE", Type: "String", Value: "", Default: ""})
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "WEBHOOK_HEADERS", Type: "Map", Value: "{}", Default: "{}"})
 		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "COMMENT", Type: "String", Value: "", Default: ""})
 	})
 

--- a/pkg/sdk/testint/notification_integrations_gen_integration_test.go
+++ b/pkg/sdk/testint/notification_integrations_gen_integration_test.go
@@ -25,6 +25,15 @@ func TestInt_NotificationIntegrations(t *testing.T) {
 	const awsSnsOtherTopicArn = "arn:aws:sns:us-east-2:123456789012:MyOtherTopic"
 	const awsSnsRoleArn = "arn:aws:iam::000000000001:/role/test"
 	const awsSnsOtherRoleArn = "arn:aws:iam::000000000001:/role/other"
+	// Slack-format webhook URLs (Snowflake validates URL format per provider).
+	// Last path segment is normally a per-channel token; for tests we use a
+	// fully-formed URL that does not depend on Snowflake secret substitution.
+	const webhookUrl = "https://hooks.slack.com/services/T00000000/B00000000/AAAAAAAAAAAAAAAAAAAAAAAA"
+	const webhookOtherUrl = "https://hooks.slack.com/services/T11111111/B11111111/BBBBBBBBBBBBBBBBBBBBBBBB"
+	// Snowflake requires the body template to contain the literal placeholder
+	// SNOWFLAKE_WEBHOOK_MESSAGE somewhere in the string.
+	const webhookBodyTemplate = `{"text": "SNOWFLAKE_WEBHOOK_MESSAGE"}`
+	const webhookOtherBodyTemplate = `{"message": "SNOWFLAKE_WEBHOOK_MESSAGE", "channel": "#other"}`
 
 	assertNotificationIntegration := func(t *testing.T, s *sdk.NotificationIntegration, name sdk.AccountObjectIdentifier, notificationType string, comment string) {
 		t.Helper()
@@ -91,6 +100,28 @@ func TestInt_NotificationIntegrations(t *testing.T) {
 			WithEmailParams(*sdk.NewEmailParamsRequest().WithAllowedRecipients([]sdk.NotificationIntegrationAllowedRecipient{{Email: "artur.sawicki@snowflake.com"}}))
 	}
 
+	createNotificationIntegrationWebhookMinimalRequest := func(t *testing.T) *sdk.CreateNotificationIntegrationRequest {
+		t.Helper()
+		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
+
+		return sdk.NewCreateNotificationIntegrationRequest(id, true).
+			WithWebhookParams(*sdk.NewWebhookParamsRequest(webhookUrl))
+	}
+
+	createNotificationIntegrationWebhookCompleteRequest := func(t *testing.T, secretId sdk.SchemaObjectIdentifier) *sdk.CreateNotificationIntegrationRequest {
+		t.Helper()
+		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
+
+		return sdk.NewCreateNotificationIntegrationRequest(id, true).
+			WithWebhookParams(
+				*sdk.NewWebhookParamsRequest(webhookUrl).
+					WithWebhookSecret(secretId).
+					WithWebhookBodyTemplate(webhookBodyTemplate).
+					WithWebhookHeaders([]sdk.WebhookHeaderRequest{{Header: "Content-Type", Value: "application/json"}}),
+			).
+			WithComment("slack webhook")
+	}
+
 	createNotificationIntegrationWithRequest := func(t *testing.T, request *sdk.CreateNotificationIntegrationRequest) *sdk.NotificationIntegration {
 		t.Helper()
 		id := request.GetName()
@@ -123,6 +154,11 @@ func TestInt_NotificationIntegrations(t *testing.T) {
 	createNotificationIntegrationEmail := func(t *testing.T) *sdk.NotificationIntegration {
 		t.Helper()
 		return createNotificationIntegrationWithRequest(t, createNotificationIntegrationEmailRequest(t))
+	}
+
+	createNotificationIntegrationWebhookMinimal := func(t *testing.T) *sdk.NotificationIntegration {
+		t.Helper()
+		return createNotificationIntegrationWithRequest(t, createNotificationIntegrationWebhookMinimalRequest(t))
 	}
 
 	t.Run("create and describe notification integration - auto google", func(t *testing.T) {
@@ -268,6 +304,54 @@ func TestInt_NotificationIntegrations(t *testing.T) {
 		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "ALLOWED_RECIPIENTS", Type: "List", Value: "", Default: "[]"})
 	})
 
+	t.Run("create and describe notification integration - webhook minimal", func(t *testing.T) {
+		request := createNotificationIntegrationWebhookMinimalRequest(t)
+
+		integration := createNotificationIntegrationWithRequest(t, request)
+
+		assertNotificationIntegration(t, integration, request.GetName(), "WEBHOOK", "")
+
+		details, err := client.NotificationIntegrations.Describe(ctx, integration.ID())
+		require.NoError(t, err)
+
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "ENABLED", Type: "Boolean", Value: "true", Default: "true"})
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "WEBHOOK_URL", Type: "String", Value: webhookUrl, Default: ""})
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "COMMENT", Type: "String", Value: "", Default: ""})
+	})
+
+	t.Run("create and describe notification integration - webhook with secret, body template, and headers", func(t *testing.T) {
+		secretId := testClientHelper().Ids.RandomSchemaObjectIdentifier()
+		_, secretCleanup := testClientHelper().Secret.CreateWithGenericString(t, secretId, "test_secret_string")
+		t.Cleanup(secretCleanup)
+
+		request := createNotificationIntegrationWebhookCompleteRequest(t, secretId)
+
+		integration := createNotificationIntegrationWithRequest(t, request)
+
+		assertNotificationIntegration(t, integration, request.GetName(), "WEBHOOK", "slack webhook")
+
+		details, err := client.NotificationIntegrations.Describe(ctx, integration.ID())
+		require.NoError(t, err)
+
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "ENABLED", Type: "Boolean", Value: "true", Default: "true"})
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "WEBHOOK_URL", Type: "String", Value: webhookUrl, Default: ""})
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "WEBHOOK_BODY_TEMPLATE", Type: "String", Value: webhookBodyTemplate, Default: ""})
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "COMMENT", Type: "String", Value: "slack webhook", Default: ""})
+
+		secretProp, err := collections.FindFirst(details, func(property sdk.NotificationIntegrationProperty) bool {
+			return property.Name == "WEBHOOK_SECRET"
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, secretProp.Value)
+
+		headersProp, err := collections.FindFirst(details, func(property sdk.NotificationIntegrationProperty) bool {
+			return property.Name == "WEBHOOK_HEADERS"
+		})
+		require.NoError(t, err)
+		assert.Contains(t, headersProp.Value, "Content-Type")
+		assert.Contains(t, headersProp.Value, "application/json")
+	})
+
 	t.Run("alter notification integration: auto", func(t *testing.T) {
 		integration := createNotificationIntegrationAutoGoogle(t)
 
@@ -360,6 +444,63 @@ func TestInt_NotificationIntegrations(t *testing.T) {
 		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "COMMENT", Type: "String", Value: "", Default: ""})
 	})
 
+	t.Run("alter notification integration: webhook", func(t *testing.T) {
+		integration := createNotificationIntegrationWebhookMinimal(t)
+
+		secretId := testClientHelper().Ids.RandomSchemaObjectIdentifier()
+		_, secretCleanup := testClientHelper().Secret.CreateWithGenericString(t, secretId, "test_secret_string")
+		t.Cleanup(secretCleanup)
+
+		setRequest := sdk.NewAlterNotificationIntegrationRequest(integration.ID()).
+			WithSet(
+				*sdk.NewNotificationIntegrationSetRequest().
+					WithEnabled(false).
+					WithSetWebhookParams(
+						*sdk.NewSetWebhookParamsRequest().
+							WithWebhookUrl(webhookOtherUrl).
+							WithWebhookSecret(secretId).
+							WithWebhookBodyTemplate(webhookOtherBodyTemplate).
+							WithWebhookHeaders([]sdk.WebhookHeaderRequest{{Header: "Content-Type", Value: "application/json"}}),
+					).
+					WithComment("changed comment"),
+			)
+		err := client.NotificationIntegrations.Alter(ctx, setRequest)
+		require.NoError(t, err)
+
+		details, err := client.NotificationIntegrations.Describe(ctx, integration.ID())
+		require.NoError(t, err)
+
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "ENABLED", Type: "Boolean", Value: "false", Default: "true"})
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "WEBHOOK_URL", Type: "String", Value: webhookOtherUrl, Default: ""})
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "WEBHOOK_BODY_TEMPLATE", Type: "String", Value: webhookOtherBodyTemplate, Default: ""})
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "COMMENT", Type: "String", Value: "changed comment", Default: ""})
+
+		secretProp, err := collections.FindFirst(details, func(property sdk.NotificationIntegrationProperty) bool {
+			return property.Name == "WEBHOOK_SECRET"
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, secretProp.Value)
+
+		unsetRequest := sdk.NewAlterNotificationIntegrationRequest(integration.ID()).
+			WithUnsetWebhookParams(
+				*sdk.NewNotificationIntegrationUnsetWebhookParamsRequest().
+					WithWebhookSecret(true).
+					WithWebhookBodyTemplate(true).
+					WithWebhookHeaders(true).
+					WithComment(true),
+			)
+		err = client.NotificationIntegrations.Alter(ctx, unsetRequest)
+		require.NoError(t, err)
+
+		details, err = client.NotificationIntegrations.Describe(ctx, integration.ID())
+		require.NoError(t, err)
+
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "ENABLED", Type: "Boolean", Value: "false", Default: "true"})
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "WEBHOOK_URL", Type: "String", Value: webhookOtherUrl, Default: ""})
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "WEBHOOK_BODY_TEMPLATE", Type: "String", Value: "", Default: ""})
+		assert.Contains(t, details, sdk.NotificationIntegrationProperty{Name: "COMMENT", Type: "String", Value: "", Default: ""})
+	})
+
 	t.Run("drop notification integration: existing", func(t *testing.T) {
 		request := createNotificationIntegrationEmailRequest(t)
 		id := request.GetName()
@@ -387,6 +528,7 @@ func TestInt_NotificationIntegrations(t *testing.T) {
 		notificationAutoAzure := createNotificationIntegrationAutoAzure(t)
 		notificationPushAmazon := createNotificationIntegrationPushAmazon(t)
 		notificationEmail := createNotificationIntegrationEmail(t)
+		notificationWebhook := createNotificationIntegrationWebhookMinimal(t)
 
 		showRequest := sdk.NewShowNotificationIntegrationRequest()
 		returnedIntegrations, err := client.NotificationIntegrations.Show(ctx, showRequest)
@@ -396,6 +538,7 @@ func TestInt_NotificationIntegrations(t *testing.T) {
 		assert.Contains(t, returnedIntegrations, *notificationAutoAzure)
 		assert.Contains(t, returnedIntegrations, *notificationPushAmazon)
 		assert.Contains(t, returnedIntegrations, *notificationEmail)
+		assert.Contains(t, returnedIntegrations, *notificationWebhook)
 	})
 
 	t.Run("show notification integration: with options", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds SDK integration test coverage for the webhook subtype of notification integrations — step 2 of the 4-step support process described in [CONTRIBUTING.md §Adding Support for a new Snowflake Object](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/CONTRIBUTING.md#adding-support-for-a-new-snowflake-object).

Step 1 (SDK) was merged as #4540. This PR (step 2) extends `pkg/sdk/testint/notification_integrations_gen_integration_test.go` to validate the webhook CRUD against a live Snowflake account. Resource (step 3) and data source (step 4) will follow in subsequent PRs.

## Changes

- **3 new subtests** in `TestInt_NotificationIntegrations` covering the webhook variant:
  - `create and describe notification integration - webhook minimal` — URL-only create, asserts `NotificationType == "WEBHOOK"` and `WEBHOOK_URL` from `DESCRIBE`
  - `create and describe notification integration - webhook with secret, body template, and headers` — full options; creates a `GENERIC_STRING` secret as a dependency, asserts every property
  - `alter notification integration: webhook` — set then unset of all four webhook params (URL, secret, body template, headers) plus enabled/comment
- **Extended** the existing `show notification integration: default` subtest to assert that a webhook integration appears in the `SHOW` output alongside the auto/push/email variants
- **Added** `CreateWebhook(t, url)` helper to `NotificationIntegrationClient` for reuse by the upcoming step-3 resource and step-4 data source PRs
- All new code mirrors the local conventions in the same file (`assert.Contains(details, sdk.NotificationIntegrationProperty{...})` for `DESCRIBE` properties; `t.Cleanup` registration; in-test closures for request builders)

## Test data choices reflect Snowflake server-side validations

These were discovered by running the tests against a live Snowflake account; calling them out so reviewers don't need to re-derive:

- **Webhook URLs must match a recognised provider format.** Test URLs use fully-formed Slack-shaped path segments (`/services/T<...>/B<...>/<24-char-token>`) so they pass validation without needing Snowflake-side secret substitution
- **`WEBHOOK_SECRET` must reference a `GENERIC_STRING` secret** (not basic-auth / OAuth flavours). Tests use `Secret.CreateWithGenericString` for the dependency
- **`WEBHOOK_BODY_TEMPLATE` must contain the literal placeholder `SNOWFLAKE_WEBHOOK_MESSAGE`.** Test templates embed it in JSON-shaped payloads

## Test plan

- [x] `go test -tags=non_account_level_tests -run 'TestInt_NotificationIntegrations/.*[Ww]ebhook.*' -v` — all 3 webhook subtests pass against a live Snowflake account (~12 s incl. setup)
- [x] `go vet -tags=non_account_level_tests ./pkg/sdk/testint/... ./pkg/acceptance/helpers/...` — no new findings in changed files
- [x] `gofmt -l` — clean on both files
- [x] `make pre-push` — gofumpt, generators, golangci-lint v2.6.1 (20 linters), test-architecture all green; no auto-fixes applied