### PR TITLE
chore: Add policies to iceberg tables SDK

### DIFF
--- a/pkg/sdk/generator/defs/iceberg_tables_def.go
+++ b/pkg/sdk/generator/defs/iceberg_tables_def.go
@@ -40,7 +40,8 @@ var icebergTableColumn = g.NewQueryStruct("IcebergTableColumn").
 	OptionalSQL("NOT NULL").
 	// TODO(next PR): add inline constraint support
 	// OptionalQueryStructField("InlineConstraint", icebergTableColumnInlineConstraint, g.KeywordOptions()).
-	// TODO(next PR): add inline masking and projection policy support
+	OptionalQueryStructField("MaskingPolicy", tableColumnMaskingPolicy, g.KeywordOptions()).
+	OptionalQueryStructField("ProjectionPolicy", tableColumnProjectionPolicy, g.KeywordOptions()).
 	OptionalTags().
 	OptionalTextAssignment("COMMENT", g.ParameterOptions().NoEquals().SingleQuotes())
 
@@ -131,6 +132,8 @@ var icebergTableAddColumnAction = g.NewQueryStruct("IcebergTableAddColumnAction"
 	// TODO(next PR): add inline constraint support
 	// OptionalQueryStructField("InlineConstraint", icebergTableColumnInlineConstraint, g.KeywordOptions()).
 	PredefinedQueryStructField("DefaultValue", g.KindOfTPointer[sdkcommons.ColumnDefaultValue](), g.KeywordOptions()).
+	OptionalQueryStructField("MaskingPolicy", tableColumnMaskingPolicy, g.KeywordOptions()).
+	OptionalQueryStructField("ProjectionPolicy", tableColumnProjectionPolicy, g.KeywordOptions()).
 	OptionalTags()
 
 var icebergTableAlterColumnAction = g.NewQueryStruct("IcebergTableAlterColumnAction").
@@ -216,6 +219,16 @@ var icebergTablesDef = g.NewInterface(
 			icebergTableAddColumnAction,
 			g.KeywordOptions(),
 		).
+		OptionalQueryStructField(
+			"DropColumnAction",
+			tableDropColumnAction,
+			g.KeywordOptions(),
+		).
+		OptionalQueryStructField(
+			"RenameColumnAction",
+			tableRenameColumnAction,
+			g.KeywordOptions(),
+		).
 		ListQueryStructField(
 			"AlterColumnAction",
 			icebergTableAlterColumnAction,
@@ -272,11 +285,18 @@ var icebergTablesDef = g.NewInterface(
 		PredefinedQueryStructField("DropRowAccessPolicy", "*ViewDropRowAccessPolicy", g.KeywordOptions()).
 		PredefinedQueryStructField("DropAndAddRowAccessPolicy", "*ViewDropAndAddRowAccessPolicy", g.ListOptions().NoParentheses()).
 		OptionalSQL("DROP ALL ROW ACCESS POLICIES").
-		// TODO(next PR): add RENAME COLUMN and DROP COLUMN actions
-		// TODO(next PR): add search optimization actions (ADD/DROP SEARCH OPTIMIZATION)
 		// TODO(next PR): add ALTER ICEBERG TABLE ... REFRESH (separate operation; see https://docs.snowflake.com/en/sql-reference/sql/alter-iceberg-table-refresh)
+		OptionalQueryStructField("SetAggregationPolicy", tableSetAggregationPolicy, g.KeywordOptions()).
+		OptionalQueryStructField("UnsetAggregationPolicy", tableUnsetAggregationPolicy, g.KeywordOptions()).
+		OptionalQueryStructField("SetJoinPolicy", tableSetJoinPolicy, g.KeywordOptions()).
+		OptionalQueryStructField("UnsetJoinPolicy", tableUnsetJoinPolicy, g.KeywordOptions()).
+		OptionalQueryStructField(
+			"SearchOptimizationAction",
+			tableSearchOptimizationAction,
+			g.KeywordOptions(),
+		).
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ExactlyOneValueSet, "AddColumnAction", "AlterColumnAction", "SetMaskingPolicyOnColumn", "UnsetMaskingPolicyOnColumn", "SetProjectionPolicyOnColumn", "UnsetProjectionPolicyOnColumn", "SetTagsOnColumn", "UnsetTagsOnColumn", "ClusteringAction", "Set", "Unset", "SetTags", "UnsetTags", "AddRowAccessPolicy", "DropRowAccessPolicy", "DropAndAddRowAccessPolicy", "DropAllRowAccessPolicies"),
+		WithValidation(g.ExactlyOneValueSet, "AddColumnAction", "DropColumnAction", "RenameColumnAction", "AlterColumnAction", "SetMaskingPolicyOnColumn", "UnsetMaskingPolicyOnColumn", "SetProjectionPolicyOnColumn", "UnsetProjectionPolicyOnColumn", "SetTagsOnColumn", "UnsetTagsOnColumn", "ClusteringAction", "Set", "Unset", "SetTags", "UnsetTags", "AddRowAccessPolicy", "DropRowAccessPolicy", "DropAndAddRowAccessPolicy", "DropAllRowAccessPolicies", "SetAggregationPolicy", "UnsetAggregationPolicy", "SetJoinPolicy", "UnsetJoinPolicy", "SearchOptimizationAction"),
 ).DropOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/drop-iceberg-table",
 	g.NewQueryStruct("DropIcebergTable").
@@ -314,11 +334,14 @@ var icebergTablesDef = g.NewInterface(
 		WithConvertGeneration(),
 	g.NewQueryStruct("ShowIcebergTables").
 		Show().
+		Terse().
 		SQL("ICEBERG TABLES").
 		OptionalLike().
 		OptionalIn().
 		OptionalStartsWith().
 		OptionalLimitFrom(),
+	// NOTE: TYPE=COLUMNS returns the same data as omitting the TYPE parameter.
+	//       TYPE=STAGE returns underlying stage details, but this is not needed for the resource.
 	g.ShowByIDInFiltering,
 	g.ShowByIDLikeFiltering,
 ).DescribeOperationWithPairedStructs(
@@ -345,14 +368,13 @@ var icebergTablesDef = g.NewInterface(
 		Describe().
 		SQL("ICEBERG TABLE").
 		Name().
-		// NOTE: TYPE=COLUMNS returns the same data as omitting the TYPE parameter.
-		//       TYPE=STAGE returns underlying stage details, but this is not needed for the resource.
 		OptionalAssignmentWithFieldName("TYPE", IcebergTableDescribeTypeEnumDef.Kind(), g.ParameterOptions().NoQuotes(), "DescribeType").
 		WithValidation(g.ValidIdentifier, "name"),
 ).WithEnums(
 	IcebergTableTargetFileSizeEnumDef,
 	IcebergTablePathLayoutEnumDef,
 	IcebergTableDescribeTypeEnumDef,
+	TableSearchMethodEnumDef,
 	IcebergTableLogEventLevelEnumDef,
 	IcebergTableTypeEnumDef,
 	IcebergTableCatalogEnumDef,

--- a/pkg/sdk/generator/defs/tables_def.go
+++ b/pkg/sdk/generator/defs/tables_def.go
@@ -41,3 +41,83 @@ var tableUnsetColumnTags = g.NewQueryStruct("TableUnsetColumnTags").
 	SQL("ALTER COLUMN").
 	Text("Name", g.KeywordOptions().Required().DoubleQuotes()).
 	UnsetTags()
+
+var TableSearchMethodEnumDef = g.NewEnum(
+	"TableSearchMethod", "TableSearchMethods",
+	"SUBSTRING", "EQUALITY", "FULL_TEXT",
+)
+
+var tableColumnMaskingPolicy = g.NewQueryStruct("TableColumnMaskingPolicy").
+	Identifier("MaskingPolicy", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("MASKING POLICY").Required()).
+	ListAssignment("USING", "Column", g.ParameterOptions().NoEquals().Parentheses())
+
+var tableColumnProjectionPolicy = g.NewQueryStruct("TableColumnProjectionPolicy").
+	Identifier("ProjectionPolicy", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("PROJECTION POLICY").Required())
+
+var tableDropColumnAction = g.NewQueryStruct("TableDropColumnAction").
+	SQL("DROP COLUMN").
+	OptionalSQL("IF EXISTS").
+	PredefinedQueryStructField("Columns", "[]Column", g.KeywordOptions().Required())
+
+var tableRenameColumnAction = g.NewQueryStruct("TableRenameColumnAction").
+	SQL("RENAME COLUMN").
+	Text("OldName", g.KeywordOptions().Required().DoubleQuotes()).
+	AssignmentWithFieldName("TO", "string", g.ParameterOptions().NoEquals().DoubleQuotes(), "NewName")
+
+func newTableSearchMethodArgs() *g.QueryStruct {
+	return g.NewQueryStruct("TableSearchMethodArgs").
+		PredefinedQueryStructField("Targets", "[]string", g.KeywordOptions()).
+		OptionalTextAssignment("ANALYZER", g.ParameterOptions().ArrowEquals().SingleQuotes())
+}
+
+func newTableSearchMethodWithTarget() *g.QueryStruct {
+	return g.NewQueryStruct("TableSearchMethodWithTarget").
+		PredefinedQueryStructField("Method", TableSearchMethodEnumDef.Kind(), g.KeywordOptions().Required()).
+		QueryStructField("Args", newTableSearchMethodArgs(), g.ListOptions().Parentheses())
+}
+
+var tableAddSearchOptimization = g.NewQueryStruct("TableAddSearchOptimization").
+	SQL("ADD SEARCH OPTIMIZATION").
+	ListQueryStructField("On", newTableSearchMethodWithTarget(), g.KeywordOptions().SQL("ON"))
+
+var tableDropSearchOptimizationOn = g.NewQueryStruct("TableDropSearchOptimizationOn").
+	OptionalQueryStructField("SearchMethodWithTarget", newTableSearchMethodWithTarget(), g.KeywordOptions()).
+	OptionalText("ColumnName", g.KeywordOptions()).
+	OptionalText("ExpressionId", g.KeywordOptions()).
+	WithValidation(g.ExactlyOneValueSet, "SearchMethodWithTarget", "ColumnName", "ExpressionId")
+
+var tableDropSearchOptimization = g.NewQueryStruct("TableDropSearchOptimization").
+	SQL("DROP SEARCH OPTIMIZATION").
+	ListQueryStructField("On", tableDropSearchOptimizationOn, g.KeywordOptions().SQL("ON"))
+
+var tableSearchOptimizationAction = g.NewQueryStruct("TableSearchOptimizationAction").
+	OptionalQueryStructField(
+		"Add",
+		tableAddSearchOptimization,
+		g.KeywordOptions(),
+	).
+	OptionalQueryStructField(
+		"Drop",
+		tableDropSearchOptimization,
+		g.KeywordOptions(),
+	).
+	WithValidation(g.ExactlyOneValueSet, "Add", "Drop")
+
+var tableSetAggregationPolicy = g.NewQueryStruct("TableSetAggregationPolicy").
+	SQL("SET").
+	Identifier("AggregationPolicy", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("AGGREGATION POLICY").Required()).
+	ListAssignment("ENTITY KEY", "Column", g.ParameterOptions().NoEquals().Parentheses()).
+	OptionalSQL("FORCE").
+	WithValidation(g.ValidIdentifier, "AggregationPolicy")
+
+var tableUnsetAggregationPolicy = g.NewQueryStruct("TableUnsetAggregationPolicy").
+	SQL("UNSET AGGREGATION POLICY")
+
+var tableSetJoinPolicy = g.NewQueryStruct("TableSetJoinPolicy").
+	SQL("SET").
+	Identifier("JoinPolicy", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("JOIN POLICY").Required()).
+	OptionalSQL("FORCE").
+	WithValidation(g.ValidIdentifier, "JoinPolicy")
+
+var tableUnsetJoinPolicy = g.NewQueryStruct("TableUnsetJoinPolicy").
+	SQL("UNSET JOIN POLICY")

--- a/pkg/sdk/iceberg_tables_dto_builders_gen.go
+++ b/pkg/sdk/iceberg_tables_dto_builders_gen.go
@@ -172,6 +172,16 @@ func (s *IcebergTableColumnRequest) WithNotNull(notNull bool) *IcebergTableColum
 	return s
 }
 
+func (s *IcebergTableColumnRequest) WithMaskingPolicy(maskingPolicy TableColumnMaskingPolicyRequest) *IcebergTableColumnRequest {
+	s.MaskingPolicy = &maskingPolicy
+	return s
+}
+
+func (s *IcebergTableColumnRequest) WithProjectionPolicy(projectionPolicy TableColumnProjectionPolicyRequest) *IcebergTableColumnRequest {
+	s.ProjectionPolicy = &projectionPolicy
+	return s
+}
+
 func (s *IcebergTableColumnRequest) WithTag(tag []TagAssociation) *IcebergTableColumnRequest {
 	s.Tag = tag
 	return s
@@ -180,6 +190,27 @@ func (s *IcebergTableColumnRequest) WithTag(tag []TagAssociation) *IcebergTableC
 func (s *IcebergTableColumnRequest) WithComment(comment string) *IcebergTableColumnRequest {
 	s.Comment = &comment
 	return s
+}
+
+func NewTableColumnMaskingPolicyRequest(
+	maskingPolicy SchemaObjectIdentifier,
+) *TableColumnMaskingPolicyRequest {
+	s := TableColumnMaskingPolicyRequest{}
+	s.MaskingPolicy = maskingPolicy
+	return &s
+}
+
+func (s *TableColumnMaskingPolicyRequest) WithUsing(using []Column) *TableColumnMaskingPolicyRequest {
+	s.Using = using
+	return s
+}
+
+func NewTableColumnProjectionPolicyRequest(
+	projectionPolicy SchemaObjectIdentifier,
+) *TableColumnProjectionPolicyRequest {
+	s := TableColumnProjectionPolicyRequest{}
+	s.ProjectionPolicy = projectionPolicy
+	return &s
 }
 
 func NewIcebergTablePartitionExpressionRequest() *IcebergTablePartitionExpressionRequest {
@@ -346,6 +377,16 @@ func (s *AlterIcebergTableRequest) WithAddColumnAction(addColumnAction IcebergTa
 	return s
 }
 
+func (s *AlterIcebergTableRequest) WithDropColumnAction(dropColumnAction TableDropColumnActionRequest) *AlterIcebergTableRequest {
+	s.DropColumnAction = &dropColumnAction
+	return s
+}
+
+func (s *AlterIcebergTableRequest) WithRenameColumnAction(renameColumnAction TableRenameColumnActionRequest) *AlterIcebergTableRequest {
+	s.RenameColumnAction = &renameColumnAction
+	return s
+}
+
 func (s *AlterIcebergTableRequest) WithAlterColumnAction(alterColumnAction []IcebergTableAlterColumnActionRequest) *AlterIcebergTableRequest {
 	s.AlterColumnAction = alterColumnAction
 	return s
@@ -426,6 +467,31 @@ func (s *AlterIcebergTableRequest) WithDropAllRowAccessPolicies(dropAllRowAccess
 	return s
 }
 
+func (s *AlterIcebergTableRequest) WithSetAggregationPolicy(setAggregationPolicy TableSetAggregationPolicyRequest) *AlterIcebergTableRequest {
+	s.SetAggregationPolicy = &setAggregationPolicy
+	return s
+}
+
+func (s *AlterIcebergTableRequest) WithUnsetAggregationPolicy(unsetAggregationPolicy TableUnsetAggregationPolicyRequest) *AlterIcebergTableRequest {
+	s.UnsetAggregationPolicy = &unsetAggregationPolicy
+	return s
+}
+
+func (s *AlterIcebergTableRequest) WithSetJoinPolicy(setJoinPolicy TableSetJoinPolicyRequest) *AlterIcebergTableRequest {
+	s.SetJoinPolicy = &setJoinPolicy
+	return s
+}
+
+func (s *AlterIcebergTableRequest) WithUnsetJoinPolicy(unsetJoinPolicy TableUnsetJoinPolicyRequest) *AlterIcebergTableRequest {
+	s.UnsetJoinPolicy = &unsetJoinPolicy
+	return s
+}
+
+func (s *AlterIcebergTableRequest) WithSearchOptimizationAction(searchOptimizationAction TableSearchOptimizationActionRequest) *AlterIcebergTableRequest {
+	s.SearchOptimizationAction = &searchOptimizationAction
+	return s
+}
+
 func NewIcebergTableAddColumnActionRequest(
 	name string,
 	columnType datatypes.DataType,
@@ -446,8 +512,44 @@ func (s *IcebergTableAddColumnActionRequest) WithDefaultValue(defaultValue Colum
 	return s
 }
 
+func (s *IcebergTableAddColumnActionRequest) WithMaskingPolicy(maskingPolicy TableColumnMaskingPolicyRequest) *IcebergTableAddColumnActionRequest {
+	s.MaskingPolicy = &maskingPolicy
+	return s
+}
+
+func (s *IcebergTableAddColumnActionRequest) WithProjectionPolicy(projectionPolicy TableColumnProjectionPolicyRequest) *IcebergTableAddColumnActionRequest {
+	s.ProjectionPolicy = &projectionPolicy
+	return s
+}
+
 func (s *IcebergTableAddColumnActionRequest) WithTag(tag []TagAssociation) *IcebergTableAddColumnActionRequest {
 	s.Tag = tag
+	return s
+}
+
+func NewTableDropColumnActionRequest(
+	columns []Column,
+) *TableDropColumnActionRequest {
+	s := TableDropColumnActionRequest{}
+	s.Columns = columns
+	return &s
+}
+
+func (s *TableDropColumnActionRequest) WithIfExists(ifExists bool) *TableDropColumnActionRequest {
+	s.IfExists = &ifExists
+	return s
+}
+
+func NewTableRenameColumnActionRequest(
+	oldName string,
+) *TableRenameColumnActionRequest {
+	s := TableRenameColumnActionRequest{}
+	s.OldName = oldName
+	return &s
+}
+
+func (s *TableRenameColumnActionRequest) WithNewName(newName string) *TableRenameColumnActionRequest {
+	s.NewName = newName
 	return s
 }
 
@@ -715,6 +817,130 @@ func (s *IcebergTableUnsetPropertiesRequest) WithComment(comment bool) *IcebergT
 	return s
 }
 
+func NewTableSetAggregationPolicyRequest(
+	aggregationPolicy SchemaObjectIdentifier,
+) *TableSetAggregationPolicyRequest {
+	s := TableSetAggregationPolicyRequest{}
+	s.AggregationPolicy = aggregationPolicy
+	return &s
+}
+
+func (s *TableSetAggregationPolicyRequest) WithEntityKey(entityKey []Column) *TableSetAggregationPolicyRequest {
+	s.EntityKey = entityKey
+	return s
+}
+
+func (s *TableSetAggregationPolicyRequest) WithForce(force bool) *TableSetAggregationPolicyRequest {
+	s.Force = &force
+	return s
+}
+
+func NewTableUnsetAggregationPolicyRequest() *TableUnsetAggregationPolicyRequest {
+	s := TableUnsetAggregationPolicyRequest{}
+	return &s
+}
+
+func NewTableSetJoinPolicyRequest(
+	joinPolicy SchemaObjectIdentifier,
+) *TableSetJoinPolicyRequest {
+	s := TableSetJoinPolicyRequest{}
+	s.JoinPolicy = joinPolicy
+	return &s
+}
+
+func (s *TableSetJoinPolicyRequest) WithForce(force bool) *TableSetJoinPolicyRequest {
+	s.Force = &force
+	return s
+}
+
+func NewTableUnsetJoinPolicyRequest() *TableUnsetJoinPolicyRequest {
+	s := TableUnsetJoinPolicyRequest{}
+	return &s
+}
+
+func NewTableSearchOptimizationActionRequest() *TableSearchOptimizationActionRequest {
+	s := TableSearchOptimizationActionRequest{}
+	return &s
+}
+
+func (s *TableSearchOptimizationActionRequest) WithAdd(add TableAddSearchOptimizationRequest) *TableSearchOptimizationActionRequest {
+	s.Add = &add
+	return s
+}
+
+func (s *TableSearchOptimizationActionRequest) WithDrop(drop TableDropSearchOptimizationRequest) *TableSearchOptimizationActionRequest {
+	s.Drop = &drop
+	return s
+}
+
+func NewTableAddSearchOptimizationRequest() *TableAddSearchOptimizationRequest {
+	s := TableAddSearchOptimizationRequest{}
+	return &s
+}
+
+func (s *TableAddSearchOptimizationRequest) WithOn(on []TableSearchMethodWithTargetRequest) *TableAddSearchOptimizationRequest {
+	s.On = on
+	return s
+}
+
+func NewTableSearchMethodWithTargetRequest(
+	method TableSearchMethod,
+) *TableSearchMethodWithTargetRequest {
+	s := TableSearchMethodWithTargetRequest{}
+	s.Method = method
+	return &s
+}
+
+func (s *TableSearchMethodWithTargetRequest) WithArgs(args TableSearchMethodArgsRequest) *TableSearchMethodWithTargetRequest {
+	s.Args = args
+	return s
+}
+
+func NewTableSearchMethodArgsRequest() *TableSearchMethodArgsRequest {
+	s := TableSearchMethodArgsRequest{}
+	return &s
+}
+
+func (s *TableSearchMethodArgsRequest) WithTargets(targets []string) *TableSearchMethodArgsRequest {
+	s.Targets = targets
+	return s
+}
+
+func (s *TableSearchMethodArgsRequest) WithAnalyzer(analyzer string) *TableSearchMethodArgsRequest {
+	s.Analyzer = &analyzer
+	return s
+}
+
+func NewTableDropSearchOptimizationRequest() *TableDropSearchOptimizationRequest {
+	s := TableDropSearchOptimizationRequest{}
+	return &s
+}
+
+func (s *TableDropSearchOptimizationRequest) WithOn(on []TableDropSearchOptimizationOnRequest) *TableDropSearchOptimizationRequest {
+	s.On = on
+	return s
+}
+
+func NewTableDropSearchOptimizationOnRequest() *TableDropSearchOptimizationOnRequest {
+	s := TableDropSearchOptimizationOnRequest{}
+	return &s
+}
+
+func (s *TableDropSearchOptimizationOnRequest) WithSearchMethodWithTarget(searchMethodWithTarget TableSearchMethodWithTargetRequest) *TableDropSearchOptimizationOnRequest {
+	s.SearchMethodWithTarget = &searchMethodWithTarget
+	return s
+}
+
+func (s *TableDropSearchOptimizationOnRequest) WithColumnName(columnName string) *TableDropSearchOptimizationOnRequest {
+	s.ColumnName = &columnName
+	return s
+}
+
+func (s *TableDropSearchOptimizationOnRequest) WithExpressionId(expressionId string) *TableDropSearchOptimizationOnRequest {
+	s.ExpressionId = &expressionId
+	return s
+}
+
 func NewDropIcebergTableRequest(
 	name SchemaObjectIdentifier,
 ) *DropIcebergTableRequest {
@@ -741,6 +967,11 @@ func (s *DropIcebergTableRequest) WithRestrict(restrict bool) *DropIcebergTableR
 func NewShowIcebergTableRequest() *ShowIcebergTableRequest {
 	s := ShowIcebergTableRequest{}
 	return &s
+}
+
+func (s *ShowIcebergTableRequest) WithTerse(terse bool) *ShowIcebergTableRequest {
+	s.Terse = &terse
+	return s
 }
 
 func (s *ShowIcebergTableRequest) WithLike(like Like) *ShowIcebergTableRequest {

--- a/pkg/sdk/iceberg_tables_dto_gen.go
+++ b/pkg/sdk/iceberg_tables_dto_gen.go
@@ -47,12 +47,23 @@ type IcebergTableColumnsAndConstraintsRequest struct {
 }
 
 type IcebergTableColumnRequest struct {
-	Name         string             // required
-	ColumnType   datatypes.DataType // required
-	DefaultValue *ColumnDefaultValue
-	NotNull      *bool
-	Tag          []TagAssociation
-	Comment      *string
+	Name             string             // required
+	ColumnType       datatypes.DataType // required
+	DefaultValue     *ColumnDefaultValue
+	NotNull          *bool
+	MaskingPolicy    *TableColumnMaskingPolicyRequest
+	ProjectionPolicy *TableColumnProjectionPolicyRequest
+	Tag              []TagAssociation
+	Comment          *string
+}
+
+type TableColumnMaskingPolicyRequest struct {
+	MaskingPolicy SchemaObjectIdentifier // required
+	Using         []Column
+}
+
+type TableColumnProjectionPolicyRequest struct {
+	ProjectionPolicy SchemaObjectIdentifier // required
 }
 
 type IcebergTablePartitionExpressionRequest struct {
@@ -116,6 +127,8 @@ type AlterIcebergTableRequest struct {
 	IfExists                      *bool
 	name                          SchemaObjectIdentifier // required
 	AddColumnAction               *IcebergTableAddColumnActionRequest
+	DropColumnAction              *TableDropColumnActionRequest
+	RenameColumnAction            *TableRenameColumnActionRequest
 	AlterColumnAction             []IcebergTableAlterColumnActionRequest
 	SetMaskingPolicyOnColumn      *TableSetColumnMaskingPolicyRequest
 	UnsetMaskingPolicyOnColumn    *TableUnsetColumnMaskingPolicyRequest
@@ -132,14 +145,31 @@ type AlterIcebergTableRequest struct {
 	DropRowAccessPolicy           *ViewDropRowAccessPolicy
 	DropAndAddRowAccessPolicy     *ViewDropAndAddRowAccessPolicy
 	DropAllRowAccessPolicies      *bool
+	SetAggregationPolicy          *TableSetAggregationPolicyRequest
+	UnsetAggregationPolicy        *TableUnsetAggregationPolicyRequest
+	SetJoinPolicy                 *TableSetJoinPolicyRequest
+	UnsetJoinPolicy               *TableUnsetJoinPolicyRequest
+	SearchOptimizationAction      *TableSearchOptimizationActionRequest
 }
 
 type IcebergTableAddColumnActionRequest struct {
-	IfNotExists  *bool
-	Name         string             // required
-	ColumnType   datatypes.DataType // required
-	DefaultValue *ColumnDefaultValue
-	Tag          []TagAssociation
+	IfNotExists      *bool
+	Name             string             // required
+	ColumnType       datatypes.DataType // required
+	DefaultValue     *ColumnDefaultValue
+	MaskingPolicy    *TableColumnMaskingPolicyRequest
+	ProjectionPolicy *TableColumnProjectionPolicyRequest
+	Tag              []TagAssociation
+}
+
+type TableDropColumnActionRequest struct {
+	IfExists *bool
+	Columns  []Column // required
+}
+
+type TableRenameColumnActionRequest struct {
+	OldName string // required
+	NewName string
 }
 
 type IcebergTableAlterColumnActionRequest struct {
@@ -222,6 +252,50 @@ type IcebergTableUnsetPropertiesRequest struct {
 	Comment                    *bool
 }
 
+type TableSetAggregationPolicyRequest struct {
+	AggregationPolicy SchemaObjectIdentifier // required
+	EntityKey         []Column
+	Force             *bool
+}
+
+type TableUnsetAggregationPolicyRequest struct{}
+
+type TableSetJoinPolicyRequest struct {
+	JoinPolicy SchemaObjectIdentifier // required
+	Force      *bool
+}
+
+type TableUnsetJoinPolicyRequest struct{}
+
+type TableSearchOptimizationActionRequest struct {
+	Add  *TableAddSearchOptimizationRequest
+	Drop *TableDropSearchOptimizationRequest
+}
+
+type TableAddSearchOptimizationRequest struct {
+	On []TableSearchMethodWithTargetRequest
+}
+
+type TableSearchMethodWithTargetRequest struct {
+	Method TableSearchMethod // required
+	Args   TableSearchMethodArgsRequest
+}
+
+type TableSearchMethodArgsRequest struct {
+	Targets  []string
+	Analyzer *string
+}
+
+type TableDropSearchOptimizationRequest struct {
+	On []TableDropSearchOptimizationOnRequest
+}
+
+type TableDropSearchOptimizationOnRequest struct {
+	SearchMethodWithTarget *TableSearchMethodWithTargetRequest
+	ColumnName             *string
+	ExpressionId           *string
+}
+
 type DropIcebergTableRequest struct {
 	IfExists *bool
 	name     SchemaObjectIdentifier // required
@@ -230,6 +304,7 @@ type DropIcebergTableRequest struct {
 }
 
 type ShowIcebergTableRequest struct {
+	Terse      *bool
 	Like       *Like
 	In         *In
 	StartsWith *string

--- a/pkg/sdk/iceberg_tables_enums_gen.go
+++ b/pkg/sdk/iceberg_tables_enums_gen.go
@@ -91,6 +91,34 @@ func ToIcebergTableDescribeType(s string) (IcebergTableDescribeType, error) {
 	}
 }
 
+type TableSearchMethod string
+
+const (
+	TableSearchMethodSubstring TableSearchMethod = "SUBSTRING"
+	TableSearchMethodEquality  TableSearchMethod = "EQUALITY"
+	TableSearchMethodFullText  TableSearchMethod = "FULL_TEXT"
+)
+
+var AllTableSearchMethods = []TableSearchMethod{
+	TableSearchMethodSubstring,
+	TableSearchMethodEquality,
+	TableSearchMethodFullText,
+}
+
+func ToTableSearchMethod(s string) (TableSearchMethod, error) {
+	s = strings.ToUpper(s)
+	switch s {
+	case string(TableSearchMethodSubstring):
+		return TableSearchMethodSubstring, nil
+	case string(TableSearchMethodEquality):
+		return TableSearchMethodEquality, nil
+	case string(TableSearchMethodFullText):
+		return TableSearchMethodFullText, nil
+	default:
+		return "", fmt.Errorf("invalid table search method: %s", s)
+	}
+}
+
 type IcebergTableLogEventLevel string
 
 const (

--- a/pkg/sdk/iceberg_tables_gen.go
+++ b/pkg/sdk/iceberg_tables_gen.go
@@ -138,7 +138,7 @@ type AlterIcebergTableOptions struct {
 	IfExists                      *bool                             `ddl:"keyword" sql:"IF EXISTS"`
 	name                          SchemaObjectIdentifier            `ddl:"identifier"`
 	AddColumnAction               *IcebergTableAddColumnAction      `ddl:"keyword"`
-	AlterColumnAction             []IcebergTableAlterColumnAction   `ddl:"keyword" sql:"ALTER"`
+	AlterColumnAction             []IcebergTableAlterColumnAction   `ddl:"keyword"`
 	SetMaskingPolicyOnColumn      *TableSetColumnMaskingPolicy      `ddl:"keyword"`
 	UnsetMaskingPolicyOnColumn    *TableUnsetColumnMaskingPolicy    `ddl:"keyword"`
 	SetProjectionPolicyOnColumn   *TableSetColumnProjectionPolicy   `ddl:"keyword"`
@@ -166,7 +166,7 @@ type IcebergTableAddColumnAction struct {
 }
 
 type IcebergTableAlterColumnAction struct {
-	column           bool                `ddl:"static" sql:"COLUMN"`
+	alterColumn      bool                `ddl:"static" sql:"ALTER COLUMN"`
 	ColumnName       string              `ddl:"keyword,double_quotes"`
 	SetNotNull       *bool               `ddl:"keyword" sql:"SET NOT NULL"`
 	DropNotNull      *bool               `ddl:"keyword" sql:"DROP NOT NULL"`
@@ -272,6 +272,7 @@ type DropIcebergTableOptions struct {
 // ShowIcebergTableOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-iceberg-tables.
 type ShowIcebergTableOptions struct {
 	show          bool       `ddl:"static" sql:"SHOW"`
+	Terse         *bool      `ddl:"keyword" sql:"TERSE"`
 	icebergTables bool       `ddl:"static" sql:"ICEBERG TABLES"`
 	Like          *Like      `ddl:"keyword" sql:"LIKE"`
 	In            *In        `ddl:"keyword" sql:"IN"`

--- a/pkg/sdk/iceberg_tables_gen.go
+++ b/pkg/sdk/iceberg_tables_gen.go
@@ -34,25 +34,26 @@ type CreateIcebergTableOptions struct {
 	PathLayout            *IcebergTablePathLayout           `ddl:"parameter,no_quotes" sql:"PATH_LAYOUT"`
 	ClusterBy             []string                          `ddl:"keyword,parentheses" sql:"CLUSTER BY"`
 	// Adjusted manually
-	ExternalVolume             *string                        `ddl:"parameter" sql:"EXTERNAL_VOLUME"`
-	Catalog                    *IcebergTableCatalog           `ddl:"parameter,single_quotes" sql:"CATALOG"`
-	BaseLocation               *string                        `ddl:"parameter,single_quotes" sql:"BASE_LOCATION"`
-	TargetFileSize             *IcebergTableTargetFileSize    `ddl:"parameter,single_quotes" sql:"TARGET_FILE_SIZE"`
-	CatalogSync                *string                        `ddl:"parameter,single_quotes" sql:"CATALOG_SYNC"`
-	StorageSerializationPolicy *StorageSerializationPolicy    `ddl:"parameter" sql:"STORAGE_SERIALIZATION_POLICY"`
-	DataRetentionTimeInDays    *int                           `ddl:"parameter" sql:"DATA_RETENTION_TIME_IN_DAYS"`
-	MaxDataExtensionTimeInDays *int                           `ddl:"parameter" sql:"MAX_DATA_EXTENSION_TIME_IN_DAYS"`
-	ChangeTracking             *bool                          `ddl:"parameter" sql:"CHANGE_TRACKING"`
-	CopyGrants                 *bool                          `ddl:"keyword" sql:"COPY GRANTS"`
-	ErrorLogging               *bool                          `ddl:"parameter" sql:"ERROR_LOGGING"`
-	Comment                    *string                        `ddl:"parameter,single_quotes" sql:"COMMENT"`
-	IcebergVersion             *int                           `ddl:"parameter" sql:"ICEBERG_VERSION"`
-	EnableIcebergMergeOnRead   *bool                          `ddl:"parameter" sql:"ENABLE_ICEBERG_MERGE_ON_READ"`
-	RowAccessPolicy            *IcebergTableRowAccessPolicy   `ddl:"keyword"`
-	AggregationPolicy          *IcebergTableAggregationPolicy `ddl:"keyword"`
-	Tag                        []TagAssociation               `ddl:"keyword,parentheses" sql:"TAG"`
-	EnableDataCompaction       *bool                          `ddl:"parameter" sql:"ENABLE_DATA_COMPACTION"`
-	Contact                    []TableContact                 `ddl:"keyword,parentheses" sql:"WITH CONTACT"`
+	ExternalVolume             *string                      `ddl:"parameter" sql:"EXTERNAL_VOLUME"`
+	Catalog                    *IcebergTableCatalog         `ddl:"parameter,single_quotes" sql:"CATALOG"`
+	BaseLocation               *string                      `ddl:"parameter,single_quotes" sql:"BASE_LOCATION"`
+	TargetFileSize             *IcebergTableTargetFileSize  `ddl:"parameter,single_quotes" sql:"TARGET_FILE_SIZE"`
+	CatalogSync                *string                      `ddl:"parameter,single_quotes" sql:"CATALOG_SYNC"`
+	StorageSerializationPolicy *StorageSerializationPolicy  `ddl:"parameter" sql:"STORAGE_SERIALIZATION_POLICY"`
+	DataRetentionTimeInDays    *int                         `ddl:"parameter" sql:"DATA_RETENTION_TIME_IN_DAYS"`
+	MaxDataExtensionTimeInDays *int                         `ddl:"parameter" sql:"MAX_DATA_EXTENSION_TIME_IN_DAYS"`
+	ChangeTracking             *bool                        `ddl:"parameter" sql:"CHANGE_TRACKING"`
+	CopyGrants                 *bool                        `ddl:"keyword" sql:"COPY GRANTS"`
+	ErrorLogging               *bool                        `ddl:"parameter" sql:"ERROR_LOGGING"`
+	Comment                    *string                      `ddl:"parameter,single_quotes" sql:"COMMENT"`
+	IcebergVersion             *int                         `ddl:"parameter" sql:"ICEBERG_VERSION"`
+	EnableIcebergMergeOnRead   *bool                        `ddl:"parameter" sql:"ENABLE_ICEBERG_MERGE_ON_READ"`
+	RowAccessPolicy            *IcebergTableRowAccessPolicy `ddl:"keyword"`
+	// Adjusted manually
+	AggregationPolicy    *IcebergTableAggregationPolicy `ddl:"keyword"`
+	Tag                  []TagAssociation               `ddl:"keyword,parentheses" sql:"TAG"`
+	EnableDataCompaction *bool                          `ddl:"parameter" sql:"ENABLE_DATA_COMPACTION"`
+	Contact              []TableContact                 `ddl:"keyword,parentheses" sql:"WITH CONTACT"`
 }
 
 type IcebergTableColumnsAndConstraints struct {
@@ -60,12 +61,23 @@ type IcebergTableColumnsAndConstraints struct {
 }
 
 type IcebergTableColumn struct {
-	Name         string              `ddl:"keyword,double_quotes"`
-	ColumnType   datatypes.DataType  `ddl:"parameter,no_quotes,no_equals"`
-	DefaultValue *ColumnDefaultValue `ddl:"keyword"`
-	NotNull      *bool               `ddl:"keyword" sql:"NOT NULL"`
-	Tag          []TagAssociation    `ddl:"keyword,parentheses" sql:"TAG"`
-	Comment      *string             `ddl:"parameter,single_quotes,no_equals" sql:"COMMENT"`
+	Name             string                       `ddl:"keyword,double_quotes"`
+	ColumnType       datatypes.DataType           `ddl:"parameter,no_quotes,no_equals"`
+	DefaultValue     *ColumnDefaultValue          `ddl:"keyword"`
+	NotNull          *bool                        `ddl:"keyword" sql:"NOT NULL"`
+	MaskingPolicy    *TableColumnMaskingPolicy    `ddl:"keyword"`
+	ProjectionPolicy *TableColumnProjectionPolicy `ddl:"keyword"`
+	Tag              []TagAssociation             `ddl:"keyword,parentheses" sql:"TAG"`
+	Comment          *string                      `ddl:"parameter,single_quotes,no_equals" sql:"COMMENT"`
+}
+
+type TableColumnMaskingPolicy struct {
+	MaskingPolicy SchemaObjectIdentifier `ddl:"identifier" sql:"MASKING POLICY"`
+	Using         []Column               `ddl:"parameter,parentheses,no_equals" sql:"USING"`
+}
+
+type TableColumnProjectionPolicy struct {
+	ProjectionPolicy SchemaObjectIdentifier `ddl:"identifier" sql:"PROJECTION POLICY"`
 }
 
 type IcebergTablePartitionExpression struct {
@@ -138,7 +150,9 @@ type AlterIcebergTableOptions struct {
 	IfExists                      *bool                             `ddl:"keyword" sql:"IF EXISTS"`
 	name                          SchemaObjectIdentifier            `ddl:"identifier"`
 	AddColumnAction               *IcebergTableAddColumnAction      `ddl:"keyword"`
-	AlterColumnAction             []IcebergTableAlterColumnAction   `ddl:"keyword"`
+	DropColumnAction              *TableDropColumnAction            `ddl:"keyword"`
+	RenameColumnAction            *TableRenameColumnAction          `ddl:"keyword"`
+	AlterColumnAction             []IcebergTableAlterColumnAction   `ddl:"keyword" sql:"ALTER"`
 	SetMaskingPolicyOnColumn      *TableSetColumnMaskingPolicy      `ddl:"keyword"`
 	UnsetMaskingPolicyOnColumn    *TableUnsetColumnMaskingPolicy    `ddl:"keyword"`
 	SetProjectionPolicyOnColumn   *TableSetColumnProjectionPolicy   `ddl:"keyword"`
@@ -154,19 +168,38 @@ type AlterIcebergTableOptions struct {
 	DropRowAccessPolicy           *ViewDropRowAccessPolicy          `ddl:"keyword"`
 	DropAndAddRowAccessPolicy     *ViewDropAndAddRowAccessPolicy    `ddl:"list,no_parentheses"`
 	DropAllRowAccessPolicies      *bool                             `ddl:"keyword" sql:"DROP ALL ROW ACCESS POLICIES"`
+	SetAggregationPolicy          *TableSetAggregationPolicy        `ddl:"keyword"`
+	UnsetAggregationPolicy        *TableUnsetAggregationPolicy      `ddl:"keyword"`
+	SetJoinPolicy                 *TableSetJoinPolicy               `ddl:"keyword"`
+	UnsetJoinPolicy               *TableUnsetJoinPolicy             `ddl:"keyword"`
+	SearchOptimizationAction      *TableSearchOptimizationAction    `ddl:"keyword"`
 }
 
 type IcebergTableAddColumnAction struct {
-	addColumn    bool                `ddl:"static" sql:"ADD COLUMN"`
-	IfNotExists  *bool               `ddl:"keyword" sql:"IF NOT EXISTS"`
-	Name         string              `ddl:"keyword,double_quotes"`
-	ColumnType   datatypes.DataType  `ddl:"parameter,no_quotes,no_equals"`
-	DefaultValue *ColumnDefaultValue `ddl:"keyword"`
-	Tag          []TagAssociation    `ddl:"keyword,parentheses" sql:"TAG"`
+	addColumn        bool                         `ddl:"static" sql:"ADD COLUMN"`
+	IfNotExists      *bool                        `ddl:"keyword" sql:"IF NOT EXISTS"`
+	Name             string                       `ddl:"keyword,double_quotes"`
+	ColumnType       datatypes.DataType           `ddl:"parameter,no_quotes,no_equals"`
+	DefaultValue     *ColumnDefaultValue          `ddl:"keyword"`
+	MaskingPolicy    *TableColumnMaskingPolicy    `ddl:"keyword"`
+	ProjectionPolicy *TableColumnProjectionPolicy `ddl:"keyword"`
+	Tag              []TagAssociation             `ddl:"keyword,parentheses" sql:"TAG"`
+}
+
+type TableDropColumnAction struct {
+	dropColumn bool     `ddl:"static" sql:"DROP COLUMN"`
+	IfExists   *bool    `ddl:"keyword" sql:"IF EXISTS"`
+	Columns    []Column `ddl:"keyword"`
+}
+
+type TableRenameColumnAction struct {
+	renameColumn bool   `ddl:"static" sql:"RENAME COLUMN"`
+	OldName      string `ddl:"keyword,double_quotes"`
+	NewName      string `ddl:"parameter,double_quotes,no_equals" sql:"TO"`
 }
 
 type IcebergTableAlterColumnAction struct {
-	alterColumn      bool                `ddl:"static" sql:"ALTER COLUMN"`
+	alterColumn      bool                `ddl:"static" sql:"COLUMN"`
 	ColumnName       string              `ddl:"keyword,double_quotes"`
 	SetNotNull       *bool               `ddl:"keyword" sql:"SET NOT NULL"`
 	DropNotNull      *bool               `ddl:"keyword" sql:"DROP NOT NULL"`
@@ -257,6 +290,58 @@ type IcebergTableUnsetProperties struct {
 	EnableDataCompaction       *bool `ddl:"keyword" sql:"ENABLE_DATA_COMPACTION"`
 	EnableIcebergMergeOnRead   *bool `ddl:"keyword" sql:"ENABLE_ICEBERG_MERGE_ON_READ"`
 	Comment                    *bool `ddl:"keyword" sql:"COMMENT"`
+}
+
+type TableSetAggregationPolicy struct {
+	set               bool                   `ddl:"static" sql:"SET"`
+	AggregationPolicy SchemaObjectIdentifier `ddl:"identifier" sql:"AGGREGATION POLICY"`
+	EntityKey         []Column               `ddl:"parameter,parentheses,no_equals" sql:"ENTITY KEY"`
+	Force             *bool                  `ddl:"keyword" sql:"FORCE"`
+}
+
+type TableUnsetAggregationPolicy struct {
+	unsetAggregationPolicy bool `ddl:"static" sql:"UNSET AGGREGATION POLICY"`
+}
+
+type TableSetJoinPolicy struct {
+	set        bool                   `ddl:"static" sql:"SET"`
+	JoinPolicy SchemaObjectIdentifier `ddl:"identifier" sql:"JOIN POLICY"`
+	Force      *bool                  `ddl:"keyword" sql:"FORCE"`
+}
+
+type TableUnsetJoinPolicy struct {
+	unsetJoinPolicy bool `ddl:"static" sql:"UNSET JOIN POLICY"`
+}
+
+type TableSearchOptimizationAction struct {
+	Add  *TableAddSearchOptimization  `ddl:"keyword"`
+	Drop *TableDropSearchOptimization `ddl:"keyword"`
+}
+
+type TableAddSearchOptimization struct {
+	addSearchOptimization bool                          `ddl:"static" sql:"ADD SEARCH OPTIMIZATION"`
+	On                    []TableSearchMethodWithTarget `ddl:"keyword" sql:"ON"`
+}
+
+type TableSearchMethodWithTarget struct {
+	Method TableSearchMethod     `ddl:"keyword"`
+	Args   TableSearchMethodArgs `ddl:"list,parentheses"`
+}
+
+type TableSearchMethodArgs struct {
+	Targets  []string `ddl:"keyword"`
+	Analyzer *string  `ddl:"parameter,single_quotes,arrow_equals" sql:"ANALYZER"`
+}
+
+type TableDropSearchOptimization struct {
+	dropSearchOptimization bool                            `ddl:"static" sql:"DROP SEARCH OPTIMIZATION"`
+	On                     []TableDropSearchOptimizationOn `ddl:"keyword" sql:"ON"`
+}
+
+type TableDropSearchOptimizationOn struct {
+	SearchMethodWithTarget *TableSearchMethodWithTarget `ddl:"keyword"`
+	ColumnName             *string                      `ddl:"keyword"`
+	ExpressionId           *string                      `ddl:"keyword"`
 }
 
 // DropIcebergTableOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-iceberg-table.

--- a/pkg/sdk/iceberg_tables_gen_test.go
+++ b/pkg/sdk/iceberg_tables_gen_test.go
@@ -10,6 +10,7 @@ func init() {
 	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[IcebergTableTargetFileSize]{"IcebergTableTargetFileSize", AllIcebergTableTargetFileSizes, ToIcebergTableTargetFileSize})
 	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[IcebergTablePathLayout]{"IcebergTablePathLayout", AllIcebergTablePathLayouts, ToIcebergTablePathLayout})
 	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[IcebergTableDescribeType]{"IcebergTableDescribeType", AllIcebergTableDescribeTypes, ToIcebergTableDescribeType})
+	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[TableSearchMethod]{"TableSearchMethod", AllTableSearchMethods, ToTableSearchMethod})
 	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[IcebergTableLogEventLevel]{"IcebergTableLogEventLevel", AllIcebergTableLogEventLevels, ToIcebergTableLogEventLevel})
 	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[IcebergTableType]{"IcebergTableType", AllIcebergTableTypes, ToIcebergTableType})
 }
@@ -18,6 +19,8 @@ func TestIcebergTables_Create(t *testing.T) {
 	id := randomSchemaObjectIdentifier()
 	aggregationPolicyId := randomSchemaObjectIdentifier()
 	rowAccessPolicyId := randomSchemaObjectIdentifier()
+	maskingPolicyId := randomSchemaObjectIdentifier()
+	projectionPolicyId := randomSchemaObjectIdentifier()
 	tagId1 := randomSchemaObjectIdentifier()
 	tagId2 := randomSchemaObjectIdentifier()
 
@@ -93,6 +96,13 @@ func TestIcebergTables_Create(t *testing.T) {
 						Expression: new("1"),
 					},
 					NotNull: new(true),
+					MaskingPolicy: &TableColumnMaskingPolicy{
+						MaskingPolicy: maskingPolicyId,
+						Using:         []Column{{"ID"}, {"NAME"}},
+					},
+					ProjectionPolicy: &TableColumnProjectionPolicy{
+						ProjectionPolicy: projectionPolicyId,
+					},
 					Tag: []TagAssociation{
 						{Name: tagId1, Value: "v1"},
 						{Name: tagId2, Value: "v2"},
@@ -176,7 +186,7 @@ func TestIcebergTables_Create(t *testing.T) {
 		assertOptsValidAndSQLEquals(
 			t, opts,
 			`CREATE OR REPLACE TRANSIENT ICEBERG TABLE %s `+
-				`("ID" NUMBER(38, 0) DEFAULT 1 NOT NULL TAG (%s = 'v1', %s = 'v2') COMMENT 'id column', `+
+				`("ID" NUMBER(38, 0) DEFAULT 1 NOT NULL MASKING POLICY %s USING ("ID", "NAME") PROJECTION POLICY %s TAG (%s = 'v1', %s = 'v2') COMMENT 'id column', `+
 				`"NAME" VARCHAR(16777216) COMMENT 'name column') `+
 				`PARTITION BY ("ID", BUCKET (4, "NAME"), TRUNCATE (10, "C1"), YEAR ("C2"), MONTH ("C3"), DAY ("C4"), HOUR ("C5")) `+
 				`PATH_LAYOUT = HIERARCHICAL `+
@@ -201,6 +211,8 @@ func TestIcebergTables_Create(t *testing.T) {
 				`ENABLE_DATA_COMPACTION = true `+
 				`WITH CONTACT (SUPPORT = 'support_team', ACCESS_APPROVAL = 'access_team')`,
 			id.FullyQualifiedName(),
+			maskingPolicyId.FullyQualifiedName(),
+			projectionPolicyId.FullyQualifiedName(),
 			tagId1.FullyQualifiedName(), tagId2.FullyQualifiedName(),
 			rowAccessPolicyId.FullyQualifiedName(),
 			aggregationPolicyId.FullyQualifiedName(),
@@ -211,6 +223,8 @@ func TestIcebergTables_Create(t *testing.T) {
 
 func TestIcebergTables_Alter(t *testing.T) {
 	id := randomSchemaObjectIdentifier()
+	aggregationPolicyId := randomSchemaObjectIdentifier()
+	joinPolicyId := randomSchemaObjectIdentifier()
 	maskingPolicyId := randomSchemaObjectIdentifier()
 	projectionPolicyId := randomSchemaObjectIdentifier()
 	rowAccessPolicy1Id := randomSchemaObjectIdentifier()
@@ -236,9 +250,9 @@ func TestIcebergTables_Alter(t *testing.T) {
 		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
-	t.Run("validation: exactly one field from [opts.AddColumnAction opts.AlterColumnAction opts.SetMaskingPolicyOnColumn opts.UnsetMaskingPolicyOnColumn opts.SetProjectionPolicyOnColumn opts.UnsetProjectionPolicyOnColumn opts.SetTagsOnColumn opts.UnsetTagsOnColumn opts.ClusteringAction opts.Set opts.Unset opts.SetTags opts.UnsetTags opts.AddRowAccessPolicy opts.DropRowAccessPolicy opts.DropAndAddRowAccessPolicy opts.DropAllRowAccessPolicies] should be present", func(t *testing.T) {
+	t.Run("validation: exactly one field from [opts.AddColumnAction opts.DropColumnAction opts.RenameColumnAction opts.AlterColumnAction opts.SetMaskingPolicyOnColumn opts.UnsetMaskingPolicyOnColumn opts.SetProjectionPolicyOnColumn opts.UnsetProjectionPolicyOnColumn opts.SetTagsOnColumn opts.UnsetTagsOnColumn opts.ClusteringAction opts.Set opts.Unset opts.SetTags opts.UnsetTags opts.AddRowAccessPolicy opts.DropRowAccessPolicy opts.DropAndAddRowAccessPolicy opts.DropAllRowAccessPolicies opts.SetAggregationPolicy opts.UnsetAggregationPolicy opts.SetJoinPolicy opts.UnsetJoinPolicy opts.SearchOptimizationAction] should be present", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterIcebergTableOptions", "AddColumnAction", "AlterColumnAction", "SetMaskingPolicyOnColumn", "UnsetMaskingPolicyOnColumn", "SetProjectionPolicyOnColumn", "UnsetProjectionPolicyOnColumn", "SetTagsOnColumn", "UnsetTagsOnColumn", "ClusteringAction", "Set", "Unset", "SetTags", "UnsetTags", "AddRowAccessPolicy", "DropRowAccessPolicy", "DropAndAddRowAccessPolicy", "DropAllRowAccessPolicies"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterIcebergTableOptions", "AddColumnAction", "DropColumnAction", "RenameColumnAction", "AlterColumnAction", "SetMaskingPolicyOnColumn", "UnsetMaskingPolicyOnColumn", "SetProjectionPolicyOnColumn", "UnsetProjectionPolicyOnColumn", "SetTagsOnColumn", "UnsetTagsOnColumn", "ClusteringAction", "Set", "Unset", "SetTags", "UnsetTags", "AddRowAccessPolicy", "DropRowAccessPolicy", "DropAndAddRowAccessPolicy", "DropAllRowAccessPolicies", "SetAggregationPolicy", "UnsetAggregationPolicy", "SetJoinPolicy", "UnsetJoinPolicy", "SearchOptimizationAction"))
 	})
 
 	t.Run("validation: exactly one field from [opts.AlterColumnAction.SetNotNull opts.AlterColumnAction.DropNotNull opts.AlterColumnAction.DataType opts.AlterColumnAction.Comment opts.AlterColumnAction.UnsetComment opts.AlterColumnAction.SetWriteDefault opts.AlterColumnAction.DropWriteDefault] should be present", func(t *testing.T) {
@@ -273,6 +287,28 @@ func TestIcebergTables_Alter(t *testing.T) {
 		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterIcebergTableOptions.Unset", "ReplaceInvalidCharacters", "CatalogSync", "DataRetentionTimeInDays", "MaxDataExtensionTimeInDays", "TargetFileSize", "LogEventLevel", "ErrorLogging", "EnableDataCompaction", "EnableIcebergMergeOnRead", "Comment"))
 	})
 
+	t.Run("validation: valid identifier for [opts.SetAggregationPolicy.AggregationPolicy]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.SetAggregationPolicy = &TableSetAggregationPolicy{
+			AggregationPolicy: emptySchemaObjectIdentifier,
+		}
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: valid identifier for [opts.SetJoinPolicy.JoinPolicy]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.SetJoinPolicy = &TableSetJoinPolicy{
+			JoinPolicy: emptySchemaObjectIdentifier,
+		}
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: exactly one field from [opts.SearchOptimizationAction.Add opts.SearchOptimizationAction.Drop] should be present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.SearchOptimizationAction = &TableSearchOptimizationAction{}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterIcebergTableOptions.SearchOptimizationAction", "Add", "Drop"))
+	})
+
 	t.Run("alter: add column", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.IfExists = new(true)
@@ -283,16 +319,43 @@ func TestIcebergTables_Alter(t *testing.T) {
 			DefaultValue: &ColumnDefaultValue{
 				Expression: new("'a'"),
 			},
+			MaskingPolicy: &TableColumnMaskingPolicy{
+				MaskingPolicy: maskingPolicyId,
+				Using:         []Column{{"NEW_COL"}, {"OTHER"}},
+			},
+			ProjectionPolicy: &TableColumnProjectionPolicy{
+				ProjectionPolicy: projectionPolicyId,
+			},
 			Tag: []TagAssociation{
 				{Name: tagId1, Value: "v1"},
 				{Name: tagId2, Value: "v2"},
 			},
 		}
 		assertOptsValidAndSQLEquals(
-			t, opts, `ALTER ICEBERG TABLE IF EXISTS %s ADD COLUMN IF NOT EXISTS "NEW_COL" VARCHAR(16777216) DEFAULT 'a' TAG (%s = 'v1', %s = 'v2')`,
+			t, opts, `ALTER ICEBERG TABLE IF EXISTS %s ADD COLUMN IF NOT EXISTS "NEW_COL" VARCHAR(16777216) DEFAULT 'a' MASKING POLICY %s USING ("NEW_COL", "OTHER") PROJECTION POLICY %s TAG (%s = 'v1', %s = 'v2')`,
 			id.FullyQualifiedName(),
+			maskingPolicyId.FullyQualifiedName(),
+			projectionPolicyId.FullyQualifiedName(),
 			tagId1.FullyQualifiedName(), tagId2.FullyQualifiedName(),
 		)
+	})
+
+	t.Run("alter: drop column", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.DropColumnAction = &TableDropColumnAction{
+			IfExists: Bool(true),
+			Columns:  []Column{{"col1"}, {"col2"}},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER ICEBERG TABLE %s DROP COLUMN IF EXISTS "col1", "col2"`, id.FullyQualifiedName())
+	})
+
+	t.Run("alter: rename column", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.RenameColumnAction = &TableRenameColumnAction{
+			OldName: "old_col",
+			NewName: "new_col",
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER ICEBERG TABLE %s RENAME COLUMN "old_col" TO "new_col"`, id.FullyQualifiedName())
 	})
 
 	t.Run("alter: alter column - set not null", func(t *testing.T) {
@@ -561,6 +624,121 @@ func TestIcebergTables_Alter(t *testing.T) {
 		opts := defaultOpts()
 		opts.DropAllRowAccessPolicies = new(true)
 		assertOptsValidAndSQLEquals(t, opts, `ALTER ICEBERG TABLE %s DROP ALL ROW ACCESS POLICIES`, id.FullyQualifiedName())
+	})
+
+	t.Run("alter: set aggregation policy", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.SetAggregationPolicy = &TableSetAggregationPolicy{
+			AggregationPolicy: aggregationPolicyId,
+			EntityKey:         []Column{{"col1"}, {"col2"}},
+			Force:             Bool(true),
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER ICEBERG TABLE %s SET AGGREGATION POLICY %s ENTITY KEY ("col1", "col2") FORCE`, id.FullyQualifiedName(), aggregationPolicyId.FullyQualifiedName())
+	})
+
+	t.Run("alter: unset aggregation policy", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.UnsetAggregationPolicy = &TableUnsetAggregationPolicy{}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER ICEBERG TABLE %s UNSET AGGREGATION POLICY`, id.FullyQualifiedName())
+	})
+
+	t.Run("alter: set join policy", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.SetJoinPolicy = &TableSetJoinPolicy{
+			JoinPolicy: joinPolicyId,
+			Force:      Bool(true),
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER ICEBERG TABLE %s SET JOIN POLICY %s FORCE`, id.FullyQualifiedName(), joinPolicyId.FullyQualifiedName())
+	})
+
+	t.Run("alter: unset join policy", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.UnsetJoinPolicy = &TableUnsetJoinPolicy{}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER ICEBERG TABLE %s UNSET JOIN POLICY`, id.FullyQualifiedName())
+	})
+
+	t.Run("alter: search optimization - add", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.SearchOptimizationAction = &TableSearchOptimizationAction{
+			Add: &TableAddSearchOptimization{
+				On: []TableSearchMethodWithTarget{
+					{
+						Method: TableSearchMethodEquality,
+						Args: TableSearchMethodArgs{
+							Targets:  []string{"col1", "col2"},
+							Analyzer: String("DEFAULT_ANALYZER"),
+						},
+					},
+					{
+						Method: TableSearchMethodSubstring,
+						Args: TableSearchMethodArgs{
+							Targets: []string{"*"},
+						},
+					},
+				},
+			},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER ICEBERG TABLE %s ADD SEARCH OPTIMIZATION ON EQUALITY (col1, col2, ANALYZER => 'DEFAULT_ANALYZER'), SUBSTRING (*)`, id.FullyQualifiedName())
+	})
+
+	t.Run("alter: search optimization - drop with search methods", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.SearchOptimizationAction = &TableSearchOptimizationAction{
+			Drop: &TableDropSearchOptimization{
+				On: []TableDropSearchOptimizationOn{
+					{
+						SearchMethodWithTarget: &TableSearchMethodWithTarget{
+							Method: TableSearchMethodFullText,
+							Args: TableSearchMethodArgs{
+								Targets: []string{"col1", "col2"},
+							},
+						},
+					},
+					{
+						SearchMethodWithTarget: &TableSearchMethodWithTarget{
+							Method: TableSearchMethodSubstring,
+							Args: TableSearchMethodArgs{
+								Targets: []string{"*"},
+							},
+						},
+					},
+				},
+			},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER ICEBERG TABLE %s DROP SEARCH OPTIMIZATION ON FULL_TEXT (col1, col2), SUBSTRING (*)`, id.FullyQualifiedName())
+	})
+
+	t.Run("alter: search optimization - drop mixed forms (search method, column name, expression id)", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.SearchOptimizationAction = &TableSearchOptimizationAction{
+			Drop: &TableDropSearchOptimization{
+				On: []TableDropSearchOptimizationOn{
+					{
+						SearchMethodWithTarget: &TableSearchMethodWithTarget{
+							Method: TableSearchMethodEquality,
+							Args: TableSearchMethodArgs{
+								Targets: []string{"col1"},
+							},
+						},
+					},
+					{ColumnName: String("col2")},
+					{ExpressionId: String("expr_123")},
+				},
+			},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER ICEBERG TABLE %s DROP SEARCH OPTIMIZATION ON EQUALITY (col1), col2, expr_123`, id.FullyQualifiedName())
+	})
+
+	t.Run("validation: exactly one field from [opts.SearchOptimizationAction.Drop.On.SearchMethodWithTarget opts.SearchOptimizationAction.Drop.On.ColumnName opts.SearchOptimizationAction.Drop.On.ExpressionId] should be present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.SearchOptimizationAction = &TableSearchOptimizationAction{
+			Drop: &TableDropSearchOptimization{
+				On: []TableDropSearchOptimizationOn{
+					{},
+				},
+			},
+		}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterIcebergTableOptions.SearchOptimizationAction.Drop.On", "SearchMethodWithTarget", "ColumnName", "ExpressionId"))
 	})
 }
 

--- a/pkg/sdk/iceberg_tables_impl_gen.go
+++ b/pkg/sdk/iceberg_tables_impl_gen.go
@@ -112,6 +112,18 @@ func (r *CreateIcebergTableRequest) toOpts() *CreateIcebergTableOptions {
 				Tag:          v.Tag,
 				Comment:      v.Comment,
 			}
+			// Adjusted manually: convert *Request sub-structs to *Options
+			if v.MaskingPolicy != nil {
+				s[i].MaskingPolicy = &TableColumnMaskingPolicy{
+					MaskingPolicy: v.MaskingPolicy.MaskingPolicy,
+					Using:         v.MaskingPolicy.Using,
+				}
+			}
+			if v.ProjectionPolicy != nil {
+				s[i].ProjectionPolicy = &TableColumnProjectionPolicy{
+					ProjectionPolicy: v.ProjectionPolicy.ProjectionPolicy,
+				}
+			}
 		}
 		opts.ColumnsAndConstraints.Columns = s
 	}
@@ -175,6 +187,29 @@ func (r *AlterIcebergTableRequest) toOpts() *AlterIcebergTableOptions {
 			ColumnType:   r.AddColumnAction.ColumnType,
 			DefaultValue: r.AddColumnAction.DefaultValue,
 			Tag:          r.AddColumnAction.Tag,
+		}
+		if r.AddColumnAction.MaskingPolicy != nil {
+			opts.AddColumnAction.MaskingPolicy = &TableColumnMaskingPolicy{
+				MaskingPolicy: r.AddColumnAction.MaskingPolicy.MaskingPolicy,
+				Using:         r.AddColumnAction.MaskingPolicy.Using,
+			}
+		}
+		if r.AddColumnAction.ProjectionPolicy != nil {
+			opts.AddColumnAction.ProjectionPolicy = &TableColumnProjectionPolicy{
+				ProjectionPolicy: r.AddColumnAction.ProjectionPolicy.ProjectionPolicy,
+			}
+		}
+	}
+	if r.DropColumnAction != nil {
+		opts.DropColumnAction = &TableDropColumnAction{
+			IfExists: r.DropColumnAction.IfExists,
+			Columns:  r.DropColumnAction.Columns,
+		}
+	}
+	if r.RenameColumnAction != nil {
+		opts.RenameColumnAction = &TableRenameColumnAction{
+			OldName: r.RenameColumnAction.OldName,
+			NewName: r.RenameColumnAction.NewName,
 		}
 	}
 	if r.AlterColumnAction != nil {
@@ -272,6 +307,68 @@ func (r *AlterIcebergTableRequest) toOpts() *AlterIcebergTableOptions {
 			Comment:                    r.Unset.Comment,
 		}
 	}
+	if r.SetAggregationPolicy != nil {
+		opts.SetAggregationPolicy = &TableSetAggregationPolicy{
+			AggregationPolicy: r.SetAggregationPolicy.AggregationPolicy,
+			EntityKey:         r.SetAggregationPolicy.EntityKey,
+			Force:             r.SetAggregationPolicy.Force,
+		}
+	}
+	if r.UnsetAggregationPolicy != nil {
+		opts.UnsetAggregationPolicy = &TableUnsetAggregationPolicy{}
+	}
+	if r.SetJoinPolicy != nil {
+		opts.SetJoinPolicy = &TableSetJoinPolicy{
+			JoinPolicy: r.SetJoinPolicy.JoinPolicy,
+			Force:      r.SetJoinPolicy.Force,
+		}
+	}
+	if r.UnsetJoinPolicy != nil {
+		opts.UnsetJoinPolicy = &TableUnsetJoinPolicy{}
+	}
+	if r.SearchOptimizationAction != nil {
+		opts.SearchOptimizationAction = &TableSearchOptimizationAction{}
+		if r.SearchOptimizationAction.Add != nil {
+			opts.SearchOptimizationAction.Add = &TableAddSearchOptimization{}
+			if r.SearchOptimizationAction.Add.On != nil {
+				s := make([]TableSearchMethodWithTarget, len(r.SearchOptimizationAction.Add.On))
+				for i, v := range r.SearchOptimizationAction.Add.On {
+					// Adjusted manually: convert Args from Request to Options shape
+					s[i] = TableSearchMethodWithTarget{
+						Method: v.Method,
+						Args: TableSearchMethodArgs{
+							Targets:  v.Args.Targets,
+							Analyzer: v.Args.Analyzer,
+						},
+					}
+				}
+				opts.SearchOptimizationAction.Add.On = s
+			}
+		}
+		if r.SearchOptimizationAction.Drop != nil {
+			opts.SearchOptimizationAction.Drop = &TableDropSearchOptimization{}
+			if r.SearchOptimizationAction.Drop.On != nil {
+				s := make([]TableDropSearchOptimizationOn, len(r.SearchOptimizationAction.Drop.On))
+				for i, v := range r.SearchOptimizationAction.Drop.On {
+					// Adjusted manually: polymorphic On — one of search_method_with_target | column_name | expression_id
+					s[i] = TableDropSearchOptimizationOn{
+						ColumnName:   v.ColumnName,
+						ExpressionId: v.ExpressionId,
+					}
+					if v.SearchMethodWithTarget != nil {
+						s[i].SearchMethodWithTarget = &TableSearchMethodWithTarget{
+							Method: v.SearchMethodWithTarget.Method,
+							Args: TableSearchMethodArgs{
+								Targets:  v.SearchMethodWithTarget.Args.Targets,
+								Analyzer: v.SearchMethodWithTarget.Args.Analyzer,
+							},
+						}
+					}
+				}
+				opts.SearchOptimizationAction.Drop.On = s
+			}
+		}
+	}
 	return opts
 }
 
@@ -287,6 +384,7 @@ func (r *DropIcebergTableRequest) toOpts() *DropIcebergTableOptions {
 
 func (r *ShowIcebergTableRequest) toOpts() *ShowIcebergTableOptions {
 	opts := &ShowIcebergTableOptions{
+		Terse:      r.Terse,
 		Like:       r.Like,
 		In:         r.In,
 		StartsWith: r.StartsWith,

--- a/pkg/sdk/iceberg_tables_validations_gen.go
+++ b/pkg/sdk/iceberg_tables_validations_gen.go
@@ -50,8 +50,8 @@ func (opts *AlterIcebergTableOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.AddColumnAction, opts.AlterColumnAction, opts.SetMaskingPolicyOnColumn, opts.UnsetMaskingPolicyOnColumn, opts.SetProjectionPolicyOnColumn, opts.UnsetProjectionPolicyOnColumn, opts.SetTagsOnColumn, opts.UnsetTagsOnColumn, opts.ClusteringAction, opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags, opts.AddRowAccessPolicy, opts.DropRowAccessPolicy, opts.DropAndAddRowAccessPolicy, opts.DropAllRowAccessPolicies) {
-		errs = append(errs, errExactlyOneOf("AlterIcebergTableOptions", "AddColumnAction", "AlterColumnAction", "SetMaskingPolicyOnColumn", "UnsetMaskingPolicyOnColumn", "SetProjectionPolicyOnColumn", "UnsetProjectionPolicyOnColumn", "SetTagsOnColumn", "UnsetTagsOnColumn", "ClusteringAction", "Set", "Unset", "SetTags", "UnsetTags", "AddRowAccessPolicy", "DropRowAccessPolicy", "DropAndAddRowAccessPolicy", "DropAllRowAccessPolicies"))
+	if !exactlyOneValueSet(opts.AddColumnAction, opts.DropColumnAction, opts.RenameColumnAction, opts.AlterColumnAction, opts.SetMaskingPolicyOnColumn, opts.UnsetMaskingPolicyOnColumn, opts.SetProjectionPolicyOnColumn, opts.UnsetProjectionPolicyOnColumn, opts.SetTagsOnColumn, opts.UnsetTagsOnColumn, opts.ClusteringAction, opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags, opts.AddRowAccessPolicy, opts.DropRowAccessPolicy, opts.DropAndAddRowAccessPolicy, opts.DropAllRowAccessPolicies, opts.SetAggregationPolicy, opts.UnsetAggregationPolicy, opts.SetJoinPolicy, opts.UnsetJoinPolicy, opts.SearchOptimizationAction) {
+		errs = append(errs, errExactlyOneOf("AlterIcebergTableOptions", "AddColumnAction", "DropColumnAction", "RenameColumnAction", "AlterColumnAction", "SetMaskingPolicyOnColumn", "UnsetMaskingPolicyOnColumn", "SetProjectionPolicyOnColumn", "UnsetProjectionPolicyOnColumn", "SetTagsOnColumn", "UnsetTagsOnColumn", "ClusteringAction", "Set", "Unset", "SetTags", "UnsetTags", "AddRowAccessPolicy", "DropRowAccessPolicy", "DropAndAddRowAccessPolicy", "DropAllRowAccessPolicies", "SetAggregationPolicy", "UnsetAggregationPolicy", "SetJoinPolicy", "UnsetJoinPolicy", "SearchOptimizationAction"))
 	}
 	// Adjusted manually: AlterColumnAction is a slice, validate each element
 	for i, col := range opts.AlterColumnAction {
@@ -72,6 +72,29 @@ func (opts *AlterIcebergTableOptions) validate() error {
 	if valueSet(opts.Unset) {
 		if !anyValueSet(opts.Unset.ReplaceInvalidCharacters, opts.Unset.CatalogSync, opts.Unset.DataRetentionTimeInDays, opts.Unset.MaxDataExtensionTimeInDays, opts.Unset.TargetFileSize, opts.Unset.LogEventLevel, opts.Unset.ErrorLogging, opts.Unset.EnableDataCompaction, opts.Unset.EnableIcebergMergeOnRead, opts.Unset.Comment) {
 			errs = append(errs, errAtLeastOneOf("AlterIcebergTableOptions.Unset", "ReplaceInvalidCharacters", "CatalogSync", "DataRetentionTimeInDays", "MaxDataExtensionTimeInDays", "TargetFileSize", "LogEventLevel", "ErrorLogging", "EnableDataCompaction", "EnableIcebergMergeOnRead", "Comment"))
+		}
+	}
+	if valueSet(opts.SetAggregationPolicy) {
+		if !ValidObjectIdentifier(opts.SetAggregationPolicy.AggregationPolicy) {
+			errs = append(errs, ErrInvalidObjectIdentifier)
+		}
+	}
+	if valueSet(opts.SetJoinPolicy) {
+		if !ValidObjectIdentifier(opts.SetJoinPolicy.JoinPolicy) {
+			errs = append(errs, ErrInvalidObjectIdentifier)
+		}
+	}
+	if valueSet(opts.SearchOptimizationAction) {
+		if !exactlyOneValueSet(opts.SearchOptimizationAction.Add, opts.SearchOptimizationAction.Drop) {
+			errs = append(errs, errExactlyOneOf("AlterIcebergTableOptions.SearchOptimizationAction", "Add", "Drop"))
+		}
+		// Adjusted manually: each Drop.On entry must have exactly one of SearchMethodWithTarget, ColumnName, or ExpressionId set.
+		if valueSet(opts.SearchOptimizationAction.Drop) {
+			for _, on := range opts.SearchOptimizationAction.Drop.On {
+				if !exactlyOneValueSet(on.SearchMethodWithTarget, on.ColumnName, on.ExpressionId) {
+					errs = append(errs, errExactlyOneOf("AlterIcebergTableOptions.SearchOptimizationAction.Drop.On", "SearchMethodWithTarget", "ColumnName", "ExpressionId"))
+				}
+			}
 		}
 	}
 	return JoinErrors(errs...)

--- a/pkg/sdk/tables.go
+++ b/pkg/sdk/tables.go
@@ -208,21 +208,21 @@ type alterTableOptions struct {
 	name     SchemaObjectIdentifier `ddl:"identifier"`
 
 	// One of
-	NewName                   *SchemaObjectIdentifier         `ddl:"identifier" sql:"RENAME TO"`
-	SwapWith                  *SchemaObjectIdentifier         `ddl:"identifier" sql:"SWAP WITH"`
-	ClusteringAction          *TableClusteringAction          `ddl:"keyword"`
-	ColumnAction              *TableColumnAction              `ddl:"keyword"`
-	ConstraintAction          *TableConstraintAction          `ddl:"keyword"`
-	ExternalTableAction       *TableExternalTableAction       `ddl:"keyword"`
-	SearchOptimizationAction  *TableSearchOptimizationAction  `ddl:"keyword"`
-	Set                       *TableSet                       `ddl:"keyword" sql:"SET"`
-	SetTags                   []TagAssociation                `ddl:"parameter,no_equals" sql:"SET TAG"`
-	UnsetTags                 []ObjectIdentifier              `ddl:"keyword" sql:"UNSET TAG"`
-	Unset                     *TableUnset                     `ddl:"keyword" sql:"UNSET"`
-	AddRowAccessPolicy        *TableAddRowAccessPolicy        `ddl:"keyword"`
-	DropRowAccessPolicy       *TableDropRowAccessPolicy       `ddl:"keyword"`
-	DropAndAddRowAccessPolicy *TableDropAndAddRowAccessPolicy `ddl:"list,no_parentheses"`
-	DropAllAccessRowPolicies  *bool                           `ddl:"keyword" sql:"DROP ALL ROW ACCESS POLICIES"`
+	NewName                   *SchemaObjectIdentifier              `ddl:"identifier" sql:"RENAME TO"`
+	SwapWith                  *SchemaObjectIdentifier              `ddl:"identifier" sql:"SWAP WITH"`
+	ClusteringAction          *TableClusteringAction               `ddl:"keyword"`
+	ColumnAction              *TableColumnAction                   `ddl:"keyword"`
+	ConstraintAction          *TableConstraintAction               `ddl:"keyword"`
+	ExternalTableAction       *TableExternalTableAction            `ddl:"keyword"`
+	SearchOptimizationAction  *TableSearchOptimizationActionLegacy `ddl:"keyword"`
+	Set                       *TableSet                            `ddl:"keyword" sql:"SET"`
+	SetTags                   []TagAssociation                     `ddl:"parameter,no_equals" sql:"SET TAG"`
+	UnsetTags                 []ObjectIdentifier                   `ddl:"keyword" sql:"UNSET TAG"`
+	Unset                     *TableUnset                          `ddl:"keyword" sql:"UNSET"`
+	AddRowAccessPolicy        *TableAddRowAccessPolicy             `ddl:"keyword"`
+	DropRowAccessPolicy       *TableDropRowAccessPolicy            `ddl:"keyword"`
+	DropAndAddRowAccessPolicy *TableDropAndAddRowAccessPolicy      `ddl:"list,no_parentheses"`
+	DropAllAccessRowPolicies  *bool                                `ddl:"keyword" sql:"DROP ALL ROW ACCESS POLICIES"`
 }
 
 type TableClusteringAction struct {
@@ -429,7 +429,7 @@ type TableExternalTableColumnDropAction struct {
 	Names    []string `ddl:"keyword"`
 }
 
-type TableSearchOptimizationAction struct {
+type TableSearchOptimizationActionLegacy struct {
 	// One of
 	Add  *AddSearchOptimization  `ddl:"keyword"`
 	Drop *DropSearchOptimization `ddl:"keyword"`

--- a/pkg/sdk/tables_dto.go
+++ b/pkg/sdk/tables_dto.go
@@ -179,7 +179,7 @@ type AlterTableRequest struct {
 	ColumnAction              *TableColumnActionRequest
 	ConstraintAction          *TableConstraintActionRequest
 	ExternalTableAction       *TableExternalTableActionRequest
-	SearchOptimizationAction  *TableSearchOptimizationActionRequest
+	SearchOptimizationAction  *TableSearchOptimizationActionLegacyRequest
 	Set                       *TableSetRequest
 	SetTags                   []TagAssociationRequest
 	UnsetTags                 []ObjectIdentifier
@@ -483,7 +483,7 @@ type TableExternalTableActionRequest struct {
 	Drop   *TableExternalTableColumnDropActionRequest
 }
 
-type TableSearchOptimizationActionRequest struct {
+type TableSearchOptimizationActionLegacyRequest struct {
 	// One of
 	AddSearchOptimizationOn  []string
 	DropSearchOptimizationOn []string

--- a/pkg/sdk/tables_dto_generated.go
+++ b/pkg/sdk/tables_dto_generated.go
@@ -608,7 +608,8 @@ func (s *AlterTableRequest) WithExternalTableAction(externalTableAction *TableEx
 	return s
 }
 
-func (s *AlterTableRequest) WithSearchOptimizationAction(searchOptimizationAction *TableSearchOptimizationActionRequest) *AlterTableRequest {
+// Adjusted manually
+func (s *AlterTableRequest) WithSearchOptimizationAction(searchOptimizationAction *TableSearchOptimizationActionLegacyRequest) *AlterTableRequest {
 	s.SearchOptimizationAction = searchOptimizationAction
 	return s
 }
@@ -1503,16 +1504,19 @@ func (s *TableExternalTableActionRequest) WithDrop(drop *TableExternalTableColum
 	return s
 }
 
-func NewTableSearchOptimizationActionRequest() *TableSearchOptimizationActionRequest {
-	return &TableSearchOptimizationActionRequest{}
+// Adjusted manually
+func NewTableSearchOptimizationActionLegacyRequest() *TableSearchOptimizationActionLegacyRequest {
+	return &TableSearchOptimizationActionLegacyRequest{}
 }
 
-func (s *TableSearchOptimizationActionRequest) WithAddSearchOptimizationOn(addSearchOptimizationOn []string) *TableSearchOptimizationActionRequest {
+// Adjusted manually
+func (s *TableSearchOptimizationActionLegacyRequest) WithAddSearchOptimizationOn(addSearchOptimizationOn []string) *TableSearchOptimizationActionLegacyRequest {
 	s.AddSearchOptimizationOn = addSearchOptimizationOn
 	return s
 }
 
-func (s *TableSearchOptimizationActionRequest) WithDropSearchOptimizationOn(dropSearchOptimizationOn []string) *TableSearchOptimizationActionRequest {
+// Adjusted manually
+func (s *TableSearchOptimizationActionLegacyRequest) WithDropSearchOptimizationOn(dropSearchOptimizationOn []string) *TableSearchOptimizationActionLegacyRequest {
 	s.DropSearchOptimizationOn = dropSearchOptimizationOn
 	return s
 }

--- a/pkg/sdk/tables_impl.go
+++ b/pkg/sdk/tables_impl.go
@@ -14,21 +14,21 @@ var (
 )
 
 var (
-	_ optionsProvider[createTableOptions]              = new(CreateTableRequest)
-	_ optionsProvider[createTableAsSelectOptions]      = new(CreateTableAsSelectRequest)
-	_ optionsProvider[createTableUsingTemplateOptions] = new(CreateTableUsingTemplateRequest)
-	_ optionsProvider[createTableLikeOptions]          = new(CreateTableLikeRequest)
-	_ optionsProvider[createTableCloneOptions]         = new(CreateTableCloneRequest)
-	_ optionsProvider[alterTableOptions]               = new(AlterTableRequest)
-	_ optionsProvider[dropTableOptions]                = new(DropTableRequest)
-	_ optionsProvider[showTableOptions]                = new(ShowTableRequest)
-	_ optionsProvider[describeTableColumnsOptions]     = new(DescribeTableColumnsRequest)
-	_ optionsProvider[describeTableStageOptions]       = new(DescribeTableStageRequest)
-	_ optionsProvider[TableColumnAction]               = new(TableColumnActionRequest)
-	_ optionsProvider[TableConstraintAction]           = new(TableConstraintActionRequest)
-	_ optionsProvider[TableExternalTableAction]        = new(TableExternalTableActionRequest)
-	_ optionsProvider[TableSearchOptimizationAction]   = new(TableSearchOptimizationActionRequest)
-	_ optionsProvider[TableSet]                        = new(TableSetRequest)
+	_ optionsProvider[createTableOptions]                  = new(CreateTableRequest)
+	_ optionsProvider[createTableAsSelectOptions]          = new(CreateTableAsSelectRequest)
+	_ optionsProvider[createTableUsingTemplateOptions]     = new(CreateTableUsingTemplateRequest)
+	_ optionsProvider[createTableLikeOptions]              = new(CreateTableLikeRequest)
+	_ optionsProvider[createTableCloneOptions]             = new(CreateTableCloneRequest)
+	_ optionsProvider[alterTableOptions]                   = new(AlterTableRequest)
+	_ optionsProvider[dropTableOptions]                    = new(DropTableRequest)
+	_ optionsProvider[showTableOptions]                    = new(ShowTableRequest)
+	_ optionsProvider[describeTableColumnsOptions]         = new(DescribeTableColumnsRequest)
+	_ optionsProvider[describeTableStageOptions]           = new(DescribeTableStageRequest)
+	_ optionsProvider[TableColumnAction]                   = new(TableColumnActionRequest)
+	_ optionsProvider[TableConstraintAction]               = new(TableConstraintActionRequest)
+	_ optionsProvider[TableExternalTableAction]            = new(TableExternalTableActionRequest)
+	_ optionsProvider[TableSearchOptimizationActionLegacy] = new(TableSearchOptimizationActionLegacyRequest)
+	_ optionsProvider[TableSet]                            = new(TableSetRequest)
 )
 
 type tables struct {
@@ -147,7 +147,7 @@ func (s *AlterTableRequest) toOpts() *alterTableOptions {
 	if s.ExternalTableAction != nil {
 		externalTableAction = s.ExternalTableAction.toOpts()
 	}
-	var searchOptimizationAction *TableSearchOptimizationAction
+	var searchOptimizationAction *TableSearchOptimizationActionLegacy
 	if s.SearchOptimizationAction != nil {
 		searchOptimizationAction = s.SearchOptimizationAction.toOpts()
 	}
@@ -240,16 +240,16 @@ func (s *TableSetRequest) toOpts() *TableSet {
 	return set
 }
 
-func (s *TableSearchOptimizationActionRequest) toOpts() *TableSearchOptimizationAction {
+func (s *TableSearchOptimizationActionLegacyRequest) toOpts() *TableSearchOptimizationActionLegacy {
 	if len(s.AddSearchOptimizationOn) > 0 {
-		return &TableSearchOptimizationAction{
+		return &TableSearchOptimizationActionLegacy{
 			Add: &AddSearchOptimization{
 				On: s.AddSearchOptimizationOn,
 			},
 		}
 	}
 	if len(s.DropSearchOptimizationOn) > 0 {
-		return &TableSearchOptimizationAction{
+		return &TableSearchOptimizationActionLegacy{
 			Drop: &DropSearchOptimization{
 				On: s.DropSearchOptimizationOn,
 			},

--- a/pkg/sdk/tables_test.go
+++ b/pkg/sdk/tables_test.go
@@ -887,17 +887,17 @@ func TestTableAlter(t *testing.T) {
 
 	t.Run("validation: search optimization - no option present", func(t *testing.T) {
 		opts := defaultOpts()
-		opts.SearchOptimizationAction = &TableSearchOptimizationAction{}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("TableSearchOptimizationAction", "Add", "Drop"))
+		opts.SearchOptimizationAction = &TableSearchOptimizationActionLegacy{}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("TableSearchOptimizationActionLegacy", "Add", "Drop"))
 	})
 
 	t.Run("validation: search optimization - two options present", func(t *testing.T) {
 		opts := defaultOpts()
-		opts.SearchOptimizationAction = &TableSearchOptimizationAction{
+		opts.SearchOptimizationAction = &TableSearchOptimizationActionLegacy{
 			Add:  &AddSearchOptimization{},
 			Drop: &DropSearchOptimization{},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("TableSearchOptimizationAction", "Add", "Drop"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("TableSearchOptimizationActionLegacy", "Add", "Drop"))
 	})
 
 	t.Run("empty options", func(t *testing.T) {
@@ -1296,7 +1296,7 @@ func TestTableAlter(t *testing.T) {
 	t.Run("add search optimization", func(t *testing.T) {
 		opts := &alterTableOptions{
 			name: id,
-			SearchOptimizationAction: &TableSearchOptimizationAction{
+			SearchOptimizationAction: &TableSearchOptimizationActionLegacy{
 				Add: &AddSearchOptimization{
 					On: []string{"SUBSTRING(*)", "GEO(*)"},
 				},
@@ -1308,7 +1308,7 @@ func TestTableAlter(t *testing.T) {
 	t.Run("drop search optimization", func(t *testing.T) {
 		opts := &alterTableOptions{
 			name: id,
-			SearchOptimizationAction: &TableSearchOptimizationAction{
+			SearchOptimizationAction: &TableSearchOptimizationActionLegacy{
 				Drop: &DropSearchOptimization{
 					On: []string{"SUBSTRING(*)", "FOO"},
 				},
@@ -1320,7 +1320,7 @@ func TestTableAlter(t *testing.T) {
 	t.Run("drop search optimization", func(t *testing.T) {
 		opts := &alterTableOptions{
 			name: id,
-			SearchOptimizationAction: &TableSearchOptimizationAction{
+			SearchOptimizationAction: &TableSearchOptimizationActionLegacy{
 				Drop: &DropSearchOptimization{
 					On: []string{"SUBSTRING(*)", "FOO"},
 				},

--- a/pkg/sdk/tables_validations.go
+++ b/pkg/sdk/tables_validations.go
@@ -262,7 +262,7 @@ func (opts *alterTableOptions) validate() error {
 			searchOptimizationAction.Add,
 			searchOptimizationAction.Drop,
 		); !ok {
-			errs = append(errs, errExactlyOneOf("TableSearchOptimizationAction", "Add", "Drop"))
+			errs = append(errs, errExactlyOneOf("TableSearchOptimizationActionLegacy", "Add", "Drop"))
 		}
 	}
 	return errors.Join(errs...)

--- a/pkg/sdk/testint/tables_integration_test.go
+++ b/pkg/sdk/testint/tables_integration_test.go
@@ -819,7 +819,7 @@ func TestInt_Table(t *testing.T) {
 		t.Cleanup(cleanupTableProvider(id))
 
 		alterRequest := sdk.NewAlterTableRequest(id).
-			WithSearchOptimizationAction(sdk.NewTableSearchOptimizationActionRequest().WithAddSearchOptimizationOn([]string{"SUBSTRING(*)", "GEO(*)"}))
+			WithSearchOptimizationAction(sdk.NewTableSearchOptimizationActionLegacyRequest().WithAddSearchOptimizationOn([]string{"SUBSTRING(*)", "GEO(*)"}))
 
 		err = client.Tables.Alter(ctx, alterRequest)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Moves shared table column/row access policy types to `table_def.go` to be reused across table variants
- Extends iceberg tables SDK with additional operations and fields (ALTER, tag associations, clustering keys, data metrics, etc.)
- Updates regular tables SDK (`tables.go`, `tables_dto.go`, etc.) to reuse the extracted common types
- Extends generated test coverage for the new iceberg table operations

## TODO
- Add inline and out of line constraints.