### PR TITLE
chore: Fix warehouse integration tests for new Snowflake defaults

### DIFF
--- a/pkg/acceptance/bettertestspoc/config/model/warehouse_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/warehouse_model_ext.go
@@ -26,8 +26,8 @@ func WarehouseSnowflakeDefaultWithoutParameters(
 		WithAutoSuspend(600).
 		WithAutoResume(r.BooleanTrue).
 		WithInitiallySuspended(false).
-		WithEnableQueryAcceleration(r.BooleanFalse).
-		WithQueryAccelerationMaxScaleFactor(8)
+		WithEnableQueryAcceleration(r.BooleanTrue).
+		WithQueryAccelerationMaxScaleFactor(2)
 }
 
 // TODO [SNOW-1501905]: currently config builder are generated from the resource schema, so there is no direct connection to the source enum (like sdk.WarehouseSize)

--- a/pkg/acceptance/helpers/snowflake_defaults.go
+++ b/pkg/acceptance/helpers/snowflake_defaults.go
@@ -24,19 +24,3 @@ func (c *SnowflakeDefaultsClient) WarehouseGenerationEmptyByDefault(t *testing.T
 	}
 	return false
 }
-
-func (c *SnowflakeDefaultsClient) WarehouseEnableQueryAcceleration(t *testing.T) bool {
-	t.Helper()
-	if c.context.snowflakeEnvironment == testenvs.SnowflakeNonProdEnvironment || c.context.snowflakeEnvironment == testenvs.SnowflakePreProdGovEnvironment {
-		return true
-	}
-	return false
-}
-
-func (c *SnowflakeDefaultsClient) WarehouseQueryAccelerationMaxScaleFactor(t *testing.T) int {
-	t.Helper()
-	if c.context.snowflakeEnvironment == testenvs.SnowflakeNonProdEnvironment || c.context.snowflakeEnvironment == testenvs.SnowflakePreProdGovEnvironment {
-		return 2
-	}
-	return 8
-}

--- a/pkg/sdk/testint/warehouses_integration_test.go
+++ b/pkg/sdk/testint/warehouses_integration_test.go
@@ -247,11 +247,11 @@ func TestInt_Warehouses(t *testing.T) {
 		assert.True(t, result.AutoResume)
 		assert.Contains(t, []sdk.WarehouseState{sdk.WarehouseStateResuming, sdk.WarehouseStateStarted}, result.State)
 		assert.Equal(t, "", result.Comment)
-		assert.Equal(t, sdk.Pointer(false), result.EnableQueryAcceleration)
-		assert.Equal(t, sdk.Pointer(8), result.QueryAccelerationMaxScaleFactor)
+		assert.Equal(t, sdk.Pointer(true), result.EnableQueryAcceleration)
+		assert.Equal(t, sdk.Pointer(2), result.QueryAccelerationMaxScaleFactor)
 		assert.Nil(t, result.ResourceConstraint)
 		assert.NotNil(t, result.Generation)
-		assert.Equal(t, sdk.WarehouseGenerationStandardGen1, *result.Generation)
+		assert.Equal(t, sdk.WarehouseGenerationStandardGen2, *result.Generation)
 		assert.Nil(t, result.MaxQueryPerformanceLevel)
 		assert.Nil(t, result.QueryThroughputMultiplier)
 	})
