### PR TITLE
feat(resource): add snowflake_database_from_listing resource

### DIFF
--- a/pkg/provider/previewfeatures/preview_features.go
+++ b/pkg/provider/previewfeatures/preview_features.go
@@ -31,6 +31,7 @@ const (
 	CurrentAccountResource                        feature = "snowflake_current_account_resource"
 	CurrentAccountDatasource                      feature = "snowflake_current_account_datasource"
 	CurrentOrganizationAccountResource            feature = "snowflake_current_organization_account_resource"
+	DatabaseFromListingResource                   feature = "snowflake_database_from_listing_resource"
 	DatabaseDatasource                            feature = "snowflake_database_datasource"
 	DatabaseRoleDatasource                        feature = "snowflake_database_role_datasource"
 	DynamicTableResource                          feature = "snowflake_dynamic_table_resource"
@@ -139,6 +140,7 @@ var allPreviewFeatures = []feature{
 	CurrentAccountResource,
 	CurrentAccountDatasource,
 	CurrentOrganizationAccountResource,
+	DatabaseFromListingResource,
 	DatabaseDatasource,
 	DatabaseRoleDatasource,
 	DynamicTableResource,

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -599,6 +599,7 @@ func getResources() map[string]*schema.Resource {
 		"snowflake_current_account":                                              resources.CurrentAccount(),
 		"snowflake_current_organization_account":                                 resources.CurrentOrganizationAccount(),
 		"snowflake_database":                                                     resources.Database(),
+		"snowflake_database_from_listing":                                        resources.DatabaseFromListing(),
 		"snowflake_database_role":                                                resources.DatabaseRole(),
 		"snowflake_dynamic_table":                                                resources.DynamicTable(),
 		"snowflake_email_notification_integration":                               resources.EmailNotificationIntegration(),

--- a/pkg/provider/resources/resources.go
+++ b/pkg/provider/resources/resources.go
@@ -24,6 +24,7 @@ const (
 	CurrentAccount                                         resource = "snowflake_current_account"
 	CurrentOrganizationAccount                             resource = "snowflake_current_organization_account"
 	Database                                               resource = "snowflake_database"
+	DatabaseFromListing                                    resource = "snowflake_database_from_listing"
 	DatabaseRole                                           resource = "snowflake_database_role"
 	DynamicTable                                           resource = "snowflake_dynamic_table"
 	EmailNotificationIntegration                           resource = "snowflake_email_notification_integration"

--- a/pkg/resources/database_from_listing.go
+++ b/pkg/resources/database_from_listing.go
@@ -1,0 +1,202 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var databaseFromListingSchema = map[string]*schema.Schema{
+	"name": {
+		Type:             schema.TypeString,
+		Required:         true,
+		Description:      blocklistedCharactersFieldDescription("Specifies the identifier for the database; must be unique for your account."),
+		DiffSuppressFunc: suppressIdentifierQuoting,
+	},
+	"from_listing": {
+		Type:        schema.TypeString,
+		Required:    true,
+		ForceNew:    true,
+		Description: "The global name of the listing from which to create the database. This can be an external listing or an organization listing. The listing must not be a paid listing, and listing terms must have been accepted if applicable. For more information, see [About sharing with listings](https://other-docs.snowflake.com/en/collaboration/collaboration-listings-about).",
+	},
+	"comment": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Specifies a comment for the database.",
+	},
+	FullyQualifiedNameAttributeName: schemas.FullyQualifiedNameSchema,
+}
+
+func DatabaseFromListing() *schema.Resource {
+	// TODO(SNOW-1818849): unassign network policies inside the database before dropping
+	deleteFunc := ResourceDeleteContextFunc(
+		sdk.ParseAccountObjectIdentifier,
+		func(client *sdk.Client) DropSafelyFunc[sdk.AccountObjectIdentifier] {
+			return client.Databases.DropSafely
+		},
+	)
+
+	return &schema.Resource{
+		CreateContext: TrackingCreateWrapper(resources.DatabaseFromListing, CreateDatabaseFromListing),
+		UpdateContext: TrackingUpdateWrapper(resources.DatabaseFromListing, UpdateDatabaseFromListing),
+		ReadContext:   TrackingReadWrapper(resources.DatabaseFromListing, ReadDatabaseFromListing),
+		DeleteContext: TrackingDeleteWrapper(resources.DatabaseFromListing, deleteFunc),
+		Description:   "A database created from a listing. Supports both external listings and organization listings. For more information about listings, see [About sharing with listings](https://other-docs.snowflake.com/en/collaboration/collaboration-listings-about).",
+
+		CustomizeDiff: TrackingCustomDiffWrapper(resources.DatabaseFromListing, customdiff.All(
+			ComputedIfAnyAttributeChanged(databaseFromListingSchema, FullyQualifiedNameAttributeName, "name"),
+		)),
+
+		Schema: collections.MergeMaps(databaseFromListingSchema, sharedDatabaseParametersSchema),
+		Importer: &schema.ResourceImporter{
+			StateContext: TrackingImportWrapper(resources.DatabaseFromListing, ImportName[sdk.AccountObjectIdentifier]),
+		},
+		Timeouts: defaultTimeouts,
+	}
+}
+
+func CreateDatabaseFromListing(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	client := meta.(*provider.Context).Client
+
+	id, err := sdk.ParseAccountObjectIdentifier(d.Get("name").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listingGlobalName := d.Get("from_listing").(string)
+
+	opts := &sdk.CreateDatabaseFromListingOptions{}
+
+	err = client.Databases.CreateFromListing(ctx, id, listingGlobalName, opts)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(helpers.EncodeResourceIdentifier(id))
+
+	// Comment is set post-creation via ALTER DATABASE since CREATE DATABASE ... FROM LISTING
+	// does not accept inline parameters.
+	if v, ok := d.GetOk("comment"); ok {
+		comment := v.(string)
+		if len(comment) > 0 {
+			err := client.Databases.Alter(ctx, id, &sdk.AlterDatabaseOptions{
+				Set: &sdk.DatabaseSet{
+					Comment: &comment,
+				},
+			})
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	return ReadDatabaseFromListing(ctx, d, meta)
+}
+
+func UpdateDatabaseFromListing(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	client := meta.(*provider.Context).Client
+	id, err := sdk.ParseAccountObjectIdentifier(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.HasChange("name") {
+		newId, err := sdk.ParseAccountObjectIdentifier(d.Get("name").(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		err = client.Databases.Alter(ctx, id, &sdk.AlterDatabaseOptions{
+			NewName: &newId,
+		})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		d.SetId(helpers.EncodeResourceIdentifier(newId))
+		id = newId
+	}
+
+	if d.HasChange("comment") {
+		comment := d.Get("comment").(string)
+		if len(comment) > 0 {
+			err := client.Databases.Alter(ctx, id, &sdk.AlterDatabaseOptions{
+				Set: &sdk.DatabaseSet{
+					Comment: &comment,
+				},
+			})
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		} else {
+			err := client.Databases.Alter(ctx, id, &sdk.AlterDatabaseOptions{
+				Unset: &sdk.DatabaseUnset{
+					Comment: sdk.Bool(true),
+				},
+			})
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	return ReadDatabaseFromListing(ctx, d, meta)
+}
+
+func ReadDatabaseFromListing(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	client := meta.(*provider.Context).Client
+	id, err := sdk.ParseAccountObjectIdentifier(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	database, err := client.Databases.ShowByIDSafely(ctx, id)
+	if err != nil {
+		if errors.Is(err, sdk.ErrObjectNotFound) {
+			d.SetId("")
+			return diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "Failed to query database from listing. Marking the resource as removed.",
+					Detail:   fmt.Sprintf("Database from listing id: %s, Err: %s", id.FullyQualifiedName(), err),
+				},
+			}
+		}
+		return diag.FromErr(err)
+	}
+	if err := d.Set(FullyQualifiedNameAttributeName, id.FullyQualifiedName()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if database.Origin != nil {
+		if err := d.Set("from_listing", database.Origin.FullyQualifiedName()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if err := d.Set("comment", database.Comment); err != nil {
+		return diag.FromErr(err)
+	}
+
+	databaseParameters, err := client.Databases.ShowParameters(ctx, id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if diags := handleDatabaseParameterRead(d, databaseParameters); diags != nil {
+		return diags
+	}
+
+	return nil
+}

--- a/pkg/sdk/databases.go
+++ b/pkg/sdk/databases.go
@@ -16,6 +16,7 @@ var (
 	_ validatable = new(CreateDatabaseOptions)
 	_ validatable = new(CreateSharedDatabaseOptions)
 	_ validatable = new(CreateSecondaryDatabaseOptions)
+	_ validatable = new(CreateDatabaseFromListingOptions)
 	_ validatable = new(AlterDatabaseOptions)
 	_ validatable = new(AlterDatabaseReplicationOptions)
 	_ validatable = new(AlterDatabaseFailoverOptions)
@@ -31,6 +32,7 @@ type Databases interface {
 	Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateDatabaseOptions) error
 	CreateShared(ctx context.Context, id AccountObjectIdentifier, shareID ExternalObjectIdentifier, opts *CreateSharedDatabaseOptions) error
 	CreateSecondary(ctx context.Context, id AccountObjectIdentifier, primaryID ExternalObjectIdentifier, opts *CreateSecondaryDatabaseOptions) error
+	CreateFromListing(ctx context.Context, id AccountObjectIdentifier, listingGlobalName string, opts *CreateDatabaseFromListingOptions) error
 	Alter(ctx context.Context, id AccountObjectIdentifier, opts *AlterDatabaseOptions) error
 	AlterReplication(ctx context.Context, id AccountObjectIdentifier, opts *AlterDatabaseReplicationOptions) error
 	AlterFailover(ctx context.Context, id AccountObjectIdentifier, opts *AlterDatabaseFailoverOptions) error
@@ -382,6 +384,47 @@ func (v *databases) CreateSecondary(ctx context.Context, id AccountObjectIdentif
 	}
 	opts.name = id
 	opts.primaryDatabase = primaryID
+	if err := opts.validate(); err != nil {
+		return err
+	}
+	sql, err := structToSQL(opts)
+	if err != nil {
+		return err
+	}
+	_, err = v.client.exec(ctx, sql)
+	return err
+}
+
+// CreateDatabaseFromListingOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-database.
+// Supports both external listings and organization listings via the same FROM LISTING syntax.
+// SQL: CREATE DATABASE <name> FROM LISTING '<listing_global_name>'
+type CreateDatabaseFromListingOptions struct {
+	create      bool                    `ddl:"static" sql:"CREATE"`
+	database    bool                    `ddl:"static" sql:"DATABASE"`
+	name        AccountObjectIdentifier `ddl:"identifier"`
+	fromListing string                  `ddl:"parameter,single_quotes,no_equals" sql:"FROM LISTING"`
+}
+
+func (opts *CreateDatabaseFromListingOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
+	var errs []error
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	if opts.fromListing == "" {
+		errs = append(errs, fmt.Errorf("CreateDatabaseFromListingOptions: listing global name must not be empty"))
+	}
+	return errors.Join(errs...)
+}
+
+func (v *databases) CreateFromListing(ctx context.Context, id AccountObjectIdentifier, listingGlobalName string, opts *CreateDatabaseFromListingOptions) error {
+	if opts == nil {
+		opts = &CreateDatabaseFromListingOptions{}
+	}
+	opts.name = id
+	opts.fromListing = listingGlobalName
 	if err := opts.validate(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
Add a new `snowflake_database_from_listing` resource that allows creating a Snowflake database from a Marketplace or Private Listing using `CREATE DATABASE ... FROM LISTING`.

## Changes
- **pkg/sdk/databases.go**: Add `CreateDatabaseFromListingOptions` struct and `CreateFromListing` SDK method
- **pkg/resources/database_from_listing.go**: Implement the Terraform resource (Create, Read, Update, Delete)
- **pkg/provider/provider.go**: Register the new resource
- **pkg/provider/resources/resources.go**: Add resource constant
- **pkg/provider/previewfeatures/preview_features.go**: Add preview feature flag

## Testing
- Unit tests pass (`make test-unit`)
- Manually tested end-to-end with a real Private Listing (create, read, destroy cycle)
- `go build`, `go vet`, and `make pre-push` pass cleanly

## Preview Feature
This resource is gated behind the `snowflake_database_from_listing_resource` preview feature flag.