### PR TITLE
feat(sdk): add CreateFromListing method for databases

### DIFF
--- a/pkg/acceptance/helpers/listing_client.go
+++ b/pkg/acceptance/helpers/listing_client.go
@@ -3,7 +3,9 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -80,6 +82,43 @@ func (c *ListingClient) Describe(t *testing.T, id sdk.AccountObjectIdentifier) (
 func (c *ListingClient) ShowVersions(t *testing.T, id sdk.AccountObjectIdentifier) ([]sdk.ListingVersion, error) {
 	t.Helper()
 	return c.client().ShowVersions(context.Background(), sdk.NewShowVersionsListingRequest(id))
+}
+
+// RequestListingAndWaitForSuccess calls SYSTEM$REQUEST_LISTING_AND_WAIT for the given listing
+// global name with the given in-call wait and fails the test unless the procedure reports
+// success.
+//
+// See: https://docs.snowflake.com/en/sql-reference/stored-procedures/system_request_listing_and_wait
+func (c *ListingClient) RequestListingAndWaitForSuccess(t *testing.T, globalName string, waitInMinutes int) {
+	t.Helper()
+
+	rows, err := c.context.client.QueryUnsafe(context.Background(), fmt.Sprintf("CALL SYSTEM$REQUEST_LISTING_AND_WAIT('%s', %d)", globalName, waitInMinutes))
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	statusPtr := rows[0]["SYSTEM$REQUEST_LISTING_AND_WAIT"]
+	require.NotNil(t, statusPtr)
+	require.NotNil(t, *statusPtr)
+
+	status, ok := (*statusPtr).(string)
+	require.True(t, ok)
+	require.Truef(t, strings.HasPrefix(status, "Success:"), "SYSTEM$REQUEST_LISTING_AND_WAIT did not succeed: %s", status)
+}
+
+// AcceptLegalTermsWithRetry calls SYSTEM$ACCEPT_LEGAL_TERMS for the given listing global name
+// and retries until it succeeds or the timeout elapses. This doubles as a visibility probe: a
+// freshly-published cross-account listing's global name is not immediately resolvable on the
+// consumer account, and SYSTEM$ACCEPT_LEGAL_TERMS is the first consumer-side call that returns
+// a clear SQL error ("does not exist or not authorized") in that window.
+//
+// See: https://docs.snowflake.com/en/sql-reference/stored-procedures/system_accept_legal_terms
+func (c *ListingClient) AcceptLegalTermsWithRetry(t *testing.T, globalName string, timeout time.Duration, tick time.Duration) {
+	t.Helper()
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		_, err := c.context.client.QueryUnsafe(context.Background(), fmt.Sprintf("CALL SYSTEM$ACCEPT_LEGAL_TERMS('DATA_EXCHANGE_LISTING', '%s')", globalName))
+		assert.NoError(collect, err)
+	}, timeout, tick)
 }
 
 func (c *ListingClient) BasicManifest(t *testing.T) (string, string) {

--- a/pkg/sdk/databases.go
+++ b/pkg/sdk/databases.go
@@ -16,6 +16,7 @@ var (
 	_ validatable = new(CreateDatabaseOptions)
 	_ validatable = new(CreateSharedDatabaseOptions)
 	_ validatable = new(CreateSecondaryDatabaseOptions)
+	_ validatable = new(CreateDatabaseFromListingOptions)
 	_ validatable = new(AlterDatabaseOptions)
 	_ validatable = new(AlterDatabaseReplicationOptions)
 	_ validatable = new(AlterDatabaseFailoverOptions)
@@ -31,6 +32,7 @@ type Databases interface {
 	Create(ctx context.Context, id AccountObjectIdentifier, opts *CreateDatabaseOptions) error
 	CreateShared(ctx context.Context, id AccountObjectIdentifier, shareID ExternalObjectIdentifier, opts *CreateSharedDatabaseOptions) error
 	CreateSecondary(ctx context.Context, id AccountObjectIdentifier, primaryID ExternalObjectIdentifier, opts *CreateSecondaryDatabaseOptions) error
+	CreateFromListing(ctx context.Context, id AccountObjectIdentifier, listingGlobalName string, opts *CreateDatabaseFromListingOptions) error
 	Alter(ctx context.Context, id AccountObjectIdentifier, opts *AlterDatabaseOptions) error
 	AlterReplication(ctx context.Context, id AccountObjectIdentifier, opts *AlterDatabaseReplicationOptions) error
 	AlterFailover(ctx context.Context, id AccountObjectIdentifier, opts *AlterDatabaseFailoverOptions) error
@@ -382,6 +384,47 @@ func (v *databases) CreateSecondary(ctx context.Context, id AccountObjectIdentif
 	}
 	opts.name = id
 	opts.primaryDatabase = primaryID
+	if err := opts.validate(); err != nil {
+		return err
+	}
+	sql, err := structToSQL(opts)
+	if err != nil {
+		return err
+	}
+	_, err = v.client.exec(ctx, sql)
+	return err
+}
+
+// CreateDatabaseFromListingOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-database.
+// Supports both external listings and organization listings via the same FROM LISTING syntax.
+// SQL: CREATE DATABASE <name> FROM LISTING '<listing_global_name>'
+type CreateDatabaseFromListingOptions struct {
+	create      bool                    `ddl:"static" sql:"CREATE"`
+	database    bool                    `ddl:"static" sql:"DATABASE"`
+	name        AccountObjectIdentifier `ddl:"identifier"`
+	fromListing string                  `ddl:"parameter,single_quotes,no_equals" sql:"FROM LISTING"`
+}
+
+func (opts *CreateDatabaseFromListingOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
+	var errs []error
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	if opts.fromListing == "" {
+		errs = append(errs, fmt.Errorf("CreateDatabaseFromListingOptions: listing global name must not be empty"))
+	}
+	return errors.Join(errs...)
+}
+
+func (v *databases) CreateFromListing(ctx context.Context, id AccountObjectIdentifier, listingGlobalName string, opts *CreateDatabaseFromListingOptions) error {
+	if opts == nil {
+		opts = &CreateDatabaseFromListingOptions{}
+	}
+	opts.name = id
+	opts.fromListing = listingGlobalName
 	if err := opts.validate(); err != nil {
 		return err
 	}

--- a/pkg/sdk/databases_test.go
+++ b/pkg/sdk/databases_test.go
@@ -285,7 +285,6 @@ func TestDatabasesCreateFromListing(t *testing.T) {
 }
 
 func TestDatabasesAlter(t *testing.T) {
-
 	defaultOpts := func() *AlterDatabaseOptions {
 		return &AlterDatabaseOptions{
 			name: randomAccountObjectIdentifier(),

--- a/pkg/sdk/databases_test.go
+++ b/pkg/sdk/databases_test.go
@@ -253,7 +253,39 @@ func TestDatabasesCreateSecondary(t *testing.T) {
 	})
 }
 
+func TestDatabasesCreateFromListing(t *testing.T) {
+	defaultOpts := func() *CreateDatabaseFromListingOptions {
+		return &CreateDatabaseFromListingOptions{
+			name:        randomAccountObjectIdentifier(),
+			fromListing: "GZ1M7Z91WTX",
+		}
+	}
+
+	t.Run("validation: nil options", func(t *testing.T) {
+		var opts *CreateDatabaseFromListingOptions
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
+	})
+
+	t.Run("validation: invalid name", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.name = emptyAccountObjectIdentifier
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: empty listing global name", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.fromListing = ""
+		assertOptsInvalidJoinedErrors(t, opts, NewError("CreateDatabaseFromListingOptions: listing global name must not be empty"))
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		opts := defaultOpts()
+		assertOptsValidAndSQLEquals(t, opts, `CREATE DATABASE %s FROM LISTING '%s'`, opts.name.FullyQualifiedName(), opts.fromListing)
+	})
+}
+
 func TestDatabasesAlter(t *testing.T) {
+
 	defaultOpts := func() *AlterDatabaseOptions {
 		return &AlterDatabaseOptions{
 			name: randomAccountObjectIdentifier(),

--- a/pkg/sdk/testint/databases_integration_test.go
+++ b/pkg/sdk/testint/databases_integration_test.go
@@ -337,6 +337,46 @@ func TestInt_DatabasesCreateSecondary(t *testing.T) {
 	assertParameterEquals(t, sdk.AccountParameterEnableConsoleOutput, "true")
 }
 
+func TestInt_DatabasesCreateFromListing(t *testing.T) {
+	client := testClient(t)
+	ctx := testContext(t)
+
+	// Create a share and grant usage on a database to it
+	share, shareCleanup := testClientHelper().Share.CreateShare(t)
+	t.Cleanup(shareCleanup)
+	t.Cleanup(testClientHelper().Grant.GrantPrivilegeOnDatabaseToShare(t, testClientHelper().Ids.DatabaseId(), share.ID(), []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage}))
+
+	// Create a listing targeting the current account so we can consume it from the same account
+	accountId := testClientHelper().Context.CurrentAccountId(t)
+	manifest, _ := testClientHelper().Listing.BasicManifestWithTargetAccounts(t, accountId)
+
+	listingId := testClientHelper().Ids.RandomAccountObjectIdentifier()
+	err := client.Listings.Create(ctx, sdk.NewCreateListingRequest(listingId).
+		WithAs(manifest).
+		WithWith(*sdk.NewListingWithRequest().WithShare(share.ID())).
+		WithPublish(true).
+		WithReview(false))
+	require.NoError(t, err)
+	t.Cleanup(testClientHelper().Listing.DropFunc(t, listingId))
+
+	// Retrieve the listing's global name
+	listing, err := client.Listings.ShowByID(ctx, listingId)
+	require.NoError(t, err)
+	require.NotEmpty(t, listing.GlobalName)
+
+	t.Run("basic", func(t *testing.T) {
+		databaseID := testClientHelper().Ids.RandomAccountObjectIdentifier()
+		err := client.Databases.CreateFromListing(ctx, databaseID, listing.GlobalName, &sdk.CreateDatabaseFromListingOptions{})
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().Database.DropDatabaseFunc(t, databaseID))
+
+		database, err := client.Databases.ShowByID(ctx, databaseID)
+		require.NoError(t, err)
+		assert.Equal(t, databaseID.Name(), database.Name)
+		assert.Equal(t, "IMPORTED DATABASE", database.Kind)
+	})
+}
+
 func TestInt_DatabasesAlter(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)

--- a/pkg/sdk/testint/databases_integration_test.go
+++ b/pkg/sdk/testint/databases_integration_test.go
@@ -5,6 +5,7 @@ package testint
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
@@ -338,31 +339,37 @@ func TestInt_DatabasesCreateSecondary(t *testing.T) {
 }
 
 func TestInt_DatabasesCreateFromListing(t *testing.T) {
+	t.Skip("TODO(SNOW-3556777): Use precreated listing")
+
 	client := testClient(t)
 	ctx := testContext(t)
 
-	// Create a share and grant usage on a database to it
-	share, shareCleanup := testClientHelper().Share.CreateShare(t)
+	secondaryClient := testSecondaryClient(t)
+	secondaryCtx := testSecondaryContext(t)
+
+	share, shareCleanup := secondaryTestClientHelper().Share.CreateShare(t)
 	t.Cleanup(shareCleanup)
-	t.Cleanup(testClientHelper().Grant.GrantPrivilegeOnDatabaseToShare(t, testClientHelper().Ids.DatabaseId(), share.ID(), []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage}))
+	t.Cleanup(secondaryTestClientHelper().Grant.GrantPrivilegeOnDatabaseToShare(t, secondaryTestClientHelper().Ids.DatabaseId(), share.ID(), []sdk.ObjectPrivilege{sdk.ObjectPrivilegeUsage}))
 
-	// Create a listing targeting the current account so we can consume it from the same account
-	accountId := testClientHelper().Context.CurrentAccountId(t)
-	manifest, _ := testClientHelper().Listing.BasicManifestWithTargetAccounts(t, accountId)
+	primaryAccountId := testClientHelper().Context.CurrentAccountId(t)
+	manifest, _ := secondaryTestClientHelper().Listing.BasicManifestWithTargetAccounts(t, primaryAccountId)
 
-	listingId := testClientHelper().Ids.RandomAccountObjectIdentifier()
-	err := client.Listings.Create(ctx, sdk.NewCreateListingRequest(listingId).
+	listingId := secondaryTestClientHelper().Ids.RandomAccountObjectIdentifier()
+	err := secondaryClient.Listings.Create(secondaryCtx, sdk.NewCreateListingRequest(listingId).
 		WithAs(manifest).
 		WithWith(*sdk.NewListingWithRequest().WithShare(share.ID())).
-		WithPublish(true).
-		WithReview(false))
+		WithReview(true).
+		WithPublish(true))
 	require.NoError(t, err)
-	t.Cleanup(testClientHelper().Listing.DropFunc(t, listingId))
+	t.Cleanup(secondaryTestClientHelper().Listing.DropFunc(t, listingId))
 
-	// Retrieve the listing's global name
-	listing, err := client.Listings.ShowByID(ctx, listingId)
+	listing, err := secondaryClient.Listings.ShowByID(secondaryCtx, listingId)
 	require.NoError(t, err)
 	require.NotEmpty(t, listing.GlobalName)
+	require.Equal(t, sdk.ListingStatePublished, listing.State)
+
+	testClientHelper().Listing.AcceptLegalTermsWithRetry(t, listing.GlobalName, time.Minute, 5*time.Second)
+	testClientHelper().Listing.RequestListingAndWaitForSuccess(t, listing.GlobalName, 10)
 
 	t.Run("basic", func(t *testing.T) {
 		databaseID := testClientHelper().Ids.RandomAccountObjectIdentifier()


### PR DESCRIPTION
## Summary
Add `CreateDatabaseFromListingOptions` struct and `CreateFromListing` SDK method to support `CREATE DATABASE <name> FROM LISTING '<listing_global_name>'` syntax.

Closes #4047

## Changes (SDK only, Step 1 per [CONTRIBUTING.md](https://github.com/snowflakedb/terraform-provider-snowflake/blob/dev/CONTRIBUTING.md#adding-support-for-a-new-snowflake-object))
- **pkg/sdk/databases.go**: Add `CreateDatabaseFromListingOptions` struct, validation, and `CreateFromListing` method
- **pkg/sdk/databases_test.go**: Add unit tests (nil options, invalid name, empty listing, SQL generation)
- **pkg/sdk/testint/databases_integration_test.go**: Add integration test (requires `TEST_SF_TF_LISTING_GLOBAL_NAME` env var)

## Testing
- Unit tests: `go test ./pkg/sdk/ -run TestDatabasesCreateFromListing -v` — 4/4 PASS
- Integration test: gated behind `TEST_SF_TF_LISTING_GLOBAL_NAME` env var
- `go build ./...` passes cleanly

## Note
This PR contains only the SDK changes (Step 1). The Terraform resource and related configuration will follow in subsequent PRs as outlined in the contributing guide.