@@ -344,11 +344,11 @@ func TestInt_Warehouses(t *testing.T) {
 		assert.True(t, warehouse.AutoResume)
 		assert.Equal(t, "", warehouse.ResourceMonitor.Name())
 		assert.Equal(t, "", warehouse.Comment)
-		assert.Equal(t, sdk.Pointer(false), warehouse.EnableQueryAcceleration)
-		assert.Equal(t, sdk.Pointer(8), warehouse.QueryAccelerationMaxScaleFactor)
+		assert.Equal(t, sdk.Pointer(true), warehouse.EnableQueryAcceleration)
+		assert.Equal(t, sdk.Pointer(2), warehouse.QueryAccelerationMaxScaleFactor)
 		assert.Nil(t, warehouse.ResourceConstraint)
 		assert.NotNil(t, warehouse.Generation)
-		assert.Equal(t, sdk.WarehouseGenerationStandardGen1, *warehouse.Generation)
+		assert.Equal(t, sdk.WarehouseGenerationStandardGen2, *warehouse.Generation)
 		assert.Nil(t, warehouse.MaxQueryPerformanceLevel)
 		assert.Nil(t, warehouse.QueryThroughputMultiplier)
 
@@ -386,7 +386,7 @@ func TestInt_Warehouses(t *testing.T) {
 		assert.Equal(t, sdk.Pointer(2), warehouseAfterSet.QueryAccelerationMaxScaleFactor)
 		assert.Nil(t, warehouseAfterSet.ResourceConstraint)
 		assert.NotNil(t, warehouseAfterSet.Generation)
-		assert.Equal(t, sdk.WarehouseGenerationStandardGen1, *warehouseAfterSet.Generation)
+		assert.Equal(t, sdk.WarehouseGenerationStandardGen2, *warehouseAfterSet.Generation)
 		assert.Nil(t, warehouseAfterSet.MaxQueryPerformanceLevel)
 		assert.Nil(t, warehouseAfterSet.QueryThroughputMultiplier)
 
@@ -415,11 +415,11 @@ func TestInt_Warehouses(t *testing.T) {
 		assert.Equal(t, sdk.Pointer(1), warehouseAfterUnset.MinClusterCount)
 		assert.Equal(t, "", warehouseAfterUnset.ResourceMonitor.Name())
 		assert.Equal(t, "", warehouseAfterUnset.Comment)
-		assert.Equal(t, sdk.Pointer(false), warehouseAfterUnset.EnableQueryAcceleration)
-		assert.Equal(t, sdk.Pointer(8), warehouseAfterUnset.QueryAccelerationMaxScaleFactor)
+		assert.Equal(t, sdk.Pointer(true), warehouseAfterUnset.EnableQueryAcceleration)
+		assert.Equal(t, sdk.Pointer(2), warehouseAfterUnset.QueryAccelerationMaxScaleFactor)
 		assert.Nil(t, warehouseAfterUnset.ResourceConstraint)
 		assert.NotNil(t, warehouseAfterUnset.Generation)
-		assert.Equal(t, sdk.WarehouseGenerationStandardGen1, *warehouseAfterUnset.Generation)
+		assert.Equal(t, sdk.WarehouseGenerationStandardGen2, *warehouseAfterUnset.Generation)
 		assert.Equal(t, sdk.WarehouseTypeStandard, warehouseAfterUnset.Type)
 		assert.Equal(t, sdk.Pointer(sdk.ScalingPolicyStandard), warehouseAfterUnset.ScalingPolicy)
 		assert.True(t, warehouseAfterUnset.AutoResume)
@@ -474,15 +474,15 @@ func TestInt_Warehouses(t *testing.T) {
 		assertThatObject(t, objectassert.Warehouse(t, warehouse.ID()).
 			HasType(sdk.WarehouseTypeStandard).
 			HasSize(sdk.WarehouseSizeMedium).
-			HasGeneration(sdk.WarehouseGenerationStandardGen1).
+			HasGeneration(sdk.WarehouseGenerationStandardGen2).
 			HasNoResourceConstraint().
 			HasMaxClusterCount(1).
 			HasMinClusterCount(1).
 			HasScalingPolicy(sdk.ScalingPolicyStandard).
 			HasAutoSuspend(600).
 			HasAutoResume(true).
-			HasEnableQueryAcceleration(false).
-			HasQueryAccelerationMaxScaleFactor(8).
+			HasEnableQueryAcceleration(true).
+			HasQueryAccelerationMaxScaleFactor(2).
 			HasNoMaxQueryPerformanceLevel().
 			HasNoQueryThroughputMultiplier(),
 		)
@@ -531,9 +531,7 @@ func TestInt_Warehouses(t *testing.T) {
 		require.NoError(t, err)
 
 		assertThatObject(t, objectassert.Warehouse(t, warehouse.ID()).
-			// NOTE: The expected behavior is to reset to the default value, which is XLarge.
-			// However, the actual behavior is to reset to Small.
-			HasMaxQueryPerformanceLevel(sdk.MaxQueryPerformanceLevelSmall).
+			HasMaxQueryPerformanceLevel(sdk.MaxQueryPerformanceLevelXLarge).
 			HasQueryThroughputMultiplier(2),
 		)
 		assertThatObject(t, objectparametersassert.WarehouseParameters(t, warehouse.ID()).
@@ -712,10 +710,10 @@ func TestInt_Warehouses(t *testing.T) {
 		assert.Equal(t, sdk.WarehouseTypeStandard, returnedWarehouse.Type)
 		assert.Nil(t, returnedWarehouse.ResourceConstraint)
 		assert.NotNil(t, returnedWarehouse.Generation)
-		assert.Equal(t, sdk.WarehouseGenerationStandardGen1, *returnedWarehouse.Generation)
+		assert.Equal(t, sdk.WarehouseGenerationStandardGen2, *returnedWarehouse.Generation)
 
 		alterOptions := &sdk.AlterWarehouseOptions{
-			Set: &sdk.WarehouseSet{Generation: sdk.Pointer(sdk.WarehouseGenerationStandardGen2)},
+			Set: &sdk.WarehouseSet{Generation: sdk.Pointer(sdk.WarehouseGenerationStandardGen1)},
 		}
 		err = client.Warehouses.Alter(ctx, warehouse.ID(), alterOptions)
 		require.NoError(t, err)
@@ -723,7 +721,7 @@ func TestInt_Warehouses(t *testing.T) {
 		returnedWarehouse, err = client.Warehouses.ShowByID(ctx, warehouse.ID())
 		require.NoError(t, err)
 		assertThatObject(t, objectassert.WarehouseFromObject(t, returnedWarehouse).
-			HasGeneration(sdk.WarehouseGenerationStandardGen2).
+			HasGeneration(sdk.WarehouseGenerationStandardGen1).
 			HasNoResourceConstraint().
 			HasType(sdk.WarehouseTypeStandard),
 		)
@@ -737,7 +735,7 @@ func TestInt_Warehouses(t *testing.T) {
 		returnedWarehouse, err = client.Warehouses.ShowByID(ctx, warehouse.ID())
 		require.NoError(t, err)
 		assert.NotNil(t, returnedWarehouse.Generation)
-		assert.Equal(t, sdk.WarehouseGenerationStandardGen1, *returnedWarehouse.Generation)
+		assert.Equal(t, sdk.WarehouseGenerationStandardGen2, *returnedWarehouse.Generation)
 	})
 
 	t.Run("alter: prove problems with unset auto suspend", func(t *testing.T) {

--- a/pkg/testacc/data_source_warehouses_acceptance_test.go
+++ b/pkg/testacc/data_source_warehouses_acceptance_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/datasourcemodel"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -70,8 +69,6 @@ func TestAcc_Warehouses_BaseUseCase_DifferentFiltering(t *testing.T) {
 func TestAcc_Warehouses_CompleteUseCase(t *testing.T) {
 	id := testClient().Ids.RandomAccountObjectIdentifier()
 	comment := random.Comment()
-
-	var _ *helpers.SnowflakeDefaultsClient = testClient().SnowflakeDefaults
 
 	warehouseModel := model.Warehouse("test", id.Name()).
 		WithComment(comment)

--- a/pkg/testacc/data_source_warehouses_acceptance_test.go
+++ b/pkg/testacc/data_source_warehouses_acceptance_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/datasourcemodel"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -70,8 +71,7 @@ func TestAcc_Warehouses_CompleteUseCase(t *testing.T) {
 	id := testClient().Ids.RandomAccountObjectIdentifier()
 	comment := random.Comment()
 
-	enableQueryAcceleration := testClient().SnowflakeDefaults.WarehouseEnableQueryAcceleration(t)
-	queryAccelerationMaxScaleFactor := testClient().SnowflakeDefaults.WarehouseQueryAccelerationMaxScaleFactor(t)
+	var _ *helpers.SnowflakeDefaultsClient = testClient().SnowflakeDefaults
 
 	warehouseModel := model.Warehouse("test", id.Name()).
 		WithComment(comment)
@@ -111,8 +111,8 @@ func TestAcc_Warehouses_CompleteUseCase(t *testing.T) {
 			HasUpdatedOnNotEmpty().
 			HasOwnerNotEmpty().
 			HasComment(comment).
-			HasEnableQueryAcceleration(enableQueryAcceleration).
-			HasQueryAccelerationMaxScaleFactor(queryAccelerationMaxScaleFactor).
+			HasEnableQueryAcceleration(true).
+			HasQueryAccelerationMaxScaleFactor(2).
 			HasResourceMonitorEmpty().
 			HasScalingPolicy(sdk.ScalingPolicyStandard).
 			HasOwnerRoleTypeNotEmpty().

--- a/pkg/testacc/plugin_framework_poc_warehouse_sdkv2_copy_acceptance_test.go
+++ b/pkg/testacc/plugin_framework_poc_warehouse_sdkv2_copy_acceptance_test.go
@@ -148,8 +148,8 @@ func TestAcc_TerraformPluginFrameworkPoc_WarehousePoc_BasicFlows(t *testing.T) {
 						HasAutoResume(true).
 						HasResourceMonitor(sdk.AccountObjectIdentifier{}).
 						HasComment(comment).
-						HasEnableQueryAcceleration(false).
-						HasQueryAccelerationMaxScaleFactor(8),
+						HasEnableQueryAcceleration(true).
+						HasQueryAccelerationMaxScaleFactor(2),
 					objectparametersassert.WarehouseParameters(t, warehouseId).
 						HasAllDefaults().
 						HasAllDefaultsExplicit(),
@@ -175,8 +175,8 @@ func TestAcc_TerraformPluginFrameworkPoc_WarehousePoc_BasicFlows(t *testing.T) {
 						HasAutoResumeString("true").
 						HasResourceMonitorString("").
 						HasCommentString(comment).
-						HasEnableQueryAccelerationString("false").
-						HasQueryAccelerationMaxScaleFactorString("8").
+						HasEnableQueryAccelerationString("true").
+						HasQueryAccelerationMaxScaleFactorString("2").
 						HasNoMaxConcurrencyLevel().
 						HasNoStatementQueuedTimeoutInSeconds().
 						HasNoStatementTimeoutInSeconds(),
@@ -192,8 +192,8 @@ func TestAcc_TerraformPluginFrameworkPoc_WarehousePoc_BasicFlows(t *testing.T) {
 						HasAutoResume(true).
 						HasResourceMonitor(sdk.AccountObjectIdentifier{}).
 						HasComment(comment).
-						HasEnableQueryAcceleration(false).
-						HasQueryAccelerationMaxScaleFactor(8),
+						HasEnableQueryAcceleration(true).
+						HasQueryAccelerationMaxScaleFactor(2),
 					objectparametersassert.WarehouseParameters(t, warehouseId).
 						HasAllDefaults().
 						HasAllDefaultsExplicit(),
@@ -234,8 +234,8 @@ func TestAcc_TerraformPluginFrameworkPoc_WarehousePoc_BasicFlows(t *testing.T) {
 						HasInitiallySuspendedString(r.BooleanFalse).
 						HasNoResourceMonitor().
 						HasCommentString(comment).
-						HasEnableQueryAccelerationString(r.BooleanFalse).
-						HasQueryAccelerationMaxScaleFactorString("8").
+						HasEnableQueryAccelerationString(r.BooleanTrue).
+						HasQueryAccelerationMaxScaleFactorString("2").
 						HasNoMaxConcurrencyLevel().
 						HasNoStatementQueuedTimeoutInSeconds().
 						HasNoStatementTimeoutInSeconds(),
@@ -268,8 +268,8 @@ func TestAcc_TerraformPluginFrameworkPoc_WarehousePoc_BasicFlows(t *testing.T) {
 						HasInitiallySuspendedString(r.BooleanFalse).
 						HasNoResourceMonitor().
 						HasCommentString(comment).
-						HasEnableQueryAccelerationString(r.BooleanFalse).
-						HasQueryAccelerationMaxScaleFactorString("8").
+						HasEnableQueryAccelerationString(r.BooleanTrue).
+						HasQueryAccelerationMaxScaleFactorString("2").
 						HasMaxConcurrencyLevelString("8").
 						HasStatementQueuedTimeoutInSecondsString("0").
 						HasStatementTimeoutInSecondsString("172800"),
@@ -306,8 +306,8 @@ func TestAcc_TerraformPluginFrameworkPoc_WarehousePoc_BasicFlows(t *testing.T) {
 						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "scaling_policy", tfjson.ActionUpdate, sdk.String(string(sdk.ScalingPolicyStandard)), sdk.String(string(sdk.ScalingPolicyEconomy))),
 						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "auto_suspend", tfjson.ActionUpdate, sdk.String("600"), sdk.String("1200")),
 						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "auto_resume", tfjson.ActionUpdate, sdk.String("true"), sdk.String("false")),
-						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "enable_query_acceleration", tfjson.ActionUpdate, sdk.String("false"), sdk.String("true")),
-						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "query_acceleration_max_scale_factor", tfjson.ActionUpdate, sdk.String("8"), sdk.String("4")),
+						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "enable_query_acceleration", tfjson.ActionUpdate, sdk.String("true"), sdk.String("false")),
+						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "query_acceleration_max_scale_factor", tfjson.ActionUpdate, sdk.String("2"), sdk.String("4")),
 
 						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "max_concurrency_level", tfjson.ActionUpdate, sdk.String("8"), sdk.String("4")),
 						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "statement_queued_timeout_in_seconds", tfjson.ActionUpdate, sdk.String("0"), sdk.String("5")),
@@ -986,7 +986,7 @@ func TestAcc_TerraformPluginFrameworkPoc_WarehousePoc_ZeroValues(t *testing.T) {
 					assert.Check(resource.TestCheckNoResourceAttr(replaceResourceReference(warehouseModel.ResourceReference()), "statement_timeout_in_seconds")),
 					objectassert.Warehouse(t, id).
 						HasAutoSuspend(600).
-						HasQueryAccelerationMaxScaleFactor(8),
+						HasQueryAccelerationMaxScaleFactor(2),
 					objectparametersassert.WarehouseParameters(t, id).
 						HasDefaultParameterValueOnLevel(sdk.WarehouseParameterStatementQueuedTimeoutInSeconds, sdk.ParameterTypeSnowflakeDefault).
 						HasDefaultParameterValueOnLevel(sdk.WarehouseParameterStatementTimeoutInSeconds, sdk.ParameterTypeSnowflakeDefault),

--- a/pkg/testacc/plugin_framework_poc_warehouse_sdkv2_copy_acceptance_test.go
+++ b/pkg/testacc/plugin_framework_poc_warehouse_sdkv2_copy_acceptance_test.go
@@ -306,7 +306,6 @@ func TestAcc_TerraformPluginFrameworkPoc_WarehousePoc_BasicFlows(t *testing.T) {
 						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "scaling_policy", tfjson.ActionUpdate, sdk.String(string(sdk.ScalingPolicyStandard)), sdk.String(string(sdk.ScalingPolicyEconomy))),
 						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "auto_suspend", tfjson.ActionUpdate, sdk.String("600"), sdk.String("1200")),
 						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "auto_resume", tfjson.ActionUpdate, sdk.String("true"), sdk.String("false")),
-						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "enable_query_acceleration", tfjson.ActionUpdate, sdk.String("true"), sdk.String("false")),
 						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "query_acceleration_max_scale_factor", tfjson.ActionUpdate, sdk.String("2"), sdk.String("4")),
 
 						planchecks.ExpectChange(replaceResourceReference(warehouseModelRenamedFull.ResourceReference()), "max_concurrency_level", tfjson.ActionUpdate, sdk.String("8"), sdk.String("4")),

--- a/pkg/testacc/resource_warehouse_acceptance_test.go
+++ b/pkg/testacc/resource_warehouse_acceptance_test.go
@@ -61,7 +61,7 @@ func TestAcc_Warehouse_BasicFlows(t *testing.T) {
 		WithAutoResume(r.BooleanFalse).
 		WithInitiallySuspended(false).
 		WithResourceMonitor(resourceMonitor.ID().Name()).
-		WithEnableQueryAcceleration(r.BooleanTrue).
+		WithEnableQueryAcceleration(r.BooleanFalse).
 		WithQueryAccelerationMaxScaleFactor(4).
 		WithMaxConcurrencyLevel(4).
 		WithStatementQueuedTimeoutInSeconds(5).
@@ -77,7 +77,7 @@ func TestAcc_Warehouse_BasicFlows(t *testing.T) {
 		WithAutoResume(r.BooleanFalse).
 		WithInitiallySuspended(false).
 		WithResourceMonitor(resourceMonitor.ID().FullyQualifiedName()).
-		WithEnableQueryAcceleration(r.BooleanTrue).
+		WithEnableQueryAcceleration(r.BooleanFalse).
 		WithQueryAccelerationMaxScaleFactor(4).
 		WithMaxConcurrencyLevel(4).
 		WithStatementQueuedTimeoutInSeconds(5).
@@ -127,8 +127,8 @@ func TestAcc_Warehouse_BasicFlows(t *testing.T) {
 						HasAutoResume(true).
 						HasResourceMonitor(sdk.AccountObjectIdentifier{}).
 						HasComment(comment).
-						HasEnableQueryAcceleration(false).
-						HasQueryAccelerationMaxScaleFactor(8),
+						HasEnableQueryAcceleration(true).
+						HasQueryAccelerationMaxScaleFactor(2),
 					resourceparametersassert.WarehouseResourceParameters(t, warehouseModel.ResourceReference()).
 						HasMaxConcurrencyLevel(8).
 						HasStatementQueuedTimeoutInSeconds(0).
@@ -149,8 +149,8 @@ func TestAcc_Warehouse_BasicFlows(t *testing.T) {
 						HasAutoResume(true).
 						HasResourceMonitor(sdk.AccountObjectIdentifier{}).
 						HasComment(comment).
-						HasEnableQueryAcceleration(false).
-						HasQueryAccelerationMaxScaleFactor(8),
+						HasEnableQueryAcceleration(true).
+						HasQueryAccelerationMaxScaleFactor(2),
 					objectparametersassert.WarehouseParameters(t, warehouseId).
 						HasAllDefaults().
 						HasAllDefaultsExplicit(),
@@ -177,8 +177,8 @@ func TestAcc_Warehouse_BasicFlows(t *testing.T) {
 						HasAutoResumeString("true").
 						HasResourceMonitorString("").
 						HasCommentString(comment).
-						HasEnableQueryAccelerationString("false").
-						HasQueryAccelerationMaxScaleFactorString("8").
+						HasEnableQueryAccelerationString("true").
+						HasQueryAccelerationMaxScaleFactorString("2").
 						HasDefaultMaxConcurrencyLevel().
 						HasDefaultStatementQueuedTimeoutInSeconds().
 						HasDefaultStatementTimeoutInSeconds(),
@@ -202,8 +202,8 @@ func TestAcc_Warehouse_BasicFlows(t *testing.T) {
 						HasAutoResume(true).
 						HasResourceMonitor(sdk.AccountObjectIdentifier{}).
 						HasComment(comment).
-						HasEnableQueryAcceleration(false).
-						HasQueryAccelerationMaxScaleFactor(8),
+						HasEnableQueryAcceleration(true).
+						HasQueryAccelerationMaxScaleFactor(2),
 					objectparametersassert.WarehouseParameters(t, warehouseId).
 						HasAllDefaults().
 						HasAllDefaultsExplicit(),
@@ -257,8 +257,8 @@ func TestAcc_Warehouse_BasicFlows(t *testing.T) {
 					resource.TestCheckNoResourceAttr(warehouseModelRenamedFullWithParameters.ResourceReference(), "initially_suspended"),
 					resource.TestCheckNoResourceAttr(warehouseModelRenamedFullWithParameters.ResourceReference(), "resource_monitor"),
 					resource.TestCheckResourceAttr(warehouseModelRenamedFullWithParameters.ResourceReference(), "comment", comment),
-					resource.TestCheckResourceAttr(warehouseModelRenamedFullWithParameters.ResourceReference(), "enable_query_acceleration", "false"),
-					resource.TestCheckResourceAttr(warehouseModelRenamedFullWithParameters.ResourceReference(), "query_acceleration_max_scale_factor", "8"),
+					resource.TestCheckResourceAttr(warehouseModelRenamedFullWithParameters.ResourceReference(), "enable_query_acceleration", "true"),
+					resource.TestCheckResourceAttr(warehouseModelRenamedFullWithParameters.ResourceReference(), "query_acceleration_max_scale_factor", "2"),
 
 					// parameters have the same values...
 					resource.TestCheckResourceAttr(warehouseModelRenamedFullWithParameters.ResourceReference(), "max_concurrency_level", "8"),
@@ -289,8 +289,8 @@ func TestAcc_Warehouse_BasicFlows(t *testing.T) {
 						planchecks.ExpectChange(warehouseModelRenamedFull.ResourceReference(), "scaling_policy", tfjson.ActionUpdate, sdk.String(string(sdk.ScalingPolicyStandard)), sdk.String(string(sdk.ScalingPolicyEconomy))),
 						planchecks.ExpectChange(warehouseModelRenamedFull.ResourceReference(), "auto_suspend", tfjson.ActionUpdate, sdk.String("600"), sdk.String("1200")),
 						planchecks.ExpectChange(warehouseModelRenamedFull.ResourceReference(), "auto_resume", tfjson.ActionUpdate, sdk.String("true"), sdk.String("false")),
-						planchecks.ExpectChange(warehouseModelRenamedFull.ResourceReference(), "enable_query_acceleration", tfjson.ActionUpdate, sdk.String("false"), sdk.String("true")),
-						planchecks.ExpectChange(warehouseModelRenamedFull.ResourceReference(), "query_acceleration_max_scale_factor", tfjson.ActionUpdate, sdk.String("8"), sdk.String("4")),
+						planchecks.ExpectChange(warehouseModelRenamedFull.ResourceReference(), "enable_query_acceleration", tfjson.ActionUpdate, sdk.String("true"), sdk.String("false")),
+						planchecks.ExpectChange(warehouseModelRenamedFull.ResourceReference(), "query_acceleration_max_scale_factor", tfjson.ActionUpdate, sdk.String("2"), sdk.String("4")),
 
 						planchecks.ExpectChange(warehouseModelRenamedFull.ResourceReference(), "max_concurrency_level", tfjson.ActionUpdate, sdk.String("8"), sdk.String("4")),
 						planchecks.ExpectChange(warehouseModelRenamedFull.ResourceReference(), "statement_queued_timeout_in_seconds", tfjson.ActionUpdate, sdk.String("0"), sdk.String("5")),
@@ -308,7 +308,7 @@ func TestAcc_Warehouse_BasicFlows(t *testing.T) {
 					resource.TestCheckNoResourceAttr(warehouseModelRenamedFull.ResourceReference(), "initially_suspended"),
 					resource.TestCheckResourceAttr(warehouseModelRenamedFull.ResourceReference(), "resource_monitor", resourceMonitor.ID().Name()),
 					resource.TestCheckResourceAttr(warehouseModelRenamedFull.ResourceReference(), "comment", newComment),
-					resource.TestCheckResourceAttr(warehouseModelRenamedFull.ResourceReference(), "enable_query_acceleration", "true"),
+					resource.TestCheckResourceAttr(warehouseModelRenamedFull.ResourceReference(), "enable_query_acceleration", "false"),
 					resource.TestCheckResourceAttr(warehouseModelRenamedFull.ResourceReference(), "query_acceleration_max_scale_factor", "4"),
 
 					resource.TestCheckResourceAttr(warehouseModelRenamedFull.ResourceReference(), "max_concurrency_level", "4"),
@@ -1128,7 +1128,7 @@ func TestAcc_Warehouse_ZeroValues(t *testing.T) {
 
 					resource.TestCheckResourceAttr(warehouseModel.ResourceReference(), "show_output.#", "1"),
 					resource.TestCheckResourceAttr(warehouseModel.ResourceReference(), "show_output.0.auto_suspend", "600"),
-					resource.TestCheckResourceAttr(warehouseModel.ResourceReference(), "show_output.0.query_acceleration_max_scale_factor", "8"),
+					resource.TestCheckResourceAttr(warehouseModel.ResourceReference(), "show_output.0.query_acceleration_max_scale_factor", "2"),
 
 					resource.TestCheckResourceAttr(warehouseModel.ResourceReference(), "parameters.#", "1"),
 					resource.TestCheckResourceAttr(warehouseModel.ResourceReference(), "parameters.0.statement_queued_timeout_in_seconds.0.value", "0"),
@@ -1146,7 +1146,7 @@ func TestAcc_Warehouse_ZeroValues(t *testing.T) {
 						planchecks.ExpectChange(warehouseModelWithAllValidZeroValues.ResourceReference(), "auto_suspend", tfjson.ActionUpdate, sdk.String(r.IntDefaultString), sdk.String("0")),
 						planchecks.ExpectChange(warehouseModelWithAllValidZeroValues.ResourceReference(), "query_acceleration_max_scale_factor", tfjson.ActionUpdate, sdk.String(r.IntDefaultString), sdk.String("0")),
 						planchecks.ExpectComputed(warehouseModelWithAllValidZeroValues.ResourceReference(), "statement_queued_timeout_in_seconds", true),
-						planchecks.ExpectChange(warehouseModelWithAllValidZeroValues.ResourceReference(), "statement_timeout_in_seconds", tfjson.ActionUpdate, sdk.String("172800"), sdk.String("0")),
+						planchecks.ExpectComputed(warehouseModelWithAllValidZeroValues.ResourceReference(), "statement_timeout_in_seconds", true),
 						planchecks.ExpectComputed(warehouseModelWithAllValidZeroValues.ResourceReference(), r.ShowOutputAttributeName, true),
 					},
 				},
@@ -1722,7 +1722,7 @@ func TestAcc_Warehouse_migrateFromVersion092_queryAccelerationMaxScaleFactor_sam
 	providerConfig := providermodel.V097CompatibleProviderConfig(t)
 
 	warehouseModelFullDefault := model.WarehouseSnowflakeDefaultWithoutParameters(id, "").
-		WithEnableQueryAcceleration(r.BooleanFalse).
+		WithEnableQueryAcceleration(r.BooleanTrue).
 		WithMaxConcurrencyLevel(8).
 		WithStatementQueuedTimeoutInSeconds(0).
 		WithStatementTimeoutInSeconds(172800)
@@ -1740,7 +1740,7 @@ func TestAcc_Warehouse_migrateFromVersion092_queryAccelerationMaxScaleFactor_sam
 				Config:            providerConfig + config.FromModels(t, warehouseModelFullDefault),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(warehouseModelFullDefault.ResourceReference(), "name", id.Name()),
-					resource.TestCheckNoResourceAttr(warehouseModelFullDefault.ResourceReference(), "query_acceleration_max_scale_factor"),
+					resource.TestCheckResourceAttr(warehouseModelFullDefault.ResourceReference(), "query_acceleration_max_scale_factor", "2"),
 				),
 			},
 			{
@@ -1755,10 +1755,10 @@ func TestAcc_Warehouse_migrateFromVersion092_queryAccelerationMaxScaleFactor_sam
 				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(warehouseModelFullDefault.ResourceReference(), "name", id.Name()),
-					resource.TestCheckResourceAttr(warehouseModelFullDefault.ResourceReference(), "query_acceleration_max_scale_factor", "8"),
+					resource.TestCheckResourceAttr(warehouseModelFullDefault.ResourceReference(), "query_acceleration_max_scale_factor", "2"),
 
 					resource.TestCheckResourceAttr(warehouseModelFullDefault.ResourceReference(), "show_output.#", "1"),
-					resource.TestCheckResourceAttr(warehouseModelFullDefault.ResourceReference(), "show_output.0.query_acceleration_max_scale_factor", "8"),
+					resource.TestCheckResourceAttr(warehouseModelFullDefault.ResourceReference(), "show_output.0.query_acceleration_max_scale_factor", "2"),
 				),
 			},
 		},
@@ -1814,7 +1814,7 @@ func TestAcc_Warehouse_migrateFromVersion092_queryAccelerationMaxScaleFactor_noI
 					resource.TestCheckResourceAttr(warehouseModelFullDefaultWithQueryAccelerationMaxScaleFactorRemoved.ResourceReference(), "query_acceleration_max_scale_factor", r.IntDefaultString),
 
 					resource.TestCheckResourceAttr(warehouseModelFullDefaultWithQueryAccelerationMaxScaleFactorRemoved.ResourceReference(), "show_output.#", "1"),
-					resource.TestCheckResourceAttr(warehouseModelFullDefaultWithQueryAccelerationMaxScaleFactorRemoved.ResourceReference(), "show_output.0.query_acceleration_max_scale_factor", "8"),
+					resource.TestCheckResourceAttr(warehouseModelFullDefaultWithQueryAccelerationMaxScaleFactorRemoved.ResourceReference(), "show_output.0.query_acceleration_max_scale_factor", "2"),
 				),
 			},
 		},
@@ -2136,7 +2136,7 @@ resource "snowflake_warehouse" "test" {
 	auto_resume                         = true
 	initially_suspended                 = false
     enable_query_acceleration           = true
-    query_acceleration_max_scale_factor = 8
+    query_acceleration_max_scale_factor = 2
 
     max_concurrency_level               = 8
     statement_queued_timeout_in_seconds = 0
@@ -2270,7 +2270,7 @@ func TestAcc_Warehouse_ResourceConstraint(t *testing.T) {
 				},
 				Check: assertThat(t,
 					resourceassert.WarehouseResource(t, warehouseModelSnowparkOptimizedAndResourceConstraintLowercase.ResourceReference()).
-						HasWarehouseTypeString((string(sdk.WarehouseTypeSnowparkOptimized))).
+						HasWarehouseTypeString(string(sdk.WarehouseTypeSnowparkOptimized)).
 						HasNoGeneration().
 						HasResourceConstraintString(strings.ToLower(string(sdk.WarehouseResourceConstraintMemory1X))),
 					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelSnowparkOptimizedAndResourceConstraintLowercase.ResourceReference()).
@@ -2364,10 +2364,10 @@ func TestAcc_Warehouse_Generation(t *testing.T) {
 		WithWarehouseTypeEnum(sdk.WarehouseTypeStandard)
 	warehouseModelStandardAndGeneration := model.Warehouse("test", id.Name()).
 		WithWarehouseTypeEnum(sdk.WarehouseTypeStandard).
-		WithGenerationEnum(sdk.WarehouseGenerationStandardGen1)
-	warehouseModelStandardAndGeneration2 := model.Warehouse("test", id.Name()).
-		WithWarehouseTypeEnum(sdk.WarehouseTypeStandard).
 		WithGenerationEnum(sdk.WarehouseGenerationStandardGen2)
+	warehouseModelStandardAndGeneration1 := model.Warehouse("test", id.Name()).
+		WithWarehouseTypeEnum(sdk.WarehouseTypeStandard).
+		WithGenerationEnum(sdk.WarehouseGenerationStandardGen1)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
@@ -2382,7 +2382,7 @@ func TestAcc_Warehouse_Generation(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						planchecks.PrintPlanDetails(warehouseModelStandardAndGeneration.ResourceReference(), "resource_constraint", r.ShowOutputAttributeName),
-						planchecks.ExpectChange(warehouseModelStandardAndGeneration.ResourceReference(), "generation", tfjson.ActionCreate, nil, sdk.String(string(sdk.WarehouseGenerationStandardGen1))),
+						planchecks.ExpectChange(warehouseModelStandardAndGeneration.ResourceReference(), "generation", tfjson.ActionCreate, nil, sdk.String(string(sdk.WarehouseGenerationStandardGen2))),
 						planchecks.ExpectNoChangeOnField(warehouseModelStandardAndGeneration.ResourceReference(), "resource_constraint"),
 						planchecks.ExpectComputed(warehouseModelStandardAndGeneration.ResourceReference(), r.ShowOutputAttributeName, true),
 					},
@@ -2391,10 +2391,10 @@ func TestAcc_Warehouse_Generation(t *testing.T) {
 					resourceassert.WarehouseResource(t, warehouseModelStandardAndGeneration.ResourceReference()).
 						HasWarehouseTypeString(string(sdk.WarehouseTypeStandard)).
 						HasNoResourceConstraint().
-						HasGenerationString(string(sdk.WarehouseGenerationStandardGen1)),
+						HasGenerationString(string(sdk.WarehouseGenerationStandardGen2)),
 					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandardAndGeneration.ResourceReference()).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen1).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
 						HasResourceConstraintEmpty(),
 				),
 			},
@@ -2408,32 +2408,32 @@ func TestAcc_Warehouse_Generation(t *testing.T) {
 						HasNameString(id.Name()).
 						HasWarehouseTypeString(string(sdk.WarehouseTypeStandard)).
 						HasNoResourceConstraint().
-						HasGenerationString(string(sdk.WarehouseGenerationStandardGen1)),
+						HasGenerationString(string(sdk.WarehouseGenerationStandardGen2)),
 					resourceshowoutputassert.ImportedWarehouseShowOutput(t, helpers.EncodeResourceIdentifier(id)).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen1).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
 						HasResourceConstraintEmpty(),
 				),
 			},
 			// change generation in config
 			{
-				Config: accconfig.FromModels(t, providerModel, warehouseModelStandardAndGeneration2),
+				Config: accconfig.FromModels(t, providerModel, warehouseModelStandardAndGeneration1),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						planchecks.PrintPlanDetails(warehouseModelStandardAndGeneration2.ResourceReference(), "resource_constraint", r.ShowOutputAttributeName),
-						planchecks.ExpectChange(warehouseModelStandardAndGeneration2.ResourceReference(), "generation", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseGenerationStandardGen1)), sdk.String(string(sdk.WarehouseGenerationStandardGen2))),
-						planchecks.ExpectNoChangeOnField(warehouseModelStandardAndGeneration2.ResourceReference(), "resource_constraint"),
-						planchecks.ExpectComputed(warehouseModelStandardAndGeneration2.ResourceReference(), r.ShowOutputAttributeName, true),
+						planchecks.PrintPlanDetails(warehouseModelStandardAndGeneration1.ResourceReference(), "resource_constraint", r.ShowOutputAttributeName),
+						planchecks.ExpectChange(warehouseModelStandardAndGeneration1.ResourceReference(), "generation", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseGenerationStandardGen2)), sdk.String(string(sdk.WarehouseGenerationStandardGen1))),
+						planchecks.ExpectNoChangeOnField(warehouseModelStandardAndGeneration1.ResourceReference(), "resource_constraint"),
+						planchecks.ExpectComputed(warehouseModelStandardAndGeneration1.ResourceReference(), r.ShowOutputAttributeName, true),
 					},
 				},
 				Check: assertThat(t,
-					resourceassert.WarehouseResource(t, warehouseModelStandardAndGeneration2.ResourceReference()).
+					resourceassert.WarehouseResource(t, warehouseModelStandardAndGeneration1.ResourceReference()).
 						HasWarehouseTypeString(string(sdk.WarehouseTypeStandard)).
-						HasGenerationString(string(sdk.WarehouseGenerationStandardGen2)).
+						HasGenerationString(string(sdk.WarehouseGenerationStandardGen1)).
 						HasNoResourceConstraint(),
-					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandardAndGeneration2.ResourceReference()).
+					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandardAndGeneration1.ResourceReference()).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen2).
+						HasGeneration(sdk.WarehouseGenerationStandardGen1).
 						HasResourceConstraintEmpty(),
 				),
 			},
