### PR TITLE
chore: Add @snowflakedb/client-side-interfaces to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snowflakedb/terraform-provider
+* @snowflakedb/terraform-provider @snowflakedb/client-side-interfaces


### PR DESCRIPTION
<!-- summary of changes -->
Adds the new `@snowflakedb/client-side-interfaces` team alongside the existing `@snowflakedb/terraform-provider` global owner.

The new team is the master team for Client-Side Services (Snowflake CLI, Terraform Provider, CI/CD integrations) under Developer Platform. Additive change — `@snowflakedb/terraform-provider` retains ownership.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests — _N/A, CODEOWNERS-only_

## References
<!-- issues documentation links, etc  -->
* New team: https://github.com/orgs/snowflakedb/teams/client-side-interfaces