### PR TITLE
chore: add stale error repo test

### DIFF
--- a/pkg/testfunctional/3_plugin_framework_functional_tests_provider_test.go
+++ b/pkg/testfunctional/3_plugin_framework_functional_tests_provider_test.go
@@ -70,6 +70,7 @@ func (p *pluginFrameworkFunctionalTestsProvider) Resources(_ context.Context) []
 		testfunctional.NewZeroValuesResource,
 		computednestedlist.NewComputedNestedListResource,
 		httpserver.NewHttpServerResource,
+		testfunctional.NewStaleErrorReproResource,
 		testfunctional.NewStringWithMetadataResource,
 		testfunctional.NewOptionalWithBackingFieldResource,
 		testfunctional.NewParameterHandlingResourcePlanModifierResource,

--- a/pkg/testfunctional/test_resource_stale_error_repro.go
+++ b/pkg/testfunctional/test_resource_stale_error_repro.go
@@ -1,0 +1,116 @@
+package testfunctional
+
+import (
+	"context"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testfunctional/common"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.ResourceWithConfigure = &staleErrorReproResource{}
+
+func NewStaleErrorReproResource() resource.Resource {
+	return &staleErrorReproResource{
+		HttpServerEmbeddable: *common.NewHttpServerEmbeddable[StaleReproRead]("stale_error_repro"),
+	}
+}
+
+type staleErrorReproResource struct {
+	common.HttpServerEmbeddable[StaleReproRead]
+}
+
+// StaleReproRead is the response type returned by the HTTP server handler.
+// The handler generates a new random value on every GET, so successive Read()
+// calls always return different values — the condition that makes the stale
+// plan error 100% reproducible in terraform-plugin-testing v1.14.0.
+type StaleReproRead struct {
+	RandomInt int64 `json:"random_int"`
+}
+
+type staleErrorReproResourceModel struct {
+	Name      types.String `tfsdk:"name"`
+	Id        types.String `tfsdk:"id"`
+	RandomInt types.Int64  `tfsdk:"random_int"`
+}
+
+func (r *staleErrorReproResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_stale_error_repro"
+}
+
+func (r *staleErrorReproResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			// random_int is re-fetched from the HTTP server on every Read call.
+			// The server generates a new value each time, so any two consecutive reads
+			// produce different state — guaranteeing the Refresh() inserted between
+			// CreatePlan and Apply by terraform-plugin-testing v1.14.0 (triggered when
+			// a destroy step has a non-nil Check) always writes a new state serial,
+			// making the plan stale on every single run.
+			"random_int": schema.Int64Attribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (r *staleErrorReproResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data staleErrorReproResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Id = types.StringValue(sdk.NewAccountObjectIdentifier(data.Name.ValueString()).FullyQualifiedName())
+
+	resp.Diagnostics.Append(r.readInto(&data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *staleErrorReproResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data staleErrorReproResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(r.readInto(&data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *staleErrorReproResource) readInto(data *staleErrorReproResourceModel) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+	result, err := r.Get()
+	if err != nil {
+		diags.AddError("Could not read resource state", err.Error())
+		return diags
+	}
+	data.RandomInt = types.Int64Value(result.RandomInt)
+	return diags
+}
+
+func (r *staleErrorReproResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
+}
+
+func (r *staleErrorReproResource) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {
+}

--- a/pkg/testfunctional/test_resource_stale_error_repro.go
+++ b/pkg/testfunctional/test_resource_stale_error_repro.go
@@ -2,10 +2,9 @@ package testfunctional
 
 import (
 	"context"
+	"math/rand/v2"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testfunctional/common"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -13,25 +12,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var _ resource.ResourceWithConfigure = &staleErrorReproResource{}
+var _ resource.Resource = &staleErrorReproResource{}
 
 func NewStaleErrorReproResource() resource.Resource {
-	return &staleErrorReproResource{
-		HttpServerEmbeddable: *common.NewHttpServerEmbeddable[StaleReproRead]("stale_error_repro"),
-	}
+	return &staleErrorReproResource{}
 }
 
-type staleErrorReproResource struct {
-	common.HttpServerEmbeddable[StaleReproRead]
-}
-
-// StaleReproRead is the response type returned by the HTTP server handler.
-// The handler generates a new random value on every GET, so successive Read()
-// calls always return different values — the condition that makes the stale
-// plan error 100% reproducible in terraform-plugin-testing v1.14.0.
-type StaleReproRead struct {
-	RandomInt int64 `json:"random_int"`
-}
+type staleErrorReproResource struct{}
 
 type staleErrorReproResourceModel struct {
 	Name      types.String `tfsdk:"name"`
@@ -55,11 +42,9 @@ func (r *staleErrorReproResource) Schema(_ context.Context, _ resource.SchemaReq
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			// random_int is re-fetched from the HTTP server on every Read call.
-			// The server generates a new value each time, so any two consecutive reads
-			// produce different state — guaranteeing the Refresh() inserted between
-			// CreatePlan and Apply by terraform-plugin-testing v1.14.0 (triggered when
-			// a destroy step has a non-nil Check) always writes a new state serial,
+			// random_int changes on every Read call, so any two consecutive reads produce
+			// different state — guaranteeing the Refresh() inserted between CreatePlan and
+			// Apply by terraform-plugin-testing v1.14.0 always writes a new state serial,
 			// making the plan stale on every single run.
 			"random_int": schema.Int64Attribute{
 				Computed: true,
@@ -76,11 +61,7 @@ func (r *staleErrorReproResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	data.Id = types.StringValue(sdk.NewAccountObjectIdentifier(data.Name.ValueString()).FullyQualifiedName())
-
-	resp.Diagnostics.Append(r.readInto(&data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	data.RandomInt = types.Int64Value(rand.Int64()) // #nosec G404
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -91,22 +72,8 @@ func (r *staleErrorReproResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	resp.Diagnostics.Append(r.readInto(&data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	data.RandomInt = types.Int64Value(rand.Int64()) // #nosec G404
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-}
-
-func (r *staleErrorReproResource) readInto(data *staleErrorReproResourceModel) diag.Diagnostics {
-	diags := diag.Diagnostics{}
-	result, err := r.Get()
-	if err != nil {
-		diags.AddError("Could not read resource state", err.Error())
-		return diags
-	}
-	data.RandomInt = types.Int64Value(result.RandomInt)
-	return diags
 }
 
 func (r *staleErrorReproResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {

--- a/pkg/testfunctional/test_resource_stale_error_repro_acceptance_test.go
+++ b/pkg/testfunctional/test_resource_stale_error_repro_acceptance_test.go
@@ -1,0 +1,104 @@
+package testfunctional_test
+
+// TestAcc_TerraformPluginFrameworkFunctional_StaleErrorRepro reproduces the
+// "Saved plan is stale" error that caused intermittent failures in production
+// acceptance tests (e.g. TestAcc_SecretWithBasicAuthentication_BasicUseCase).
+//
+// Root cause (terraform-plugin-testing v1.14.0):
+//   When a destroy step has a non-nil Check function, the framework inserts an
+//   explicit Refresh() call between CreatePlan(-destroy) and Apply:
+//
+//     1. CreatePlan(-destroy) — plan file embeds the current state snapshot (serial N, value V1)
+//     2. Refresh()            — re-reads all resources; if any value changed, writes a new
+//                               state file (serial N+1, value V2)
+//     3. Apply(plan file)     — Terraform checks plan's embedded serial N against the
+//                               current serial N+1 → "Saved plan is stale"
+//
+//   In production, V1 == V2 most of the time (Snowflake returns byte-identical
+//   responses), so the failure was intermittent (~50% on slow machines).
+//
+// Why this test is consistent:
+//   The HTTP server handler (randomIntHandler) generates a fresh random int64 on
+//   every GET request. Because Read() always returns a different value, step 2
+//   always writes a new serial, making the plan stale on every single run.
+//
+// Fix (terraform-plugin-testing v1.15.0):
+//   The framework no longer calls Refresh() in the destroy+Check path.
+//   In v1.15.0 the Refresh() is removed → the test passes.
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"testing"
+
+	tfresource "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testfunctional"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+// randomIntHandler returns a brand-new random int64 on every GET request.
+// This guarantees that the state after Refresh() differs from the state embedded
+// in the destroy plan, making "Saved plan is stale" 100% reproducible.
+type randomIntHandler struct{}
+
+func (h *randomIntHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(testfunctional.StaleReproRead{RandomInt: rand.Int63()})
+	case http.MethodPost:
+		w.WriteHeader(http.StatusCreated)
+	}
+}
+
+func init() {
+	allTestHandlers["stale_error_repro"] = &randomIntHandler{}
+}
+
+func TestAcc_TerraformPluginFrameworkFunctional_StaleErrorRepro(t *testing.T) {
+	id := sdk.NewAccountObjectIdentifier("stale-repro")
+	resourceType := fmt.Sprintf("%s_stale_error_repro", PluginFrameworkFunctionalTestsProviderName)
+	resourceReference := fmt.Sprintf("%s.test", resourceType)
+
+	tfresource.Test(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: providerForPluginFrameworkFunctionalTestsFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []tfresource.TestStep{
+			{
+				Config: staleErrorReproConfig(id, resourceType),
+				Check: tfresource.ComposeTestCheckFunc(
+					tfresource.TestCheckResourceAttr(resourceReference, "name", id.Name()),
+				),
+			},
+			// Destroy step with a non-nil Check.
+			// In terraform-plugin-testing v1.14.0 this triggers Refresh() between
+			// CreatePlan and Apply.  Because random_int changes on every Read, the
+			// plan is always stale → test fails with "Saved plan is stale".
+			// In v1.15.0 the Refresh() is removed → test passes.
+			{
+				Destroy: true,
+				Config:  staleErrorReproConfig(id, resourceType),
+				// The check is intentionally a no-op: its only purpose is to be
+				// non-nil, which is the condition terraform-plugin-testing v1.14.0
+				// uses to decide whether to insert a Refresh() between plan and apply.
+				// A no-op also ensures the test passes on v1.15.0 once upgraded.
+				Check: tfresource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func staleErrorReproConfig(id sdk.AccountObjectIdentifier, resourceType string) string {
+	return fmt.Sprintf(`
+resource "%[2]s" "test" {
+  provider = "%[3]s"
+  name     = "%[1]s"
+}
+`, id.Name(), resourceType, PluginFrameworkFunctionalTestsProviderName)
+}

--- a/pkg/testfunctional/test_resource_stale_error_repro_acceptance_test.go
+++ b/pkg/testfunctional/test_resource_stale_error_repro_acceptance_test.go
@@ -27,37 +27,14 @@ package testfunctional_test
 //   In v1.15.0 the Refresh() is removed → the test passes.
 
 import (
-	"encoding/json"
 	"fmt"
-	"math/rand/v2"
-	"net/http"
 	"testing"
 
 	tfresource "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testfunctional"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
-
-// randomIntHandler returns a brand-new random int64 on every GET request.
-// This guarantees that the state after Refresh() differs from the state embedded
-// in the destroy plan, making "Saved plan is stale" 100% reproducible.
-type randomIntHandler struct{}
-
-func (h *randomIntHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(testfunctional.StaleReproRead{RandomInt: rand.Int64()}) // #nosec G404
-	case http.MethodPost:
-		w.WriteHeader(http.StatusCreated)
-	}
-}
-
-func init() {
-	allTestHandlers["stale_error_repro"] = &randomIntHandler{}
-}
 
 func TestAcc_TerraformPluginFrameworkFunctional_StaleErrorRepro(t *testing.T) {
 	id := sdk.NewAccountObjectIdentifier("stale-repro")

--- a/pkg/testfunctional/test_resource_stale_error_repro_acceptance_test.go
+++ b/pkg/testfunctional/test_resource_stale_error_repro_acceptance_test.go
@@ -29,7 +29,7 @@ package testfunctional_test
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"testing"
 
@@ -49,7 +49,7 @@ func (h *randomIntHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(testfunctional.StaleReproRead{RandomInt: rand.Int63()})
+		_ = json.NewEncoder(w).Encode(testfunctional.StaleReproRead{RandomInt: rand.Int64()}) // #nosec G404
 	case http.MethodPost:
 		w.WriteHeader(http.StatusCreated)
 	}


### PR DESCRIPTION
## Changes
- Added a functional test that reproduces "Stale plan" error, which we observed during delete steps
- Observations: By running `go get github.com/hashicorp/terraform-plugin-testing@v1.14.0 && go mod tidy` I was able to 100% reproduce the error, and on the currently used testing library, as the release notes suggested, the error does not appear anymore, and the test passes.