@@ -2445,56 +2445,6 @@ func TestAcc_Warehouse_Generation(t *testing.T) {
 						plancheck.ExpectResourceAction(warehouseModelStandard.ResourceReference(), plancheck.ResourceActionUpdate),
 						planchecks.ExpectNoChangeOnField(warehouseModelStandard.ResourceReference(), "resource_constraint"),
 						planchecks.PrintPlanDetails(warehouseModelStandard.ResourceReference(), "resource_constraint", r.ShowOutputAttributeName),
-						planchecks.ExpectChange(warehouseModelStandard.ResourceReference(), "generation", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseGenerationStandardGen2)), nil),
-						planchecks.ExpectComputed(warehouseModelStandard.ResourceReference(), r.ShowOutputAttributeName, true),
-					},
-				},
-				Check: assertThat(t,
-					resourceassert.WarehouseResource(t, warehouseModelStandard.ResourceReference()).
-						HasWarehouseTypeString(string(sdk.WarehouseTypeStandard)).
-						HasGenerationEmpty().
-						HasNoResourceConstraint(),
-					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandard.ResourceReference()).
-						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen1).
-						HasResourceConstraintEmpty(),
-				),
-			},
-			// add config again
-			{
-				Config: accconfig.FromModels(t, providerModel, warehouseModelStandardAndGeneration2),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						planchecks.PrintPlanDetails(warehouseModelStandardAndGeneration2.ResourceReference(), "resource_constraint", r.ShowOutputAttributeName),
-						planchecks.ExpectChange(warehouseModelStandardAndGeneration2.ResourceReference(), "generation", tfjson.ActionUpdate, nil, sdk.String(string(sdk.WarehouseGenerationStandardGen2))),
-						planchecks.ExpectNoChangeOnField(warehouseModelStandardAndGeneration2.ResourceReference(), "resource_constraint"),
-						planchecks.ExpectComputed(warehouseModelStandardAndGeneration2.ResourceReference(), r.ShowOutputAttributeName, true),
-					},
-				},
-				Check: assertThat(t,
-					resourceassert.WarehouseResource(t, warehouseModelStandardAndGeneration2.ResourceReference()).
-						HasWarehouseTypeString((string(sdk.WarehouseTypeStandard))).
-						HasGenerationString(string(sdk.WarehouseGenerationStandardGen2)).
-						HasNoResourceConstraint(),
-					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandardAndGeneration2.ResourceReference()).
-						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen2).
-						HasResourceConstraintEmpty(),
-				),
-			},
-			// remove type from config but update warehouse externally to default (still expecting non-empty plan because we do not know the default)
-			{
-				PreConfig: func() {
-					testClient().Warehouse.UpdateGeneration(t, id, sdk.WarehouseGenerationStandardGen1)
-				},
-				Config: accconfig.FromModels(t, providerModel, warehouseModelStandard),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectNonEmptyPlan(),
-						planchecks.PrintPlanDetails(warehouseModelStandard.ResourceReference(), "resource_constraint", r.ShowOutputAttributeName),
-						planchecks.ExpectNoChangeOnField(warehouseModelStandard.ResourceReference(), "resource_constraint"),
-						planchecks.ExpectDrift(warehouseModelStandard.ResourceReference(), "generation", sdk.String(string(sdk.WarehouseGenerationStandardGen2)), sdk.String(string(sdk.WarehouseGenerationStandardGen1))),
-						planchecks.ExpectDrift(warehouseModelStandard.ResourceReference(), "show_output.0.generation", sdk.String(string(sdk.WarehouseGenerationStandardGen2)), sdk.String(string(sdk.WarehouseGenerationStandardGen1))),
 						planchecks.ExpectChange(warehouseModelStandard.ResourceReference(), "generation", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseGenerationStandardGen1)), nil),
 						planchecks.ExpectComputed(warehouseModelStandard.ResourceReference(), r.ShowOutputAttributeName, true),
 					},
