### PR TITLE
feat: Adjust oauth_scopes to be optional in secret with client credentials flow

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -26,6 +26,16 @@ for changes required after enabling given [Snowflake BCR Bundle](https://docs.sn
 
 ## v2.16.0 ➞ v2.17.0
 
+### *(enhancement)* `snowflake_secret_with_client_credentials` — `oauth_scopes` is now optional
+
+`oauth_scopes` was previously marked as required in the `snowflake_secret_with_client_credentials` resource, but Snowflake treats it as optional.
+When omitted, the scopes are inherited internally from the attached security integration during the OAuth client credentials flow.
+
+No changes are needed for existing configurations that already specify `oauth_scopes`.
+If you want to omit `oauth_scopes` and rely on the integration's scopes, simply remove the field from your configuration.
+
+References: [#3272](https://github.com/snowflakedb/terraform-provider-snowflake/issues/3272)
+
 ### *(new feature)* snowflake_catalog_integration_aws_glue: new `describe_output` attributes
 
 The `snowflake_catalog_integration_aws_glue` resource now exposes two additional attributes under `describe_output`:

--- a/docs/resources/secret_with_client_credentials.md
+++ b/docs/resources/secret_with_client_credentials.md
@@ -12,8 +12,16 @@ Resource used to manage secret objects with OAuth Client Credentials. For more i
 ## Example Usage
 
 ```terraform
-# basic resource
-resource "snowflake_secret_with_client_credentials" "test" {
+# basic resource (without oauth_scopes — scopes are inherited from the security integration)
+resource "snowflake_secret_with_client_credentials" "basic" {
+  name               = "EXAMPLE_SECRET"
+  database           = "EXAMPLE_DB"
+  schema             = "EXAMPLE_SCHEMA"
+  api_authentication = snowflake_api_authentication_integration_with_client_credentials.example.fully_qualified_name
+}
+
+# resource with explicit oauth_scopes
+resource "snowflake_secret_with_client_credentials" "with_scopes" {
   name               = "EXAMPLE_SECRET"
   database           = "EXAMPLE_DB"
   schema             = "EXAMPLE_SCHEMA"
@@ -22,7 +30,7 @@ resource "snowflake_secret_with_client_credentials" "test" {
 }
 
 # resource with all fields set
-resource "snowflake_secret_with_client_credentials" "test" {
+resource "snowflake_secret_with_client_credentials" "complete" {
   name               = "EXAMPLE_SECRET"
   database           = "EXAMPLE_DB"
   schema             = "EXAMPLE_SCHEMA"
@@ -44,12 +52,12 @@ resource "snowflake_secret_with_client_credentials" "test" {
 - `api_authentication` (String) Specifies the name value of the Snowflake security integration that connects Snowflake to an external service. For more information about this resource, see [docs](./api_authentication_integration_with_client_credentials).
 - `database` (String) The database in which to create the secret Due to technical limitations (read more [here](../guides/identifiers_rework_design_decisions#known-limitations-and-identifier-recommendations)), avoid using the following characters: `|`, `.`, `"`.
 - `name` (String) String that specifies the identifier (i.e. name) for the secret, must be unique in your schema. Due to technical limitations (read more [here](../guides/identifiers_rework_design_decisions#known-limitations-and-identifier-recommendations)), avoid using the following characters: `|`, `.`, `"`.
-- `oauth_scopes` (Set of String) Specifies a list of scopes to use when making a request from the OAuth server by a role with USAGE on the integration during the OAuth client credentials flow.
 - `schema` (String) The schema in which to create the secret. Due to technical limitations (read more [here](../guides/identifiers_rework_design_decisions#known-limitations-and-identifier-recommendations)), avoid using the following characters: `|`, `.`, `"`.
 
 ### Optional
 
 - `comment` (String) Specifies a comment for the secret.
+- `oauth_scopes` (Set of String) Specifies a list of scopes to use when making a request from the OAuth server by a role with USAGE on the integration during the OAuth client credentials flow. If not specified, no scopes are set on the secret; the effective scopes during the OAuth flow are inherited from the security integration.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/examples/resources/snowflake_secret_with_client_credentials/resource.tf
+++ b/examples/resources/snowflake_secret_with_client_credentials/resource.tf
@@ -1,5 +1,13 @@
-# basic resource
-resource "snowflake_secret_with_client_credentials" "test" {
+# basic resource (without oauth_scopes — scopes are inherited from the security integration)
+resource "snowflake_secret_with_client_credentials" "basic" {
+  name               = "EXAMPLE_SECRET"
+  database           = "EXAMPLE_DB"
+  schema             = "EXAMPLE_SCHEMA"
+  api_authentication = snowflake_api_authentication_integration_with_client_credentials.example.fully_qualified_name
+}
+
+# resource with explicit oauth_scopes
+resource "snowflake_secret_with_client_credentials" "with_scopes" {
   name               = "EXAMPLE_SECRET"
   database           = "EXAMPLE_DB"
   schema             = "EXAMPLE_SCHEMA"
@@ -8,7 +16,7 @@ resource "snowflake_secret_with_client_credentials" "test" {
 }
 
 # resource with all fields set
-resource "snowflake_secret_with_client_credentials" "test" {
+resource "snowflake_secret_with_client_credentials" "complete" {
   name               = "EXAMPLE_SECRET"
   database           = "EXAMPLE_DB"
   schema             = "EXAMPLE_SCHEMA"

--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/secret_with_client_credentials_resource_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/secret_with_client_credentials_resource_gen.go
@@ -164,6 +164,11 @@ func (s *SecretWithClientCredentialsResourceAssert) HasFullyQualifiedNameEmpty()
 	return s
 }
 
+func (s *SecretWithClientCredentialsResourceAssert) HasOauthScopesEmpty() *SecretWithClientCredentialsResourceAssert {
+	s.AddAssertion(assert.ValueSet("oauth_scopes.#", "0"))
+	return s
+}
+
 func (s *SecretWithClientCredentialsResourceAssert) HasSecretTypeEmpty() *SecretWithClientCredentialsResourceAssert {
 	s.AddAssertion(assert.ValueSet("secret_type", ""))
 	return s

--- a/pkg/acceptance/bettertestspoc/config/model/secret_with_client_credentials_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/secret_with_client_credentials_model_gen.go
@@ -35,14 +35,12 @@ func SecretWithClientCredentials(
 	schema string,
 	name string,
 	apiAuthentication string,
-	oauthScopes []string,
 ) *SecretWithClientCredentialsModel {
 	s := &SecretWithClientCredentialsModel{ResourceModelMeta: config.Meta(resourceName, resources.SecretWithClientCredentials)}
 	s.WithDatabase(database)
 	s.WithSchema(schema)
 	s.WithName(name)
 	s.WithApiAuthentication(apiAuthentication)
-	s.WithOauthScopes(oauthScopes)
 	return s
 }
 
@@ -51,14 +49,12 @@ func SecretWithClientCredentialsWithDefaultMeta(
 	schema string,
 	name string,
 	apiAuthentication string,
-	oauthScopes []string,
 ) *SecretWithClientCredentialsModel {
 	s := &SecretWithClientCredentialsModel{ResourceModelMeta: config.DefaultMeta(resources.SecretWithClientCredentials)}
 	s.WithDatabase(database)
 	s.WithSchema(schema)
 	s.WithName(name)
 	s.WithApiAuthentication(apiAuthentication)
-	s.WithOauthScopes(oauthScopes)
 	return s
 }
 

--- a/pkg/resources/secret_with_oauth_client_credentials.go
+++ b/pkg/resources/secret_with_oauth_client_credentials.go
@@ -28,8 +28,8 @@ var secretClientCredentialsSchema = func() map[string]*schema.Schema {
 		"oauth_scopes": {
 			Type:        schema.TypeSet,
 			Elem:        &schema.Schema{Type: schema.TypeString},
-			Required:    true,
-			Description: "Specifies a list of scopes to use when making a request from the OAuth server by a role with USAGE on the integration during the OAuth client credentials flow.",
+			Optional:    true,
+			Description: "Specifies a list of scopes to use when making a request from the OAuth server by a role with USAGE on the integration during the OAuth client credentials flow. If not specified, no scopes are set on the secret; the effective scopes during the OAuth flow are inherited from the security integration.",
 		},
 	}
 	return collections.MergeMaps(secretCommonSchema, secretClientCredentials)
@@ -97,12 +97,14 @@ func CreateContextSecretWithClientCredentials(ctx context.Context, d *schema.Res
 
 	request := sdk.NewCreateWithOAuthClientCredentialsFlowSecretRequest(id, apiIntegration)
 
-	stringScopes := expandStringList(d.Get("oauth_scopes").(*schema.Set).List())
-	oauthScopes := make([]sdk.ApiIntegrationScope, len(stringScopes))
-	for i, scope := range stringScopes {
-		oauthScopes[i] = sdk.ApiIntegrationScope{Scope: scope}
+	if v, ok := d.GetOk("oauth_scopes"); ok {
+		stringScopes := expandStringList(v.(*schema.Set).List())
+		oauthScopes := make([]sdk.ApiIntegrationScope, len(stringScopes))
+		for i, scope := range stringScopes {
+			oauthScopes[i] = sdk.ApiIntegrationScope{Scope: scope}
+		}
+		request.WithOauthScopes(sdk.OauthScopesListRequest{OauthScopesList: oauthScopes})
 	}
-	request.WithOauthScopes(sdk.OauthScopesListRequest{OauthScopesList: oauthScopes})
 
 	if v, ok := d.GetOk("comment"); ok {
 		request.WithComment(v.(string))

--- a/pkg/sdk/testint/secrets_gen_integration_test.go
+++ b/pkg/sdk/testint/secrets_gen_integration_test.go
@@ -119,7 +119,6 @@ func TestInt_Secrets(t *testing.T) {
 		})
 	})
 
-	// TODO [SNOW-1678756]: oauth_copes not inherited or not displayed correctly when not provided
 	t.Run("Create: SecretWithOAuthClientCredentialsFlow - Empty Scopes List", func(t *testing.T) {
 		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
 		request := sdk.NewCreateWithOAuthClientCredentialsFlowSecretRequest(id, integrationId).WithOauthScopes(sdk.OauthScopesListRequest{})
@@ -145,6 +144,61 @@ func TestInt_Secrets(t *testing.T) {
 		assert.NotContains(t, details.OauthScopes, "foo")
 		assert.NotContains(t, details.OauthScopes, "bar")
 		assert.Equal(t, []string{}, details.OauthScopes)
+	})
+
+	// Verifies that oauth_scopes are not inherited from the security integration when not set on the secret.
+	// DESC SECRET returns null (empty) for oauth_scopes regardless of what the integration has configured.
+	// Inheritance is internal to Snowflake's OAuth flow and not surfaced in describe output.
+	t.Run("OauthScopes: null when not set, visible when set, null after clearing", func(t *testing.T) {
+		scopedIntegrationId := testClientHelper().Ids.RandomAccountObjectIdentifier()
+		_, scopedIntegrationCleanup := testClientHelper().SecurityIntegration.CreateApiAuthenticationClientCredentialsWithRequest(t,
+			sdk.NewCreateApiAuthenticationWithClientCredentialsFlowSecurityIntegrationRequest(scopedIntegrationId, true, "foo", "foo").
+				WithOauthAllowedScopes([]sdk.AllowedScope{{Scope: "scope1"}, {Scope: "scope2"}, {Scope: "scope3"}}),
+		)
+		t.Cleanup(scopedIntegrationCleanup)
+
+		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
+		err := client.Secrets.CreateWithOAuthClientCredentialsFlow(ctx,
+			sdk.NewCreateWithOAuthClientCredentialsFlowSecretRequest(id, scopedIntegrationId),
+		)
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().Secret.DropFunc(t, id))
+
+		// DESC returns null (empty) when oauth_scopes are not set — inheritance is not surfaced
+		details, err := client.Secrets.Describe(ctx, id)
+		require.NoError(t, err)
+		assert.Empty(t, details.OauthScopes)
+
+		// Set 2 out of 3 available scopes on the secret
+		err = client.Secrets.Alter(ctx, sdk.NewAlterSecretRequest(id).WithSet(
+			*sdk.NewSecretSetRequest().WithSetForFlow(*sdk.NewSetForFlowRequest().
+				WithSetForOAuthClientCredentials(*sdk.NewSetForOAuthClientCredentialsRequest().
+					WithOauthScopes(sdk.OauthScopesListRequest{OauthScopesList: []sdk.ApiIntegrationScope{
+						{Scope: "scope1"}, {Scope: "scope2"},
+					}}),
+				),
+			),
+		))
+		require.NoError(t, err)
+
+		// DESC now shows exactly the scopes that were set
+		details, err = client.Secrets.Describe(ctx, id)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"scope1", "scope2"}, details.OauthScopes)
+
+		// Clear scopes by setting an empty list — DESC returns null (empty) again
+		err = client.Secrets.Alter(ctx, sdk.NewAlterSecretRequest(id).WithSet(
+			*sdk.NewSecretSetRequest().WithSetForFlow(*sdk.NewSetForFlowRequest().
+				WithSetForOAuthClientCredentials(*sdk.NewSetForOAuthClientCredentialsRequest().
+					WithOauthScopes(sdk.OauthScopesListRequest{}),
+				),
+			),
+		))
+		require.NoError(t, err)
+
+		details, err = client.Secrets.Describe(ctx, id)
+		require.NoError(t, err)
+		assert.Empty(t, details.OauthScopes)
 	})
 
 	t.Run("Create: SecretWithOAuthAuthorizationCodeFlow - refreshTokenExpiry date format", func(t *testing.T) {

--- a/pkg/testacc/resource_secret_with_oauth_client_credentials_acceptance_test.go
+++ b/pkg/testacc/resource_secret_with_oauth_client_credentials_acceptance_test.go
@@ -38,9 +38,11 @@ func TestAcc_SecretWithOauthClientCredentials_BasicUseCase(t *testing.T) {
 	oauthScopes := []string{"scope1", "scope2"}
 	currentRole := testClient().Context.CurrentRole(t).Name()
 
-	basic := model.SecretWithClientCredentials("test", id.DatabaseName(), id.SchemaName(), id.Name(), integrationId.Name(), oauthScopes)
+	basic := model.SecretWithClientCredentials("test", id.DatabaseName(), id.SchemaName(), id.Name(), integrationId.Name()).
+		WithOauthScopes(oauthScopes)
 
-	complete := model.SecretWithClientCredentials("test", id.DatabaseName(), id.SchemaName(), id.Name(), integrationId.Name(), []string{"scope3", "scope4"}).
+	complete := model.SecretWithClientCredentials("test", id.DatabaseName(), id.SchemaName(), id.Name(), integrationId.Name()).
+		WithOauthScopes([]string{"scope3", "scope4"}).
 		WithComment(comment)
 
 	assertBasic := []assert.TestCheckFuncProvider{
@@ -221,6 +223,73 @@ func TestAcc_SecretWithOauthClientCredentials_BasicUseCase(t *testing.T) {
 	})
 }
 
+// TestAcc_SecretWithClientCredentials_WithoutOAuthScopes verifies that oauth_scopes is optional.
+// When omitted, DESC SECRET shows no scopes (inheritance from the integration is internal to Snowflake's OAuth flow).
+func TestAcc_SecretWithClientCredentials_WithoutOAuthScopes(t *testing.T) {
+	integrationId := testClient().Ids.RandomAccountObjectIdentifier()
+	_, apiIntegrationCleanup := testClient().SecurityIntegration.CreateApiAuthenticationClientCredentialsWithRequest(t,
+		sdk.NewCreateApiAuthenticationWithClientCredentialsFlowSecurityIntegrationRequest(integrationId, true, "test_client_id", "test_client_secret").
+			WithOauthAllowedScopes([]sdk.AllowedScope{{Scope: "scope1"}, {Scope: "scope2"}, {Scope: "scope3"}}),
+	)
+	t.Cleanup(apiIntegrationCleanup)
+
+	id := testClient().Ids.RandomSchemaObjectIdentifier()
+	secretModelWithoutScopes := model.SecretWithClientCredentials("test", id.DatabaseName(), id.SchemaName(), id.Name(), integrationId.Name())
+	secretModelWithScopes := model.SecretWithClientCredentials("test", id.DatabaseName(), id.SchemaName(), id.Name(), integrationId.Name()).
+		WithOauthScopes([]string{"scope1", "scope2"})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.SecretWithClientCredentials),
+		Steps: []resource.TestStep{
+			// Create without oauth_scopes: DESC shows no scopes (not inherited from integration)
+			{
+				Config: config.FromModels(t, secretModelWithoutScopes),
+				Check: assertThat(t,
+					resourceassert.SecretWithClientCredentialsResource(t, secretModelWithoutScopes.ResourceReference()).
+						HasNameString(id.Name()).
+						HasApiAuthenticationString(integrationId.Name()).
+						HasOauthScopes(),
+					assert.Check(resource.TestCheckResourceAttr(secretModelWithoutScopes.ResourceReference(), "describe_output.0.oauth_scopes.#", "0")),
+				),
+			},
+			// Update: set 2 out of 3 integration scopes
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(secretModelWithScopes.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: config.FromModels(t, secretModelWithScopes),
+				Check: assertThat(t,
+					resourceassert.SecretWithClientCredentialsResource(t, secretModelWithScopes.ResourceReference()).
+						HasOauthScopes("scope1", "scope2"),
+					assert.Check(resource.TestCheckResourceAttr(secretModelWithScopes.ResourceReference(), "describe_output.0.oauth_scopes.#", "2")),
+					assert.Check(resource.TestCheckTypeSetElemAttr(secretModelWithScopes.ResourceReference(), "describe_output.0.oauth_scopes.*", "scope1")),
+					assert.Check(resource.TestCheckTypeSetElemAttr(secretModelWithScopes.ResourceReference(), "describe_output.0.oauth_scopes.*", "scope2")),
+				),
+			},
+			// Update: remove oauth_scopes from config — scopes cleared, DESC shows null again
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(secretModelWithoutScopes.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: config.FromModels(t, secretModelWithoutScopes),
+				Check: assertThat(t,
+					resourceassert.SecretWithClientCredentialsResource(t, secretModelWithoutScopes.ResourceReference()).
+						HasOauthScopes(),
+					assert.Check(resource.TestCheckResourceAttr(secretModelWithoutScopes.ResourceReference(), "describe_output.0.oauth_scopes.#", "0")),
+				),
+			},
+		},
+	})
+}
+
 func TestAcc_SecretWithClientCredentials_EmptyScopesList(t *testing.T) {
 	integrationId := testClient().Ids.RandomAccountObjectIdentifier()
 	_, apiIntegrationCleanup := testClient().SecurityIntegration.CreateApiAuthenticationClientCredentialsWithRequest(t,
@@ -232,9 +301,9 @@ func TestAcc_SecretWithClientCredentials_EmptyScopesList(t *testing.T) {
 	id := testClient().Ids.RandomSchemaObjectIdentifier()
 	name := id.Name()
 
-	secretModel := model.SecretWithClientCredentials("s", id.DatabaseName(), id.SchemaName(), name, integrationId.Name(), []string{})
-	secretModelEmptyScopes := model.SecretWithClientCredentials("s", id.DatabaseName(), id.SchemaName(), name, integrationId.Name(), []string{})
-	secretModelWithScope := model.SecretWithClientCredentials("s", id.DatabaseName(), id.SchemaName(), name, integrationId.Name(), []string{}).WithOauthScopes([]string{"foo"})
+	secretModel := model.SecretWithClientCredentials("s", id.DatabaseName(), id.SchemaName(), name, integrationId.Name())
+	secretModelEmptyScopes := model.SecretWithClientCredentials("s", id.DatabaseName(), id.SchemaName(), name, integrationId.Name()).WithOauthScopes([]string{})
+	secretModelWithScope := model.SecretWithClientCredentials("s", id.DatabaseName(), id.SchemaName(), name, integrationId.Name()).WithOauthScopes([]string{"foo"})
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
@@ -310,7 +379,7 @@ func TestAcc_SecretWithClientCredentials_ExternalSecretTypeChange(t *testing.T) 
 	id := testClient().Ids.RandomSchemaObjectIdentifier()
 	name := id.Name()
 
-	secretModel := model.SecretWithClientCredentials("s", id.DatabaseName(), id.SchemaName(), name, integrationId.Name(), []string{"foo", "bar"})
+	secretModel := model.SecretWithClientCredentials("s", id.DatabaseName(), id.SchemaName(), name, integrationId.Name()).WithOauthScopes([]string{"foo", "bar"})
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
@@ -368,7 +437,7 @@ func TestAcc_SecretWithClientCredentials_ExternalSecretTypeChangeToOAuthAuthCode
 	id := testClient().Ids.RandomSchemaObjectIdentifier()
 	name := id.Name()
 
-	secretModel := model.SecretWithClientCredentials("s", id.DatabaseName(), id.SchemaName(), name, integrationId.Name(), []string{"foo", "bar"})
+	secretModel := model.SecretWithClientCredentials("s", id.DatabaseName(), id.SchemaName(), name, integrationId.Name()).WithOauthScopes([]string{"foo", "bar"})
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,


### PR DESCRIPTION
## Changes
- oauth_scopes, although shown as required in the CREATE SECRET syntax, appears to be optional in the field description. This discrepancy was discussed internally and confirmed: the field is optional, which had already been raised in #3272. As part of this change, oauth_scopes was made optional in the resource (the SDK had already been adjusted), and integration and acceptance tests were added to validate the oauth_scopes behavior. 