### PR TITLE
chore: Add missing integration tests for budget example instance methods

### DIFF
--- a/pkg/acceptance/helpers/grant_client.go
+++ b/pkg/acceptance/helpers/grant_client.go
@@ -571,6 +571,28 @@ func (c *GrantClient) RevokePrivilegeOnDatabaseFromShare(
 	require.NoError(t, err)
 }
 
+func (c *GrantClient) GrantUsageOnIntegrationToSnowflakeApplication(t *testing.T, integrationId sdk.AccountObjectIdentifier) func() {
+	t.Helper()
+	ctx := context.Background()
+
+	query := fmt.Sprintf(`GRANT USAGE ON INTEGRATION %s TO APPLICATION SNOWFLAKE`, integrationId.FullyQualifiedName())
+	_, err := c.context.client.ExecForTests(ctx, query)
+	require.NoError(t, err)
+
+	return func() {
+		c.RevokeUsageOnIntegrationToSnowflakeApplication(t, integrationId)
+	}
+}
+
+func (c *GrantClient) RevokeUsageOnIntegrationToSnowflakeApplication(t *testing.T, integrationId sdk.AccountObjectIdentifier) {
+	t.Helper()
+	ctx := context.Background()
+
+	query := fmt.Sprintf(`REVOKE USAGE ON INTEGRATION %s FROM APPLICATION SNOWFLAKE`, integrationId.FullyQualifiedName())
+	_, err := c.context.client.ExecForTests(ctx, query)
+	require.NoError(t, err)
+}
+
 func (c *GrantClient) ShowGrantsToShare(t *testing.T, shareId sdk.AccountObjectIdentifier) ([]sdk.Grant, error) {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/acceptance/helpers/grant_client.go
+++ b/pkg/acceptance/helpers/grant_client.go
@@ -571,6 +571,7 @@ func (c *GrantClient) RevokePrivilegeOnDatabaseFromShare(
 	require.NoError(t, err)
 }
 
+// TODO [SNOW-1830929]: don't use direct SQL
 func (c *GrantClient) GrantUsageOnIntegrationToSnowflakeApplication(t *testing.T, integrationId sdk.AccountObjectIdentifier) func() {
 	t.Helper()
 	ctx := context.Background()
@@ -584,11 +585,84 @@ func (c *GrantClient) GrantUsageOnIntegrationToSnowflakeApplication(t *testing.T
 	}
 }
 
+// TODO [SNOW-1830929]: don't use direct SQL
 func (c *GrantClient) RevokeUsageOnIntegrationToSnowflakeApplication(t *testing.T, integrationId sdk.AccountObjectIdentifier) {
 	t.Helper()
 	ctx := context.Background()
 
 	query := fmt.Sprintf(`REVOKE USAGE ON INTEGRATION %s FROM APPLICATION SNOWFLAKE`, integrationId.FullyQualifiedName())
+	_, err := c.context.client.ExecForTests(ctx, query)
+	require.NoError(t, err)
+}
+
+// TODO [SNOW-1830929]: don't use direct SQL
+func (c *GrantClient) GrantUsageOnDatabaseToSnowflakeApplication(t *testing.T, databaseId sdk.AccountObjectIdentifier) func() {
+	t.Helper()
+	ctx := context.Background()
+
+	query := fmt.Sprintf(`GRANT USAGE ON DATABASE %s TO APPLICATION SNOWFLAKE`, databaseId.FullyQualifiedName())
+	_, err := c.context.client.ExecForTests(ctx, query)
+	require.NoError(t, err)
+
+	return func() {
+		c.RevokeUsageOnDatabaseToSnowflakeApplication(t, databaseId)
+	}
+}
+
+// TODO [SNOW-1830929]: don't use direct SQL
+func (c *GrantClient) RevokeUsageOnDatabaseToSnowflakeApplication(t *testing.T, databaseId sdk.AccountObjectIdentifier) {
+	t.Helper()
+	ctx := context.Background()
+
+	query := fmt.Sprintf(`REVOKE USAGE ON DATABASE %s FROM APPLICATION SNOWFLAKE`, databaseId.FullyQualifiedName())
+	_, err := c.context.client.ExecForTests(ctx, query)
+	require.NoError(t, err)
+}
+
+// TODO [SNOW-1830929]: don't use direct SQL
+func (c *GrantClient) GrantUsageOnSchemaToSnowflakeApplication(t *testing.T, schemaId sdk.DatabaseObjectIdentifier) func() {
+	t.Helper()
+	ctx := context.Background()
+
+	query := fmt.Sprintf(`GRANT USAGE ON SCHEMA %s TO APPLICATION SNOWFLAKE`, schemaId.FullyQualifiedName())
+	_, err := c.context.client.ExecForTests(ctx, query)
+	require.NoError(t, err)
+
+	return func() {
+		c.RevokeUsageOnSchemaToSnowflakeApplication(t, schemaId)
+	}
+}
+
+// TODO [SNOW-1830929]: don't use direct SQL
+func (c *GrantClient) RevokeUsageOnSchemaToSnowflakeApplication(t *testing.T, schemaId sdk.DatabaseObjectIdentifier) {
+	t.Helper()
+	ctx := context.Background()
+
+	query := fmt.Sprintf(`REVOKE USAGE ON SCHEMA %s FROM APPLICATION SNOWFLAKE`, schemaId.FullyQualifiedName())
+	_, err := c.context.client.ExecForTests(ctx, query)
+	require.NoError(t, err)
+}
+
+// TODO [SNOW-1830929]: don't use direct SQL
+func (c *GrantClient) GrantUsageOnProcedureToSnowflakeApplication(t *testing.T, procedureId sdk.SchemaObjectIdentifierWithArguments) func() {
+	t.Helper()
+	ctx := context.Background()
+
+	query := fmt.Sprintf(`GRANT USAGE ON PROCEDURE %s TO APPLICATION SNOWFLAKE`, procedureId.FullyQualifiedName())
+	_, err := c.context.client.ExecForTests(ctx, query)
+	require.NoError(t, err)
+
+	return func() {
+		c.RevokeUsageOnProcedureToSnowflakeApplication(t, procedureId)
+	}
+}
+
+// TODO [SNOW-1830929]: don't use direct SQL
+func (c *GrantClient) RevokeUsageOnProcedureToSnowflakeApplication(t *testing.T, procedureId sdk.SchemaObjectIdentifierWithArguments) {
+	t.Helper()
+	ctx := context.Background()
+
+	query := fmt.Sprintf(`REVOKE USAGE ON PROCEDURE %s FROM APPLICATION SNOWFLAKE`, procedureId.FullyQualifiedName())
 	_, err := c.context.client.ExecForTests(ctx, query)
 	require.NoError(t, err)
 }

--- a/pkg/sdk/budgets_dto_builders_gen.go
+++ b/pkg/sdk/budgets_dto_builders_gen.go
@@ -103,6 +103,22 @@ func NewGetNotificationIntegrationsBudgetRequest(
 	return &s
 }
 
+func NewGetNotificationEmailBudgetRequest(
+	name SchemaObjectIdentifier,
+) *GetNotificationEmailBudgetRequest {
+	s := GetNotificationEmailBudgetRequest{}
+	s.name = name
+	return &s
+}
+
+func NewGetNotificationIntegrationNameBudgetRequest(
+	name SchemaObjectIdentifier,
+) *GetNotificationIntegrationNameBudgetRequest {
+	s := GetNotificationIntegrationNameBudgetRequest{}
+	s.name = name
+	return &s
+}
+
 func NewSetCycleStartActionBudgetRequest(
 	name SchemaObjectIdentifier,
 	args BudgetSetCycleStartActionArgsRequest,

--- a/pkg/sdk/budgets_dto_builders_gen.go
+++ b/pkg/sdk/budgets_dto_builders_gen.go
@@ -130,7 +130,7 @@ func NewSetCycleStartActionBudgetRequest(
 }
 
 func NewBudgetSetCycleStartActionArgsRequest(
-	procedure SchemaObjectIdentifier,
+	procedure SchemaObjectIdentifierWithArguments,
 	arguments []string,
 ) *BudgetSetCycleStartActionArgsRequest {
 	s := BudgetSetCycleStartActionArgsRequest{}

--- a/pkg/sdk/budgets_dto_gen.go
+++ b/pkg/sdk/budgets_dto_gen.go
@@ -3,14 +3,16 @@
 package sdk
 
 var (
-	_ optionsProvider[CreateBudgetOptions]                      = new(CreateBudgetRequest)
-	_ optionsProvider[DropBudgetOptions]                        = new(DropBudgetRequest)
-	_ optionsProvider[SetSpendingLimitBudgetOptions]            = new(SetSpendingLimitBudgetRequest)
-	_ optionsProvider[GetSpendingLimitBudgetOptions]            = new(GetSpendingLimitBudgetRequest)
-	_ optionsProvider[SetEmailNotificationsBudgetOptions]       = new(SetEmailNotificationsBudgetRequest)
-	_ optionsProvider[GetNotificationIntegrationsBudgetOptions] = new(GetNotificationIntegrationsBudgetRequest)
-	_ optionsProvider[SetCycleStartActionBudgetOptions]         = new(SetCycleStartActionBudgetRequest)
-	_ optionsProvider[GetCycleStartActionBudgetOptions]         = new(GetCycleStartActionBudgetRequest)
+	_ optionsProvider[CreateBudgetOptions]                         = new(CreateBudgetRequest)
+	_ optionsProvider[DropBudgetOptions]                           = new(DropBudgetRequest)
+	_ optionsProvider[SetSpendingLimitBudgetOptions]               = new(SetSpendingLimitBudgetRequest)
+	_ optionsProvider[GetSpendingLimitBudgetOptions]               = new(GetSpendingLimitBudgetRequest)
+	_ optionsProvider[SetEmailNotificationsBudgetOptions]          = new(SetEmailNotificationsBudgetRequest)
+	_ optionsProvider[GetNotificationIntegrationsBudgetOptions]    = new(GetNotificationIntegrationsBudgetRequest)
+	_ optionsProvider[GetNotificationEmailBudgetOptions]           = new(GetNotificationEmailBudgetRequest)
+	_ optionsProvider[GetNotificationIntegrationNameBudgetOptions] = new(GetNotificationIntegrationNameBudgetRequest)
+	_ optionsProvider[SetCycleStartActionBudgetOptions]            = new(SetCycleStartActionBudgetRequest)
+	_ optionsProvider[GetCycleStartActionBudgetOptions]            = new(GetCycleStartActionBudgetRequest)
 )
 
 type CreateBudgetRequest struct {
@@ -53,6 +55,14 @@ type BudgetEmailRequest struct {
 }
 
 type GetNotificationIntegrationsBudgetRequest struct {
+	name SchemaObjectIdentifier // required
+}
+
+type GetNotificationEmailBudgetRequest struct {
+	name SchemaObjectIdentifier // required
+}
+
+type GetNotificationIntegrationNameBudgetRequest struct {
 	name SchemaObjectIdentifier // required
 }
 

--- a/pkg/sdk/budgets_dto_gen.go
+++ b/pkg/sdk/budgets_dto_gen.go
@@ -72,8 +72,8 @@ type SetCycleStartActionBudgetRequest struct {
 }
 
 type BudgetSetCycleStartActionArgsRequest struct {
-	Procedure SchemaObjectIdentifier // required
-	Arguments []string               // required
+	Procedure SchemaObjectIdentifierWithArguments // required
+	Arguments []string                            // required
 }
 
 type GetCycleStartActionBudgetRequest struct {

--- a/pkg/sdk/budgets_ext.go
+++ b/pkg/sdk/budgets_ext.go
@@ -1,0 +1,7 @@
+package sdk
+
+import "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
+
+func NewBudgetSetEmailNotificationsArgsRequestFromEmails(emails ...string) *BudgetSetEmailNotificationsArgsRequest {
+	return NewBudgetSetEmailNotificationsArgsRequest(collections.Map(emails, func(email string) BudgetEmailRequest { return BudgetEmailRequest{email} }))
+}

--- a/pkg/sdk/budgets_gen.go
+++ b/pkg/sdk/budgets_gen.go
@@ -123,8 +123,8 @@ type SetCycleStartActionBudgetOptions struct {
 }
 
 type BudgetSetCycleStartActionArgs struct {
-	Procedure SchemaObjectIdentifier `ddl:"identifier,system_reference" sql:"PROCEDURE"`
-	Arguments []string               `ddl:"list"`
+	Procedure SchemaObjectIdentifierWithArguments `ddl:"identifier,system_reference" sql:"PROCEDURE"`
+	Arguments []string                            `ddl:"list"`
 }
 
 // GetCycleStartActionBudgetOptions is based on https://docs.snowflake.com/en/sql-reference/classes/budget/methods/get_cycle_start_action.
@@ -135,16 +135,16 @@ type GetCycleStartActionBudgetOptions struct {
 }
 
 type getCycleStartActionRow struct {
-	ActionUuid             string    `db:"action_uuid"`
-	ProcedureFqn           string    `db:"procedure_fqn"`
-	ProcedureArgs          string    `db:"procedure_args"`
-	AddedTimestamp         time.Time `db:"added_timestamp"`
-	LastTriggeredTimestamp time.Time `db:"last_triggered_timestamp"`
+	ActionUuid             string    `db:"ACTION_UUID"`
+	ProcedureFqn           string    `db:"PROCEDURE_FQN"`
+	ProcedureArgs          string    `db:"PROCEDURE_ARGS"`
+	AddedTimestamp         time.Time `db:"ADDED_TIMESTAMP"`
+	LastTriggeredTimestamp time.Time `db:"LAST_TRIGGERED_TIMESTAMP"`
 }
 
 type BudgetCycleStartAction struct {
 	ActionUuid             string
-	ProcedureFqn           string
+	ProcedureId            SchemaObjectIdentifierWithArguments
 	ProcedureArgs          []string
 	AddedTimestamp         time.Time
 	LastTriggeredTimestamp time.Time

--- a/pkg/sdk/budgets_gen.go
+++ b/pkg/sdk/budgets_gen.go
@@ -15,6 +15,8 @@ type Budgets interface {
 	GetSpendingLimit(ctx context.Context, request *GetSpendingLimitBudgetRequest) (*int, error)
 	SetEmailNotifications(ctx context.Context, request *SetEmailNotificationsBudgetRequest) (*string, error)
 	GetNotificationIntegrations(ctx context.Context, request *GetNotificationIntegrationsBudgetRequest) ([]BudgetNotificationIntegration, error)
+	GetNotificationEmail(ctx context.Context, request *GetNotificationEmailBudgetRequest) (*string, error)
+	GetNotificationIntegrationName(ctx context.Context, request *GetNotificationIntegrationNameBudgetRequest) (*string, error)
 	SetCycleStartAction(ctx context.Context, request *SetCycleStartActionBudgetRequest) (*string, error)
 	GetCycleStartAction(ctx context.Context, request *GetCycleStartActionBudgetRequest) (*BudgetCycleStartAction, error)
 }
@@ -94,6 +96,24 @@ type BudgetNotificationIntegration struct {
 }
 
 type budgetGetNotificationIntegrationsArgs struct{}
+
+// GetNotificationEmailBudgetOptions is based on https://docs.snowflake.com/en/sql-reference/classes/budget/methods/get_notification_email.
+type GetNotificationEmailBudgetOptions struct {
+	call bool                           `ddl:"static" sql:"CALL"`
+	name SchemaObjectIdentifier         `ddl:"identifier,instance_method" sql:"GET_NOTIFICATION_EMAIL"`
+	args budgetGetNotificationEmailArgs `ddl:"list,must_parentheses"`
+}
+
+type budgetGetNotificationEmailArgs struct{}
+
+// GetNotificationIntegrationNameBudgetOptions is based on https://docs.snowflake.com/en/sql-reference/classes/budget/methods/get_notification_integration_name.
+type GetNotificationIntegrationNameBudgetOptions struct {
+	call bool                                     `ddl:"static" sql:"CALL"`
+	name SchemaObjectIdentifier                   `ddl:"identifier,instance_method" sql:"GET_NOTIFICATION_INTEGRATION_NAME"`
+	args budgetGetNotificationIntegrationNameArgs `ddl:"list,must_parentheses"`
+}
+
+type budgetGetNotificationIntegrationNameArgs struct{}
 
 // SetCycleStartActionBudgetOptions is based on https://docs.snowflake.com/en/sql-reference/classes/budget/methods/set_cycle_start_action.
 type SetCycleStartActionBudgetOptions struct {

--- a/pkg/sdk/budgets_gen_test.go
+++ b/pkg/sdk/budgets_gen_test.go
@@ -108,6 +108,7 @@ func TestBudgets_SetSpendingLimit(t *testing.T) {
 
 	t.Run("basic", func(t *testing.T) {
 		opts := defaultOpts()
+		// manually adjusted
 		opts.args = BudgetSetSpendingLimitArgs{SpendingLimit: 1000}
 		assertOptsValidAndSQLEquals(t, opts, "CALL %s!SET_SPENDING_LIMIT (1000)", id.FullyQualifiedName())
 	})
@@ -178,6 +179,7 @@ func TestBudgets_SetEmailNotifications(t *testing.T) {
 
 	t.Run("all options", func(t *testing.T) {
 		opts := defaultOpts()
+		// manually adjusted
 		opts.args.NotificationIntegration = &notificationIntegrationId
 		assertOptsValidAndSQLEquals(t, opts, "CALL %s!SET_EMAIL_NOTIFICATIONS ('\\\"%s\\\"', 'test@example.com')", id.FullyQualifiedName(), notificationIntegrationId.Name())
 	})
@@ -208,6 +210,66 @@ func TestBudgets_GetNotificationIntegrations(t *testing.T) {
 		opts := defaultOpts()
 		// manually adjusted
 		assertOptsValidAndSQLEquals(t, opts, "CALL %s!GET_NOTIFICATION_INTEGRATIONS ()", id.FullyQualifiedName())
+	})
+
+	// all options removed manually
+}
+
+func TestBudgets_GetNotificationEmail(t *testing.T) {
+	id := randomSchemaObjectIdentifier()
+	// Minimal valid GetNotificationEmailBudgetOptions
+	defaultOpts := func() *GetNotificationEmailBudgetOptions {
+		return &GetNotificationEmailBudgetOptions{
+			name: id,
+		}
+	}
+
+	t.Run("validation: nil options", func(t *testing.T) {
+		opts := (*GetNotificationEmailBudgetOptions)(nil)
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
+	})
+
+	t.Run("validation: valid identifier for [opts.name]", func(t *testing.T) {
+		opts := defaultOpts()
+		// manually adjusted
+		opts.name = emptySchemaObjectIdentifier
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		opts := defaultOpts()
+		// manually adjusted
+		assertOptsValidAndSQLEquals(t, opts, "CALL %s!GET_NOTIFICATION_EMAIL ()", id.FullyQualifiedName())
+	})
+
+	// all options removed manually
+}
+
+func TestBudgets_GetNotificationIntegrationName(t *testing.T) {
+	id := randomSchemaObjectIdentifier()
+	// Minimal valid GetNotificationIntegrationNameBudgetOptions
+	defaultOpts := func() *GetNotificationIntegrationNameBudgetOptions {
+		return &GetNotificationIntegrationNameBudgetOptions{
+			name: id,
+		}
+	}
+
+	t.Run("validation: nil options", func(t *testing.T) {
+		opts := (*GetNotificationIntegrationNameBudgetOptions)(nil)
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
+	})
+
+	t.Run("validation: valid identifier for [opts.name]", func(t *testing.T) {
+		opts := defaultOpts()
+		// manually adjusted
+		opts.name = emptySchemaObjectIdentifier
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		opts := defaultOpts()
+		// manually adjusted
+		assertOptsValidAndSQLEquals(t, opts, "CALL %s!GET_NOTIFICATION_INTEGRATION_NAME ()", id.FullyQualifiedName())
 	})
 
 	// all options removed manually

--- a/pkg/sdk/budgets_gen_test.go
+++ b/pkg/sdk/budgets_gen_test.go
@@ -283,7 +283,7 @@ func TestBudgets_SetCycleStartAction(t *testing.T) {
 		return &SetCycleStartActionBudgetOptions{
 			name: id,
 			args: BudgetSetCycleStartActionArgs{
-				Procedure: procedureId.SchemaObjectId(),
+				Procedure: procedureId,
 				Arguments: []string{"arg1"},
 			},
 		}
@@ -304,14 +304,14 @@ func TestBudgets_SetCycleStartAction(t *testing.T) {
 	t.Run("one arg", func(t *testing.T) {
 		opts := defaultOpts()
 		// manually adjusted
-		assertOptsValidAndSQLEquals(t, opts, "CALL %s!SET_CYCLE_START_ACTION (SYSTEM$REFERENCE('PROCEDURE', '%s'), arg1)", id.FullyQualifiedName(), procedureId.SchemaObjectId().FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, "CALL %s!SET_CYCLE_START_ACTION (SYSTEM$REFERENCE('PROCEDURE', '%s'), arg1)", id.FullyQualifiedName(), procedureId.FullyQualifiedName())
 	})
 
 	t.Run("more args", func(t *testing.T) {
 		procedureId2 := randomSchemaObjectIdentifierWithArguments(DataTypeVARCHAR, DataTypeVARCHAR)
 		opts := defaultOpts()
-		opts.args = BudgetSetCycleStartActionArgs{Procedure: procedureId2.SchemaObjectId(), Arguments: []string{"arg1", "arg2"}}
-		assertOptsValidAndSQLEquals(t, opts, "CALL %s!SET_CYCLE_START_ACTION (SYSTEM$REFERENCE('PROCEDURE', '%s'), arg1, arg2)", id.FullyQualifiedName(), procedureId2.SchemaObjectId().FullyQualifiedName())
+		opts.args = BudgetSetCycleStartActionArgs{Procedure: procedureId2, Arguments: []string{"arg1", "arg2"}}
+		assertOptsValidAndSQLEquals(t, opts, "CALL %s!SET_CYCLE_START_ACTION (SYSTEM$REFERENCE('PROCEDURE', '%s'), arg1, arg2)", id.FullyQualifiedName(), procedureId2.FullyQualifiedName())
 	})
 }
 

--- a/pkg/sdk/budgets_impl_gen.go
+++ b/pkg/sdk/budgets_impl_gen.go
@@ -51,6 +51,14 @@ func (v *budgets) GetNotificationIntegrations(ctx context.Context, request *GetN
 	return convertRows[getNotificationIntegrationsRow, BudgetNotificationIntegration](dbRows)
 }
 
+func (v *budgets) GetNotificationEmail(ctx context.Context, request *GetNotificationEmailBudgetRequest) (*string, error) {
+	return validateAndQueryOne[string](v.client, ctx, request.toOpts())
+}
+
+func (v *budgets) GetNotificationIntegrationName(ctx context.Context, request *GetNotificationIntegrationNameBudgetRequest) (*string, error) {
+	return validateAndQueryOne[string](v.client, ctx, request.toOpts())
+}
+
 func (v *budgets) SetCycleStartAction(ctx context.Context, request *SetCycleStartActionBudgetRequest) (*string, error) {
 	return validateAndQueryOne[string](v.client, ctx, request.toOpts())
 }
@@ -126,8 +134,26 @@ func (r *GetNotificationIntegrationsBudgetRequest) toOpts() *GetNotificationInte
 }
 
 func (r getNotificationIntegrationsRow) convert() (*BudgetNotificationIntegration, error) {
-	// TODO: Mapping
-	return &BudgetNotificationIntegration{}, nil
+	// added manually
+	return &BudgetNotificationIntegration{
+		IntegrationName:      r.IntegrationName,
+		LastNotificationTime: r.LastNotificationTime,
+		AddedDate:            r.AddedDate,
+	}, nil
+}
+
+func (r *GetNotificationEmailBudgetRequest) toOpts() *GetNotificationEmailBudgetOptions {
+	opts := &GetNotificationEmailBudgetOptions{
+		name: r.name,
+	}
+	return opts
+}
+
+func (r *GetNotificationIntegrationNameBudgetRequest) toOpts() *GetNotificationIntegrationNameBudgetOptions {
+	opts := &GetNotificationIntegrationNameBudgetOptions{
+		name: r.name,
+	}
+	return opts
 }
 
 func (r *SetCycleStartActionBudgetRequest) toOpts() *SetCycleStartActionBudgetOptions {
@@ -149,6 +175,12 @@ func (r *GetCycleStartActionBudgetRequest) toOpts() *GetCycleStartActionBudgetOp
 }
 
 func (r getCycleStartActionRow) convert() (*BudgetCycleStartAction, error) {
-	// TODO: Mapping
-	return &BudgetCycleStartAction{}, nil
+	// added manually
+	return &BudgetCycleStartAction{
+		ActionUuid:             r.ActionUuid,
+		ProcedureFqn:           r.ProcedureFqn,
+		ProcedureArgs:          ParseCommaSeparatedStringArray(r.ProcedureArgs, false),
+		AddedTimestamp:         r.AddedTimestamp,
+		LastTriggeredTimestamp: r.LastTriggeredTimestamp,
+	}, nil
 }

--- a/pkg/sdk/budgets_impl_gen.go
+++ b/pkg/sdk/budgets_impl_gen.go
@@ -4,6 +4,7 @@ package sdk
 
 import (
 	"context"
+	"fmt"
 )
 
 var _ Budgets = (*budgets)(nil)
@@ -176,11 +177,17 @@ func (r *GetCycleStartActionBudgetRequest) toOpts() *GetCycleStartActionBudgetOp
 
 func (r getCycleStartActionRow) convert() (*BudgetCycleStartAction, error) {
 	// added manually
-	return &BudgetCycleStartAction{
+	budget := &BudgetCycleStartAction{
 		ActionUuid:             r.ActionUuid,
-		ProcedureFqn:           r.ProcedureFqn,
 		ProcedureArgs:          ParseCommaSeparatedStringArray(r.ProcedureArgs, false),
 		AddedTimestamp:         r.AddedTimestamp,
 		LastTriggeredTimestamp: r.LastTriggeredTimestamp,
-	}, nil
+	}
+	id, err := ParseSchemaObjectIdentifierWithArguments(r.ProcedureFqn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse procedure fully qualified name for budget: %w", err)
+	} else {
+		budget.ProcedureId = id
+	}
+	return budget, nil
 }

--- a/pkg/sdk/budgets_validations_gen.go
+++ b/pkg/sdk/budgets_validations_gen.go
@@ -9,6 +9,8 @@ var (
 	_ validatable = new(GetSpendingLimitBudgetOptions)
 	_ validatable = new(SetEmailNotificationsBudgetOptions)
 	_ validatable = new(GetNotificationIntegrationsBudgetOptions)
+	_ validatable = new(GetNotificationEmailBudgetOptions)
+	_ validatable = new(GetNotificationIntegrationNameBudgetOptions)
 	_ validatable = new(SetCycleStartActionBudgetOptions)
 	_ validatable = new(GetCycleStartActionBudgetOptions)
 )
@@ -72,6 +74,28 @@ func (opts *SetEmailNotificationsBudgetOptions) validate() error {
 }
 
 func (opts *GetNotificationIntegrationsBudgetOptions) validate() error {
+	if opts == nil {
+		return ErrNilOptions
+	}
+	var errs []error
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *GetNotificationEmailBudgetOptions) validate() error {
+	if opts == nil {
+		return ErrNilOptions
+	}
+	var errs []error
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *GetNotificationIntegrationNameBudgetOptions) validate() error {
 	if opts == nil {
 		return ErrNilOptions
 	}

--- a/pkg/sdk/generator/defs/budgets_def.go
+++ b/pkg/sdk/generator/defs/budgets_def.go
@@ -24,17 +24,19 @@ var getNotificationIntegrationsResult = g.StructPair(
 
 // stored_procedure_reference and array_construct_statement are omitted as they are duplicated ways of setting the same input
 var setCycleStartActionArgs = g.NewQueryStruct("SetCycleStartActionArgs").
-	Identifier("Procedure", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Required().SystemReference("PROCEDURE")).
+	Identifier("Procedure", g.KindOfT[sdkcommons.SchemaObjectIdentifierWithArguments](), g.IdentifierOptions().Required().SystemReference("PROCEDURE")).
 	List("Arguments", "string", g.ListOptions().Required())
 
 var getCycleStartActionResult = g.StructPair(
 	"getCycleStartActionRow",
 	"BudgetCycleStartAction",
-).Text("action_uuid").
-	Text("procedure_fqn").
-	StringList("procedure_args").
-	Time("added_timestamp").
-	Time("last_triggered_timestamp")
+).
+	// uppercase column names used on purpose
+	Text("ACTION_UUID").
+	SchemaObjectIdentifierWithArguments("PROCEDURE_FQN", g.WithPlainFieldName("ProcedureId")).
+	StringList("PROCEDURE_ARGS").
+	Time("ADDED_TIMESTAMP").
+	Time("LAST_TRIGGERED_TIMESTAMP")
 
 var budgetsDef = g.NewInterface(
 	"Budgets",

--- a/pkg/sdk/generator/defs/budgets_def.go
+++ b/pkg/sdk/generator/defs/budgets_def.go
@@ -82,6 +82,16 @@ var budgetsDef = g.NewInterface(
 	getNotificationIntegrationsResult,
 	g.InstanceMethodKindSlice,
 ).InstanceMethodOperationScalar(
+	"https://docs.snowflake.com/en/sql-reference/classes/budget/methods/get_notification_email",
+	"GET_NOTIFICATION_EMAIL",
+	nil,
+	"string",
+).InstanceMethodOperationScalar(
+	"https://docs.snowflake.com/en/sql-reference/classes/budget/methods/get_notification_integration_name",
+	"GET_NOTIFICATION_INTEGRATION_NAME",
+	nil,
+	"string",
+).InstanceMethodOperationScalar(
 	"https://docs.snowflake.com/en/sql-reference/classes/budget/methods/set_cycle_start_action",
 	"SET_CYCLE_START_ACTION",
 	setCycleStartActionArgs,

--- a/pkg/sdk/generator/gen/paired_struct.go
+++ b/pkg/sdk/generator/gen/paired_struct.go
@@ -254,6 +254,27 @@ func (p *PairedStructs) OptionalSchemaObjectIdentifier(dbColumnName string, opts
 	return p.addField(dbColumnName, "sql.NullString", "*SchemaObjectIdentifier", allOpts)
 }
 
+// SchemaObjectIdentifierWithArguments adds a SchemaObjectIdentifierWithArguments field. The db kind is string and the plain kind
+// is SchemaObjectIdentifierWithArguments. The plain field name defaults to "Id", but can be overridden with WithPlainFieldName.
+//
+//	db:    <FieldName> string `db:"<dbColumnName>"`
+//	plain: Id SchemaObjectIdentifierWithArguments
+func (p *PairedStructs) SchemaObjectIdentifierWithArguments(dbColumnName string, opts ...PairedFieldOption) *PairedStructs {
+	allOpts := append([]PairedFieldOption{WithPlainFieldName("Id")}, opts...)
+	return p.addField(dbColumnName, "string", "SchemaObjectIdentifierWithArguments", allOpts)
+}
+
+// OptionalSchemaObjectIdentifierWithArguments adds a nullable SchemaObjectIdentifierWithArguments field. The db kind is string
+// and the plain kind is *SchemaObjectIdentifierWithArguments. The plain field name defaults to "Id", but can be
+// overridden with WithPlainFieldName.
+//
+//	db:    <FieldName> string `db:"<dbColumnName>"`
+//	plain: Id *SchemaObjectIdentifierWithArguments
+func (p *PairedStructs) OptionalSchemaObjectIdentifierWithArguments(dbColumnName string, opts ...PairedFieldOption) *PairedStructs {
+	allOpts := append([]PairedFieldOption{WithPlainFieldName("Id")}, opts...)
+	return p.addField(dbColumnName, "sql.NullString", "*SchemaObjectIdentifierWithArguments", allOpts)
+}
+
 // asDbStruct materializes the definition as a *dbStruct following the old implementation.
 func (p *PairedStructs) asDbStruct() *dbStruct {
 	s := DbStruct(p.dbName)

--- a/pkg/sdk/testint/budgets_gen_integration_test.go
+++ b/pkg/sdk/testint/budgets_gen_integration_test.go
@@ -38,17 +38,51 @@ func TestInt_Budgets(t *testing.T) {
 		require.Equal(t, 500, *spendingLimit)
 	})
 
-	t.Run("SetEmailNotifications and GetNotificationIntegrations", func(t *testing.T) {
-		t.Skip("TODO [next PR]: implement")
+	t.Run("SetEmailNotifications, GetNotificationEmail, and GetNotificationIntegrationName", func(t *testing.T) {
 		budgetId, budgetCleanup := testClientHelper().Budget.Create(t)
 		t.Cleanup(budgetCleanup)
-		_ = budgetId
+
+		integration, integrationCleanup := testClientHelper().NotificationIntegration.Create(t)
+		t.Cleanup(integrationCleanup)
+
+		revokePrivilege := testClientHelper().Grant.GrantUsageOnIntegrationToSnowflakeApplication(t, integration.ID())
+		t.Cleanup(revokePrivilege)
+
+		result, err := client.Budgets.SetEmailNotifications(ctx, sdk.NewSetEmailNotificationsBudgetRequest(
+			budgetId,
+			*sdk.NewBudgetSetEmailNotificationsArgsRequestFromEmails("artur.sawicki@snowflake.com").
+				WithNotificationIntegration(integration.ID()),
+		))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		email, err := client.Budgets.GetNotificationEmail(ctx, sdk.NewGetNotificationEmailBudgetRequest(budgetId))
+		require.NoError(t, err)
+		require.NotNil(t, email)
+		require.Equal(t, *email, "artur.sawicki@snowflake.com")
+
+		integrationName, err := client.Budgets.GetNotificationIntegrationName(ctx, sdk.NewGetNotificationIntegrationNameBudgetRequest(budgetId))
+		require.NoError(t, err)
+		require.NotNil(t, integrationName)
+		require.Equal(t, integration.ID().Name(), *integrationName)
 	})
 
 	t.Run("SetCycleStartAction and GetCycleStartAction", func(t *testing.T) {
-		t.Skip("TODO [next PR]: implement")
 		budgetId, budgetCleanup := testClientHelper().Budget.Create(t)
 		t.Cleanup(budgetCleanup)
-		_ = budgetId
+
+		procedureId, procCleanup := testClientHelper().Procedure.Create(t)
+		t.Cleanup(procCleanup)
+
+		result, err := client.Budgets.SetCycleStartAction(ctx, sdk.NewSetCycleStartActionBudgetRequest(
+			budgetId, *sdk.NewBudgetSetCycleStartActionArgsRequest(procedureId.ID().SchemaObjectId(), []string{}),
+		))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		action, err := client.Budgets.GetCycleStartAction(ctx, sdk.NewGetCycleStartActionBudgetRequest(budgetId))
+		require.NoError(t, err)
+		require.NotNil(t, action)
+		require.Equal(t, procedureId.ID().SchemaObjectId().FullyQualifiedName(), action.ProcedureFqn)
 	})
 }

--- a/pkg/sdk/testint/budgets_gen_integration_test.go
+++ b/pkg/sdk/testint/budgets_gen_integration_test.go
@@ -67,15 +67,27 @@ func TestInt_Budgets(t *testing.T) {
 		require.Equal(t, integration.ID().Name(), *integrationName)
 	})
 
+	// TODO [next PR]: try procedure with one arg
+	// TODO [next PR]: try procedure with 2 args (string and int)
+	// TODO [next PR]: get rid of the ARRAY_CONSTRUCT() workaround for empty list
 	t.Run("SetCycleStartAction and GetCycleStartAction", func(t *testing.T) {
 		budgetId, budgetCleanup := testClientHelper().Budget.Create(t)
 		t.Cleanup(budgetCleanup)
 
-		procedureId, procCleanup := testClientHelper().Procedure.Create(t)
+		procedure, procCleanup := testClientHelper().Procedure.Create(t)
 		t.Cleanup(procCleanup)
 
+		revokeDatabasePrivilege := testClientHelper().Grant.GrantUsageOnDatabaseToSnowflakeApplication(t, procedure.ID().DatabaseId())
+		t.Cleanup(revokeDatabasePrivilege)
+
+		revokeSchemaPrivilege := testClientHelper().Grant.GrantUsageOnSchemaToSnowflakeApplication(t, procedure.ID().SchemaId())
+		t.Cleanup(revokeSchemaPrivilege)
+
+		revokeProcedurePrivilege := testClientHelper().Grant.GrantUsageOnProcedureToSnowflakeApplication(t, procedure.ID())
+		t.Cleanup(revokeProcedurePrivilege)
+
 		result, err := client.Budgets.SetCycleStartAction(ctx, sdk.NewSetCycleStartActionBudgetRequest(
-			budgetId, *sdk.NewBudgetSetCycleStartActionArgsRequest(procedureId.ID().SchemaObjectId(), []string{}),
+			budgetId, *sdk.NewBudgetSetCycleStartActionArgsRequest(procedure.ID(), []string{"ARRAY_CONSTRUCT()"}),
 		))
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -83,6 +95,10 @@ func TestInt_Budgets(t *testing.T) {
 		action, err := client.Budgets.GetCycleStartAction(ctx, sdk.NewGetCycleStartActionBudgetRequest(budgetId))
 		require.NoError(t, err)
 		require.NotNil(t, action)
-		require.Equal(t, procedureId.ID().SchemaObjectId().FullyQualifiedName(), action.ProcedureFqn)
+		require.Empty(t, action.ActionUuid)
+		require.Equal(t, procedure.ID().FullyQualifiedName(), action.ProcedureId.FullyQualifiedName())
+		require.Empty(t, action.ProcedureArgs)
+		require.NotEmpty(t, action.AddedTimestamp)
+		require.Empty(t, action.LastTriggeredTimestamp)
 	})
 }

--- a/pkg/sdk/testint/budgets_gen_integration_test.go
+++ b/pkg/sdk/testint/budgets_gen_integration_test.go
@@ -38,6 +38,7 @@ func TestInt_Budgets(t *testing.T) {
 		require.Equal(t, 500, *spendingLimit)
 	})
 
+	// TODO [next PR]: consider wrapping the outputs in cases where the scalar output is parsable (e.g. comma-separated list here)
 	t.Run("SetEmailNotifications, GetNotificationEmail, and GetNotificationIntegrationName", func(t *testing.T) {
 		budgetId, budgetCleanup := testClientHelper().Budget.Create(t)
 		t.Cleanup(budgetCleanup)


### PR DESCRIPTION
Continuation of https://github.com/snowflakedb/terraform-provider-snowflake/pull/4688.

- Add two instance methods to pass the integration tests
- Adjust the definitions (procedure ID type, upper-cased column names)
- Add schema object identifier with arguments helper to struct pair
- Add temporary grants to the application to test client helper

Follow-ups:
- Improve arguments handling (string -> any, brackets in SQL builder, get rid of the `ARRAY_CONSTRUCT` workaround) + integration tests
- Implement all budget instance methods (+ defs alphabetic ordering)
- Solve added TODOs/reassign them
- (after review) fix revoke helper names (To -> From)