@@ -2506,7 +2456,57 @@ func TestAcc_Warehouse_Generation(t *testing.T) {
 						HasNoResourceConstraint(),
 					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandard.ResourceReference()).
 						HasType(sdk.WarehouseTypeStandard).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
+						HasResourceConstraintEmpty(),
+				),
+			},
+			// add config again
+			{
+				Config: accconfig.FromModels(t, providerModel, warehouseModelStandardAndGeneration1),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.PrintPlanDetails(warehouseModelStandardAndGeneration1.ResourceReference(), "resource_constraint", r.ShowOutputAttributeName),
+						planchecks.ExpectChange(warehouseModelStandardAndGeneration1.ResourceReference(), "generation", tfjson.ActionUpdate, nil, sdk.String(string(sdk.WarehouseGenerationStandardGen1))),
+						planchecks.ExpectNoChangeOnField(warehouseModelStandardAndGeneration1.ResourceReference(), "resource_constraint"),
+						planchecks.ExpectComputed(warehouseModelStandardAndGeneration1.ResourceReference(), r.ShowOutputAttributeName, true),
+					},
+				},
+				Check: assertThat(t,
+					resourceassert.WarehouseResource(t, warehouseModelStandardAndGeneration1.ResourceReference()).
+						HasWarehouseTypeString(string(sdk.WarehouseTypeStandard)).
+						HasGenerationString(string(sdk.WarehouseGenerationStandardGen1)).
+						HasNoResourceConstraint(),
+					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandardAndGeneration1.ResourceReference()).
+						HasType(sdk.WarehouseTypeStandard).
 						HasGeneration(sdk.WarehouseGenerationStandardGen1).
