### PR TITLE
fix: snowflake_saml2_integration enabled defaults to TRUE on unset

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -146,6 +146,14 @@ The field is only populated when the [BCR-2291](https://docs.snowflake.com/en/re
 
 No configuration changes are required.
 
+### *(bug fix)* `snowflake_saml2_integration`: removing `enabled` from config now restores Snowflake's default of `TRUE`
+
+Previously, removing the `enabled` attribute from a `snowflake_saml2_integration` configuration (returning it to its default unmanaged state) caused the provider to issue `ALTER ... SET ENABLED = FALSE`. This contradicted Snowflake's behavior, where the default for `ENABLED` on a SAML2 integration is `TRUE` after [BCR-2166](https://docs.snowflake.com/en/release-notes/bcr-bundles/2026_01/bcr-2166) in bundle `2026_01`.
+
+The provider now issues `ALTER ... SET ENABLED = TRUE` when `enabled` is removed from config, aligning the unmanaged state with Snowflake's actual default. The `UNSET` operation for this object is still not supported in Snowflake.
+
+If you previously relied on the prior behavior (the integration being silently disabled when `enabled` was unset), set `enabled = "false"` explicitly in your configuration before upgrading. Otherwise, no changes are required.
+
 ## v2.15.x ➞ v2.16.0
 
 ### *(improvement)* snowflake_password_policy resource rework

--- a/SNOWFLAKE_BCR_MIGRATION_GUIDE.md
+++ b/SNOWFLAKE_BCR_MIGRATION_GUIDE.md
@@ -94,6 +94,18 @@ If you manage External OAuth security integrations with the [`snowflake_external
 
 Reference: [BCR-2218](https://docs.snowflake.com/en/release-notes/bcr-bundles/2026_02/bcr-2218)
 
+## [Bundle 2026_01](https://docs.snowflake.com/en/release-notes/bcr-bundles/2026_01_bundle)
+
+### CREATE INTEGRATION: `ENABLED` defaults to `TRUE`
+
+When this bundle is enabled on your account, `CREATE ... INTEGRATION` statements that do not specify `ENABLED` default to `ENABLED = TRUE` (previously `FALSE`). This affects all integration types, including SAML2.
+
+The [`snowflake_saml2_integration`](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/saml2_integration) resource has been adjusted to align with this default. The UNSET operation for this integration is not supported in Snowflake, so when `enabled` is removed in config, the provider now sets this as `TRUE`. See the corresponding entry in the [migration guide](./MIGRATION_GUIDE.md#bug-fix-snowflake_saml2_integration-removing-enabled-from-config-now-restores-snowflakes-default-of-true) for details and recommended action.
+
+If you want the integration to remain disabled, set `enabled = "false"` explicitly. Otherwise, no configuration changes are required.
+
+Reference: [BCR-2166](https://docs.snowflake.com/en/release-notes/bcr-bundles/2026_01/bcr-2166)
+
 ## [Bundle 2025_07](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_07_bundle)
 
 ### USAGE privilege on CATALOG INTEGRATION and EXTERNAL VOLUME required for database owner role for all operations

--- a/pkg/resources/saml2_integration.go
+++ b/pkg/resources/saml2_integration.go
@@ -663,7 +663,7 @@ func UpdateContextSAML2Integration(ctx context.Context, d *schema.ResourceData, 
 			set.WithEnabled(parsed)
 		} else {
 			// TODO(SNOW-1515781): UNSET is not implemented
-			set.WithEnabled(false)
+			set.WithEnabled(true)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes `snowflake_saml2_integration` so that removing `enabled` from configuration restores Snowflake's documented default of `TRUE` instead of forcing `FALSE`. The SAML2 SDK does not expose `UNSET ENABLED` (tracked under SNOW-1515781), so the resource explicitly sets `TRUE` to match Snowflake's default (also confirmed by [BCR-2166](https://docs.snowflake.com/en/release-notes/bcr-bundles/2026_01/bcr-2166), bundle `2026_01`).

Migration guide entries added to both `MIGRATION_GUIDE.md` and `SNOWFLAKE_BCR_MIGRATION_GUIDE.md`.

All other integration resources were verified and are working correctly: the OAuth pair (`oauth_integration_for_partner_applications`, `oauth_integration_for_custom_clients`) already issue `UNSET ENABLED` and pick up Snowflake's new default; resources where `enabled` is `Required` are unaffected; resources with Go-bool `Default: true` (`storage_integration`, `api_integration`, `notification_integration`) already match the new default. SAML2 was the only outlier.

[BCR-2166]: https://snowflakecomputing.atlassian.net/browse/BCR-2166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