### PR TITLE
fix: grants on connections to account role

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -42,6 +42,22 @@ The `snowflake_system_get_privatelink_config` data source now exposes additional
 
 No changes are required for existing configurations that only reference the previously available attributes.
 
+### *(bug fix)* snowflake_grant_privileges_to_account_role: CONNECTION object type support
+
+Previously, attempting to grant privileges on a `CONNECTION` object type in the `on_account_object` block would fail with the following error, despite `CONNECTION` being listed as an allowed value in the schema:
+
+```
+Error: [grants_validations.go:315] exactly one of GrantOnAccountObject
+fields [User ResourceMonitor Warehouse ComputePool Database Integration
+FailoverGroup ReplicationGroup ExternalVolume] must be set
+```
+
+This has been fixed — the resource now correctly handles `CONNECTION` as an account object type.
+
+No changes are required for existing configurations.
+
+References: [#4727](https://github.com/snowflakedb/terraform-provider-snowflake/issues/4727)
+
 ## v2.15.x ➞ v2.16.0
 
 ### *(improvement)* snowflake_password_policy resource rework

--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/grant_privileges_to_account_role_resource_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/grant_privileges_to_account_role_resource_ext.go
@@ -1,0 +1,18 @@
+package resourceassert
+
+import (
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+)
+
+func (g *GrantPrivilegesToAccountRoleResourceAssert) HasOnAccountObject(objectType sdk.ObjectType, id sdk.AccountObjectIdentifier) *GrantPrivilegesToAccountRoleResourceAssert {
+	g.AddAssertion(assert.ValueSet("on_account_object.#", "1"))
+	g.AddAssertion(assert.ValueSet("on_account_object.0.object_type", objectType.String()))
+	g.AddAssertion(assert.ValueSet("on_account_object.0.object_name", id.Name()))
+	return g
+}
+
+func (g *GrantPrivilegesToAccountRoleResourceAssert) HasResourceId(expected string) *GrantPrivilegesToAccountRoleResourceAssert {
+	g.AddAssertion(assert.ValueSet("id", expected))
+	return g
+}

--- a/pkg/resources/grant_privileges_to_account_role.go
+++ b/pkg/resources/grant_privileges_to_account_role.go
@@ -1115,6 +1115,8 @@ func getAccountRoleGrantOn(d *schema.ResourceData) (*sdk.AccountRoleGrantOn, err
 		switch sdk.ObjectType(objectType) {
 		case sdk.ObjectTypeDatabase:
 			grantOnAccountObject.Database = &objectIdentifier
+		case sdk.ObjectTypeConnection:
+			grantOnAccountObject.Connection = &objectIdentifier
 		case sdk.ObjectTypeFailoverGroup:
 			grantOnAccountObject.FailoverGroup = &objectIdentifier
 		case sdk.ObjectTypeIntegration:
@@ -1268,6 +1270,9 @@ func createGrantPrivilegesToAccountRoleIdFromSchema(d *schema.ResourceData) (id 
 		case on.AccountObject.Integration != nil:
 			onAccountObjectGrantData.ObjectType = sdk.ObjectTypeIntegration
 			onAccountObjectGrantData.ObjectName = *on.AccountObject.Integration
+		case on.AccountObject.Connection != nil:
+			onAccountObjectGrantData.ObjectType = sdk.ObjectTypeConnection
+			onAccountObjectGrantData.ObjectName = *on.AccountObject.Connection
 		case on.AccountObject.FailoverGroup != nil:
 			onAccountObjectGrantData.ObjectType = sdk.ObjectTypeFailoverGroup
 			onAccountObjectGrantData.ObjectName = *on.AccountObject.FailoverGroup

--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -53,6 +53,7 @@ type GrantOnAccountObject struct {
 	ComputePool      *AccountObjectIdentifier `ddl:"identifier" sql:"COMPUTE POOL"`
 	Database         *AccountObjectIdentifier `ddl:"identifier" sql:"DATABASE"`
 	Integration      *AccountObjectIdentifier `ddl:"identifier" sql:"INTEGRATION"`
+	Connection       *AccountObjectIdentifier `ddl:"identifier" sql:"CONNECTION"`
 	FailoverGroup    *AccountObjectIdentifier `ddl:"identifier" sql:"FAILOVER GROUP"`
 	ReplicationGroup *AccountObjectIdentifier `ddl:"identifier" sql:"REPLICATION GROUP"`
 	ExternalVolume   *AccountObjectIdentifier `ddl:"identifier" sql:"EXTERNAL VOLUME"`

--- a/pkg/sdk/grants_test.go
+++ b/pkg/sdk/grants_test.go
@@ -64,6 +64,21 @@ func TestGrantPrivilegesToAccountRole(t *testing.T) {
 		assertOptsValidAndSQLEquals(t, opts, `GRANT ALL PRIVILEGES ON COMPUTE POOL "compute pool" TO ROLE "role1"`)
 	})
 
+	t.Run("on account object - connection", func(t *testing.T) {
+		opts := &GrantPrivilegesToAccountRoleOptions{
+			privileges: &AccountRoleGrantPrivileges{
+				AllPrivileges: Bool(true),
+			},
+			on: &AccountRoleGrantOn{
+				AccountObject: &GrantOnAccountObject{
+					Connection: Pointer(NewAccountObjectIdentifier("myconn")),
+				},
+			},
+			accountRole: NewAccountObjectIdentifier("role1"),
+		}
+		assertOptsValidAndSQLEquals(t, opts, `GRANT ALL PRIVILEGES ON CONNECTION "myconn" TO ROLE "role1"`)
+	})
+
 	t.Run("on account object - exactly one of validation", func(t *testing.T) {
 		opts := &GrantPrivilegesToAccountRoleOptions{
 			privileges: &AccountRoleGrantPrivileges{
@@ -77,7 +92,7 @@ func TestGrantPrivilegesToAccountRole(t *testing.T) {
 			},
 			accountRole: NewAccountObjectIdentifier("role1"),
 		}
-		assertOptsInvalid(t, opts, errExactlyOneOf("GrantOnAccountObject", "User", "ResourceMonitor", "Warehouse", "ComputePool", "Database", "Integration", "FailoverGroup", "ReplicationGroup", "ExternalVolume"))
+		assertOptsInvalid(t, opts, errExactlyOneOf("GrantOnAccountObject", "User", "ResourceMonitor", "Warehouse", "ComputePool", "Database", "Integration", "Connection", "FailoverGroup", "ReplicationGroup", "ExternalVolume"))
 	})
 
 	t.Run("on account object - exactly one of validation - empty options", func(t *testing.T) {
@@ -90,7 +105,7 @@ func TestGrantPrivilegesToAccountRole(t *testing.T) {
 			},
 			accountRole: NewAccountObjectIdentifier("role1"),
 		}
-		assertOptsInvalid(t, opts, errExactlyOneOf("GrantOnAccountObject", "User", "ResourceMonitor", "Warehouse", "ComputePool", "Database", "Integration", "FailoverGroup", "ReplicationGroup", "ExternalVolume"))
+		assertOptsInvalid(t, opts, errExactlyOneOf("GrantOnAccountObject", "User", "ResourceMonitor", "Warehouse", "ComputePool", "Database", "Integration", "Connection", "FailoverGroup", "ReplicationGroup", "ExternalVolume"))
 	})
 
 	t.Run("on schema", func(t *testing.T) {

--- a/pkg/sdk/grants_validations.go
+++ b/pkg/sdk/grants_validations.go
@@ -311,8 +311,8 @@ func (v *AccountRoleGrantOn) validate() error {
 }
 
 func (v *GrantOnAccountObject) validate() error {
-	if !exactlyOneValueSet(v.User, v.ResourceMonitor, v.Warehouse, v.ComputePool, v.Database, v.Integration, v.FailoverGroup, v.ReplicationGroup, v.ExternalVolume) {
-		return errExactlyOneOf("GrantOnAccountObject", "User", "ResourceMonitor", "Warehouse", "ComputePool", "Database", "Integration", "FailoverGroup", "ReplicationGroup", "ExternalVolume")
+	if !exactlyOneValueSet(v.User, v.ResourceMonitor, v.Warehouse, v.ComputePool, v.Database, v.Integration, v.Connection, v.FailoverGroup, v.ReplicationGroup, v.ExternalVolume) {
+		return errExactlyOneOf("GrantOnAccountObject", "User", "ResourceMonitor", "Warehouse", "ComputePool", "Database", "Integration", "Connection", "FailoverGroup", "ReplicationGroup", "ExternalVolume")
 	}
 	return nil
 }

--- a/pkg/sdk/testint/grants_integration_test.go
+++ b/pkg/sdk/testint/grants_integration_test.go
@@ -124,6 +124,8 @@ func TestInt_GrantAndRevokePrivilegesToAccountRole(t *testing.T) {
 	})
 
 	t.Run("on account object - connection", func(t *testing.T) {
+		t.Skip("TODO(SNOW-1002023): Unskip; Connection object type is not supported in non Business Critical Snowflake Edition")
+
 		roleTest, roleCleanup := testClientHelper().Role.CreateRole(t)
 		t.Cleanup(roleCleanup)
 

--- a/pkg/sdk/testint/grants_integration_test.go
+++ b/pkg/sdk/testint/grants_integration_test.go
@@ -123,6 +123,46 @@ func TestInt_GrantAndRevokePrivilegesToAccountRole(t *testing.T) {
 		assert.Empty(t, grants)
 	})
 
+	t.Run("on account object - connection", func(t *testing.T) {
+		roleTest, roleCleanup := testClientHelper().Role.CreateRole(t)
+		t.Cleanup(roleCleanup)
+
+		connection, connectionCleanup := testClientHelper().Connection.Create(t)
+		t.Cleanup(connectionCleanup)
+
+		privileges := &sdk.AccountRoleGrantPrivileges{
+			AccountObjectPrivileges: []sdk.AccountObjectPrivilege{sdk.AccountObjectPrivilegeFailover},
+		}
+		on := &sdk.AccountRoleGrantOn{
+			AccountObject: &sdk.GrantOnAccountObject{
+				Connection: sdk.Pointer(connection.ID()),
+			},
+		}
+
+		err := client.Grants.GrantPrivilegesToAccountRole(ctx, privileges, on, roleTest.ID(), nil)
+		require.NoError(t, err)
+
+		grants, err := client.Grants.Show(ctx, &sdk.ShowGrantOptions{
+			To: &sdk.ShowGrantsTo{
+				Role: roleTest.ID(),
+			},
+		})
+		require.NoError(t, err)
+		assert.Len(t, grants, 1)
+		assert.Equal(t, sdk.AccountObjectPrivilegeFailover.String(), grants[0].Privilege)
+
+		// now revoke and verify that the grant(s) are gone
+		err = client.Grants.RevokePrivilegesFromAccountRole(ctx, privileges, on, roleTest.ID(), nil)
+		require.NoError(t, err)
+		grants, err = client.Grants.Show(ctx, &sdk.ShowGrantOptions{
+			To: &sdk.ShowGrantsTo{
+				Role: roleTest.ID(),
+			},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, grants)
+	})
+
 	t.Run("on schema", func(t *testing.T) {
 		roleTest, roleCleanup := testClientHelper().Role.CreateRole(t)
 		t.Cleanup(roleCleanup)

--- a/pkg/testacc/resource_grant_privileges_to_account_role_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_account_role_acceptance_test.go
@@ -1725,6 +1725,38 @@ func TestAcc_GrantPrivilegesToAccountRole_OnExternalVolume(t *testing.T) {
 	})
 }
 
+// proves https://github.com/snowflakedb/terraform-provider-snowflake/issues/4727 is fixed
+func TestAcc_GrantPrivilegesToAccountRole_OnConnection(t *testing.T) {
+	role, roleCleanup := testClient().Role.CreateRole(t)
+	t.Cleanup(roleCleanup)
+	connection, connectionCleanup := testClient().Connection.Create(t)
+	t.Cleanup(connectionCleanup)
+
+	grantModel := model.GrantPrivilegesToAccountRole("test", role.ID().Name()).
+		WithPrivileges(string(sdk.AccountObjectPrivilegeFailover)).
+		WithOnAccountObject(sdk.ObjectTypeConnection, connection.ID())
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckAccountRolePrivilegesRevoked(t),
+		Steps: []resource.TestStep{
+			{
+				Config: accconfig.FromModels(t, grantModel),
+				Check: assertThat(t,
+					resourceassert.GrantPrivilegesToAccountRoleResource(t, grantModel.ResourceReference()).
+						HasAccountRoleName(role.ID().Name()).
+						HasPrivileges(string(sdk.AccountObjectPrivilegeFailover)).
+						HasOnAccountObject(sdk.ObjectTypeConnection, connection.ID()).
+						HasResourceId(fmt.Sprintf("%s|false|false|FAILOVER|OnAccountObject|CONNECTION|%s", role.ID().FullyQualifiedName(), connection.ID().FullyQualifiedName())),
+				),
+			},
+		},
+	})
+}
+
 // proved https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2651
 func TestAcc_GrantPrivilegesToAccountRole_MLPrivileges(t *testing.T) {
 	role, roleCleanup := testClient().Role.CreateRole(t)

--- a/pkg/testacc/resource_grant_privileges_to_account_role_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_account_role_acceptance_test.go
@@ -1727,6 +1727,8 @@ func TestAcc_GrantPrivilegesToAccountRole_OnExternalVolume(t *testing.T) {
 
 // proves https://github.com/snowflakedb/terraform-provider-snowflake/issues/4727 is fixed
 func TestAcc_GrantPrivilegesToAccountRole_OnConnection(t *testing.T) {
+	t.Skip("TODO(SNOW-1002023): Unskip; Connection object type is not supported in non Business Critical Snowflake Edition")
+
 	role, roleCleanup := testClient().Role.CreateRole(t)
 	t.Cleanup(roleCleanup)
 	connection, connectionCleanup := testClient().Connection.Create(t)


### PR DESCRIPTION
## Changes
- Add missing field handling for grants on account object of type `CONNECTION`.
- Adjust SDK, grants_validations, and resource levels
- Add unit, integration, and acceptance tests

## References
- https://github.com/snowflakedb/terraform-provider-snowflake/issues/4727