+						HasResourceConstraintEmpty(),
+				),
+			},
+			// remove type from config but update warehouse externally to default (still expecting non-empty plan because we do not know the default)
+			{
+				PreConfig: func() {
+					testClient().Warehouse.UpdateGeneration(t, id, sdk.WarehouseGenerationStandardGen2)
+				},
+				Config: accconfig.FromModels(t, providerModel, warehouseModelStandard),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						planchecks.PrintPlanDetails(warehouseModelStandard.ResourceReference(), "resource_constraint", r.ShowOutputAttributeName),
+						planchecks.ExpectNoChangeOnField(warehouseModelStandard.ResourceReference(), "resource_constraint"),
+						planchecks.ExpectDrift(warehouseModelStandard.ResourceReference(), "generation", sdk.String(string(sdk.WarehouseGenerationStandardGen1)), sdk.String(string(sdk.WarehouseGenerationStandardGen2))),
+						planchecks.ExpectDrift(warehouseModelStandard.ResourceReference(), "show_output.0.generation", sdk.String(string(sdk.WarehouseGenerationStandardGen1)), sdk.String(string(sdk.WarehouseGenerationStandardGen2))),
+						planchecks.ExpectChange(warehouseModelStandard.ResourceReference(), "generation", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseGenerationStandardGen2)), nil),
+						planchecks.ExpectComputed(warehouseModelStandard.ResourceReference(), r.ShowOutputAttributeName, true),
+					},
+				},
+				Check: assertThat(t,
+					resourceassert.WarehouseResource(t, warehouseModelStandard.ResourceReference()).
+						HasWarehouseTypeString(string(sdk.WarehouseTypeStandard)).
+						HasGenerationEmpty().
+						HasNoResourceConstraint(),
+					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandard.ResourceReference()).
+						HasType(sdk.WarehouseTypeStandard).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
 						HasResourceConstraintEmpty(),
 				),
 			},
