### PR TITLE
chore: Adjust tag tests

### DIFF
--- a/pkg/testacc/resource_tag_account_level_acceptance_test.go
+++ b/pkg/testacc/resource_tag_account_level_acceptance_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testprofiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -16,7 +17,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
-func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
+func TestAcc_Tag_CompleteUseCase_OnConflict_Bcr2291(t *testing.T) {
+	if testenvs.GetSnowflakeEnvironmentWithProdDefault() != testenvs.SnowflakeNonProdEnvironment {
+		t.Skip("Tag propagation tests are only supported in non-prod environments")
+	}
+
 	id := secondaryTestClient().Ids.RandomSchemaObjectIdentifier()
 
 	// Ensure the bundle is always re-enabled after the test, even on failure.
@@ -122,7 +127,11 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 	})
 }
 
-func TestAcc_Tag_OnConflictAllowedValuesSequence_Bcr2291(t *testing.T) {
+func TestAcc_Tag_CompleteUseCase_OnConflictAllowedValuesSequence_Bcr2291(t *testing.T) {
+	if testenvs.GetSnowflakeEnvironmentWithProdDefault() != testenvs.SnowflakeNonProdEnvironment {
+		t.Skip("Tag propagation tests are only supported in non-prod environments")
+	}
+
 	id := secondaryTestClient().Ids.RandomSchemaObjectIdentifier()
 
 	// Ensure the bundle is always re-enabled after the test, even on failure.

--- a/pkg/testacc/resource_tag_account_level_acceptance_test.go
+++ b/pkg/testacc/resource_tag_account_level_acceptance_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert/resourceassert"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testprofiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -15,12 +17,14 @@ import (
 )
 
 func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
-	id := testClient().Ids.RandomSchemaObjectIdentifier()
+	id := secondaryTestClient().Ids.RandomSchemaObjectIdentifier()
 
 	// Ensure the bundle is always re-enabled after the test, even on failure.
 	t.Cleanup(func() {
-		testClient().BcrBundles.EnableBcrBundle(t, "2026_03")
+		secondaryTestClient().BcrBundles.EnableBcrBundle(t, "2026_03")
 	})
+
+	providerModel := providermodel.SnowflakeProvider().WithProfile(testprofiles.Secondary)
 
 	withPropagateOnly := model.TagBase("test", id).
 		WithPropagateEnum(sdk.TagPropagationOnDependency)
@@ -35,15 +39,15 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: disable the 2026_03 bundle and create the tag with propagate + on_conflict.
 			// Creating with `on_conflict` works regardless of the bundle; only SHOW TAGS is affected by BCR-2291.
 			{
+				ProtoV6ProviderFactories: secondaryAccountProviderFactory,
 				PreConfig: func() {
-					testClient().BcrBundles.DisableBcrBundle(t, "2026_03")
+					secondaryTestClient().BcrBundles.DisableBcrBundle(t, "2026_03")
 				},
-				Config: config.FromModels(t, withPropagateAndOnConflict),
+				Config: config.FromModels(t, providerModel, withPropagateAndOnConflict),
 				Check: assertThat(t,
 					resourceassert.TagResource(t, resourceRef).
 						HasPropagateEnum(sdk.TagPropagationOnDependency).
@@ -53,8 +57,9 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 			// Step 2: with the bundle disabled, externally change ON_CONFLICT. The column is
 			// absent from SHOW TAGS, so Read cannot see the drift and the plan is a no-op.
 			{
+				ProtoV6ProviderFactories: secondaryAccountProviderFactory,
 				PreConfig: func() {
-					testClient().Tag.Alter(t, sdk.NewAlterTagRequest(id).
+					secondaryTestClient().Tag.Alter(t, sdk.NewAlterTagRequest(id).
 						WithSet(*sdk.NewTagSetRequest().WithPropagate(
 							*sdk.NewTagPropagateRequest(sdk.TagPropagationOnDependency).
 								WithOnConflict(sdk.TagOnConflict{CustomValue: sdk.String("other_value_no_bcr")}),
@@ -66,7 +71,7 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 						plancheck.ExpectEmptyPlan(),
 					},
 				},
-				Config: config.FromModels(t, withPropagateAndOnConflict),
+				Config: config.FromModels(t, providerModel, withPropagateAndOnConflict),
 				Check: assertThat(t,
 					resourceassert.TagResource(t, resourceRef).
 						HasOnConflictCustomValue("conflict_value"),
@@ -75,15 +80,16 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 			// Step 3: enable the 2026_03 bundle. Read now observes the external value set in
 			// step 2 and the plan reconciles the resource back to the configured value.
 			{
+				ProtoV6ProviderFactories: secondaryAccountProviderFactory,
 				PreConfig: func() {
-					testClient().BcrBundles.EnableBcrBundle(t, "2026_03")
+					secondaryTestClient().BcrBundles.EnableBcrBundle(t, "2026_03")
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceRef, plancheck.ResourceActionUpdate),
 					},
 				},
-				Config: config.FromModels(t, withPropagateAndOnConflict),
+				Config: config.FromModels(t, providerModel, withPropagateAndOnConflict),
 				Check: assertThat(t,
 					resourceassert.TagResource(t, resourceRef).
 						HasOnConflictCustomValue("conflict_value"),
@@ -92,8 +98,9 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 			// Step 4: with the bundle still enabled, externally set a different ON_CONFLICT while
 			// the config drops the attribute. The drift is detected and the value is cleared.
 			{
+				ProtoV6ProviderFactories: secondaryAccountProviderFactory,
 				PreConfig: func() {
-					testClient().Tag.Alter(t, sdk.NewAlterTagRequest(id).
+					secondaryTestClient().Tag.Alter(t, sdk.NewAlterTagRequest(id).
 						WithSet(*sdk.NewTagSetRequest().WithPropagate(
 							*sdk.NewTagPropagateRequest(sdk.TagPropagationOnDependency).
 								WithOnConflict(sdk.TagOnConflict{CustomValue: sdk.String("external_value")}),
@@ -105,7 +112,7 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 						plancheck.ExpectResourceAction(withPropagateOnly.ResourceReference(), plancheck.ResourceActionUpdate),
 					},
 				},
-				Config: config.FromModels(t, withPropagateOnly),
+				Config: config.FromModels(t, providerModel, withPropagateOnly),
 				Check: assertThat(t,
 					resourceassert.TagResource(t, withPropagateOnly.ResourceReference()).
 						HasOnConflictEmpty(),
@@ -116,12 +123,14 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 }
 
 func TestAcc_Tag_OnConflictAllowedValuesSequence_Bcr2291(t *testing.T) {
-	id := testClient().Ids.RandomSchemaObjectIdentifier()
+	id := secondaryTestClient().Ids.RandomSchemaObjectIdentifier()
 
 	// Ensure the bundle is always re-enabled after the test, even on failure.
 	t.Cleanup(func() {
-		testClient().BcrBundles.EnableBcrBundle(t, "2026_03")
+		secondaryTestClient().BcrBundles.EnableBcrBundle(t, "2026_03")
 	})
+
+	providerModel := providermodel.SnowflakeProvider().WithProfile(testprofiles.Secondary)
 
 	withAllowedValues := model.TagBase("test", id).
 		WithOrderedAllowedValues("confidential", "internal", "public").
@@ -137,14 +146,14 @@ func TestAcc_Tag_OnConflictAllowedValuesSequence_Bcr2291(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: with the bundle enabled, create a tag with allowed_values + allowed_values_sequence on_conflict.
 			{
+				ProtoV6ProviderFactories: secondaryAccountProviderFactory,
 				PreConfig: func() {
-					testClient().BcrBundles.EnableBcrBundle(t, "2026_03")
+					secondaryTestClient().BcrBundles.EnableBcrBundle(t, "2026_03")
 				},
-				Config: config.FromModels(t, withAllowedValues),
+				Config: config.FromModels(t, providerModel, withAllowedValues),
 				Check: assertThat(t,
 					resourceassert.TagResource(t, resourceRef).
 						HasPropagateEnum(sdk.TagPropagationOnDependency).
@@ -153,12 +162,13 @@ func TestAcc_Tag_OnConflictAllowedValuesSequence_Bcr2291(t *testing.T) {
 			},
 			// Step 2: drop on_conflict; the value is cleared.
 			{
+				ProtoV6ProviderFactories: secondaryAccountProviderFactory,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(withPropagateOnly.ResourceReference(), plancheck.ResourceActionUpdate),
 					},
 				},
-				Config: config.FromModels(t, withPropagateOnly),
+				Config: config.FromModels(t, providerModel, withPropagateOnly),
 				Check: assertThat(t,
 					resourceassert.TagResource(t, withPropagateOnly.ResourceReference()).
 						HasOnConflictEmpty(),

--- a/pkg/testacc/resource_tag_account_level_acceptance_test.go
+++ b/pkg/testacc/resource_tag_account_level_acceptance_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert/resourceassert"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testprofiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -17,14 +15,12 @@ import (
 )
 
 func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
-	id := secondaryTestClient().Ids.RandomSchemaObjectIdentifier()
+	id := testClient().Ids.RandomSchemaObjectIdentifier()
 
 	// Ensure the bundle is always re-enabled after the test, even on failure.
 	t.Cleanup(func() {
-		secondaryTestClient().BcrBundles.EnableBcrBundle(t, "2026_03")
+		testClient().BcrBundles.EnableBcrBundle(t, "2026_03")
 	})
-
-	providerModel := providermodel.SnowflakeProvider().WithProfile(testprofiles.Secondary)
 
 	withPropagateOnly := model.TagBase("test", id).
 		WithPropagateEnum(sdk.TagPropagationOnDependency)
@@ -39,15 +35,15 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: disable the 2026_03 bundle and create the tag with propagate + on_conflict.
 			// Creating with `on_conflict` works regardless of the bundle; only SHOW TAGS is affected by BCR-2291.
 			{
-				ProtoV6ProviderFactories: secondaryAccountProviderFactory,
 				PreConfig: func() {
-					secondaryTestClient().BcrBundles.DisableBcrBundle(t, "2026_03")
+					testClient().BcrBundles.DisableBcrBundle(t, "2026_03")
 				},
-				Config: config.FromModels(t, providerModel, withPropagateAndOnConflict),
+				Config: config.FromModels(t, withPropagateAndOnConflict),
 				Check: assertThat(t,
 					resourceassert.TagResource(t, resourceRef).
 						HasPropagateEnum(sdk.TagPropagationOnDependency).
@@ -57,9 +53,8 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 			// Step 2: with the bundle disabled, externally change ON_CONFLICT. The column is
 			// absent from SHOW TAGS, so Read cannot see the drift and the plan is a no-op.
 			{
-				ProtoV6ProviderFactories: secondaryAccountProviderFactory,
 				PreConfig: func() {
-					secondaryTestClient().Tag.Alter(t, sdk.NewAlterTagRequest(id).
+					testClient().Tag.Alter(t, sdk.NewAlterTagRequest(id).
 						WithSet(*sdk.NewTagSetRequest().WithPropagate(
 							*sdk.NewTagPropagateRequest(sdk.TagPropagationOnDependency).
 								WithOnConflict(sdk.TagOnConflict{CustomValue: sdk.String("other_value_no_bcr")}),
@@ -71,7 +66,7 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 						plancheck.ExpectEmptyPlan(),
 					},
 				},
-				Config: config.FromModels(t, providerModel, withPropagateAndOnConflict),
+				Config: config.FromModels(t, withPropagateAndOnConflict),
 				Check: assertThat(t,
 					resourceassert.TagResource(t, resourceRef).
 						HasOnConflictCustomValue("conflict_value"),
@@ -80,16 +75,15 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 			// Step 3: enable the 2026_03 bundle. Read now observes the external value set in
 			// step 2 and the plan reconciles the resource back to the configured value.
 			{
-				ProtoV6ProviderFactories: secondaryAccountProviderFactory,
 				PreConfig: func() {
-					secondaryTestClient().BcrBundles.EnableBcrBundle(t, "2026_03")
+					testClient().BcrBundles.EnableBcrBundle(t, "2026_03")
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceRef, plancheck.ResourceActionUpdate),
 					},
 				},
-				Config: config.FromModels(t, providerModel, withPropagateAndOnConflict),
+				Config: config.FromModels(t, withPropagateAndOnConflict),
 				Check: assertThat(t,
 					resourceassert.TagResource(t, resourceRef).
 						HasOnConflictCustomValue("conflict_value"),
@@ -98,9 +92,8 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 			// Step 4: with the bundle still enabled, externally set a different ON_CONFLICT while
 			// the config drops the attribute. The drift is detected and the value is cleared.
 			{
-				ProtoV6ProviderFactories: secondaryAccountProviderFactory,
 				PreConfig: func() {
-					secondaryTestClient().Tag.Alter(t, sdk.NewAlterTagRequest(id).
+					testClient().Tag.Alter(t, sdk.NewAlterTagRequest(id).
 						WithSet(*sdk.NewTagSetRequest().WithPropagate(
 							*sdk.NewTagPropagateRequest(sdk.TagPropagationOnDependency).
 								WithOnConflict(sdk.TagOnConflict{CustomValue: sdk.String("external_value")}),
@@ -112,7 +105,7 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 						plancheck.ExpectResourceAction(withPropagateOnly.ResourceReference(), plancheck.ResourceActionUpdate),
 					},
 				},
-				Config: config.FromModels(t, providerModel, withPropagateOnly),
+				Config: config.FromModels(t, withPropagateOnly),
 				Check: assertThat(t,
 					resourceassert.TagResource(t, withPropagateOnly.ResourceReference()).
 						HasOnConflictEmpty(),
@@ -123,14 +116,12 @@ func TestAcc_Tag_OnConflict_Bcr2291(t *testing.T) {
 }
 
 func TestAcc_Tag_OnConflictAllowedValuesSequence_Bcr2291(t *testing.T) {
-	id := secondaryTestClient().Ids.RandomSchemaObjectIdentifier()
+	id := testClient().Ids.RandomSchemaObjectIdentifier()
 
 	// Ensure the bundle is always re-enabled after the test, even on failure.
 	t.Cleanup(func() {
-		secondaryTestClient().BcrBundles.EnableBcrBundle(t, "2026_03")
+		testClient().BcrBundles.EnableBcrBundle(t, "2026_03")
 	})
-
-	providerModel := providermodel.SnowflakeProvider().WithProfile(testprofiles.Secondary)
 
 	withAllowedValues := model.TagBase("test", id).
 		WithOrderedAllowedValues("confidential", "internal", "public").
@@ -146,14 +137,14 @@ func TestAcc_Tag_OnConflictAllowedValuesSequence_Bcr2291(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: with the bundle enabled, create a tag with allowed_values + allowed_values_sequence on_conflict.
 			{
-				ProtoV6ProviderFactories: secondaryAccountProviderFactory,
 				PreConfig: func() {
-					secondaryTestClient().BcrBundles.EnableBcrBundle(t, "2026_03")
+					testClient().BcrBundles.EnableBcrBundle(t, "2026_03")
 				},
-				Config: config.FromModels(t, providerModel, withAllowedValues),
+				Config: config.FromModels(t, withAllowedValues),
 				Check: assertThat(t,
 					resourceassert.TagResource(t, resourceRef).
 						HasPropagateEnum(sdk.TagPropagationOnDependency).
@@ -162,13 +153,12 @@ func TestAcc_Tag_OnConflictAllowedValuesSequence_Bcr2291(t *testing.T) {
 			},
 			// Step 2: drop on_conflict; the value is cleared.
 			{
-				ProtoV6ProviderFactories: secondaryAccountProviderFactory,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(withPropagateOnly.ResourceReference(), plancheck.ResourceActionUpdate),
 					},
 				},
-				Config: config.FromModels(t, providerModel, withPropagateOnly),
+				Config: config.FromModels(t, withPropagateOnly),
 				Check: assertThat(t,
 					resourceassert.TagResource(t, withPropagateOnly.ResourceReference()).
 						HasOnConflictEmpty(),


### PR DESCRIPTION
## Changes
- Due to Snowflake Edition differences, BCR tests for tags have to be moved from prod to non-prod CI, where a higher Snowflake Edition account is used, and the test is able to utilize tag propagation.