### PR TITLE
chore: Unskip SHOW WAREHOUSES starts-with + limit test

### DIFF
--- a/pkg/sdk/testint/warehouses_integration_test.go
+++ b/pkg/sdk/testint/warehouses_integration_test.go
@@ -92,7 +92,6 @@ func TestInt_Warehouses(t *testing.T) {
 	})
 
 	t.Run("show: with starts with, and limit", func(t *testing.T) {
-		t.Skip("TODO(SNOW-2683898): Unskip after the regression is fixed in Snowflake")
 		showOptions := &sdk.ShowWarehouseOptions{
 			StartsWith: sdk.String(precreatedWarehouseId.Name()),
 			LimitFrom: &sdk.LimitFrom{


### PR DESCRIPTION
## Summary
- Remove the `t.Skip` on `TestInt_Warehouses/show: with starts with, and limit`. The Snowflake regression that caused STARTS WITH + LIMIT to be ignored on `SHOW WAREHOUSES` has been fixed, so the assertion that one warehouse is returned now holds.
- Verified the sub-test passes: `TF_ACC=1 go test -tags=account_level_tests -run '^TestInt_Warehouses$/show:_with_starts_with,_and_limit$' ./pkg/sdk/testint/`.