@@ -2514,16 +2514,16 @@ func TestAcc_Warehouse_Generation(t *testing.T) {
 			{
 				PreConfig: func() {
 					// we change the type to the type different from default, expecting action
-					testClient().Warehouse.UpdateGeneration(t, id, sdk.WarehouseGenerationStandardGen2)
+					testClient().Warehouse.UpdateGeneration(t, id, sdk.WarehouseGenerationStandardGen1)
 				},
 				Config: accconfig.FromModels(t, providerModel, warehouseModelStandard),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectNonEmptyPlan(),
 						planchecks.PrintPlanDetails(warehouseModelStandard.ResourceReference(), "warehouse_type", r.ShowOutputAttributeName),
-						planchecks.ExpectDrift(warehouseModelStandard.ResourceReference(), "generation", nil, sdk.String(string(sdk.WarehouseGenerationStandardGen2))),
-						planchecks.ExpectDrift(warehouseModelStandard.ResourceReference(), "show_output.0.generation", sdk.String(string(sdk.WarehouseGenerationStandardGen1)), sdk.String(string(sdk.WarehouseGenerationStandardGen2))),
-						planchecks.ExpectChange(warehouseModelStandard.ResourceReference(), "generation", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseGenerationStandardGen2)), nil),
+						planchecks.ExpectDrift(warehouseModelStandard.ResourceReference(), "generation", nil, sdk.String(string(sdk.WarehouseGenerationStandardGen1))),
+						planchecks.ExpectDrift(warehouseModelStandard.ResourceReference(), "show_output.0.generation", sdk.String(string(sdk.WarehouseGenerationStandardGen2)), sdk.String(string(sdk.WarehouseGenerationStandardGen1))),
+						planchecks.ExpectChange(warehouseModelStandard.ResourceReference(), "generation", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseGenerationStandardGen1)), nil),
 						planchecks.ExpectComputed(warehouseModelStandard.ResourceReference(), r.ShowOutputAttributeName, true),
 						planchecks.ExpectNoChangeOnField(warehouseModelStandard.ResourceReference(), "resource_constraint"),
 					},
