### PR TITLE
chore: Reduce SDK manual changes - enums and predefined structs

### DIFF
--- a/pkg/sdk/api_integrations_gen.go
+++ b/pkg/sdk/api_integrations_gen.go
@@ -46,14 +46,14 @@ type AwsApiParams struct {
 }
 
 type AzureApiParams struct {
-	apiProvider          string  `ddl:"static" sql:"API_PROVIDER = azure_api_management"`
+	apiProvider          bool    `ddl:"static" sql:"API_PROVIDER = azure_api_management"`
 	AzureTenantId        string  `ddl:"parameter,single_quotes" sql:"AZURE_TENANT_ID"`
 	AzureAdApplicationId string  `ddl:"parameter,single_quotes" sql:"AZURE_AD_APPLICATION_ID"`
 	ApiKey               *string `ddl:"parameter,single_quotes" sql:"API_KEY"`
 }
 
 type GoogleApiParams struct {
-	apiProvider    string `ddl:"static" sql:"API_PROVIDER = google_api_gateway"`
+	apiProvider    bool   `ddl:"static" sql:"API_PROVIDER = google_api_gateway"`
 	GoogleAudience string `ddl:"parameter,single_quotes" sql:"GOOGLE_AUDIENCE"`
 }
 

--- a/pkg/sdk/file_formats_gen.go
+++ b/pkg/sdk/file_formats_gen.go
@@ -25,7 +25,7 @@ type FileFormatOptions struct {
 }
 
 type FileFormatCsvOptions struct {
-	formatType                 string                       `ddl:"static" sql:"TYPE = CSV"`
+	formatType                 bool                         `ddl:"static" sql:"TYPE = CSV"`
 	Compression                *CsvCompression              `ddl:"parameter,no_quotes" sql:"COMPRESSION"`
 	RecordDelimiter            *StageFileFormatStringOrNone `ddl:"list,no_parentheses" sql:"RECORD_DELIMITER ="`
 	FieldDelimiter             *StageFileFormatStringOrNone `ddl:"list,no_parentheses" sql:"FIELD_DELIMITER ="`
@@ -61,7 +61,7 @@ type StageFileFormatStringOrAuto struct {
 }
 
 type FileFormatJsonOptions struct {
-	formatType               string                       `ddl:"static" sql:"TYPE = JSON"`
+	formatType               bool                         `ddl:"static" sql:"TYPE = JSON"`
 	Compression              *JsonCompression             `ddl:"parameter,no_quotes" sql:"COMPRESSION"`
 	DateFormat               *StageFileFormatStringOrAuto `ddl:"list,no_parentheses" sql:"DATE_FORMAT ="`
 	TimeFormat               *StageFileFormatStringOrAuto `ddl:"list,no_parentheses" sql:"TIME_FORMAT ="`
@@ -81,7 +81,7 @@ type FileFormatJsonOptions struct {
 }
 
 type FileFormatAvroOptions struct {
-	formatType               string           `ddl:"static" sql:"TYPE = AVRO"`
+	formatType               bool             `ddl:"static" sql:"TYPE = AVRO"`
 	Compression              *AvroCompression `ddl:"parameter,no_quotes" sql:"COMPRESSION"`
 	TrimSpace                *bool            `ddl:"parameter" sql:"TRIM_SPACE"`
 	ReplaceInvalidCharacters *bool            `ddl:"parameter" sql:"REPLACE_INVALID_CHARACTERS"`
@@ -89,14 +89,14 @@ type FileFormatAvroOptions struct {
 }
 
 type FileFormatOrcOptions struct {
-	formatType               string       `ddl:"static" sql:"TYPE = ORC"`
+	formatType               bool         `ddl:"static" sql:"TYPE = ORC"`
 	TrimSpace                *bool        `ddl:"parameter" sql:"TRIM_SPACE"`
 	ReplaceInvalidCharacters *bool        `ddl:"parameter" sql:"REPLACE_INVALID_CHARACTERS"`
 	NullIf                   []NullString `ddl:"parameter,parentheses" sql:"NULL_IF"`
 }
 
 type FileFormatParquetOptions struct {
-	formatType               string              `ddl:"static" sql:"TYPE = PARQUET"`
+	formatType               bool                `ddl:"static" sql:"TYPE = PARQUET"`
 	Compression              *ParquetCompression `ddl:"parameter,no_quotes" sql:"COMPRESSION"`
 	SnappyCompression        *bool               `ddl:"parameter" sql:"SNAPPY_COMPRESSION"`
 	BinaryAsText             *bool               `ddl:"parameter" sql:"BINARY_AS_TEXT"`
@@ -108,7 +108,7 @@ type FileFormatParquetOptions struct {
 }
 
 type FileFormatXmlOptions struct {
-	formatType               string          `ddl:"static" sql:"TYPE = XML"`
+	formatType               bool            `ddl:"static" sql:"TYPE = XML"`
 	Compression              *XmlCompression `ddl:"parameter,no_quotes" sql:"COMPRESSION"`
 	IgnoreUtf8Errors         *bool           `ddl:"parameter" sql:"IGNORE_UTF8_ERRORS"`
 	PreserveSpace            *bool           `ddl:"parameter" sql:"PRESERVE_SPACE"`

--- a/pkg/sdk/generator/defs/api_integrations_def.go
+++ b/pkg/sdk/generator/defs/api_integrations_def.go
@@ -33,7 +33,7 @@ var apiIntegrationsDef = g.NewInterface(
 			OptionalQueryStructField(
 				"AzureApiProviderParams",
 				g.NewQueryStruct("AzureApiParams").
-					PredefinedQueryStructField("apiProvider", "string", g.StaticOptions().SQL("API_PROVIDER = azure_api_management")).
+					SQLWithCustomFieldName("apiProvider", "API_PROVIDER = azure_api_management").
 					TextAssignment("AZURE_TENANT_ID", g.ParameterOptions().SingleQuotes().Required()).
 					TextAssignment("AZURE_AD_APPLICATION_ID", g.ParameterOptions().SingleQuotes().Required()).
 					OptionalTextAssignment("API_KEY", g.ParameterOptions().SingleQuotes()),
@@ -42,7 +42,7 @@ var apiIntegrationsDef = g.NewInterface(
 			OptionalQueryStructField(
 				"GoogleApiProviderParams",
 				g.NewQueryStruct("GoogleApiParams").
-					PredefinedQueryStructField("apiProvider", "string", g.StaticOptions().SQL("API_PROVIDER = google_api_gateway")).
+					SQLWithCustomFieldName("apiProvider", "API_PROVIDER = google_api_gateway").
 					TextAssignment("GOOGLE_AUDIENCE", g.ParameterOptions().SingleQuotes().Required()),
 				g.KeywordOptions(),
 			).

--- a/pkg/sdk/generator/defs/authentication_policies_def.go
+++ b/pkg/sdk/generator/defs/authentication_policies_def.go
@@ -70,12 +70,8 @@ var (
 							OptionalNumberAssignment("DEFAULT_EXPIRY_IN_DAYS", g.ParameterOptions().NoQuotes()).
 							OptionalNumberAssignment("MAX_EXPIRY_IN_DAYS", g.ParameterOptions().NoQuotes()).
 							OptionalBooleanAssignment("REQUIRE_ROLE_RESTRICTION_FOR_SERVICE_USERS", g.ParameterOptions()).
-							OptionalAssignment(
-			"NETWORK_POLICY_EVALUATION",
-			NetworkPolicyEvaluationOptionEnumDef.Kind(),
-			g.ParameterOptions().NoQuotes(),
-		).
-		WithValidation(g.AtLeastOneValueSet, "DefaultExpiryInDays", "MaxExpiryInDays", "RequireRoleRestrictionForServiceUsers", "NetworkPolicyEvaluation")
+							OptionalEnumAssignment("NETWORK_POLICY_EVALUATION", NetworkPolicyEvaluationOptionEnumDef, g.ParameterOptions().NoQuotes()).
+							WithValidation(g.AtLeastOneValueSet, "DefaultExpiryInDays", "MaxExpiryInDays", "RequireRoleRestrictionForServiceUsers", "NetworkPolicyEvaluation")
 	AuthenticationPolicyAllowedProviderListItemDef = g.NewQueryStruct("AuthenticationPolicyAllowedProviderListItem").Enum("Provider", AllowedProviderOptionEnumDef, g.KeywordOptions().SingleQuotes().Required())
 	AuthenticationPolicyClientPolicyEntryDef       = g.NewQueryStruct("AuthenticationPolicyClientPolicyEntry").
 							Enum("ClientType", ClientPolicyDriverTypeEnumDef, g.KeywordOptions().NoQuotes().Required()).

--- a/pkg/sdk/generator/defs/authentication_policies_def.go
+++ b/pkg/sdk/generator/defs/authentication_policies_def.go
@@ -55,17 +55,17 @@ var (
 		"ALL", "NONE",
 	)
 
-	AuthenticationMethodsOptionDef = g.NewQueryStruct("AuthenticationMethods").PredefinedQueryStructField("Method", AuthenticationMethodsOptionEnumDef.Kind(), g.KeywordOptions().SingleQuotes().Required())
-	ClientTypesOptionDef           = g.NewQueryStruct("ClientTypes").PredefinedQueryStructField("ClientType", ClientTypesOptionEnumDef.Kind(), g.KeywordOptions().SingleQuotes().Required())
+	AuthenticationMethodsOptionDef = g.NewQueryStruct("AuthenticationMethods").Enum("Method", AuthenticationMethodsOptionEnumDef, g.KeywordOptions().SingleQuotes().Required())
+	ClientTypesOptionDef           = g.NewQueryStruct("ClientTypes").Enum("ClientType", ClientTypesOptionEnumDef, g.KeywordOptions().SingleQuotes().Required())
 	SecurityIntegrationsOptionDef  = g.NewQueryStruct("SecurityIntegrationsOption").
 					OptionalSQLWithCustomFieldName("All", "('ALL')").
 					UnnamedList("SecurityIntegrations", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.KeywordOptions().Parentheses()).
 					WithValidation(g.ExactlyOneValueSet, "All", "SecurityIntegrations")
 	AuthenticationPolicyMfaPolicyDef = g.NewQueryStruct("AuthenticationPolicyMfaPolicy").
-						PredefinedQueryStructField("EnforceMfaOnExternalAuthentication", EnforceMfaOnExternalAuthenticationOptionEnumDef.KindPtr(), g.ParameterOptions().SQL("ENFORCE_MFA_ON_EXTERNAL_AUTHENTICATION")).
+						OptionalEnum("EnforceMfaOnExternalAuthentication", EnforceMfaOnExternalAuthenticationOptionEnumDef, g.ParameterOptions().SQL("ENFORCE_MFA_ON_EXTERNAL_AUTHENTICATION")).
 						ListAssignment("ALLOWED_METHODS", "AuthenticationPolicyMfaPolicyListItem", g.ParameterOptions().Parentheses()).
 						WithValidation(g.AtLeastOneValueSet, "EnforceMfaOnExternalAuthentication", "AllowedMethods")
-	AuthenticationPolicyMfaPolicyListItemDef = g.NewQueryStruct("AuthenticationPolicyMfaPolicyListItem").PredefinedQueryStructField("Method", MfaPolicyAllowedMethodsOptionEnumDef.Kind(), g.KeywordOptions().SingleQuotes().Required())
+	AuthenticationPolicyMfaPolicyListItemDef = g.NewQueryStruct("AuthenticationPolicyMfaPolicyListItem").Enum("Method", MfaPolicyAllowedMethodsOptionEnumDef, g.KeywordOptions().SingleQuotes().Required())
 	AuthenticationPolicyPatPolicyDef         = g.NewQueryStruct("AuthenticationPolicyPatPolicy").
 							OptionalNumberAssignment("DEFAULT_EXPIRY_IN_DAYS", g.ParameterOptions().NoQuotes()).
 							OptionalNumberAssignment("MAX_EXPIRY_IN_DAYS", g.ParameterOptions().NoQuotes()).
@@ -76,9 +76,9 @@ var (
 			g.ParameterOptions().NoQuotes(),
 		).
 		WithValidation(g.AtLeastOneValueSet, "DefaultExpiryInDays", "MaxExpiryInDays", "RequireRoleRestrictionForServiceUsers", "NetworkPolicyEvaluation")
-	AuthenticationPolicyAllowedProviderListItemDef = g.NewQueryStruct("AuthenticationPolicyAllowedProviderListItem").PredefinedQueryStructField("Provider", AllowedProviderOptionEnumDef.Kind(), g.KeywordOptions().SingleQuotes().Required())
+	AuthenticationPolicyAllowedProviderListItemDef = g.NewQueryStruct("AuthenticationPolicyAllowedProviderListItem").Enum("Provider", AllowedProviderOptionEnumDef, g.KeywordOptions().SingleQuotes().Required())
 	AuthenticationPolicyClientPolicyEntryDef       = g.NewQueryStruct("AuthenticationPolicyClientPolicyEntry").
-							PredefinedQueryStructField("ClientType", ClientPolicyDriverTypeEnumDef.Kind(), g.KeywordOptions().NoQuotes().Required()).
+							Enum("ClientType", ClientPolicyDriverTypeEnumDef, g.KeywordOptions().NoQuotes().Required()).
 							OptionalQueryStructField("Params", AuthenticationPolicyClientPolicyEntryParamsDef, g.ListOptions().SQL("=").Parentheses().Required())
 	AuthenticationPolicyClientPolicyEntryParamsDef = g.NewQueryStruct("AuthenticationPolicyClientPolicyEntryParams").
 							OptionalTextAssignment("MINIMUM_VERSION", g.ParameterOptions().SingleQuotes())
@@ -104,7 +104,7 @@ var authenticationPoliciesDef = g.NewInterface(
 			IfNotExists().
 			Name().
 			ListAssignment("AUTHENTICATION_METHODS", "AuthenticationMethods", g.ParameterOptions().Parentheses()).
-			PredefinedQueryStructField("MfaEnrollment", MfaEnrollmentOptionEnumDef.KindPtr(), g.ParameterOptions().SQL("MFA_ENROLLMENT")).
+			OptionalEnum("MfaEnrollment", MfaEnrollmentOptionEnumDef, g.ParameterOptions().SQL("MFA_ENROLLMENT")).
 			OptionalQueryStructField("MfaPolicy", AuthenticationPolicyMfaPolicyDef, g.ListOptions().SQL("MFA_POLICY =").Parentheses().NoComma()).
 			ListAssignment("CLIENT_TYPES", "ClientTypes", g.ParameterOptions().Parentheses()).
 			ListAssignment("CLIENT_POLICY", "AuthenticationPolicyClientPolicyEntry", g.ParameterOptions().Parentheses()).
@@ -135,7 +135,7 @@ var authenticationPoliciesDef = g.NewInterface(
 				"Set",
 				g.NewQueryStruct("AuthenticationPolicySet").
 					ListAssignment("AUTHENTICATION_METHODS", "AuthenticationMethods", g.ParameterOptions().Parentheses()).
-					PredefinedQueryStructField("MfaEnrollment", MfaEnrollmentOptionEnumDef.KindPtr(), g.ParameterOptions().SQL("MFA_ENROLLMENT")).
+					OptionalEnum("MfaEnrollment", MfaEnrollmentOptionEnumDef, g.ParameterOptions().SQL("MFA_ENROLLMENT")).
 					OptionalQueryStructField("MfaPolicy", AuthenticationPolicyMfaPolicyDef, g.ListOptions().SQL("MFA_POLICY =").Parentheses().NoComma()).
 					ListAssignment("CLIENT_TYPES", "ClientTypes", g.ParameterOptions().Parentheses()).
 					ListAssignment("CLIENT_POLICY", "AuthenticationPolicyClientPolicyEntry", g.ParameterOptions().Parentheses()).

--- a/pkg/sdk/generator/defs/catalog_integrations_def.go
+++ b/pkg/sdk/generator/defs/catalog_integrations_def.go
@@ -31,16 +31,16 @@ var (
 
 var openCatalogRestConfigDef = g.NewQueryStruct("OpenCatalogRestConfig").
 	TextAssignment("CATALOG_URI", g.ParameterOptions().SingleQuotes().Required()).
-	OptionalAssignment("CATALOG_API_TYPE", CatalogIntegrationCatalogApiTypeEnumDef.Kind(), g.ParameterOptions().NoQuotes()).
+	OptionalEnumAssignment("CATALOG_API_TYPE", CatalogIntegrationCatalogApiTypeEnumDef, g.ParameterOptions().NoQuotes()).
 	TextAssignment("CATALOG_NAME", g.ParameterOptions().SingleQuotes().Required()).
-	OptionalAssignment("ACCESS_DELEGATION_MODE", CatalogIntegrationAccessDelegationModeEnumDef.Kind(), g.ParameterOptions().NoQuotes())
+	OptionalEnumAssignment("ACCESS_DELEGATION_MODE", CatalogIntegrationAccessDelegationModeEnumDef, g.ParameterOptions().NoQuotes())
 
 var icebergRestRestConfigDef = g.NewQueryStruct("IcebergRestRestConfig").
 	TextAssignment("CATALOG_URI", g.ParameterOptions().SingleQuotes().Required()).
 	OptionalTextAssignment("PREFIX", g.ParameterOptions().SingleQuotes()).
 	OptionalTextAssignment("CATALOG_NAME", g.ParameterOptions().SingleQuotes()).
-	OptionalAssignment("CATALOG_API_TYPE", CatalogIntegrationCatalogApiTypeEnumDef.Kind(), g.ParameterOptions().NoQuotes()).
-	OptionalAssignment("ACCESS_DELEGATION_MODE", CatalogIntegrationAccessDelegationModeEnumDef.Kind(), g.ParameterOptions().NoQuotes())
+	OptionalEnumAssignment("CATALOG_API_TYPE", CatalogIntegrationCatalogApiTypeEnumDef, g.ParameterOptions().NoQuotes()).
+	OptionalEnumAssignment("ACCESS_DELEGATION_MODE", CatalogIntegrationAccessDelegationModeEnumDef, g.ParameterOptions().NoQuotes())
 
 var oAuthRestAuthenticationDef = g.NewQueryStruct("OAuthRestAuthentication").
 	SQLWithCustomFieldName("restAuthType", "TYPE = OAUTH").
@@ -87,7 +87,7 @@ var catalogIntegrationsDef = g.NewInterface(
 				"ObjectStorageCatalogSourceParams",
 				g.NewQueryStruct("ObjectStorageParams").
 					SQLWithCustomFieldName("catalogSource", "CATALOG_SOURCE = OBJECT_STORE").
-					Assignment("TABLE_FORMAT", CatalogIntegrationTableFormatEnumDef.Kind(), g.ParameterOptions().NoQuotes().Required()),
+					EnumAssignment("TABLE_FORMAT", CatalogIntegrationTableFormatEnumDef, g.ParameterOptions().NoQuotes().Required()),
 				g.KeywordOptions()).
 			OptionalQueryStructField(
 				"OpenCatalogCatalogSourceParams",
@@ -207,8 +207,8 @@ var catalogIntegrationsDef = g.NewInterface(
 			WithValidation(g.ValidIdentifier, "name"),
 		g.PlainStruct("CatalogIntegrationAwsGlueDetails").
 			AccountObjectIdentifier().
-			Field("CatalogSource", CatalogIntegrationCatalogSourceTypeEnumDef.Kind()).
-			Field("TableFormat", CatalogIntegrationTableFormatEnumDef.Kind()).
+			Enum("CatalogSource", CatalogIntegrationCatalogSourceTypeEnumDef).
+			Enum("TableFormat", CatalogIntegrationTableFormatEnumDef).
 			Bool("Enabled").
 			Number("RefreshIntervalSeconds").
 			Text("Comment").
@@ -218,15 +218,15 @@ var catalogIntegrationsDef = g.NewInterface(
 			Text("CatalogNamespace"),
 		g.PlainStruct("CatalogIntegrationObjectStorageDetails").
 			AccountObjectIdentifier().
-			Field("CatalogSource", CatalogIntegrationCatalogSourceTypeEnumDef.Kind()).
-			Field("TableFormat", CatalogIntegrationTableFormatEnumDef.Kind()).
+			Enum("CatalogSource", CatalogIntegrationCatalogSourceTypeEnumDef).
+			Enum("TableFormat", CatalogIntegrationTableFormatEnumDef).
 			Bool("Enabled").
 			Number("RefreshIntervalSeconds").
 			Text("Comment"),
 		g.PlainStruct("CatalogIntegrationOpenCatalogDetails").
 			AccountObjectIdentifier().
-			Field("CatalogSource", CatalogIntegrationCatalogSourceTypeEnumDef.Kind()).
-			Field("TableFormat", CatalogIntegrationTableFormatEnumDef.Kind()).
+			Enum("CatalogSource", CatalogIntegrationCatalogSourceTypeEnumDef).
+			Enum("TableFormat", CatalogIntegrationTableFormatEnumDef).
 			Bool("Enabled").
 			Number("RefreshIntervalSeconds").
 			Text("Comment").
@@ -235,8 +235,8 @@ var catalogIntegrationsDef = g.NewInterface(
 			Field("RestAuthentication", "OAuthRestAuthenticationDetails"),
 		g.PlainStruct("CatalogIntegrationIcebergRestDetails").
 			AccountObjectIdentifier().
-			Field("CatalogSource", CatalogIntegrationCatalogSourceTypeEnumDef.Kind()).
-			Field("TableFormat", CatalogIntegrationTableFormatEnumDef.Kind()).
+			Enum("CatalogSource", CatalogIntegrationCatalogSourceTypeEnumDef).
+			Enum("TableFormat", CatalogIntegrationTableFormatEnumDef).
 			Bool("Enabled").
 			Number("RefreshIntervalSeconds").
 			Text("Comment").
@@ -247,8 +247,8 @@ var catalogIntegrationsDef = g.NewInterface(
 			OptionalField("SigV4RestAuthentication", "SigV4RestAuthenticationDetails"),
 		g.PlainStruct("CatalogIntegrationAllDetails").
 			AccountObjectIdentifier().
-			Field("CatalogSource", CatalogIntegrationCatalogSourceTypeEnumDef.Kind()).
-			Field("TableFormat", CatalogIntegrationTableFormatEnumDef.Kind()).
+			Enum("CatalogSource", CatalogIntegrationCatalogSourceTypeEnumDef).
+			Enum("TableFormat", CatalogIntegrationTableFormatEnumDef).
 			Bool("Enabled").
 			Number("RefreshIntervalSeconds").
 			Text("Comment").
@@ -263,15 +263,15 @@ var catalogIntegrationsDef = g.NewInterface(
 			OptionalField("SigV4RestAuthentication", "SigV4RestAuthenticationDetails"),
 		g.PlainStruct("OpenCatalogRestConfigDetails").
 			Text("CatalogUri").
-			Field("CatalogApiType", CatalogIntegrationCatalogApiTypeEnumDef.Kind()).
+			Enum("CatalogApiType", CatalogIntegrationCatalogApiTypeEnumDef).
 			Text("CatalogName").
-			Field("AccessDelegationMode", CatalogIntegrationAccessDelegationModeEnumDef.Kind()),
+			Enum("AccessDelegationMode", CatalogIntegrationAccessDelegationModeEnumDef),
 		g.PlainStruct("IcebergRestRestConfigDetails").
 			Text("CatalogUri").
 			Text("Prefix").
 			Text("CatalogName").
-			Field("CatalogApiType", CatalogIntegrationCatalogApiTypeEnumDef.Kind()).
-			Field("AccessDelegationMode", CatalogIntegrationAccessDelegationModeEnumDef.Kind()),
+			Enum("CatalogApiType", CatalogIntegrationCatalogApiTypeEnumDef).
+			Enum("AccessDelegationMode", CatalogIntegrationAccessDelegationModeEnumDef),
 		g.PlainStruct("OAuthRestAuthenticationDetails").
 			Text("OauthTokenUri").
 			Text("OauthClientId").

--- a/pkg/sdk/generator/defs/compute_pools_def.go
+++ b/pkg/sdk/generator/defs/compute_pools_def.go
@@ -84,7 +84,7 @@ var computePoolsDef = g.NewInterface(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-compute-pools",
 	g.StructPair("computePoolsRow", "ComputePool").
 		Text("name").
-		PlainField("state", ComputePoolStateEnumDef.Kind()).
+		Enum("state", ComputePoolStateEnumDef).
 		Number("min_nodes").
 		Number("max_nodes").
 		PlainField("instance_family", "ComputePoolInstanceFamily").
@@ -113,7 +113,7 @@ var computePoolsDef = g.NewInterface(
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-compute-pool",
 	g.StructPair("computePoolDescRow", "ComputePoolDetails").
 		Text("name").
-		PlainField("state", ComputePoolStateEnumDef.Kind()).
+		Enum("state", ComputePoolStateEnumDef).
 		Number("min_nodes").
 		Number("max_nodes").
 		PlainField("instance_family", "ComputePoolInstanceFamily").

--- a/pkg/sdk/generator/defs/data_metric_function_references_def.go
+++ b/pkg/sdk/generator/defs/data_metric_function_references_def.go
@@ -21,11 +21,8 @@ var dataMetricFunctionReferenceParametersDef = g.NewQueryStruct("dataMetricFunct
 
 var dataMetricFunctionReferenceFunctionArgumentsDef = g.NewQueryStruct("dataMetricFunctionReferenceFunctionArguments").
 	PredefinedQueryStructField("refEntityName", "[]ObjectIdentifier", g.ParameterOptions().ArrowEquals().SingleQuotes().SQL("REF_ENTITY_NAME").Required()).
-	OptionalAssignment(
-		"REF_ENTITY_DOMAIN",
-		DataMetricFunctionRefEntityDomainOptionEnumDef.Kind(),
-		g.ParameterOptions().SingleQuotes().ArrowEquals().Required(),
-	).WithValidation(g.ValidateValueSet, "RefEntityDomain").
+	OptionalEnumAssignment("REF_ENTITY_DOMAIN", DataMetricFunctionRefEntityDomainOptionEnumDef, g.ParameterOptions().SingleQuotes().ArrowEquals().Required()).
+	WithValidation(g.ValidateValueSet, "RefEntityDomain").
 	WithValidation(g.ValidateValueSet, "refEntityName")
 
 var dataMetricFunctionReferencesDef = g.NewInterface(

--- a/pkg/sdk/generator/defs/external_functions_def.go
+++ b/pkg/sdk/generator/defs/external_functions_def.go
@@ -63,9 +63,9 @@ var externalFunctionsDef = g.NewInterface(
 			externalFunctionArgument,
 			g.ListOptions().MustParentheses()).
 		PredefinedQueryStructField("ResultDataType", g.KindOfT[sdkcommons.DataType](), g.ParameterOptions().NoEquals().SQL("RETURNS").Required()).
-		PredefinedQueryStructField("ReturnNullValues", g.KindOfTPointer[sdkcommons.ReturnNullValues](), g.KeywordOptions()).
-		PredefinedQueryStructField("NullInputBehavior", g.KindOfTPointer[sdkcommons.NullInputBehavior](), g.KeywordOptions()).
-		PredefinedQueryStructField("ReturnResultsBehavior", g.KindOfTPointer[sdkcommons.ReturnResultsBehavior](), g.KeywordOptions()).
+		WithField(g.OptionalEnumLegacy[sdkcommons.ReturnNullValues]("ReturnNullValues", g.KeywordOptions())).
+		WithField(g.OptionalEnumLegacy[sdkcommons.NullInputBehavior]("NullInputBehavior", g.KeywordOptions())).
+		WithField(g.OptionalEnumLegacy[sdkcommons.ReturnResultsBehavior]("ReturnResultsBehavior", g.KeywordOptions())).
 		OptionalTextAssignment("COMMENT", g.ParameterOptions().SingleQuotes()).
 		Identifier("ApiIntegration", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("API_INTEGRATION =").Required()).
 		ListQueryStructField(

--- a/pkg/sdk/generator/defs/external_volumes_def.go
+++ b/pkg/sdk/generator/defs/external_volumes_def.go
@@ -34,7 +34,7 @@ var (
 )
 
 var externalS3StorageLocationDef = g.NewQueryStruct("S3StorageLocationParams").
-	Assignment("STORAGE_PROVIDER", S3StorageProviderEnumDef.Kind(), g.ParameterOptions().SingleQuotes().Required()).
+	EnumAssignment("STORAGE_PROVIDER", S3StorageProviderEnumDef, g.ParameterOptions().SingleQuotes().Required()).
 	TextAssignment("STORAGE_AWS_ROLE_ARN", g.ParameterOptions().SingleQuotes().Required()).
 	TextAssignment("STORAGE_BASE_URL", g.ParameterOptions().SingleQuotes().Required()).
 	OptionalTextAssignment("STORAGE_AWS_EXTERNAL_ID", g.ParameterOptions().SingleQuotes()).
@@ -43,7 +43,7 @@ var externalS3StorageLocationDef = g.NewQueryStruct("S3StorageLocationParams").
 	OptionalQueryStructField(
 		"Encryption",
 		g.NewQueryStruct("ExternalVolumeS3Encryption").
-			AssignmentWithFieldName("TYPE", S3EncryptionTypeEnumDef.Kind(), g.ParameterOptions().SingleQuotes().Required(), "EncryptionType").
+			EnumAssignmentWithFieldName("TYPE", S3EncryptionTypeEnumDef, g.ParameterOptions().SingleQuotes().Required(), "EncryptionType").
 			OptionalTextAssignment("KMS_KEY_ID", g.ParameterOptions().SingleQuotes()),
 		g.ListOptions().Parentheses().NoComma().SQL("ENCRYPTION ="),
 	)
@@ -54,7 +54,7 @@ var externalGCSStorageLocationDef = g.NewQueryStruct("GCSStorageLocationParams")
 	OptionalQueryStructField(
 		"Encryption",
 		g.NewQueryStruct("ExternalVolumeGCSEncryption").
-			AssignmentWithFieldName("TYPE", GCSEncryptionTypeEnumDef.Kind(), g.ParameterOptions().SingleQuotes().Required(), "EncryptionType").
+			EnumAssignmentWithFieldName("TYPE", GCSEncryptionTypeEnumDef, g.ParameterOptions().SingleQuotes().Required(), "EncryptionType").
 			OptionalTextAssignment("KMS_KEY_ID", g.ParameterOptions().SingleQuotes()),
 		g.ListOptions().Parentheses().NoComma().SQL("ENCRYPTION ="),
 	)

--- a/pkg/sdk/generator/defs/file_formats_def.go
+++ b/pkg/sdk/generator/defs/file_formats_def.go
@@ -64,7 +64,7 @@ func fileFormatDef() *g.QueryStruct {
 		OptionalQueryStructField(
 			"CsvOptions",
 			g.NewQueryStruct("FileFormatCsvOptions").
-				PredefinedQueryStructField("formatType", "string", g.StaticOptions().SQL("TYPE = CSV")).
+				SQLWithCustomFieldName("formatType", "TYPE = CSV").
 				OptionalAssignment("COMPRESSION", CsvCompressionEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
 				OptionalQueryStructField("RecordDelimiter", stageFileFormatStringOrNone(), g.ListOptions().NoParentheses().SQL("RECORD_DELIMITER =")).
 				OptionalQueryStructField("FieldDelimiter", stageFileFormatStringOrNone(), g.ListOptions().NoParentheses().SQL("FIELD_DELIMITER =")).
@@ -93,7 +93,7 @@ func fileFormatDef() *g.QueryStruct {
 		OptionalQueryStructField(
 			"JsonOptions",
 			g.NewQueryStruct("FileFormatJsonOptions").
-				PredefinedQueryStructField("formatType", "string", g.StaticOptions().SQL("TYPE = JSON")).
+				SQLWithCustomFieldName("formatType", "TYPE = JSON").
 				OptionalAssignment("COMPRESSION", JsonCompressionEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
 				OptionalQueryStructField("DateFormat", stageFileFormatStringOrAuto(), g.ListOptions().NoParentheses().SQL("DATE_FORMAT =")).
 				OptionalQueryStructField("TimeFormat", stageFileFormatStringOrAuto(), g.ListOptions().NoParentheses().SQL("TIME_FORMAT =")).
@@ -116,7 +116,7 @@ func fileFormatDef() *g.QueryStruct {
 		OptionalQueryStructField(
 			"AvroOptions",
 			g.NewQueryStruct("FileFormatAvroOptions").
-				PredefinedQueryStructField("formatType", "string", g.StaticOptions().SQL("TYPE = AVRO")).
+				SQLWithCustomFieldName("formatType", "TYPE = AVRO").
 				OptionalAssignment("COMPRESSION", AvroCompressionEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
 				OptionalBooleanAssignment("TRIM_SPACE", g.ParameterOptions()).
 				OptionalBooleanAssignment("REPLACE_INVALID_CHARACTERS", g.ParameterOptions()).
@@ -126,7 +126,7 @@ func fileFormatDef() *g.QueryStruct {
 		OptionalQueryStructField(
 			"OrcOptions",
 			g.NewQueryStruct("FileFormatOrcOptions").
-				PredefinedQueryStructField("formatType", "string", g.StaticOptions().SQL("TYPE = ORC")).
+				SQLWithCustomFieldName("formatType", "TYPE = ORC").
 				OptionalBooleanAssignment("TRIM_SPACE", g.ParameterOptions()).
 				OptionalBooleanAssignment("REPLACE_INVALID_CHARACTERS", g.ParameterOptions()).
 				ListAssignment("NULL_IF", "NullString", g.ParameterOptions().Parentheses()),
@@ -135,7 +135,7 @@ func fileFormatDef() *g.QueryStruct {
 		OptionalQueryStructField(
 			"ParquetOptions",
 			g.NewQueryStruct("FileFormatParquetOptions").
-				PredefinedQueryStructField("formatType", "string", g.StaticOptions().SQL("TYPE = PARQUET")).
+				SQLWithCustomFieldName("formatType", "TYPE = PARQUET").
 				OptionalAssignment("COMPRESSION", ParquetCompressionEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
 				OptionalBooleanAssignment("SNAPPY_COMPRESSION", g.ParameterOptions()).
 				OptionalBooleanAssignment("BINARY_AS_TEXT", g.ParameterOptions()).
@@ -150,7 +150,7 @@ func fileFormatDef() *g.QueryStruct {
 		OptionalQueryStructField(
 			"XmlOptions",
 			g.NewQueryStruct("FileFormatXmlOptions").
-				PredefinedQueryStructField("formatType", "string", g.StaticOptions().SQL("TYPE = XML")).
+				SQLWithCustomFieldName("formatType", "TYPE = XML").
 				OptionalAssignment("COMPRESSION", XmlCompressionEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
 				OptionalBooleanAssignment("IGNORE_UTF8_ERRORS", g.ParameterOptions()).
 				OptionalBooleanAssignment("PRESERVE_SPACE", g.ParameterOptions()).

--- a/pkg/sdk/generator/defs/file_formats_def.go
+++ b/pkg/sdk/generator/defs/file_formats_def.go
@@ -65,7 +65,7 @@ func fileFormatDef() *g.QueryStruct {
 			"CsvOptions",
 			g.NewQueryStruct("FileFormatCsvOptions").
 				SQLWithCustomFieldName("formatType", "TYPE = CSV").
-				OptionalAssignment("COMPRESSION", CsvCompressionEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
+				OptionalEnumAssignment("COMPRESSION", CsvCompressionEnumDef, g.ParameterOptions().NoQuotes()).
 				OptionalQueryStructField("RecordDelimiter", stageFileFormatStringOrNone(), g.ListOptions().NoParentheses().SQL("RECORD_DELIMITER =")).
 				OptionalQueryStructField("FieldDelimiter", stageFileFormatStringOrNone(), g.ListOptions().NoParentheses().SQL("FIELD_DELIMITER =")).
 				OptionalBooleanAssignment("MULTI_LINE", g.ParameterOptions()).
@@ -76,7 +76,7 @@ func fileFormatDef() *g.QueryStruct {
 				OptionalQueryStructField("DateFormat", stageFileFormatStringOrAuto(), g.ListOptions().NoParentheses().SQL("DATE_FORMAT =")).
 				OptionalQueryStructField("TimeFormat", stageFileFormatStringOrAuto(), g.ListOptions().NoParentheses().SQL("TIME_FORMAT =")).
 				OptionalQueryStructField("TimestampFormat", stageFileFormatStringOrAuto(), g.ListOptions().NoParentheses().SQL("TIMESTAMP_FORMAT =")).
-				OptionalAssignment("BINARY_FORMAT", BinaryFormatEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
+				OptionalEnumAssignment("BINARY_FORMAT", BinaryFormatEnumDef, g.ParameterOptions().NoQuotes()).
 				OptionalQueryStructField("Escape", stageFileFormatStringOrNone(), g.ListOptions().NoParentheses().SQL("ESCAPE =")).
 				OptionalQueryStructField("EscapeUnenclosedField", stageFileFormatStringOrNone(), g.ListOptions().NoParentheses().SQL("ESCAPE_UNENCLOSED_FIELD =")).
 				OptionalBooleanAssignment("TRIM_SPACE", g.ParameterOptions()).
@@ -86,7 +86,7 @@ func fileFormatDef() *g.QueryStruct {
 				OptionalBooleanAssignment("REPLACE_INVALID_CHARACTERS", g.ParameterOptions()).
 				OptionalBooleanAssignment("EMPTY_FIELD_AS_NULL", g.ParameterOptions()).
 				OptionalBooleanAssignment("SKIP_BYTE_ORDER_MARK", g.ParameterOptions()).
-				OptionalAssignment("ENCODING", CsvEncodingEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
+				OptionalEnumAssignment("ENCODING", CsvEncodingEnumDef, g.ParameterOptions().NoQuotes()).
 				WithValidation(g.ConflictingFields, "SkipHeader", "ParseHeader"),
 			g.KeywordOptions(),
 		).
@@ -94,11 +94,11 @@ func fileFormatDef() *g.QueryStruct {
 			"JsonOptions",
 			g.NewQueryStruct("FileFormatJsonOptions").
 				SQLWithCustomFieldName("formatType", "TYPE = JSON").
-				OptionalAssignment("COMPRESSION", JsonCompressionEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
+				OptionalEnumAssignment("COMPRESSION", JsonCompressionEnumDef, g.ParameterOptions().NoQuotes()).
 				OptionalQueryStructField("DateFormat", stageFileFormatStringOrAuto(), g.ListOptions().NoParentheses().SQL("DATE_FORMAT =")).
 				OptionalQueryStructField("TimeFormat", stageFileFormatStringOrAuto(), g.ListOptions().NoParentheses().SQL("TIME_FORMAT =")).
 				OptionalQueryStructField("TimestampFormat", stageFileFormatStringOrAuto(), g.ListOptions().NoParentheses().SQL("TIMESTAMP_FORMAT =")).
-				OptionalAssignment("BINARY_FORMAT", BinaryFormatEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
+				OptionalEnumAssignment("BINARY_FORMAT", BinaryFormatEnumDef, g.ParameterOptions().NoQuotes()).
 				OptionalBooleanAssignment("TRIM_SPACE", g.ParameterOptions()).
 				OptionalBooleanAssignment("MULTI_LINE", g.ParameterOptions()).
 				ListAssignment("NULL_IF", "NullString", g.ParameterOptions().Parentheses()).
@@ -117,7 +117,7 @@ func fileFormatDef() *g.QueryStruct {
 			"AvroOptions",
 			g.NewQueryStruct("FileFormatAvroOptions").
 				SQLWithCustomFieldName("formatType", "TYPE = AVRO").
-				OptionalAssignment("COMPRESSION", AvroCompressionEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
+				OptionalEnumAssignment("COMPRESSION", AvroCompressionEnumDef, g.ParameterOptions().NoQuotes()).
 				OptionalBooleanAssignment("TRIM_SPACE", g.ParameterOptions()).
 				OptionalBooleanAssignment("REPLACE_INVALID_CHARACTERS", g.ParameterOptions()).
 				ListAssignment("NULL_IF", "NullString", g.ParameterOptions().Parentheses()),
@@ -136,7 +136,7 @@ func fileFormatDef() *g.QueryStruct {
 			"ParquetOptions",
 			g.NewQueryStruct("FileFormatParquetOptions").
 				SQLWithCustomFieldName("formatType", "TYPE = PARQUET").
-				OptionalAssignment("COMPRESSION", ParquetCompressionEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
+				OptionalEnumAssignment("COMPRESSION", ParquetCompressionEnumDef, g.ParameterOptions().NoQuotes()).
 				OptionalBooleanAssignment("SNAPPY_COMPRESSION", g.ParameterOptions()).
 				OptionalBooleanAssignment("BINARY_AS_TEXT", g.ParameterOptions()).
 				OptionalBooleanAssignment("USE_LOGICAL_TYPE", g.ParameterOptions()).
@@ -151,7 +151,7 @@ func fileFormatDef() *g.QueryStruct {
 			"XmlOptions",
 			g.NewQueryStruct("FileFormatXmlOptions").
 				SQLWithCustomFieldName("formatType", "TYPE = XML").
-				OptionalAssignment("COMPRESSION", XmlCompressionEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
+				OptionalEnumAssignment("COMPRESSION", XmlCompressionEnumDef, g.ParameterOptions().NoQuotes()).
 				OptionalBooleanAssignment("IGNORE_UTF8_ERRORS", g.ParameterOptions()).
 				OptionalBooleanAssignment("PRESERVE_SPACE", g.ParameterOptions()).
 				OptionalBooleanAssignment("STRIP_OUTER_ELEMENT", g.ParameterOptions()).

--- a/pkg/sdk/generator/defs/hybrid_tables_def.go
+++ b/pkg/sdk/generator/defs/hybrid_tables_def.go
@@ -17,7 +17,7 @@ var hybridTableColumn = g.NewQueryStruct("HybridTableColumn").
 
 var hybridTableOutOfLineConstraint = g.NewQueryStruct("HybridTableOutOfLineConstraint").
 	OptionalAssignmentWithFieldName("CONSTRAINT", "*string", g.ParameterOptions().NoEquals().DoubleQuotes(), "Name").
-	PredefinedQueryStructField("Type", g.KindOfT[sdkcommons.ColumnConstraintType](), g.KeywordOptions().Required()).
+	WithField(g.EnumLegacy[sdkcommons.ColumnConstraintType]("Type", g.KeywordOptions().Required())).
 	PredefinedQueryStructField("Columns", "[]string", g.KeywordOptions().Parentheses()).
 	// NOTE: Constraint modifier flags (Enforced, NotEnforced, Deferrable, NotDeferrable,
 	// InitiallyDeferred, InitiallyImmediate, Enable, Disable, Validate, Novalidate, Rely, Norely)
@@ -83,7 +83,7 @@ var hybridTableAlterColumnAction = g.NewQueryStruct("HybridTableAlterColumnActio
 	SQL("COLUMN").
 	Text("ColumnName", g.KeywordOptions().Required().DoubleQuotes()).
 	OptionalSQL("DROP DEFAULT").
-	PredefinedQueryStructField("SetDefault", g.KindOfTPointer[sdkcommons.SequenceName](), g.ParameterOptions().NoEquals().SQL("SET DEFAULT")).
+	WithField(g.OptionalEnumLegacy[sdkcommons.SequenceName]("SetDefault", g.ParameterOptions().NoEquals().SQL("SET DEFAULT"))).
 	PredefinedQueryStructField("Type", "*DataType", g.ParameterOptions().NoEquals().SQL("SET DATA TYPE")).
 	OptionalTextAssignment("COMMENT", g.ParameterOptions().NoEquals().SingleQuotes()).
 	OptionalSQL("UNSET COMMENT").
@@ -112,7 +112,7 @@ var hybridTableClusteringAction = g.NewQueryStruct("HybridTableClusteringAction"
 	OptionalQueryStructField(
 		"ChangeReclusterState",
 		g.NewQueryStruct("HybridTableReclusterChangeState").
-			PredefinedQueryStructField("State", g.KindOfTPointer[sdkcommons.ReclusterState](), g.KeywordOptions()).
+			WithField(g.OptionalEnumLegacy[sdkcommons.ReclusterState]("State", g.KeywordOptions())).
 			SQL("RECLUSTER"),
 		g.KeywordOptions(),
 	).

--- a/pkg/sdk/generator/defs/listings_def.go
+++ b/pkg/sdk/generator/defs/listings_def.go
@@ -33,7 +33,7 @@ var listingPairs = g.StructPair("listingDBRow", "Listing").
 	Text("created_on").
 	Text("updated_on").
 	OptionalText("published_on").
-	PlainField("state", ListingStateEnumDef.Kind()).
+	Enum("state", ListingStateEnumDef).
 	OptionalText("review_state").
 	OptionalText("comment").
 	Text("owner").
@@ -222,7 +222,7 @@ var listingsDef = g.NewInterface(
 			Describe().
 			SQL("LISTING").
 			Name().
-			OptionalAssignment("REVISION", ListingRevisionEnumDef.Kind(), g.ParameterOptions().NoQuotes()).
+			OptionalEnumAssignment("REVISION", ListingRevisionEnumDef, g.ParameterOptions().NoQuotes()).
 			WithValidation(g.ValidIdentifier, "name"),
 	).
 	CustomShowOperationWithPairedStructs(

--- a/pkg/sdk/generator/defs/managed_accounts_def.go
+++ b/pkg/sdk/generator/defs/managed_accounts_def.go
@@ -33,7 +33,7 @@ var managedAccountsDef = g.NewInterface(
 				g.NewQueryStruct("CreateManagedAccountParams").
 					TextAssignment("ADMIN_NAME", g.ParameterOptions().SingleQuotes().Required()).
 					TextAssignment("ADMIN_PASSWORD", g.ParameterOptions().SingleQuotes().Required()).
-					PredefinedQueryStructField("typeProvider", "string", g.StaticOptions().SQL("TYPE = READER")).
+					SQLWithCustomFieldName("typeProvider", "TYPE = READER").
 					OptionalComment().
 					WithValidation(g.ValidateValueSet, "AdminName").
 					WithValidation(g.ValidateValueSet, "AdminPassword"),

--- a/pkg/sdk/generator/defs/network_rules_def.go
+++ b/pkg/sdk/generator/defs/network_rules_def.go
@@ -29,9 +29,9 @@ var networkRulesDef = g.NewInterface(
 			OrReplace().
 			SQL("NETWORK RULE").
 			Name().
-			AssignmentWithFieldName("TYPE", NetworkRuleTypeEnumDef.Kind(), g.ParameterOptions().Required().NoQuotes(), "NetworkRuleType").
+			EnumAssignmentWithFieldName("TYPE", NetworkRuleTypeEnumDef, g.ParameterOptions().Required().NoQuotes(), "NetworkRuleType").
 			ListAssignment("VALUE_LIST", "NetworkRuleValue", g.ParameterOptions().Required().Parentheses()).
-			Assignment("MODE", NetworkRuleModeEnumDef.Kind(), g.ParameterOptions().Required().NoQuotes()).
+			EnumAssignment("MODE", NetworkRuleModeEnumDef, g.ParameterOptions().Required().NoQuotes()).
 			OptionalComment().
 			WithValidation(g.ValidIdentifier, "name"),
 		g.NewQueryStruct("NetworkRuleValue").

--- a/pkg/sdk/generator/defs/notification_integrations_def.go
+++ b/pkg/sdk/generator/defs/notification_integrations_def.go
@@ -11,7 +11,7 @@ var NotificationIntegrationAllowedRecipientDef = g.NewQueryStruct("NotificationI
 
 var NotificationIntegrationWebhookHeaderDef = g.NewQueryStruct("WebhookHeader").
 	Text("Header", g.KeywordOptions().SingleQuotes().Required()).
-	PredefinedQueryStructField("equals", "bool", g.StaticOptions().SQL("=")).
+	SQLWithCustomFieldName("equals", "=").
 	Text("Value", g.KeywordOptions().SingleQuotes().Required())
 
 // TODO [SNOW-1016561]: all integrations reuse almost the same show, drop, and describe. For now we are copying it. Consider reusing in linked issue.
@@ -32,18 +32,18 @@ var notificationIntegrationsDef = g.NewInterface(
 			OptionalQueryStructField(
 				"AutomatedDataLoadsParams",
 				g.NewQueryStruct("AutomatedDataLoadsParams").
-					PredefinedQueryStructField("notificationType", "string", g.StaticOptions().SQL("TYPE = QUEUE")).
+					SQLWithCustomFieldName("notificationType", "TYPE = QUEUE").
 					OptionalQueryStructField(
 						"GoogleAutoParams",
 						g.NewQueryStruct("GoogleAutoParams").
-							PredefinedQueryStructField("notificationProvider", "string", g.StaticOptions().SQL("NOTIFICATION_PROVIDER = GCP_PUBSUB")).
+							SQLWithCustomFieldName("notificationProvider", "NOTIFICATION_PROVIDER = GCP_PUBSUB").
 							TextAssignment("GCP_PUBSUB_SUBSCRIPTION_NAME", g.ParameterOptions().SingleQuotes().Required()),
 						g.KeywordOptions(),
 					).
 					OptionalQueryStructField(
 						"AzureAutoParams",
 						g.NewQueryStruct("AzureAutoParams").
-							PredefinedQueryStructField("notificationProvider", "string", g.StaticOptions().SQL("NOTIFICATION_PROVIDER = AZURE_STORAGE_QUEUE")).
+							SQLWithCustomFieldName("notificationProvider", "NOTIFICATION_PROVIDER = AZURE_STORAGE_QUEUE").
 							TextAssignment("AZURE_STORAGE_QUEUE_PRIMARY_URI", g.ParameterOptions().SingleQuotes().Required()).
 							TextAssignment("AZURE_TENANT_ID", g.ParameterOptions().SingleQuotes().Required()),
 						g.KeywordOptions(),
@@ -54,12 +54,12 @@ var notificationIntegrationsDef = g.NewInterface(
 			OptionalQueryStructField(
 				"PushNotificationParams",
 				g.NewQueryStruct("PushNotificationParams").
-					PredefinedQueryStructField("direction", "string", g.StaticOptions().SQL("DIRECTION = OUTBOUND")).
-					PredefinedQueryStructField("notificationType", "string", g.StaticOptions().SQL("TYPE = QUEUE")).
+					SQLWithCustomFieldName("direction", "DIRECTION = OUTBOUND").
+					SQLWithCustomFieldName("notificationType", "TYPE = QUEUE").
 					OptionalQueryStructField(
 						"AmazonPushParams",
 						g.NewQueryStruct("AmazonPushParams").
-							PredefinedQueryStructField("notificationProvider", "string", g.StaticOptions().SQL("NOTIFICATION_PROVIDER = AWS_SNS")).
+							SQLWithCustomFieldName("notificationProvider", "NOTIFICATION_PROVIDER = AWS_SNS").
 							TextAssignment("AWS_SNS_TOPIC_ARN", g.ParameterOptions().SingleQuotes().Required()).
 							TextAssignment("AWS_SNS_ROLE_ARN", g.ParameterOptions().SingleQuotes().Required()),
 						g.KeywordOptions(),
@@ -67,14 +67,14 @@ var notificationIntegrationsDef = g.NewInterface(
 					OptionalQueryStructField(
 						"GooglePushParams",
 						g.NewQueryStruct("GooglePushParams").
-							PredefinedQueryStructField("notificationProvider", "string", g.StaticOptions().SQL("NOTIFICATION_PROVIDER = GCP_PUBSUB")).
+							SQLWithCustomFieldName("notificationProvider", "NOTIFICATION_PROVIDER = GCP_PUBSUB").
 							TextAssignment("GCP_PUBSUB_TOPIC_NAME", g.ParameterOptions().SingleQuotes().Required()),
 						g.KeywordOptions(),
 					).
 					OptionalQueryStructField(
 						"AzurePushParams",
 						g.NewQueryStruct("AzurePushParams").
-							PredefinedQueryStructField("notificationProvider", "string", g.StaticOptions().SQL("NOTIFICATION_PROVIDER = AZURE_EVENT_GRID")).
+							SQLWithCustomFieldName("notificationProvider", "NOTIFICATION_PROVIDER = AZURE_EVENT_GRID").
 							TextAssignment("AZURE_EVENT_GRID_TOPIC_ENDPOINT", g.ParameterOptions().SingleQuotes().Required()).
 							TextAssignment("AZURE_TENANT_ID", g.ParameterOptions().SingleQuotes().Required()),
 						g.KeywordOptions(),
@@ -85,7 +85,7 @@ var notificationIntegrationsDef = g.NewInterface(
 			OptionalQueryStructField(
 				"EmailParams",
 				g.NewQueryStruct("EmailParams").
-					PredefinedQueryStructField("notificationType", "string", g.StaticOptions().SQL("TYPE = EMAIL")).
+					SQLWithCustomFieldName("notificationType", "TYPE = EMAIL").
 					ListAssignment("ALLOWED_RECIPIENTS", "NotificationIntegrationAllowedRecipient", g.ParameterOptions().Parentheses()),
 				g.KeywordOptions(),
 			).

--- a/pkg/sdk/generator/defs/organization_accounts_def.go
+++ b/pkg/sdk/generator/defs/organization_accounts_def.go
@@ -29,7 +29,7 @@ var organizationAccountsDef = g.NewInterface(
 			OptionalTextAssignment("LAST_NAME", g.ParameterOptions().SingleQuotes()).
 			TextAssignment("EMAIL", g.ParameterOptions().Required().SingleQuotes()).
 			OptionalBooleanAssignment("MUST_CHANGE_PASSWORD", g.ParameterOptions()).
-			Assignment("EDITION", OrganizationAccountEditionEnumDef.Kind(), g.ParameterOptions().Required().NoQuotes()).
+			EnumAssignment("EDITION", OrganizationAccountEditionEnumDef, g.ParameterOptions().Required().NoQuotes()).
 			OptionalTextAssignment("REGION_GROUP", g.ParameterOptions().DoubleQuotes()).
 			OptionalTextAssignment("REGION", g.ParameterOptions().DoubleQuotes()).
 			OptionalComment().
@@ -88,7 +88,7 @@ var organizationAccountsDef = g.NewInterface(
 			Text("organization_name").
 			Text("account_name").
 			Text("snowflake_region").
-			PlainField("edition", OrganizationAccountEditionEnumDef.Kind()).
+			Enum("edition", OrganizationAccountEditionEnumDef).
 			Text("account_url").
 			Text("created_on").
 			OptionalText("comment").

--- a/pkg/sdk/generator/defs/postgres_instances_def.go
+++ b/pkg/sdk/generator/defs/postgres_instances_def.go
@@ -34,9 +34,8 @@ var postgresInstancesDef = g.NewInterface(
 		Name().
 		TextAssignment("COMPUTE_FAMILY", g.ParameterOptions().SingleQuotes()).
 		NumberAssignment("STORAGE_SIZE_GB", g.ParameterOptions()).
-		Assignment(
-			"AUTHENTICATION_AUTHORITY",
-			PostgresInstanceAuthenticationAuthorityEnumDef.Kind(),
+		EnumAssignment(
+			"AUTHENTICATION_AUTHORITY", PostgresInstanceAuthenticationAuthorityEnumDef,
 			g.ParameterOptions().NoQuotes().Required(),
 		).
 		OptionalNumberAssignment("POSTGRES_VERSION", g.ParameterOptions()).
@@ -92,9 +91,8 @@ var postgresInstancesDef = g.NewInterface(
 			"Set",
 			g.NewQueryStruct("PostgresInstanceSet").
 				OptionalTextAssignment("NETWORK_POLICY", g.ParameterOptions().SingleQuotes()).
-				OptionalAssignment(
-					"AUTHENTICATION_AUTHORITY",
-					PostgresInstanceAuthenticationAuthorityEnumDef.Kind(),
+				OptionalEnumAssignment(
+					"AUTHENTICATION_AUTHORITY", PostgresInstanceAuthenticationAuthorityEnumDef,
 					g.ParameterOptions().NoQuotes(),
 				).
 				OptionalTextAssignment("COMMENT", g.ParameterOptions().SingleQuotes()).
@@ -185,7 +183,7 @@ var postgresInstancesDef = g.NewInterface(
 		OptionalText("PostgresSettings").
 		Bool("IsHa").
 		Number("RetentionTime").
-		Field("State", PostgresInstanceStateEnumDef.Kind()).
+		Enum("State", PostgresInstanceStateEnumDef).
 		OptionalText("Comment"),
 	g.NewQueryStruct("ShowPostgresInstances").
 		Show().

--- a/pkg/sdk/generator/defs/secrets_def.go
+++ b/pkg/sdk/generator/defs/secrets_def.go
@@ -91,7 +91,7 @@ var secretsDef = g.NewInterface(
 		SQL("SECRET").
 		IfNotExists().
 		Name().
-		PredefinedQueryStructField("secretType", "string", g.StaticOptions().SQL(fmt.Sprintf("TYPE = %s", sdkcommons.SecretTypeOAuth2))).
+		SQLWithCustomFieldName("secretType", fmt.Sprintf("TYPE = %s", sdkcommons.SecretTypeOAuth2)).
 		Identifier("ApiIntegration", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().Required().Equals().SQL("API_AUTHENTICATION")).
 		OptionalQueryStructField("OauthScopes", oauthScopesListDef, g.ParameterOptions().SQL("OAUTH_SCOPES").Parentheses()).
 		OptionalComment().
@@ -107,7 +107,7 @@ var secretsDef = g.NewInterface(
 		SQL("SECRET").
 		IfNotExists().
 		Name().
-		PredefinedQueryStructField("secretType", "string", g.StaticOptions().SQL(fmt.Sprintf("TYPE = %s", sdkcommons.SecretTypeOAuth2))).
+		SQLWithCustomFieldName("secretType", fmt.Sprintf("TYPE = %s", sdkcommons.SecretTypeOAuth2)).
 		TextAssignment("OAUTH_REFRESH_TOKEN", g.ParameterOptions().NoParentheses().SingleQuotes().Required()).
 		TextAssignment("OAUTH_REFRESH_TOKEN_EXPIRY_TIME", g.ParameterOptions().NoParentheses().SingleQuotes().Required()).
 		Identifier("ApiIntegration", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().Required().Equals().SQL("API_AUTHENTICATION")).
@@ -123,7 +123,7 @@ var secretsDef = g.NewInterface(
 		SQL("SECRET").
 		IfNotExists().
 		Name().
-		PredefinedQueryStructField("secretType", "string", g.StaticOptions().SQL(fmt.Sprintf("TYPE = %s", sdkcommons.SecretTypePassword))).
+		SQLWithCustomFieldName("secretType", fmt.Sprintf("TYPE = %s", sdkcommons.SecretTypePassword)).
 		TextAssignment("USERNAME", g.ParameterOptions().NoParentheses().SingleQuotes().Required()).
 		TextAssignment("PASSWORD", g.ParameterOptions().NoParentheses().SingleQuotes().Required()).
 		OptionalComment().
@@ -138,7 +138,7 @@ var secretsDef = g.NewInterface(
 		SQL("SECRET").
 		IfNotExists().
 		Name().
-		PredefinedQueryStructField("secretType", "string", g.StaticOptions().SQL(fmt.Sprintf("TYPE = %s", sdkcommons.SecretTypeGenericString))).
+		SQLWithCustomFieldName("secretType", fmt.Sprintf("TYPE = %s", sdkcommons.SecretTypeGenericString)).
 		TextAssignment("SECRET_STRING", g.ParameterOptions().SingleQuotes().Required()).
 		OptionalComment().
 		WithValidation(g.ValidIdentifier, "name").

--- a/pkg/sdk/generator/defs/security_integrations_def.go
+++ b/pkg/sdk/generator/defs/security_integrations_def.go
@@ -320,8 +320,8 @@ var securityIntegrationsDef = g.NewInterface(
 		"https://docs.snowflake.com/en/sql-reference/sql/create-security-integration-api-auth",
 		createSecurityIntegrationOperation("CreateApiAuthenticationWithClientCredentialsFlow", func(qs *g.QueryStruct) *g.QueryStruct {
 			return qs.
-				PredefinedQueryStructField("integrationType", "string", g.StaticOptions().SQL("TYPE = API_AUTHENTICATION")).
-				PredefinedQueryStructField("authType", "string", g.StaticOptions().SQL("AUTH_TYPE = OAUTH2")).
+				SQLWithCustomFieldName("integrationType", "TYPE = API_AUTHENTICATION").
+				SQLWithCustomFieldName("authType", "AUTH_TYPE = OAUTH2").
 				BooleanAssignment("ENABLED", g.ParameterOptions().Required()).
 				OptionalTextAssignment("OAUTH_TOKEN_ENDPOINT", g.ParameterOptions().SingleQuotes()).
 				OptionalAssignment(
@@ -343,8 +343,8 @@ var securityIntegrationsDef = g.NewInterface(
 		"https://docs.snowflake.com/en/sql-reference/sql/create-security-integration-api-auth",
 		createSecurityIntegrationOperation("CreateApiAuthenticationWithAuthorizationCodeGrantFlow", func(qs *g.QueryStruct) *g.QueryStruct {
 			return qs.
-				PredefinedQueryStructField("integrationType", "string", g.StaticOptions().SQL("TYPE = API_AUTHENTICATION")).
-				PredefinedQueryStructField("authType", "string", g.StaticOptions().SQL("AUTH_TYPE = OAUTH2")).
+				SQLWithCustomFieldName("integrationType", "TYPE = API_AUTHENTICATION").
+				SQLWithCustomFieldName("authType", "AUTH_TYPE = OAUTH2").
 				BooleanAssignment("ENABLED", g.ParameterOptions().Required()).
 				OptionalTextAssignment("OAUTH_AUTHORIZATION_ENDPOINT", g.ParameterOptions().SingleQuotes()).
 				OptionalTextAssignment("OAUTH_TOKEN_ENDPOINT", g.ParameterOptions().SingleQuotes()).
@@ -366,8 +366,8 @@ var securityIntegrationsDef = g.NewInterface(
 		"https://docs.snowflake.com/en/sql-reference/sql/create-security-integration-api-auth",
 		createSecurityIntegrationOperation("CreateApiAuthenticationWithJwtBearerFlow", func(qs *g.QueryStruct) *g.QueryStruct {
 			return qs.
-				PredefinedQueryStructField("integrationType", "string", g.StaticOptions().SQL("TYPE = API_AUTHENTICATION")).
-				PredefinedQueryStructField("authType", "string", g.StaticOptions().SQL("AUTH_TYPE = OAUTH2")).
+				SQLWithCustomFieldName("integrationType", "TYPE = API_AUTHENTICATION").
+				SQLWithCustomFieldName("authType", "AUTH_TYPE = OAUTH2").
 				BooleanAssignment("ENABLED", g.ParameterOptions().Required()).
 				TextAssignment("OAUTH_ASSERTION_ISSUER", g.ParameterOptions().Required().SingleQuotes()).
 				OptionalTextAssignment("OAUTH_AUTHORIZATION_ENDPOINT", g.ParameterOptions().SingleQuotes()).
@@ -389,7 +389,7 @@ var securityIntegrationsDef = g.NewInterface(
 		"https://docs.snowflake.com/en/sql-reference/sql/create-security-integration-oauth-external",
 		createSecurityIntegrationOperation("CreateExternalOauth", func(qs *g.QueryStruct) *g.QueryStruct {
 			return qs.
-				PredefinedQueryStructField("integrationType", "string", g.StaticOptions().SQL("TYPE = EXTERNAL_OAUTH")).
+				SQLWithCustomFieldName("integrationType", "TYPE = EXTERNAL_OAUTH").
 				BooleanAssignment("ENABLED", g.ParameterOptions().Required()).
 				Assignment(
 					"EXTERNAL_OAUTH_TYPE",
@@ -432,7 +432,7 @@ var securityIntegrationsDef = g.NewInterface(
 		"https://docs.snowflake.com/en/sql-reference/sql/create-security-integration-oauth-snowflake",
 		createSecurityIntegrationOperation("CreateOauthForPartnerApplications", func(qs *g.QueryStruct) *g.QueryStruct {
 			return qs.
-				PredefinedQueryStructField("integrationType", "string", g.StaticOptions().SQL("TYPE = OAUTH")).
+				SQLWithCustomFieldName("integrationType", "TYPE = OAUTH").
 				Assignment(
 					"OAUTH_CLIENT",
 					OauthSecurityIntegrationClientOptionEnumDef.Kind(),
@@ -457,8 +457,8 @@ var securityIntegrationsDef = g.NewInterface(
 		"https://docs.snowflake.com/en/sql-reference/sql/create-security-integration-oauth-snowflake",
 		createSecurityIntegrationOperation("CreateOauthForCustomClients", func(qs *g.QueryStruct) *g.QueryStruct {
 			return qs.
-				PredefinedQueryStructField("integrationType", "string", g.StaticOptions().SQL("TYPE = OAUTH")).
-				PredefinedQueryStructField("oauthClient", "string", g.StaticOptions().SQL("OAUTH_CLIENT = CUSTOM")).
+				SQLWithCustomFieldName("integrationType", "TYPE = OAUTH").
+				SQLWithCustomFieldName("oauthClient", "OAUTH_CLIENT = CUSTOM").
 				Assignment(
 					"OAUTH_CLIENT_TYPE",
 					OauthSecurityIntegrationClientTypeOptionEnumDef.Kind(),
@@ -487,7 +487,7 @@ var securityIntegrationsDef = g.NewInterface(
 		"https://docs.snowflake.com/en/sql-reference/sql/create-security-integration-saml2",
 		createSecurityIntegrationOperation("CreateSaml2", func(qs *g.QueryStruct) *g.QueryStruct {
 			return qs.
-				PredefinedQueryStructField("integrationType", "string", g.StaticOptions().SQL("TYPE = SAML2")).
+				SQLWithCustomFieldName("integrationType", "TYPE = SAML2").
 				OptionalBooleanAssignment("ENABLED", g.ParameterOptions()).
 				TextAssignment("SAML2_ISSUER", g.ParameterOptions().Required().SingleQuotes()).
 				TextAssignment("SAML2_SSO_URL", g.ParameterOptions().Required().SingleQuotes()).
@@ -521,7 +521,7 @@ var securityIntegrationsDef = g.NewInterface(
 		"https://docs.snowflake.com/en/sql-reference/sql/create-security-integration-scim",
 		createSecurityIntegrationOperation("CreateScim", func(qs *g.QueryStruct) *g.QueryStruct {
 			return qs.
-				PredefinedQueryStructField("integrationType", "string", g.StaticOptions().SQL("TYPE = SCIM")).
+				SQLWithCustomFieldName("integrationType", "TYPE = SCIM").
 				OptionalBooleanAssignment("ENABLED", g.ParameterOptions()).
 				Assignment(
 					"SCIM_CLIENT",

--- a/pkg/sdk/generator/defs/security_integrations_def.go
+++ b/pkg/sdk/generator/defs/security_integrations_def.go
@@ -101,9 +101,8 @@ func alterSecurityIntegrationOperation(structName string, opts func(qs *g.QueryS
 var apiAuthClientCredentialsFlowIntegrationSetDef = g.NewQueryStruct("ApiAuthenticationWithClientCredentialsFlowIntegrationSet").
 	OptionalBooleanAssignment("ENABLED", g.ParameterOptions()).
 	OptionalTextAssignment("OAUTH_TOKEN_ENDPOINT", g.ParameterOptions().SingleQuotes()).
-	OptionalAssignment(
-		"OAUTH_CLIENT_AUTH_METHOD",
-		ApiAuthenticationSecurityIntegrationOauthClientAuthMethodOptionEnumDef.Kind(),
+	OptionalEnumAssignment(
+		"OAUTH_CLIENT_AUTH_METHOD", ApiAuthenticationSecurityIntegrationOauthClientAuthMethodOptionEnumDef,
 		g.ParameterOptions(),
 	).
 	OptionalTextAssignment("OAUTH_CLIENT_ID", g.ParameterOptions().SingleQuotes()).
@@ -125,9 +124,8 @@ var apiAuthCodeGrantFlowIntegrationSetDef = g.NewQueryStruct("ApiAuthenticationW
 	OptionalBooleanAssignment("ENABLED", g.ParameterOptions()).
 	OptionalTextAssignment("OAUTH_AUTHORIZATION_ENDPOINT", g.ParameterOptions().SingleQuotes()).
 	OptionalTextAssignment("OAUTH_TOKEN_ENDPOINT", g.ParameterOptions().SingleQuotes()).
-	OptionalAssignment(
-		"OAUTH_CLIENT_AUTH_METHOD",
-		ApiAuthenticationSecurityIntegrationOauthClientAuthMethodOptionEnumDef.Kind(),
+	OptionalEnumAssignment(
+		"OAUTH_CLIENT_AUTH_METHOD", ApiAuthenticationSecurityIntegrationOauthClientAuthMethodOptionEnumDef,
 		g.ParameterOptions(),
 	).
 	OptionalTextAssignment("OAUTH_CLIENT_ID", g.ParameterOptions().SingleQuotes()).
@@ -149,9 +147,8 @@ var apiAuthJwtBearerFlowIntegrationSetDef = g.NewQueryStruct("ApiAuthenticationW
 	OptionalBooleanAssignment("ENABLED", g.ParameterOptions()).
 	OptionalTextAssignment("OAUTH_AUTHORIZATION_ENDPOINT", g.ParameterOptions().SingleQuotes()).
 	OptionalTextAssignment("OAUTH_TOKEN_ENDPOINT", g.ParameterOptions().SingleQuotes()).
-	OptionalAssignment(
-		"OAUTH_CLIENT_AUTH_METHOD",
-		ApiAuthenticationSecurityIntegrationOauthClientAuthMethodOptionEnumDef.Kind(),
+	OptionalEnumAssignment(
+		"OAUTH_CLIENT_AUTH_METHOD", ApiAuthenticationSecurityIntegrationOauthClientAuthMethodOptionEnumDef,
 		g.ParameterOptions(),
 	).
 	OptionalTextAssignment("OAUTH_CLIENT_ID", g.ParameterOptions().SingleQuotes()).
@@ -170,16 +167,14 @@ var apiAuthJwtBearerFlowIntegrationUnsetDef = g.NewQueryStruct("ApiAuthenticatio
 
 var externalOauthIntegrationSetDef = g.NewQueryStruct("ExternalOauthIntegrationSet").
 	OptionalBooleanAssignment("ENABLED", g.ParameterOptions()).
-	OptionalAssignment(
-		"EXTERNAL_OAUTH_TYPE",
-		ExternalOauthSecurityIntegrationTypeOptionEnumDef.Kind(),
+	OptionalEnumAssignment(
+		"EXTERNAL_OAUTH_TYPE", ExternalOauthSecurityIntegrationTypeOptionEnumDef,
 		g.ParameterOptions(),
 	).
 	OptionalTextAssignment("EXTERNAL_OAUTH_ISSUER", g.ParameterOptions().SingleQuotes()).
 	ListAssignment("EXTERNAL_OAUTH_TOKEN_USER_MAPPING_CLAIM", "TokenUserMappingClaim", g.ParameterOptions().Parentheses()).
-	OptionalAssignment(
-		"EXTERNAL_OAUTH_SNOWFLAKE_USER_MAPPING_ATTRIBUTE",
-		ExternalOauthSecurityIntegrationSnowflakeUserMappingAttributeOptionEnumDef.Kind(),
+	OptionalEnumAssignment(
+		"EXTERNAL_OAUTH_SNOWFLAKE_USER_MAPPING_ATTRIBUTE", ExternalOauthSecurityIntegrationSnowflakeUserMappingAttributeOptionEnumDef,
 		g.ParameterOptions().SingleQuotes(),
 	).
 	ListAssignment("EXTERNAL_OAUTH_JWS_KEYS_URL", "JwsKeysUrl", g.ParameterOptions().Parentheses()).
@@ -188,9 +183,8 @@ var externalOauthIntegrationSetDef = g.NewQueryStruct("ExternalOauthIntegrationS
 	OptionalTextAssignment("EXTERNAL_OAUTH_RSA_PUBLIC_KEY", g.ParameterOptions().SingleQuotes()).
 	OptionalTextAssignment("EXTERNAL_OAUTH_RSA_PUBLIC_KEY_2", g.ParameterOptions().SingleQuotes()).
 	OptionalQueryStructField("ExternalOauthAudienceList", audienceListDef, g.ParameterOptions().SQL("EXTERNAL_OAUTH_AUDIENCE_LIST").Parentheses()).
-	OptionalAssignment(
-		"EXTERNAL_OAUTH_ANY_ROLE_MODE",
-		ExternalOauthSecurityIntegrationAnyRoleModeOptionEnumDef.Kind(),
+	OptionalEnumAssignment(
+		"EXTERNAL_OAUTH_ANY_ROLE_MODE", ExternalOauthSecurityIntegrationAnyRoleModeOptionEnumDef,
 		g.ParameterOptions(),
 	).
 	OptionalTextAssignment("EXTERNAL_OAUTH_SCOPE_DELIMITER", g.ParameterOptions().SingleQuotes()).
@@ -214,9 +208,8 @@ var oauthForPartnerApplicationsIntegrationSetDef = g.NewQueryStruct("OauthForPar
 	OptionalBooleanAssignment("OAUTH_ISSUE_REFRESH_TOKENS", g.ParameterOptions()).
 	OptionalTextAssignment("OAUTH_REDIRECT_URI", g.ParameterOptions().SingleQuotes()).
 	OptionalNumberAssignment("OAUTH_REFRESH_TOKEN_VALIDITY", g.ParameterOptions()).
-	OptionalAssignment(
-		"OAUTH_USE_SECONDARY_ROLES",
-		OauthSecurityIntegrationUseSecondaryRolesOptionEnumDef.Kind(),
+	OptionalEnumAssignment(
+		"OAUTH_USE_SECONDARY_ROLES", OauthSecurityIntegrationUseSecondaryRolesOptionEnumDef,
 		g.ParameterOptions(),
 	).
 	OptionalQueryStructField("BlockedRolesList", blockedRolesListDef, g.ParameterOptions().SQL("BLOCKED_ROLES_LIST").Parentheses()).
@@ -238,9 +231,8 @@ var oauthForCustomClientsIntegrationSetDef = g.NewQueryStruct("OauthForCustomCli
 	OptionalQueryStructField("BlockedRolesList", blockedRolesListDef, g.ParameterOptions().SQL("BLOCKED_ROLES_LIST").Parentheses()).
 	OptionalBooleanAssignment("OAUTH_ISSUE_REFRESH_TOKENS", g.ParameterOptions()).
 	OptionalNumberAssignment("OAUTH_REFRESH_TOKEN_VALIDITY", g.ParameterOptions()).
-	OptionalAssignment(
-		"OAUTH_USE_SECONDARY_ROLES",
-		OauthSecurityIntegrationUseSecondaryRolesOptionEnumDef.Kind(),
+	OptionalEnumAssignment(
+		"OAUTH_USE_SECONDARY_ROLES", OauthSecurityIntegrationUseSecondaryRolesOptionEnumDef,
 		g.ParameterOptions(),
 	).
 	OptionalTextAssignment("NETWORK_POLICY", g.ParameterOptions().NoQuotes()).
@@ -263,9 +255,8 @@ var saml2IntegrationSetDef = g.NewQueryStruct("Saml2IntegrationSet").
 	OptionalBooleanAssignment("ENABLED", g.ParameterOptions()).
 	OptionalTextAssignment("SAML2_ISSUER", g.ParameterOptions().SingleQuotes()).
 	OptionalTextAssignment("SAML2_SSO_URL", g.ParameterOptions().SingleQuotes()).
-	OptionalAssignment(
-		"SAML2_PROVIDER",
-		Saml2SecurityIntegrationSaml2ProviderOptionEnumDef.Kind(),
+	OptionalEnumAssignment(
+		"SAML2_PROVIDER", Saml2SecurityIntegrationSaml2ProviderOptionEnumDef,
 		g.ParameterOptions().SingleQuotes(),
 	).
 	OptionalTextAssignment("SAML2_X509_CERT", g.ParameterOptions().SingleQuotes()).
@@ -324,9 +315,8 @@ var securityIntegrationsDef = g.NewInterface(
 				SQLWithCustomFieldName("authType", "AUTH_TYPE = OAUTH2").
 				BooleanAssignment("ENABLED", g.ParameterOptions().Required()).
 				OptionalTextAssignment("OAUTH_TOKEN_ENDPOINT", g.ParameterOptions().SingleQuotes()).
-				OptionalAssignment(
-					"OAUTH_CLIENT_AUTH_METHOD",
-					ApiAuthenticationSecurityIntegrationOauthClientAuthMethodOptionEnumDef.Kind(),
+				OptionalEnumAssignment(
+					"OAUTH_CLIENT_AUTH_METHOD", ApiAuthenticationSecurityIntegrationOauthClientAuthMethodOptionEnumDef,
 					g.ParameterOptions(),
 				).
 				TextAssignment("OAUTH_CLIENT_ID", g.ParameterOptions().Required().SingleQuotes()).
@@ -348,9 +338,8 @@ var securityIntegrationsDef = g.NewInterface(
 				BooleanAssignment("ENABLED", g.ParameterOptions().Required()).
 				OptionalTextAssignment("OAUTH_AUTHORIZATION_ENDPOINT", g.ParameterOptions().SingleQuotes()).
 				OptionalTextAssignment("OAUTH_TOKEN_ENDPOINT", g.ParameterOptions().SingleQuotes()).
-				OptionalAssignment(
-					"OAUTH_CLIENT_AUTH_METHOD",
-					ApiAuthenticationSecurityIntegrationOauthClientAuthMethodOptionEnumDef.Kind(),
+				OptionalEnumAssignment(
+					"OAUTH_CLIENT_AUTH_METHOD", ApiAuthenticationSecurityIntegrationOauthClientAuthMethodOptionEnumDef,
 					g.ParameterOptions(),
 				).
 				TextAssignment("OAUTH_CLIENT_ID", g.ParameterOptions().Required().SingleQuotes()).
@@ -372,9 +361,8 @@ var securityIntegrationsDef = g.NewInterface(
 				TextAssignment("OAUTH_ASSERTION_ISSUER", g.ParameterOptions().Required().SingleQuotes()).
 				OptionalTextAssignment("OAUTH_AUTHORIZATION_ENDPOINT", g.ParameterOptions().SingleQuotes()).
 				OptionalTextAssignment("OAUTH_TOKEN_ENDPOINT", g.ParameterOptions().SingleQuotes()).
-				OptionalAssignment(
-					"OAUTH_CLIENT_AUTH_METHOD",
-					ApiAuthenticationSecurityIntegrationOauthClientAuthMethodOptionEnumDef.Kind(),
+				OptionalEnumAssignment(
+					"OAUTH_CLIENT_AUTH_METHOD", ApiAuthenticationSecurityIntegrationOauthClientAuthMethodOptionEnumDef,
 					g.ParameterOptions(),
 				).
 				TextAssignment("OAUTH_CLIENT_ID", g.ParameterOptions().Required().SingleQuotes()).
@@ -391,16 +379,14 @@ var securityIntegrationsDef = g.NewInterface(
 			return qs.
 				SQLWithCustomFieldName("integrationType", "TYPE = EXTERNAL_OAUTH").
 				BooleanAssignment("ENABLED", g.ParameterOptions().Required()).
-				Assignment(
-					"EXTERNAL_OAUTH_TYPE",
-					ExternalOauthSecurityIntegrationTypeOptionEnumDef.Kind(),
+				EnumAssignment(
+					"EXTERNAL_OAUTH_TYPE", ExternalOauthSecurityIntegrationTypeOptionEnumDef,
 					g.ParameterOptions().Required(),
 				).
 				TextAssignment("EXTERNAL_OAUTH_ISSUER", g.ParameterOptions().Required().SingleQuotes()).
 				ListAssignment("EXTERNAL_OAUTH_TOKEN_USER_MAPPING_CLAIM", "TokenUserMappingClaim", g.ParameterOptions().Required().Parentheses()).
-				Assignment(
-					"EXTERNAL_OAUTH_SNOWFLAKE_USER_MAPPING_ATTRIBUTE",
-					ExternalOauthSecurityIntegrationSnowflakeUserMappingAttributeOptionEnumDef.Kind(),
+				EnumAssignment(
+					"EXTERNAL_OAUTH_SNOWFLAKE_USER_MAPPING_ATTRIBUTE", ExternalOauthSecurityIntegrationSnowflakeUserMappingAttributeOptionEnumDef,
 					g.ParameterOptions().SingleQuotes().Required(),
 				).
 				ListAssignment("EXTERNAL_OAUTH_JWS_KEYS_URL", "JwsKeysUrl", g.ParameterOptions().Parentheses()).
@@ -409,9 +395,8 @@ var securityIntegrationsDef = g.NewInterface(
 				OptionalTextAssignment("EXTERNAL_OAUTH_RSA_PUBLIC_KEY", g.ParameterOptions().SingleQuotes()).
 				OptionalTextAssignment("EXTERNAL_OAUTH_RSA_PUBLIC_KEY_2", g.ParameterOptions().SingleQuotes()).
 				OptionalQueryStructField("ExternalOauthAudienceList", audienceListDef, g.ParameterOptions().SQL("EXTERNAL_OAUTH_AUDIENCE_LIST").Parentheses()).
-				OptionalAssignment(
-					"EXTERNAL_OAUTH_ANY_ROLE_MODE",
-					ExternalOauthSecurityIntegrationAnyRoleModeOptionEnumDef.Kind(),
+				OptionalEnumAssignment(
+					"EXTERNAL_OAUTH_ANY_ROLE_MODE", ExternalOauthSecurityIntegrationAnyRoleModeOptionEnumDef,
 					g.ParameterOptions(),
 				).
 				OptionalTextAssignment("EXTERNAL_OAUTH_SCOPE_DELIMITER", g.ParameterOptions().SingleQuotes()).
@@ -433,18 +418,16 @@ var securityIntegrationsDef = g.NewInterface(
 		createSecurityIntegrationOperation("CreateOauthForPartnerApplications", func(qs *g.QueryStruct) *g.QueryStruct {
 			return qs.
 				SQLWithCustomFieldName("integrationType", "TYPE = OAUTH").
-				Assignment(
-					"OAUTH_CLIENT",
-					OauthSecurityIntegrationClientOptionEnumDef.Kind(),
+				EnumAssignment(
+					"OAUTH_CLIENT", OauthSecurityIntegrationClientOptionEnumDef,
 					g.ParameterOptions().Required(),
 				).
 				OptionalTextAssignment("OAUTH_REDIRECT_URI", g.ParameterOptions().SingleQuotes()).
 				OptionalBooleanAssignment("ENABLED", g.ParameterOptions()).
 				OptionalBooleanAssignment("OAUTH_ISSUE_REFRESH_TOKENS", g.ParameterOptions()).
 				OptionalNumberAssignment("OAUTH_REFRESH_TOKEN_VALIDITY", g.ParameterOptions()).
-				OptionalAssignment(
-					"OAUTH_USE_SECONDARY_ROLES",
-					OauthSecurityIntegrationUseSecondaryRolesOptionEnumDef.Kind(),
+				OptionalEnumAssignment(
+					"OAUTH_USE_SECONDARY_ROLES", OauthSecurityIntegrationUseSecondaryRolesOptionEnumDef,
 					g.ParameterOptions(),
 				).
 				OptionalQueryStructField("BlockedRolesList", blockedRolesListDef, g.ParameterOptions().SQL("BLOCKED_ROLES_LIST").Parentheses())
@@ -459,18 +442,16 @@ var securityIntegrationsDef = g.NewInterface(
 			return qs.
 				SQLWithCustomFieldName("integrationType", "TYPE = OAUTH").
 				SQLWithCustomFieldName("oauthClient", "OAUTH_CLIENT = CUSTOM").
-				Assignment(
-					"OAUTH_CLIENT_TYPE",
-					OauthSecurityIntegrationClientTypeOptionEnumDef.Kind(),
+				EnumAssignment(
+					"OAUTH_CLIENT_TYPE", OauthSecurityIntegrationClientTypeOptionEnumDef,
 					g.ParameterOptions().Required().SingleQuotes(),
 				).
 				TextAssignment("OAUTH_REDIRECT_URI", g.ParameterOptions().Required().SingleQuotes()).
 				OptionalBooleanAssignment("ENABLED", g.ParameterOptions()).
 				OptionalBooleanAssignment("OAUTH_ALLOW_NON_TLS_REDIRECT_URI", g.ParameterOptions()).
 				OptionalBooleanAssignment("OAUTH_ENFORCE_PKCE", g.ParameterOptions()).
-				OptionalAssignment(
-					"OAUTH_USE_SECONDARY_ROLES",
-					OauthSecurityIntegrationUseSecondaryRolesOptionEnumDef.Kind(),
+				OptionalEnumAssignment(
+					"OAUTH_USE_SECONDARY_ROLES", OauthSecurityIntegrationUseSecondaryRolesOptionEnumDef,
 					g.ParameterOptions(),
 				).
 				OptionalQueryStructField("PreAuthorizedRolesList", preAuthorizedRolesListDef, g.ParameterOptions().SQL("PRE_AUTHORIZED_ROLES_LIST").Parentheses()).
@@ -491,9 +472,8 @@ var securityIntegrationsDef = g.NewInterface(
 				OptionalBooleanAssignment("ENABLED", g.ParameterOptions()).
 				TextAssignment("SAML2_ISSUER", g.ParameterOptions().Required().SingleQuotes()).
 				TextAssignment("SAML2_SSO_URL", g.ParameterOptions().Required().SingleQuotes()).
-				Assignment(
-					"SAML2_PROVIDER",
-					Saml2SecurityIntegrationSaml2ProviderOptionEnumDef.Kind(),
+				EnumAssignment(
+					"SAML2_PROVIDER", Saml2SecurityIntegrationSaml2ProviderOptionEnumDef,
 					g.ParameterOptions().Required().SingleQuotes(),
 				).
 				TextAssignment("SAML2_X509_CERT", g.ParameterOptions().Required().SingleQuotes()).
@@ -523,11 +503,7 @@ var securityIntegrationsDef = g.NewInterface(
 			return qs.
 				SQLWithCustomFieldName("integrationType", "TYPE = SCIM").
 				OptionalBooleanAssignment("ENABLED", g.ParameterOptions()).
-				Assignment(
-					"SCIM_CLIENT",
-					ScimSecurityIntegrationScimClientOptionEnumDef.Kind(),
-					g.ParameterOptions().SingleQuotes().Required(),
-				).
+				EnumAssignment("SCIM_CLIENT", ScimSecurityIntegrationScimClientOptionEnumDef, g.ParameterOptions().SingleQuotes().Required()).
 				TextAssignment("RUN_AS_ROLE", g.ParameterOptions().Required().NoQuotes()).
 				OptionalTextAssignment("NETWORK_POLICY", g.ParameterOptions().NoQuotes()).
 				OptionalBooleanAssignment("SYNC_PASSWORD", g.ParameterOptions())

--- a/pkg/sdk/generator/defs/services_def.go
+++ b/pkg/sdk/generator/defs/services_def.go
@@ -150,7 +150,7 @@ var servicesDef = g.NewInterface(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-services",
 	g.StructPair("servicesRow", "Service").
 		Text("name").
-		PlainField("status", ServiceStatusEnumDef.Kind()).
+		Enum("status", ServiceStatusEnumDef).
 		Text("database_name").
 		Text("schema_name").
 		Text("owner").
@@ -194,7 +194,7 @@ var servicesDef = g.NewInterface(
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-service",
 	g.StructPair("serviceDescRow", "ServiceDetails").
 		Text("name").
-		PlainField("status", ServiceStatusEnumDef.Kind()).
+		Enum("status", ServiceStatusEnumDef).
 		Text("database_name").
 		Text("schema_name").
 		Text("owner").

--- a/pkg/sdk/generator/defs/stages_def.go
+++ b/pkg/sdk/generator/defs/stages_def.go
@@ -110,27 +110,27 @@ var externalS3StageParamsDef = func() *g.QueryStruct {
 			OptionalQueryStructField(
 				"AwsCse",
 				g.NewQueryStruct("ExternalStageS3EncryptionAwsCse").
-					PredefinedQueryStructField("encryptionType", "string", g.StaticOptions().SQL("TYPE = 'AWS_CSE'")).
+					SQLWithCustomFieldName("encryptionType", "TYPE = 'AWS_CSE'").
 					TextAssignment("MASTER_KEY", g.ParameterOptions().Required().SingleQuotes()),
 				g.KeywordOptions(),
 			).
 			OptionalQueryStructField(
 				"AwsSseS3",
 				g.NewQueryStruct("ExternalStageS3EncryptionAwsSseS3").
-					PredefinedQueryStructField("encryptionType", "string", g.StaticOptions().SQL("TYPE = 'AWS_SSE_S3'")),
+					SQLWithCustomFieldName("encryptionType", "TYPE = 'AWS_SSE_S3'"),
 				g.KeywordOptions(),
 			).
 			OptionalQueryStructField(
 				"AwsSseKms",
 				g.NewQueryStruct("ExternalStageS3EncryptionAwsSseKms").
-					PredefinedQueryStructField("encryptionType", "string", g.StaticOptions().SQL("TYPE = 'AWS_SSE_KMS'")).
+					SQLWithCustomFieldName("encryptionType", "TYPE = 'AWS_SSE_KMS'").
 					OptionalTextAssignment("KMS_KEY_ID", g.ParameterOptions().SingleQuotes()),
 				g.KeywordOptions(),
 			).
 			OptionalQueryStructField(
 				"None",
 				g.NewQueryStruct("ExternalStageS3EncryptionNone").
-					PredefinedQueryStructField("encryptionType", "string", g.StaticOptions().SQL("TYPE = 'NONE'")),
+					SQLWithCustomFieldName("encryptionType", "TYPE = 'NONE'"),
 				g.KeywordOptions(),
 			).
 			WithValidation(g.ExactlyOneValueSet, "AwsCse", "AwsSseS3", "AwsSseKms", "None"),
@@ -151,14 +151,14 @@ var externalGCSStageParamsDef = func() *g.QueryStruct {
 				OptionalQueryStructField(
 					"GcsSseKms",
 					g.NewQueryStruct("ExternalStageGCSEncryptionGcsSseKms").
-						PredefinedQueryStructField("encryptionType", "string", g.StaticOptions().SQL("TYPE = 'GCS_SSE_KMS'")).
+						SQLWithCustomFieldName("encryptionType", "TYPE = 'GCS_SSE_KMS'").
 						OptionalTextAssignment("KMS_KEY_ID", g.ParameterOptions().SingleQuotes()),
 					g.KeywordOptions(),
 				).
 				OptionalQueryStructField(
 					"None",
 					g.NewQueryStruct("ExternalStageGCSEncryptionNone").
-						PredefinedQueryStructField("encryptionType", "string", g.StaticOptions().SQL("TYPE = 'NONE'")),
+						SQLWithCustomFieldName("encryptionType", "TYPE = 'NONE'"),
 					g.KeywordOptions(),
 				).
 				WithValidation(g.ExactlyOneValueSet, "GcsSseKms", "None"),
@@ -182,14 +182,14 @@ var externalAzureStageParamsDef = func() *g.QueryStruct {
 				OptionalQueryStructField(
 					"AzureCse",
 					g.NewQueryStruct("ExternalStageAzureEncryptionAzureCse").
-						PredefinedQueryStructField("encryptionType", "string", g.StaticOptions().SQL("TYPE = 'AZURE_CSE'")).
+						SQLWithCustomFieldName("encryptionType", "TYPE = 'AZURE_CSE'").
 						TextAssignment("MASTER_KEY", g.ParameterOptions().Required().SingleQuotes()),
 					g.KeywordOptions(),
 				).
 				OptionalQueryStructField(
 					"None",
 					g.NewQueryStruct("ExternalStageAzureEncryptionNone").
-						PredefinedQueryStructField("encryptionType", "string", g.StaticOptions().SQL("TYPE = 'NONE'")),
+						SQLWithCustomFieldName("encryptionType", "TYPE = 'NONE'"),
 					g.KeywordOptions(),
 				).
 				WithValidation(g.ExactlyOneValueSet, "AzureCse", "None"),
@@ -229,13 +229,13 @@ var stagesDef = g.NewInterface(
 						OptionalQueryStructField(
 							"SnowflakeFull",
 							g.NewQueryStruct("InternalStageEncryptionSnowflakeFull").
-								PredefinedQueryStructField("encryptionType", "string", g.StaticOptions().SQL("TYPE = 'SNOWFLAKE_FULL'")),
+								SQLWithCustomFieldName("encryptionType", "TYPE = 'SNOWFLAKE_FULL'"),
 							g.KeywordOptions(),
 						).
 						OptionalQueryStructField(
 							"SnowflakeSse",
 							g.NewQueryStruct("InternalStageEncryptionSnowflakeSse").
-								PredefinedQueryStructField("encryptionType", "string", g.StaticOptions().SQL("TYPE = 'SNOWFLAKE_SSE'")),
+								SQLWithCustomFieldName("encryptionType", "TYPE = 'SNOWFLAKE_SSE'"),
 							g.KeywordOptions(),
 						).
 						WithValidation(g.ExactlyOneValueSet, "SnowflakeFull", "SnowflakeSse"),

--- a/pkg/sdk/generator/defs/storage_integrations_def.go
+++ b/pkg/sdk/generator/defs/storage_integrations_def.go
@@ -25,7 +25,7 @@ var storageIntegrationsDef = g.NewInterface(
 			OptionalQueryStructField(
 				"S3StorageProviderParams",
 				g.NewQueryStruct("S3StorageParams").
-					PredefinedQueryStructField("Protocol", g.KindOfT[sdkcommons.S3Protocol](), g.ParameterOptions().SQL("STORAGE_PROVIDER").SingleQuotes().Required()).
+					WithField(g.EnumLegacy[sdkcommons.S3Protocol]("Protocol", g.ParameterOptions().SQL("STORAGE_PROVIDER").SingleQuotes().Required())).
 					TextAssignment("STORAGE_AWS_ROLE_ARN", g.ParameterOptions().SingleQuotes().Required()).
 					OptionalTextAssignment("STORAGE_AWS_EXTERNAL_ID", g.ParameterOptions().SingleQuotes()).
 					OptionalTextAssignment("STORAGE_AWS_OBJECT_ACL", g.ParameterOptions().SingleQuotes()).

--- a/pkg/sdk/generator/defs/streams_def.go
+++ b/pkg/sdk/generator/defs/streams_def.go
@@ -41,11 +41,11 @@ var (
 			OptionalText("owner").
 			OptionalText("comment").
 			OptionalText("table_name").
-			Field("source_type", "sql.NullString", StreamSourceTypeEnumDef.KindPtr()).
+			OptionalEnum("source_type", StreamSourceTypeEnumDef).
 			Field("base_tables", "sql.NullString", "[]string").
 			OptionalText("type").
 			Field("stale", "string", "bool").
-			Field("mode", "sql.NullString", StreamModeEnumDef.KindPtr()).
+			OptionalEnum("mode", StreamModeEnumDef).
 			OptionalTime("stale_after").
 			OptionalText("invalid_reason").
 			OptionalText("owner_role_type")

--- a/pkg/sdk/generator/defs/views_def.go
+++ b/pkg/sdk/generator/defs/views_def.go
@@ -60,11 +60,7 @@ var dataMetricFunctionDef = g.NewQueryStruct("ViewDataMetricFunction").
 var modifyDataMetricFunctionDef = g.NewQueryStruct("ViewModifyDataMetricFunction").
 	Identifier("DataMetricFunction", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Required()).
 	ListAssignment("ON", "Column", g.ParameterOptions().Required().NoEquals().Parentheses()).
-	Assignment(
-		"",
-		ViewDataMetricScheduleStatusOperationOptionEnumDef.Kind(),
-		g.ParameterOptions().NoEquals().NoQuotes(),
-	).
+	EnumAssignment("", ViewDataMetricScheduleStatusOperationOptionEnumDef, g.ParameterOptions().NoEquals().NoQuotes()).
 	WithValidation(g.ValidIdentifier, "DataMetricFunction")
 
 var viewColumn = g.NewQueryStruct("ViewColumn").

--- a/pkg/sdk/generator/gen/enum_builders.go
+++ b/pkg/sdk/generator/gen/enum_builders.go
@@ -27,3 +27,39 @@ func (v *QueryStruct) WithField(field *Field) *QueryStruct {
 	v.fields = append(v.fields, field)
 	return v
 }
+
+// EnumAssignment adds a required enum parameter assignment.
+func (v *QueryStruct) EnumAssignment(sqlPrefix string, enum *Enum, transformer *ParameterTransformer) *QueryStruct {
+	return v.Assignment(sqlPrefix, enum.Kind(), transformer)
+}
+
+// OptionalEnumAssignment adds an optional enum parameter assignment (pointer kind).
+func (v *QueryStruct) OptionalEnumAssignment(sqlPrefix string, enum *Enum, transformer *ParameterTransformer) *QueryStruct {
+	return v.Assignment(sqlPrefix, enum.KindPtr(), transformer)
+}
+
+// EnumAssignmentWithFieldName adds a required enum parameter assignment with a custom Go field name.
+func (v *QueryStruct) EnumAssignmentWithFieldName(sqlPrefix string, enum *Enum, transformer *ParameterTransformer, fieldName string) *QueryStruct {
+	return v.AssignmentWithFieldName(sqlPrefix, enum.Kind(), transformer, fieldName)
+}
+
+// Enum adds a required enum field to a PairedStructs.
+//
+//	db:    <FieldName> string          `db:"<dbColumnName>"`
+//	plain: <FieldName> <EnumType>
+func (p *PairedStructs) Enum(dbColumnName string, enum *Enum, opts ...PairedFieldOption) *PairedStructs {
+	return p.PlainField(dbColumnName, enum.Kind(), opts...)
+}
+
+// OptionalEnum adds an optional enum field to a PairedStructs.
+//
+//	db:    <FieldName> sql.NullString  `db:"<dbColumnName>"`
+//	plain: <FieldName> *<EnumType>
+func (p *PairedStructs) OptionalEnum(dbColumnName string, enum *Enum, opts ...PairedFieldOption) *PairedStructs {
+	return p.addField(dbColumnName, "sql.NullString", enum.KindPtr(), opts)
+}
+
+// Enum adds a required enum field to a plainStruct.
+func (v *plainStruct) Enum(name string, enum *Enum) *plainStruct {
+	return v.Field(name, enum.Kind())
+}

--- a/pkg/sdk/generator/gen/enum_builders.go
+++ b/pkg/sdk/generator/gen/enum_builders.go
@@ -1,0 +1,29 @@
+package gen
+
+// Enum adds a required enum field using a generator-defined Enum.
+func (v *QueryStruct) Enum(name string, enum *Enum, transformer FieldTransformer) *QueryStruct {
+	return v.PredefinedQueryStructField(name, enum.Kind(), transformer)
+}
+
+// OptionalEnum adds an optional enum field using a generator-defined Enum.
+func (v *QueryStruct) OptionalEnum(name string, enum *Enum, transformer FieldTransformer) *QueryStruct {
+	return v.PredefinedQueryStructField(name, enum.KindPtr(), transformer)
+}
+
+// EnumLegacy returns a required Field for a non-generated enum T.
+// Use with WithField: .WithField(g.EnumLegacy[sdkcommons.T]("Name", transformer))
+func EnumLegacy[T any](name string, transformer FieldTransformer) *Field {
+	return NewField(name, KindOfT[T](), Tags(), transformer)
+}
+
+// OptionalEnumLegacy returns an optional Field for a non-generated enum T.
+// Use with WithField: .WithField(g.OptionalEnumLegacy[sdkcommons.T]("Name", transformer))
+func OptionalEnumLegacy[T any](name string, transformer FieldTransformer) *Field {
+	return NewField(name, KindOfTPointer[T](), Tags(), transformer)
+}
+
+// WithField appends a pre-built *Field to the QueryStruct.
+func (v *QueryStruct) WithField(field *Field) *QueryStruct {
+	v.fields = append(v.fields, field)
+	return v
+}

--- a/pkg/sdk/managed_accounts_gen.go
+++ b/pkg/sdk/managed_accounts_gen.go
@@ -27,7 +27,7 @@ type CreateManagedAccountOptions struct {
 type CreateManagedAccountParams struct {
 	AdminName     string  `ddl:"parameter,single_quotes" sql:"ADMIN_NAME"`
 	AdminPassword string  `ddl:"parameter,single_quotes" sql:"ADMIN_PASSWORD"`
-	typeProvider  string  `ddl:"static" sql:"TYPE = READER"`
+	typeProvider  bool    `ddl:"static" sql:"TYPE = READER"`
 	Comment       *string `ddl:"parameter,single_quotes" sql:"COMMENT"`
 }
 

--- a/pkg/sdk/notification_integrations_gen.go
+++ b/pkg/sdk/notification_integrations_gen.go
@@ -45,49 +45,49 @@ type WebhookHeader struct {
 }
 
 type AutomatedDataLoadsParams struct {
-	notificationType string            `ddl:"static" sql:"TYPE = QUEUE"`
+	notificationType bool              `ddl:"static" sql:"TYPE = QUEUE"`
 	GoogleAutoParams *GoogleAutoParams `ddl:"keyword"`
 	AzureAutoParams  *AzureAutoParams  `ddl:"keyword"`
 }
 
 type GoogleAutoParams struct {
-	notificationProvider      string `ddl:"static" sql:"NOTIFICATION_PROVIDER = GCP_PUBSUB"`
+	notificationProvider      bool   `ddl:"static" sql:"NOTIFICATION_PROVIDER = GCP_PUBSUB"`
 	GcpPubsubSubscriptionName string `ddl:"parameter,single_quotes" sql:"GCP_PUBSUB_SUBSCRIPTION_NAME"`
 }
 
 type AzureAutoParams struct {
-	notificationProvider        string `ddl:"static" sql:"NOTIFICATION_PROVIDER = AZURE_STORAGE_QUEUE"`
+	notificationProvider        bool   `ddl:"static" sql:"NOTIFICATION_PROVIDER = AZURE_STORAGE_QUEUE"`
 	AzureStorageQueuePrimaryUri string `ddl:"parameter,single_quotes" sql:"AZURE_STORAGE_QUEUE_PRIMARY_URI"`
 	AzureTenantId               string `ddl:"parameter,single_quotes" sql:"AZURE_TENANT_ID"`
 }
 
 type PushNotificationParams struct {
-	direction        string            `ddl:"static" sql:"DIRECTION = OUTBOUND"`
-	notificationType string            `ddl:"static" sql:"TYPE = QUEUE"`
+	direction        bool              `ddl:"static" sql:"DIRECTION = OUTBOUND"`
+	notificationType bool              `ddl:"static" sql:"TYPE = QUEUE"`
 	AmazonPushParams *AmazonPushParams `ddl:"keyword"`
 	GooglePushParams *GooglePushParams `ddl:"keyword"`
 	AzurePushParams  *AzurePushParams  `ddl:"keyword"`
 }
 
 type AmazonPushParams struct {
-	notificationProvider string `ddl:"static" sql:"NOTIFICATION_PROVIDER = AWS_SNS"`
+	notificationProvider bool   `ddl:"static" sql:"NOTIFICATION_PROVIDER = AWS_SNS"`
 	AwsSnsTopicArn       string `ddl:"parameter,single_quotes" sql:"AWS_SNS_TOPIC_ARN"`
 	AwsSnsRoleArn        string `ddl:"parameter,single_quotes" sql:"AWS_SNS_ROLE_ARN"`
 }
 
 type GooglePushParams struct {
-	notificationProvider string `ddl:"static" sql:"NOTIFICATION_PROVIDER = GCP_PUBSUB"`
+	notificationProvider bool   `ddl:"static" sql:"NOTIFICATION_PROVIDER = GCP_PUBSUB"`
 	GcpPubsubTopicName   string `ddl:"parameter,single_quotes" sql:"GCP_PUBSUB_TOPIC_NAME"`
 }
 
 type AzurePushParams struct {
-	notificationProvider        string `ddl:"static" sql:"NOTIFICATION_PROVIDER = AZURE_EVENT_GRID"`
+	notificationProvider        bool   `ddl:"static" sql:"NOTIFICATION_PROVIDER = AZURE_EVENT_GRID"`
 	AzureEventGridTopicEndpoint string `ddl:"parameter,single_quotes" sql:"AZURE_EVENT_GRID_TOPIC_ENDPOINT"`
 	AzureTenantId               string `ddl:"parameter,single_quotes" sql:"AZURE_TENANT_ID"`
 }
 
 type EmailParams struct {
-	notificationType  string                                    `ddl:"static" sql:"TYPE = EMAIL"`
+	notificationType  bool                                      `ddl:"static" sql:"TYPE = EMAIL"`
 	AllowedRecipients []NotificationIntegrationAllowedRecipient `ddl:"parameter,parentheses" sql:"ALLOWED_RECIPIENTS"`
 }
 

--- a/pkg/sdk/secrets_gen.go
+++ b/pkg/sdk/secrets_gen.go
@@ -29,7 +29,7 @@ type CreateWithOAuthClientCredentialsFlowSecretOptions struct {
 	secret         bool                    `ddl:"static" sql:"SECRET"`
 	IfNotExists    *bool                   `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name           SchemaObjectIdentifier  `ddl:"identifier"`
-	secretType     string                  `ddl:"static" sql:"TYPE = OAUTH2"`
+	secretType     bool                    `ddl:"static" sql:"TYPE = OAUTH2"`
 	ApiIntegration AccountObjectIdentifier `ddl:"identifier,equals" sql:"API_AUTHENTICATION"`
 	OauthScopes    *OauthScopesList        `ddl:"parameter,parentheses" sql:"OAUTH_SCOPES"`
 	Comment        *string                 `ddl:"parameter,single_quotes" sql:"COMMENT"`
@@ -50,7 +50,7 @@ type CreateWithOAuthAuthorizationCodeFlowSecretOptions struct {
 	secret                      bool                    `ddl:"static" sql:"SECRET"`
 	IfNotExists                 *bool                   `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name                        SchemaObjectIdentifier  `ddl:"identifier"`
-	secretType                  string                  `ddl:"static" sql:"TYPE = OAUTH2"`
+	secretType                  bool                    `ddl:"static" sql:"TYPE = OAUTH2"`
 	OauthRefreshToken           string                  `ddl:"parameter,single_quotes,no_parentheses" sql:"OAUTH_REFRESH_TOKEN"`
 	OauthRefreshTokenExpiryTime string                  `ddl:"parameter,single_quotes,no_parentheses" sql:"OAUTH_REFRESH_TOKEN_EXPIRY_TIME"`
 	ApiIntegration              AccountObjectIdentifier `ddl:"identifier,equals" sql:"API_AUTHENTICATION"`
@@ -64,7 +64,7 @@ type CreateWithBasicAuthenticationSecretOptions struct {
 	secret      bool                   `ddl:"static" sql:"SECRET"`
 	IfNotExists *bool                  `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name        SchemaObjectIdentifier `ddl:"identifier"`
-	secretType  string                 `ddl:"static" sql:"TYPE = PASSWORD"`
+	secretType  bool                   `ddl:"static" sql:"TYPE = PASSWORD"`
 	Username    string                 `ddl:"parameter,single_quotes,no_parentheses" sql:"USERNAME"`
 	Password    string                 `ddl:"parameter,single_quotes,no_parentheses" sql:"PASSWORD"`
 	Comment     *string                `ddl:"parameter,single_quotes" sql:"COMMENT"`
@@ -77,7 +77,7 @@ type CreateWithGenericStringSecretOptions struct {
 	secret       bool                   `ddl:"static" sql:"SECRET"`
 	IfNotExists  *bool                  `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name         SchemaObjectIdentifier `ddl:"identifier"`
-	secretType   string                 `ddl:"static" sql:"TYPE = GENERIC_STRING"`
+	secretType   bool                   `ddl:"static" sql:"TYPE = GENERIC_STRING"`
 	SecretString string                 `ddl:"parameter,single_quotes" sql:"SECRET_STRING"`
 	Comment      *string                `ddl:"parameter,single_quotes" sql:"COMMENT"`
 }

--- a/pkg/sdk/security_integrations_gen.go
+++ b/pkg/sdk/security_integrations_gen.go
@@ -40,8 +40,8 @@ type CreateApiAuthenticationWithClientCredentialsFlowSecurityIntegrationOptions 
 	securityIntegration         bool                                                             `ddl:"static" sql:"SECURITY INTEGRATION"`
 	IfNotExists                 *bool                                                            `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name                        AccountObjectIdentifier                                          `ddl:"identifier"`
-	integrationType             string                                                           `ddl:"static" sql:"TYPE = API_AUTHENTICATION"`
-	authType                    string                                                           `ddl:"static" sql:"AUTH_TYPE = OAUTH2"`
+	integrationType             bool                                                             `ddl:"static" sql:"TYPE = API_AUTHENTICATION"`
+	authType                    bool                                                             `ddl:"static" sql:"AUTH_TYPE = OAUTH2"`
 	Enabled                     bool                                                             `ddl:"parameter" sql:"ENABLED"`
 	OauthTokenEndpoint          *string                                                          `ddl:"parameter,single_quotes" sql:"OAUTH_TOKEN_ENDPOINT"`
 	OauthClientAuthMethod       *ApiAuthenticationSecurityIntegrationOauthClientAuthMethodOption `ddl:"parameter" sql:"OAUTH_CLIENT_AUTH_METHOD"`
@@ -65,8 +65,8 @@ type CreateApiAuthenticationWithAuthorizationCodeGrantFlowSecurityIntegrationOpt
 	securityIntegration         bool                                                             `ddl:"static" sql:"SECURITY INTEGRATION"`
 	IfNotExists                 *bool                                                            `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name                        AccountObjectIdentifier                                          `ddl:"identifier"`
-	integrationType             string                                                           `ddl:"static" sql:"TYPE = API_AUTHENTICATION"`
-	authType                    string                                                           `ddl:"static" sql:"AUTH_TYPE = OAUTH2"`
+	integrationType             bool                                                             `ddl:"static" sql:"TYPE = API_AUTHENTICATION"`
+	authType                    bool                                                             `ddl:"static" sql:"AUTH_TYPE = OAUTH2"`
 	Enabled                     bool                                                             `ddl:"parameter" sql:"ENABLED"`
 	OauthAuthorizationEndpoint  *string                                                          `ddl:"parameter,single_quotes" sql:"OAUTH_AUTHORIZATION_ENDPOINT"`
 	OauthTokenEndpoint          *string                                                          `ddl:"parameter,single_quotes" sql:"OAUTH_TOKEN_ENDPOINT"`
@@ -87,8 +87,8 @@ type CreateApiAuthenticationWithJwtBearerFlowSecurityIntegrationOptions struct {
 	securityIntegration        bool                                                             `ddl:"static" sql:"SECURITY INTEGRATION"`
 	IfNotExists                *bool                                                            `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name                       AccountObjectIdentifier                                          `ddl:"identifier"`
-	integrationType            string                                                           `ddl:"static" sql:"TYPE = API_AUTHENTICATION"`
-	authType                   string                                                           `ddl:"static" sql:"AUTH_TYPE = OAUTH2"`
+	integrationType            bool                                                             `ddl:"static" sql:"TYPE = API_AUTHENTICATION"`
+	authType                   bool                                                             `ddl:"static" sql:"AUTH_TYPE = OAUTH2"`
 	Enabled                    bool                                                             `ddl:"parameter" sql:"ENABLED"`
 	OauthAssertionIssuer       string                                                           `ddl:"parameter,single_quotes" sql:"OAUTH_ASSERTION_ISSUER"`
 	OauthAuthorizationEndpoint *string                                                          `ddl:"parameter,single_quotes" sql:"OAUTH_AUTHORIZATION_ENDPOINT"`
@@ -109,7 +109,7 @@ type CreateExternalOauthSecurityIntegrationOptions struct {
 	securityIntegration                        bool                                                                `ddl:"static" sql:"SECURITY INTEGRATION"`
 	IfNotExists                                *bool                                                               `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name                                       AccountObjectIdentifier                                             `ddl:"identifier"`
-	integrationType                            string                                                              `ddl:"static" sql:"TYPE = EXTERNAL_OAUTH"`
+	integrationType                            bool                                                                `ddl:"static" sql:"TYPE = EXTERNAL_OAUTH"`
 	Enabled                                    bool                                                                `ddl:"parameter" sql:"ENABLED"`
 	ExternalOauthType                          ExternalOauthSecurityIntegrationTypeOption                          `ddl:"parameter" sql:"EXTERNAL_OAUTH_TYPE"`
 	ExternalOauthIssuer                        string                                                              `ddl:"parameter,single_quotes" sql:"EXTERNAL_OAUTH_ISSUER"`
@@ -158,7 +158,7 @@ type CreateOauthForPartnerApplicationsSecurityIntegrationOptions struct {
 	securityIntegration       bool                                             `ddl:"static" sql:"SECURITY INTEGRATION"`
 	IfNotExists               *bool                                            `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name                      AccountObjectIdentifier                          `ddl:"identifier"`
-	integrationType           string                                           `ddl:"static" sql:"TYPE = OAUTH"`
+	integrationType           bool                                             `ddl:"static" sql:"TYPE = OAUTH"`
 	OauthClient               OauthSecurityIntegrationClientOption             `ddl:"parameter" sql:"OAUTH_CLIENT"`
 	OauthRedirectUri          *string                                          `ddl:"parameter,single_quotes" sql:"OAUTH_REDIRECT_URI"`
 	Enabled                   *bool                                            `ddl:"parameter" sql:"ENABLED"`
@@ -180,8 +180,8 @@ type CreateOauthForCustomClientsSecurityIntegrationOptions struct {
 	securityIntegration         bool                                             `ddl:"static" sql:"SECURITY INTEGRATION"`
 	IfNotExists                 *bool                                            `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name                        AccountObjectIdentifier                          `ddl:"identifier"`
-	integrationType             string                                           `ddl:"static" sql:"TYPE = OAUTH"`
-	oauthClient                 string                                           `ddl:"static" sql:"OAUTH_CLIENT = CUSTOM"`
+	integrationType             bool                                             `ddl:"static" sql:"TYPE = OAUTH"`
+	oauthClient                 bool                                             `ddl:"static" sql:"OAUTH_CLIENT = CUSTOM"`
 	OauthClientType             OauthSecurityIntegrationClientTypeOption         `ddl:"parameter,single_quotes" sql:"OAUTH_CLIENT_TYPE"`
 	OauthRedirectUri            string                                           `ddl:"parameter,single_quotes" sql:"OAUTH_REDIRECT_URI"`
 	Enabled                     *bool                                            `ddl:"parameter" sql:"ENABLED"`
@@ -205,7 +205,7 @@ type CreateSaml2SecurityIntegrationOptions struct {
 	securityIntegration            bool                                                      `ddl:"static" sql:"SECURITY INTEGRATION"`
 	IfNotExists                    *bool                                                     `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name                           AccountObjectIdentifier                                   `ddl:"identifier"`
-	integrationType                string                                                    `ddl:"static" sql:"TYPE = SAML2"`
+	integrationType                bool                                                      `ddl:"static" sql:"TYPE = SAML2"`
 	Enabled                        *bool                                                     `ddl:"parameter" sql:"ENABLED"`
 	Saml2Issuer                    string                                                    `ddl:"parameter,single_quotes" sql:"SAML2_ISSUER"`
 	Saml2SsoUrl                    string                                                    `ddl:"parameter,single_quotes" sql:"SAML2_SSO_URL"`
@@ -240,7 +240,7 @@ type CreateScimSecurityIntegrationOptions struct {
 	securityIntegration bool                                    `ddl:"static" sql:"SECURITY INTEGRATION"`
 	IfNotExists         *bool                                   `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name                AccountObjectIdentifier                 `ddl:"identifier"`
-	integrationType     string                                  `ddl:"static" sql:"TYPE = SCIM"`
+	integrationType     bool                                    `ddl:"static" sql:"TYPE = SCIM"`
 	Enabled             *bool                                   `ddl:"parameter" sql:"ENABLED"`
 	ScimClient          ScimSecurityIntegrationScimClientOption `ddl:"parameter,single_quotes" sql:"SCIM_CLIENT"`
 	RunAsRole           string                                  `ddl:"parameter,no_quotes" sql:"RUN_AS_ROLE"`

--- a/pkg/sdk/stages_gen.go
+++ b/pkg/sdk/stages_gen.go
@@ -49,11 +49,11 @@ type InternalStageEncryption struct {
 }
 
 type InternalStageEncryptionSnowflakeFull struct {
-	encryptionType string `ddl:"static" sql:"TYPE = 'SNOWFLAKE_FULL'"`
+	encryptionType bool `ddl:"static" sql:"TYPE = 'SNOWFLAKE_FULL'"`
 }
 
 type InternalStageEncryptionSnowflakeSse struct {
-	encryptionType string `ddl:"static" sql:"TYPE = 'SNOWFLAKE_SSE'"`
+	encryptionType bool `ddl:"static" sql:"TYPE = 'SNOWFLAKE_SSE'"`
 }
 
 type InternalDirectoryTableOptions struct {
@@ -105,21 +105,21 @@ type ExternalStageS3Encryption struct {
 }
 
 type ExternalStageS3EncryptionAwsCse struct {
-	encryptionType string `ddl:"static" sql:"TYPE = 'AWS_CSE'"`
+	encryptionType bool   `ddl:"static" sql:"TYPE = 'AWS_CSE'"`
 	MasterKey      string `ddl:"parameter,single_quotes" sql:"MASTER_KEY"`
 }
 
 type ExternalStageS3EncryptionAwsSseS3 struct {
-	encryptionType string `ddl:"static" sql:"TYPE = 'AWS_SSE_S3'"`
+	encryptionType bool `ddl:"static" sql:"TYPE = 'AWS_SSE_S3'"`
 }
 
 type ExternalStageS3EncryptionAwsSseKms struct {
-	encryptionType string  `ddl:"static" sql:"TYPE = 'AWS_SSE_KMS'"`
+	encryptionType bool    `ddl:"static" sql:"TYPE = 'AWS_SSE_KMS'"`
 	KmsKeyId       *string `ddl:"parameter,single_quotes" sql:"KMS_KEY_ID"`
 }
 
 type ExternalStageS3EncryptionNone struct {
-	encryptionType string `ddl:"static" sql:"TYPE = 'NONE'"`
+	encryptionType bool `ddl:"static" sql:"TYPE = 'NONE'"`
 }
 
 type StageS3CommonDirectoryTableOptions struct {
@@ -155,12 +155,12 @@ type ExternalStageGCSEncryption struct {
 }
 
 type ExternalStageGCSEncryptionGcsSseKms struct {
-	encryptionType string  `ddl:"static" sql:"TYPE = 'GCS_SSE_KMS'"`
+	encryptionType bool    `ddl:"static" sql:"TYPE = 'GCS_SSE_KMS'"`
 	KmsKeyId       *string `ddl:"parameter,single_quotes" sql:"KMS_KEY_ID"`
 }
 
 type ExternalStageGCSEncryptionNone struct {
-	encryptionType string `ddl:"static" sql:"TYPE = 'NONE'"`
+	encryptionType bool `ddl:"static" sql:"TYPE = 'NONE'"`
 }
 
 type ExternalGCSDirectoryTableOptions struct {
@@ -203,12 +203,12 @@ type ExternalStageAzureEncryption struct {
 }
 
 type ExternalStageAzureEncryptionAzureCse struct {
-	encryptionType string `ddl:"static" sql:"TYPE = 'AZURE_CSE'"`
+	encryptionType bool   `ddl:"static" sql:"TYPE = 'AZURE_CSE'"`
 	MasterKey      string `ddl:"parameter,single_quotes" sql:"MASTER_KEY"`
 }
 
 type ExternalStageAzureEncryptionNone struct {
-	encryptionType string `ddl:"static" sql:"TYPE = 'NONE'"`
+	encryptionType bool `ddl:"static" sql:"TYPE = 'NONE'"`
 }
 
 type ExternalAzureDirectoryTableOptions struct {


### PR DESCRIPTION
Continuation of efforts to reduce the manual changes in the SDK generation:
- Enum helpers (needed for proper convert generation)
- Proper usage of `PredefinedQueryStructField` (more parts incoming; this is needed to properly mark the preexisting structs to adjust generation for them).
                                                                                                                                                                                                                                                                                                                                                                                                                       
Details:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  - Replace `PredefinedQueryStructField` static-sentinel calls (lowercase name + kind="string") with `SQLWithCustomFieldName` across 7 def files; regenerate affected objects                                                                                                                                                                                                                                                                                                                               
  - Add typed enum helpers to the generator DSL — `Enum`/`OptionalEnum` (for `*Enum` objects), `EnumLegacy[T]`/`OptionalEnumLegacy[T]` (for non-generated enum types), `EnumAssignment`/`OptionalEnumAssignment`/`EnumAssignmentWithFieldName` (for query struct parameter fields), and `Enum`/`OptionalEnum` on `PairedStructs`/`plainStruct` (for `Show`/`Describe` result mapping)                                                                                                                                               
  - Replace all `PredefinedQueryStructField`, `Assignment`, `OptionalAssignment`, `AssignmentWithFieldName`, `PlainField`, and `Field` calls that passed `EnumDef.Kind()`/`KindPtr()` explicitly with the new typed helpers across 20+ def files                                                                                                                                                                                                                                                                        