### PR TITLE
fix: job fork status for tests

### DIFF
--- a/.github/workflows/tests-account-level.yml
+++ b/.github/workflows/tests-account-level.yml
@@ -179,7 +179,6 @@ jobs:
         id: update_check_run
         env:
           pr_number: ${{ github.event.client_payload.pull_request.number }}
-          number: ${{ github.event.client_payload.pull_request.number }}
           check_run_id: ${{ job.check_run_id }}
           # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
           conclusion: ${{ job.status }}
@@ -203,7 +202,7 @@ jobs:
             const externalId = `fork-pr-${process.env.pr_number}-${jobName}`;
             const output = {
               title: `Tests ${conclusion}`,
-              summary: `Integration tests ${conclusion}. See the [workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`
+              summary: `Account-level tests ${conclusion}. See the [workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`
             };
 
             const { data: existingRuns } = await github.rest.checks.listForRef({
@@ -219,8 +218,8 @@ jobs:
                 run.external_id === externalId
               )
               .sort((left, right) => {
-                const leftDate = new Date(left.started_at || left.completed_at || 0).getTime();
-                const rightDate = new Date(right.started_at || right.completed_at || 0).getTime();
+                const leftDate = Math.max(new Date(left.started_at || 0).getTime(), new Date(left.completed_at || 0).getTime());
+                const rightDate = Math.max(new Date(right.started_at || 0).getTime(), new Date(right.completed_at || 0).getTime());
                 return rightDate - leftDate;
               })[0];
 

--- a/.github/workflows/tests-account-level.yml
+++ b/.github/workflows/tests-account-level.yml
@@ -170,16 +170,15 @@ jobs:
             Account-level tests ${{ job.status }} for [${{ github.event.client_payload.slash_command.args.named.sha || github.event.pull_request.head.sha }}](https://github.com/snowflakedb/terraform-provider-snowflake/actions/runs/${{ github.run_id }})
 
       # For fork PRs, tests run via repository_dispatch (triggered by /ok-to-test),
-      # but the resulting check runs are tied to the default branch, not the fork PR.
-      # This step updates the (skipped) check run on the fork PR's head SHA so the
-      # PR status reflects the actual test outcome. It resolves the job's display name
-      # via job.check_run_id (since github.job returns the job_id, not the display name)
-      # and uses it to find the matching check run on the fork PR's commit.
+      # but the job check runs are tied to the default branch, not the fork PR SHA.
+      # This step mirrors the job result onto the fork PR head SHA using a dedicated
+      # synthetic check run that we own, reusing it across reruns to avoid duplicates.
       - name: Set fork job status
         uses: actions/github-script@v6
         if: ${{ always() }}
         id: update_check_run
         env:
+          pr_number: ${{ github.event.client_payload.pull_request.number }}
           number: ${{ github.event.client_payload.pull_request.number }}
           check_run_id: ${{ job.check_run_id }}
           # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
@@ -200,20 +199,52 @@ jobs:
             const jobName = currentCheck.name;
             console.log(`Current job check run name: ${jobName}`);
             const ref = process.env.sha;
-            const { data: checks } = await github.rest.checks.listForRef({
+            const conclusion = process.env.conclusion;
+            const externalId = `fork-pr-${process.env.pr_number}-${jobName}`;
+            const output = {
+              title: `Tests ${conclusion}`,
+              summary: `Integration tests ${conclusion}. See the [workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`
+            };
+
+            const { data: existingRuns } = await github.rest.checks.listForRef({
               ...context.repo,
-              ref
+              ref,
+              check_name: jobName,
             });
-            const check = checks.check_runs.filter(c => c.name === jobName);
-            console.log(check);
-            if (check.length === 0) {
-              console.log(`No matching check run found for "${jobName}" on ${ref}`);
-              return;
+
+            const existingRun = existingRuns.check_runs
+              .filter((run) =>
+                run.head_sha === ref &&
+                run.name === jobName &&
+                run.external_id === externalId
+              )
+              .sort((left, right) => {
+                const leftDate = new Date(left.started_at || left.completed_at || 0).getTime();
+                const rightDate = new Date(right.started_at || right.completed_at || 0).getTime();
+                return rightDate - leftDate;
+              })[0];
+
+            let result;
+            if (existingRun) {
+              ({ data: result } = await github.rest.checks.update({
+                ...context.repo,
+                check_run_id: existingRun.id,
+                status: 'completed',
+                conclusion,
+                external_id: externalId,
+                output,
+              }));
+              console.log(`Updated check run ${existingRun.id}: ${conclusion} for "${jobName}" on ${ref}`);
+            } else {
+              ({ data: result } = await github.rest.checks.create({
+                ...context.repo,
+                name: jobName,
+                head_sha: ref,
+                status: 'completed',
+                conclusion,
+                external_id: externalId,
+                output,
+              }));
+              console.log(`Created check run: ${conclusion} for "${jobName}" on ${ref}`);
             }
-            const { data: result } = await github.rest.checks.update({
-              ...context.repo,
-              check_run_id: check[0].id,
-              status: 'completed',
-              conclusion: process.env.conclusion
-            });
             return result;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,16 +191,15 @@ jobs:
             Integration tests ${{ job.status }} for [${{ github.event.client_payload.slash_command.args.named.sha || github.event.pull_request.head.sha }}](https://github.com/snowflakedb/terraform-provider-snowflake/actions/runs/${{ github.run_id }})
 
       # For fork PRs, tests run via repository_dispatch (triggered by /ok-to-test),
-      # but the resulting check runs are tied to the default branch, not the fork PR.
-      # This step creates a new check run on the fork PR's head SHA so the PR status
-      # reflects the actual test outcome.
-      # Note: checks.update is blocked (GitHub only allows updating check runs you created).
-      # checks.create works because we own the newly created check run.
+      # but the job check runs are tied to the default branch, not the fork PR SHA.
+      # This step mirrors the job result onto the fork PR head SHA using a dedicated
+      # synthetic check run that we own, reusing it across reruns to avoid duplicates.
       - name: Set fork job status
         uses: actions/github-script@v6
         if: ${{ always() }}
         id: update_check_run
         env:
+          pr_number: ${{ github.event.client_payload.pull_request.number }}
           number: ${{ github.event.client_payload.pull_request.number }}
           check_run_id: ${{ job.check_run_id }}
           conclusion: ${{ job.status }}
@@ -221,16 +220,51 @@ jobs:
             console.log(`Current job check run name: ${jobName}`);
             const ref = process.env.sha;
             const conclusion = process.env.conclusion;
-            const { data: result } = await github.rest.checks.create({
+            const externalId = `fork-pr-${process.env.pr_number}-${jobName}`;
+            const output = {
+              title: `Tests ${conclusion}`,
+              summary: `Integration tests ${conclusion}. See the [workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`
+            };
+
+            const { data: existingRuns } = await github.rest.checks.listForRef({
               ...context.repo,
-              name: jobName,
-              head_sha: ref,
-              status: 'completed',
-              conclusion: conclusion,
-              output: {
-                title: `Tests ${conclusion}`,
-                summary: `Integration tests ${conclusion}. See the [workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`
-              }
+              ref,
+              check_name: jobName,
             });
-            console.log(`Created check run: ${conclusion} for "${jobName}" on ${ref}`);
+
+            const existingRun = existingRuns.check_runs
+              .filter((run) =>
+                run.head_sha === ref &&
+                run.name === jobName &&
+                run.external_id === externalId
+              )
+              .sort((left, right) => {
+                const leftDate = new Date(left.started_at || left.completed_at || 0).getTime();
+                const rightDate = new Date(right.started_at || right.completed_at || 0).getTime();
+                return rightDate - leftDate;
+              })[0];
+
+            let result;
+            if (existingRun) {
+              ({ data: result } = await github.rest.checks.update({
+                ...context.repo,
+                check_run_id: existingRun.id,
+                status: 'completed',
+                conclusion,
+                external_id: externalId,
+                output,
+              }));
+              console.log(`Updated check run ${existingRun.id}: ${conclusion} for "${jobName}" on ${ref}`);
+            } else {
+              ({ data: result } = await github.rest.checks.create({
+                ...context.repo,
+                name: jobName,
+                head_sha: ref,
+                status: 'completed',
+                conclusion,
+                external_id: externalId,
+                output,
+              }));
+              console.log(`Created check run: ${conclusion} for "${jobName}" on ${ref}`);
+            }
             return result;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -192,10 +192,10 @@ jobs:
 
       # For fork PRs, tests run via repository_dispatch (triggered by /ok-to-test),
       # but the resulting check runs are tied to the default branch, not the fork PR.
-      # This step updates the (skipped) check run on the fork PR's head SHA so the
-      # PR status reflects the actual test outcome. It resolves the job's display name
-      # via job.check_run_id (since github.job returns the job_id, not the display name)
-      # and uses it to find the matching check run on the fork PR's commit.
+      # This step creates a new check run on the fork PR's head SHA so the PR status
+      # reflects the actual test outcome.
+      # Note: checks.update is blocked (GitHub only allows updating check runs you created).
+      # checks.create works because we own the newly created check run.
       - name: Set fork job status
         uses: actions/github-script@v6
         if: ${{ always() }}
@@ -203,7 +203,6 @@ jobs:
         env:
           number: ${{ github.event.client_payload.pull_request.number }}
           check_run_id: ${{ job.check_run_id }}
-          # Conveniently, job.status maps to https://developer.github.com/v3/checks/runs/#update-a-check-run
           conclusion: ${{ job.status }}
           sha: ${{ github.event.client_payload.slash_command.args.named.sha }}
           event_name: ${{ github.event_name }}
@@ -221,20 +220,17 @@ jobs:
             const jobName = currentCheck.name;
             console.log(`Current job check run name: ${jobName}`);
             const ref = process.env.sha;
-            const { data: checks } = await github.rest.checks.listForRef({
+            const conclusion = process.env.conclusion;
+            const { data: result } = await github.rest.checks.create({
               ...context.repo,
-              ref
-            });
-            const check = checks.check_runs.filter(c => c.name === jobName);
-            console.log(check);
-            if (check.length === 0) {
-              console.log(`No matching check run found for "${jobName}" on ${ref}`);
-              return;
-            }
-            const { data: result } = await github.rest.checks.update({
-              ...context.repo,
-              check_run_id: check[0].id,
+              name: jobName,
+              head_sha: ref,
               status: 'completed',
-              conclusion: process.env.conclusion
+              conclusion: conclusion,
+              output: {
+                title: `Tests ${conclusion}`,
+                summary: `Integration tests ${conclusion}. See the [workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`
+              }
             });
+            console.log(`Created check run: ${conclusion} for "${jobName}" on ${ref}`);
             return result;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -200,7 +200,6 @@ jobs:
         id: update_check_run
         env:
           pr_number: ${{ github.event.client_payload.pull_request.number }}
-          number: ${{ github.event.client_payload.pull_request.number }}
           check_run_id: ${{ job.check_run_id }}
           conclusion: ${{ job.status }}
           sha: ${{ github.event.client_payload.slash_command.args.named.sha }}
@@ -239,8 +238,8 @@ jobs:
                 run.external_id === externalId
               )
               .sort((left, right) => {
-                const leftDate = new Date(left.started_at || left.completed_at || 0).getTime();
-                const rightDate = new Date(right.started_at || right.completed_at || 0).getTime();
+                const leftDate = Math.max(new Date(left.started_at || 0).getTime(), new Date(left.completed_at || 0).getTime());
+                const rightDate = Math.max(new Date(right.started_at || 0).getTime(), new Date(right.completed_at || 0).getTime());
                 return rightDate - leftDate;
               })[0];
 


### PR DESCRIPTION
## Changes
- Fix fork PR status mirroring for repository_dispatch workflows.
- Stop trying to update GitHub-owned job check runs and instead mirror results to a synthetic check run owned by the workflow.
- Reuse the synthetic check across reruns with a stable external_id to avoid duplicate statuses on PRs.
- Apply the same behavior to both regular integration tests and account-level tests.

Addresses [the current failures](https://github.com/snowflakedb/terraform-provider-snowflake/actions/runs/25807738289/job/75815171830)