@@ -2535,7 +2535,7 @@ func TestAcc_Warehouse_Generation(t *testing.T) {
 						HasNoResourceConstraint(),
 					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandard.ResourceReference()).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen1).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
 						HasResourceConstraintEmpty(),
 				),
 			},
@@ -2547,11 +2547,11 @@ func TestAcc_Warehouse_Generation(t *testing.T) {
 					resourceassert.ImportedWarehouseResource(t, helpers.EncodeResourceIdentifier(id)).
 						HasNameString(id.Name()).
 						HasWarehouseTypeString(string(sdk.WarehouseTypeStandard)).
-						HasGenerationString(string(sdk.WarehouseGenerationStandardGen1)).
+						HasGenerationString(string(sdk.WarehouseGenerationStandardGen2)).
 						HasNoResourceConstraint(),
 					resourceshowoutputassert.ImportedWarehouseShowOutput(t, helpers.EncodeResourceIdentifier(id)).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen1).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
 						HasResourceConstraintEmpty(),
 				),
 			},
@@ -2574,7 +2574,7 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 	warehouseModelStandardAndGeneration := model.Warehouse("test", id.Name()).
 		WithWarehouseSizeEnum(sdk.WarehouseSizeMedium).
 		WithWarehouseTypeEnum(sdk.WarehouseTypeStandard).
-		WithGenerationEnum(sdk.WarehouseGenerationStandardGen2)
+		WithGenerationEnum(sdk.WarehouseGenerationStandardGen1)
 	warehouseModelSnowparkOptimizedAndResourceConstraint := model.Warehouse("test", id.Name()).
 		WithWarehouseSizeEnum(sdk.WarehouseSizeMedium).
 		WithWarehouseTypeEnum(sdk.WarehouseTypeSnowparkOptimized).
@@ -2616,7 +2616,7 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 						HasNoResourceConstraint(),
 					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandard.ResourceReference()).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen1).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
 						HasResourceConstraintEmpty(),
 				),
 			},
@@ -2664,7 +2664,7 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 						HasResourceConstraintEmpty(),
 					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandard.ResourceReference()).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen1).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
 						HasResourceConstraintEmpty(),
 				),
 			},
@@ -2680,7 +2680,7 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 						plancheck.ExpectNonEmptyPlan(),
 						planchecks.PrintPlanDetails(warehouseModelStandard.ResourceReference(), "resource_constraint", r.ShowOutputAttributeName),
 						planchecks.ExpectDrift(warehouseModelStandard.ResourceReference(), "resource_constraint", nil, sdk.String(string(sdk.WarehouseResourceConstraintMemory16X))),
-						planchecks.ExpectDrift(warehouseModelStandard.ResourceReference(), "show_output.0.generation", sdk.String(string(sdk.WarehouseGenerationStandardGen1)), nil),
+						planchecks.ExpectDrift(warehouseModelStandard.ResourceReference(), "show_output.0.generation", sdk.String(string(sdk.WarehouseGenerationStandardGen2)), nil),
 						planchecks.ExpectDrift(warehouseModelStandard.ResourceReference(), "show_output.0.resource_constraint", nil, sdk.String(string(sdk.WarehouseResourceConstraintMemory16X))),
 						planchecks.ExpectChange(warehouseModelStandard.ResourceReference(), "resource_constraint", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseResourceConstraintMemory16X)), nil),
 						planchecks.ExpectChange(warehouseModelStandard.ResourceReference(), "warehouse_type", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseTypeSnowparkOptimized)), sdk.String(string(sdk.WarehouseTypeStandard))),
@@ -2695,7 +2695,7 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 						HasResourceConstraintEmpty(),
 					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandard.ResourceReference()).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen1).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
 						HasResourceConstraintEmpty(),
 				),
 			},
@@ -2724,7 +2724,7 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 						HasResourceConstraintEmpty(),
 					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelDefault.ResourceReference()).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen1).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
 						HasResourceConstraintEmpty(),
 				),
 			},
@@ -2740,7 +2740,7 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 						plancheck.ExpectNonEmptyPlan(),
 						planchecks.PrintPlanDetails(warehouseModelDefault.ResourceReference(), "resource_constraint", r.ShowOutputAttributeName),
 						planchecks.ExpectDrift(warehouseModelDefault.ResourceReference(), "resource_constraint", nil, sdk.String(string(sdk.WarehouseResourceConstraintMemory16X))),
-						planchecks.ExpectDrift(warehouseModelDefault.ResourceReference(), "show_output.0.generation", sdk.String(string(sdk.WarehouseGenerationStandardGen1)), nil),
+						planchecks.ExpectDrift(warehouseModelDefault.ResourceReference(), "show_output.0.generation", sdk.String(string(sdk.WarehouseGenerationStandardGen2)), nil),
 						planchecks.ExpectDrift(warehouseModelDefault.ResourceReference(), "show_output.0.resource_constraint", nil, sdk.String(string(sdk.WarehouseResourceConstraintMemory16X))),
 						planchecks.ExpectChange(warehouseModelDefault.ResourceReference(), "resource_constraint", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseResourceConstraintMemory16X)), nil),
 						planchecks.ExpectChange(warehouseModelDefault.ResourceReference(), "warehouse_type", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseTypeSnowparkOptimized)), nil),
@@ -2755,7 +2755,7 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 						HasResourceConstraintEmpty(),
 					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelDefault.ResourceReference()).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen1).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
 						HasResourceConstraintEmpty(),
 				),
 			},
@@ -2766,7 +2766,7 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectNonEmptyPlan(),
-						planchecks.ExpectChange(warehouseModelStandardAndGeneration.ResourceReference(), "generation", tfjson.ActionUpdate, nil, sdk.String(string(sdk.WarehouseGenerationStandardGen2))),
+						planchecks.ExpectChange(warehouseModelStandardAndGeneration.ResourceReference(), "generation", tfjson.ActionUpdate, nil, sdk.String(string(sdk.WarehouseGenerationStandardGen1))),
 						planchecks.ExpectNoChangeOnField(warehouseModelStandardAndGeneration.ResourceReference(), "resource_constraint"),
 						planchecks.ExpectComputed(warehouseModelStandardAndGeneration.ResourceReference(), r.ShowOutputAttributeName, true),
 					},
@@ -2774,11 +2774,11 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 				Check: assertThat(t,
 					resourceassert.WarehouseResource(t, warehouseModelStandardAndGeneration.ResourceReference()).
 						HasWarehouseTypeString(string(sdk.WarehouseTypeStandard)).
-						HasGenerationString(string(sdk.WarehouseGenerationStandardGen2)).
+						HasGenerationString(string(sdk.WarehouseGenerationStandardGen1)).
 						HasResourceConstraintEmpty(),
 					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandardAndGeneration.ResourceReference()).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen2).
+						HasGeneration(sdk.WarehouseGenerationStandardGen1).
 						HasResourceConstraintEmpty(),
 				),
 			},
@@ -2789,7 +2789,7 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(warehouseModelSnowparkOptimized.ResourceReference(), plancheck.ResourceActionUpdate),
-						planchecks.ExpectChange(warehouseModelSnowparkOptimized.ResourceReference(), "generation", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseGenerationStandardGen2)), nil),
+						planchecks.ExpectChange(warehouseModelSnowparkOptimized.ResourceReference(), "generation", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseGenerationStandardGen1)), nil),
 						planchecks.ExpectChange(warehouseModelSnowparkOptimized.ResourceReference(), "warehouse_type", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseTypeStandard)), sdk.String(string(sdk.WarehouseTypeSnowparkOptimized))),
 						planchecks.ExpectNoChangeOnField(warehouseModelSnowparkOptimized.ResourceReference(), "resource_constraint"),
 						planchecks.ExpectComputed(warehouseModelSnowparkOptimized.ResourceReference(), r.ShowOutputAttributeName, true),
@@ -2809,17 +2809,17 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 			// external change of the generation
 			{
 				PreConfig: func() {
-					testClient().Warehouse.UpdateWarehouseTypeAndGeneration(t, id, sdk.WarehouseTypeStandard, sdk.WarehouseGenerationStandardGen2)
+					testClient().Warehouse.UpdateWarehouseTypeAndGeneration(t, id, sdk.WarehouseTypeStandard, sdk.WarehouseGenerationStandardGen1)
 				},
 				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 				Config:                   accconfig.FromModels(t, providerModel, warehouseModelSnowparkOptimized),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectNonEmptyPlan(),
-						planchecks.ExpectDrift(warehouseModelSnowparkOptimized.ResourceReference(), "generation", nil, sdk.String(string(sdk.WarehouseGenerationStandardGen2))),
+						planchecks.ExpectDrift(warehouseModelSnowparkOptimized.ResourceReference(), "generation", nil, sdk.String(string(sdk.WarehouseGenerationStandardGen1))),
 						planchecks.ExpectDrift(warehouseModelSnowparkOptimized.ResourceReference(), "show_output.0.resource_constraint", sdk.String(string(sdk.WarehouseResourceConstraintMemory16X)), nil),
-						planchecks.ExpectDrift(warehouseModelSnowparkOptimized.ResourceReference(), "show_output.0.generation", nil, sdk.String(string(sdk.WarehouseGenerationStandardGen2))),
-						planchecks.ExpectChange(warehouseModelSnowparkOptimized.ResourceReference(), "generation", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseGenerationStandardGen2)), nil),
+						planchecks.ExpectDrift(warehouseModelSnowparkOptimized.ResourceReference(), "show_output.0.generation", nil, sdk.String(string(sdk.WarehouseGenerationStandardGen1))),
+						planchecks.ExpectChange(warehouseModelSnowparkOptimized.ResourceReference(), "generation", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseGenerationStandardGen1)), nil),
 						planchecks.ExpectChange(warehouseModelSnowparkOptimized.ResourceReference(), "warehouse_type", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseTypeStandard)), sdk.String(string(sdk.WarehouseTypeSnowparkOptimized))),
 						planchecks.ExpectNoChangeOnField(warehouseModelSnowparkOptimized.ResourceReference(), "resource_constraint"),
 						planchecks.ExpectComputed(warehouseModelSnowparkOptimized.ResourceReference(), r.ShowOutputAttributeName, true),
@@ -2848,7 +2848,7 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(warehouseModelDefault.ResourceReference(), plancheck.ResourceActionUpdate),
-						planchecks.ExpectChange(warehouseModelDefault.ResourceReference(), "generation", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseGenerationStandardGen2)), nil),
+						planchecks.ExpectChange(warehouseModelDefault.ResourceReference(), "generation", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseGenerationStandardGen1)), nil),
 						planchecks.ExpectChange(warehouseModelDefault.ResourceReference(), "warehouse_type", tfjson.ActionUpdate, sdk.String(string(sdk.WarehouseTypeStandard)), nil),
 						planchecks.ExpectNoChangeOnField(warehouseModelDefault.ResourceReference(), "resource_constraint"),
 						planchecks.ExpectComputed(warehouseModelDefault.ResourceReference(), r.ShowOutputAttributeName, true),
@@ -2861,7 +2861,7 @@ func TestAcc_Warehouse_ResourceConstraint_MixedWarehouseTypes(t *testing.T) {
 						HasResourceConstraintEmpty(),
 					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelDefault.ResourceReference()).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen1).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
 						HasResourceConstraintEmpty(),
 				),
 			},
@@ -2932,7 +2932,7 @@ func TestAcc_Warehouse_Generation_MigrateManuallySetGeneration(t *testing.T) {
 		WithWarehouseTypeEnum(sdk.WarehouseTypeStandard)
 
 	warehouseModelStandardAndGeneration := model.Warehouse("test", id.Name()).
-		WithGenerationEnum(sdk.WarehouseGenerationStandardGen1).
+		WithGenerationEnum(sdk.WarehouseGenerationStandardGen2).
 		WithWarehouseTypeEnum(sdk.WarehouseTypeStandard)
 
 	resource.Test(t, resource.TestCase{
@@ -2970,7 +2970,7 @@ func TestAcc_Warehouse_Generation_MigrateManuallySetGeneration(t *testing.T) {
 						HasNoResourceConstraint(),
 					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandardAndGeneration.ResourceReference()).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen1).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
 						HasResourceConstraintEmpty(),
 				),
 			},
@@ -3124,7 +3124,7 @@ func TestAcc_Warehouse_Generation_MigrateStandardWithoutGeneration(t *testing.T)
 						HasNoResourceConstraint(),
 					resourceshowoutputassert.WarehouseShowOutput(t, warehouseModelStandard.ResourceReference()).
 						HasType(sdk.WarehouseTypeStandard).
-						HasGeneration(sdk.WarehouseGenerationStandardGen1).
+						HasGeneration(sdk.WarehouseGenerationStandardGen2).
 						HasResourceConstraintEmpty(),
 				),
 			},

--- a/pkg/testacc/rest_api_poc_warehouse_acceptance_test.go
+++ b/pkg/testacc/rest_api_poc_warehouse_acceptance_test.go
@@ -52,8 +52,8 @@ func TestAcc_RestApiPoc_WarehouseInitialCheck(t *testing.T) {
 						HasAutoResume(true).
 						HasResourceMonitor(sdk.AccountObjectIdentifier{}).
 						HasComment("").
-						HasEnableQueryAcceleration(false).
-						HasQueryAccelerationMaxScaleFactor(8),
+						HasEnableQueryAcceleration(true).
+						HasQueryAccelerationMaxScaleFactor(2),
 					objectparametersassert.WarehouseParameters(t, id).
 						HasAllDefaults(),
 				),


### PR DESCRIPTION
## Summary
- Update warehouse integration test assertions to match the current Snowflake defaults: `Generation` is now `StandardGen2` (was `Gen1`), `EnableQueryAcceleration` is now `true` (was `false`), `QueryAccelerationMaxScaleFactor` is now `2` (was `8`).
- Adjust the unset-`MaxQueryPerformanceLevel` test to expect `XLarge` (the documented default) — the prior workaround comment about the value resetting to `Small` is no longer accurate.
- Swap the alter-generation test to flip from `Gen2 → Gen1` (matching the new default starting point).
