### PR TITLE
chore: Generate convert for more SDK objects - part 2

### DIFF
--- a/pkg/sdk/generator/defs/image_repositories_def.go
+++ b/pkg/sdk/generator/defs/image_repositories_def.go
@@ -68,8 +68,9 @@ var imageRepositoriesDef = g.NewInterface(
 		Text("owner").
 		Text("owner_role_type").
 		Text("comment").
-		PlainField("encryption", "ImageRepositoryEncryptionType").
-		Text("privatelink_repository_url"),
+		Enum("encryption", ImageRepositoryEncryptionTypeDef).
+		Text("privatelink_repository_url").
+		WithConvertGeneration(),
 	g.NewQueryStruct("ShowImageRepositories").
 		Show().
 		SQL("IMAGE REPOSITORIES").

--- a/pkg/sdk/generator/defs/listings_def.go
+++ b/pkg/sdk/generator/defs/listings_def.go
@@ -50,7 +50,8 @@ var listingPairs = g.StructPair("listingDBRow", "Listing").
 	OptionalText("rejected_on").
 	OptionalText("organization_profile_name").
 	OptionalText("uniform_listing_locator").
-	OptionalText("detailed_target_accounts")
+	OptionalText("detailed_target_accounts").
+	WithConvertGeneration()
 
 // There are more fields listed than in https://docs.snowflake.com/en/sql-reference/sql/desc-listing
 // They are mapped straight from the DESC LISTING output.
@@ -66,7 +67,7 @@ var listingDetailsPairs = g.StructPair("listingDetailsDBRow", "ListingDetails").
 	OptionalText("subtitle").
 	OptionalText("description").
 	OptionalText("listing_terms").
-	PlainField("state", "ListingState").
+	Enum("state", ListingStateEnumDef).
 	OptionalAccountObjectIdentifier("share", g.WithPlainFieldName("Share")).
 	OptionalAccountObjectIdentifier("application_package", g.WithPlainFieldName("ApplicationPackage")).
 	OptionalText("business_needs").
@@ -113,7 +114,8 @@ var listingDetailsPairs = g.StructPair("listingDetailsDBRow", "ListingDetails").
 	OptionalBool("is_share").
 	OptionalText("request_approval_type").
 	OptionalText("monetization_display_order").
-	OptionalText("legacy_uniform_listing_locators")
+	OptionalText("legacy_uniform_listing_locators").
+	WithConvertGeneration()
 
 var listingVersionPairs = g.StructPair("listingVersionDBRow", "ListingVersion").
 	Text("created_on").
@@ -126,7 +128,8 @@ var listingVersionPairs = g.StructPair("listingVersionDBRow", "ListingVersion").
 	Bool("is_last").
 	OptionalText("comment").
 	Text("source_location_url").
-	OptionalText("git_commit_hash")
+	OptionalText("git_commit_hash").
+	WithConvertGeneration()
 
 var listingsDef = g.NewInterface(
 	"Listings",

--- a/pkg/sdk/generator/defs/network_rules_def.go
+++ b/pkg/sdk/generator/defs/network_rules_def.go
@@ -81,10 +81,11 @@ var networkRulesDef = g.NewInterface(
 			Text("schema_name").
 			Text("owner").
 			Text("comment").
-			PlainField("type", "NetworkRuleType").
-			PlainField("mode", "NetworkRuleMode").
+			Enum("type", NetworkRuleTypeEnumDef).
+			Enum("mode", NetworkRuleModeEnumDef).
 			Number("entries_in_valuelist", g.WithPlainFieldName("EntriesInValueList")).
-			Text("owner_role_type"),
+			Text("owner_role_type").
+			WithConvertGeneration(),
 		g.NewQueryStruct("ShowNetworkRules").
 			Show().
 			SQL("NETWORK RULES").
@@ -105,9 +106,10 @@ var networkRulesDef = g.NewInterface(
 			Text("schema_name").
 			Text("owner").
 			Text("comment").
-			PlainField("type", "NetworkRuleType").
-			PlainField("mode", "NetworkRuleMode").
-			StringList("value_list"),
+			Enum("type", NetworkRuleTypeEnumDef).
+			Enum("mode", NetworkRuleModeEnumDef).
+			StringList("value_list").
+			WithConvertGeneration(),
 		g.NewQueryStruct("ShowNetworkRules").
 			Describe().
 			SQL("NETWORK RULE").

--- a/pkg/sdk/generator/defs/organization_accounts_def.go
+++ b/pkg/sdk/generator/defs/organization_accounts_def.go
@@ -106,7 +106,8 @@ var organizationAccountsDef = g.NewInterface(
 			OptionalText("organization_old_url_saved_on").
 			OptionalText("organization_old_url_last_used").
 			Bool("is_events_account").
-			Bool("is_organization_account"),
+			Bool("is_organization_account").
+			WithConvertGeneration(),
 		g.NewQueryStruct("ShowOrganizationAccounts").
 			Show().
 			SQL("ORGANIZATION ACCOUNTS").

--- a/pkg/sdk/generator/defs/stages_def.go
+++ b/pkg/sdk/generator/defs/stages_def.go
@@ -388,7 +388,8 @@ var stagesDef = g.NewInterface(
 			Text("property", g.WithPlainFieldName("Name")).
 			Text("property_type", g.WithPlainFieldName("Type")).
 			Text("property_value", g.WithPlainFieldName("Value")).
-			Text("property_default", g.WithPlainFieldName("Default")),
+			Text("property_default", g.WithPlainFieldName("Default")).
+			WithConvertGeneration(),
 		g.NewQueryStruct("DescStage").
 			Describe().
 			SQL("STAGE").
@@ -408,13 +409,14 @@ var stagesDef = g.NewInterface(
 			Text("owner").
 			Text("comment").
 			OptionalText("region").
-			PlainField("type", "StageType").
-			Field("cloud", "sql.NullString", "*StageCloud").
+			Enum("type", StageTypeEnumDef).
+			OptionalEnum("cloud", StageCloudEnumDef).
 			// notification_channel is deprecated in Snowflake.
 			Field("storage_integration", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("StorageIntegration")).
 			OptionalText("endpoint").
 			Field("owner_role_type", "sql.NullString", "*string").
-			Field("directory_enabled", "string", "bool"),
+			Field("directory_enabled", "string", "bool").
+			WithConvertGeneration(),
 		g.NewQueryStruct("ShowStages").
 			Show().
 			SQL("STAGES").

--- a/pkg/sdk/generator/defs/user_programmatic_access_tokens_def.go
+++ b/pkg/sdk/generator/defs/user_programmatic_access_tokens_def.go
@@ -13,21 +13,24 @@ var programmaticAccessTokenPairs = g.StructPair("programmaticAccessTokenResultDB
 	AccountObjectIdentifier("user_name", g.WithPlainFieldName("UserName")).
 	OptionalAccountObjectIdentifier("role_restriction", g.WithPlainFieldName("RoleRestriction")).
 	Time("expires_at").
-	PlainField("status", "ProgrammaticAccessTokenStatus").
+	Enum("status", ProgrammaticAccessTokenStatusDef).
 	OptionalText("comment").
 	Time("created_on").
 	Text("created_by").
 	OptionalNumber("mins_to_bypass_network_policy_requirement").
-	OptionalText("rotated_to")
+	OptionalText("rotated_to").
+	WithConvertGeneration()
 
 var addProgrammaticAccessTokenResultPairs = g.StructPair("addProgrammaticAccessTokenResultDBRow", "AddProgrammaticAccessTokenResult").
 	Text("token_name").
-	Text("token_secret")
+	Text("token_secret").
+	WithConvertGeneration()
 
 var rotateProgrammaticAccessTokenResultPairs = g.StructPair("rotateProgrammaticAccessTokenResultDBRow", "RotateProgrammaticAccessTokenResult").
 	Text("token_name").
 	Text("token_secret").
-	Text("rotated_token_name")
+	Text("rotated_token_name").
+	WithConvertGeneration()
 
 var userProgrammaticAccessTokensDef = g.NewInterface(
 	"UserProgrammaticAccessTokens",

--- a/pkg/sdk/image_repositories_enums_gen.go
+++ b/pkg/sdk/image_repositories_enums_gen.go
@@ -4,7 +4,6 @@ package sdk
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 )
 
@@ -22,8 +21,12 @@ var AllImageRepositoryEncryptionTypes = []ImageRepositoryEncryptionType{
 
 func ToImageRepositoryEncryptionType(s string) (ImageRepositoryEncryptionType, error) {
 	s = strings.ToUpper(s)
-	if !slices.Contains(AllImageRepositoryEncryptionTypes, ImageRepositoryEncryptionType(s)) {
-		return "", fmt.Errorf("invalid ImageRepositoryEncryptionType: %s", s)
+	switch s {
+	case string(ImageRepositoryEncryptionTypeSnowflakeFull):
+		return ImageRepositoryEncryptionTypeSnowflakeFull, nil
+	case string(ImageRepositoryEncryptionTypeSnowflakeSse):
+		return ImageRepositoryEncryptionTypeSnowflakeSse, nil
+	default:
+		return "", fmt.Errorf("invalid image repository encryption type: %s", s)
 	}
-	return ImageRepositoryEncryptionType(s), nil
 }

--- a/pkg/sdk/image_repositories_impl_gen.go
+++ b/pkg/sdk/image_repositories_impl_gen.go
@@ -107,8 +107,7 @@ func (r *ShowImageRepositoryRequest) toOpts() *ShowImageRepositoryOptions {
 }
 
 func (r imageRepositoriesRow) convert() (*ImageRepository, error) {
-	// added manually
-	imageRepository := &ImageRepository{
+	result := &ImageRepository{
 		CreatedOn:                r.CreatedOn,
 		Name:                     r.Name,
 		DatabaseName:             r.DatabaseName,
@@ -119,10 +118,6 @@ func (r imageRepositoriesRow) convert() (*ImageRepository, error) {
 		Comment:                  r.Comment,
 		PrivatelinkRepositoryUrl: r.PrivatelinkRepositoryUrl,
 	}
-	if encryption, err := ToImageRepositoryEncryptionType(r.Encryption); err != nil {
-		return nil, err
-	} else {
-		imageRepository.Encryption = encryption
-	}
-	return imageRepository, nil
+	mapStringWithMapping(&result.Encryption, r.Encryption, ToImageRepositoryEncryptionType)
+	return result, nil
 }

--- a/pkg/sdk/listings_impl_gen.go
+++ b/pkg/sdk/listings_impl_gen.go
@@ -36,6 +36,14 @@ func (v *listings) Drop(ctx context.Context, request *DropListingRequest) error 
 }
 
 func (v *listings) DropSafely(ctx context.Context, id AccountObjectIdentifier) error {
+	// Adjusted manually
+	if l, err := v.ShowByIDSafely(ctx, id); err == nil {
+		if l.State == ListingStatePublished {
+			if err := v.Alter(ctx, NewAlterListingRequest(id).WithIfExists(true).WithUnpublish(true)); err != nil {
+				return err
+			}
+		}
+	}
 	return SafeDrop(v.client, func() error { return v.Drop(ctx, NewDropListingRequest(id).WithIfExists(true)) }, ctx, id)
 }
 

--- a/pkg/sdk/listings_impl_gen.go
+++ b/pkg/sdk/listings_impl_gen.go
@@ -36,14 +36,6 @@ func (v *listings) Drop(ctx context.Context, request *DropListingRequest) error 
 }
 
 func (v *listings) DropSafely(ctx context.Context, id AccountObjectIdentifier) error {
-	// Adjusted manually
-	if l, err := v.ShowByIDSafely(ctx, id); err == nil {
-		if l.State == ListingStatePublished {
-			if err := v.Alter(ctx, NewAlterListingRequest(id).WithIfExists(true).WithUnpublish(true)); err != nil {
-				return err
-			}
-		}
-	}
 	return SafeDrop(v.client, func() error { return v.Drop(ctx, NewDropListingRequest(id).WithIfExists(true)) }, ctx, id)
 }
 
@@ -163,8 +155,7 @@ func (r *ShowListingRequest) toOpts() *ShowListingOptions {
 }
 
 func (r listingDBRow) convert() (*Listing, error) {
-	// added manually
-	l := &Listing{
+	result := &Listing{
 		GlobalName:     r.GlobalName,
 		Name:           r.Name,
 		Title:          r.Title,
@@ -178,25 +169,21 @@ func (r listingDBRow) convert() (*Listing, error) {
 		IsApplication:  r.IsApplication,
 		IsTargeted:     r.IsTargeted,
 	}
-	// TODO [SNOW-3108659]: else return err?
-	if state, err := ToListingState(r.State); err == nil {
-		l.State = state
-	}
-	mapNullString(&l.ReviewState, r.ReviewState)
-	mapNullString(&l.Subtitle, r.Subtitle)
-	mapNullString(&l.PublishedOn, r.PublishedOn)
-	mapNullString(&l.Comment, r.Comment)
-	mapNullString(&l.Regions, r.Regions)
-	mapNullBool(&l.IsLimitedTrial, r.IsLimitedTrial)
-	mapNullBool(&l.IsByRequest, r.IsByRequest)
-	mapNullString(&l.Distribution, r.Distribution)
-	mapNullBool(&l.IsMountlessQueryable, r.IsMountlessQueryable)
-	mapNullString(&l.RejectedOn, r.RejectedOn)
-	mapNullString(&l.OrganizationProfileName, r.OrganizationProfileName)
-	mapNullString(&l.UniformListingLocator, r.UniformListingLocator)
-	mapNullString(&l.DetailedTargetAccounts, r.DetailedTargetAccounts)
-
-	return l, nil
+	mapNullString(&result.Subtitle, r.Subtitle)
+	mapNullString(&result.PublishedOn, r.PublishedOn)
+	mapStringWithMapping(&result.State, r.State, ToListingState)
+	mapNullString(&result.ReviewState, r.ReviewState)
+	mapNullString(&result.Comment, r.Comment)
+	mapNullString(&result.Regions, r.Regions)
+	mapNullBool(&result.IsLimitedTrial, r.IsLimitedTrial)
+	mapNullBool(&result.IsByRequest, r.IsByRequest)
+	mapNullString(&result.Distribution, r.Distribution)
+	mapNullBool(&result.IsMountlessQueryable, r.IsMountlessQueryable)
+	mapNullString(&result.RejectedOn, r.RejectedOn)
+	mapNullString(&result.OrganizationProfileName, r.OrganizationProfileName)
+	mapNullString(&result.UniformListingLocator, r.UniformListingLocator)
+	mapNullString(&result.DetailedTargetAccounts, r.DetailedTargetAccounts)
+	return result, nil
 }
 
 func (r *DescribeListingRequest) toOpts() *DescribeListingOptions {
@@ -208,8 +195,7 @@ func (r *DescribeListingRequest) toOpts() *DescribeListingOptions {
 }
 
 func (r listingDetailsDBRow) convert() (*ListingDetails, error) {
-	// added manually
-	ld := &ListingDetails{
+	result := &ListingDetails{
 		GlobalName:    r.GlobalName,
 		Name:          r.Name,
 		Owner:         r.Owner,
@@ -218,61 +204,59 @@ func (r listingDetailsDBRow) convert() (*ListingDetails, error) {
 		UpdatedOn:     r.UpdatedOn,
 		Title:         r.Title,
 		Revisions:     r.Revisions,
-		ManifestYaml:  r.ManifestYaml,
 		IsMonetized:   r.IsMonetized,
 		IsApplication: r.IsApplication,
 		IsTargeted:    r.IsTargeted,
+		ManifestYaml:  r.ManifestYaml,
 	}
-
-	mapNullString(&ld.ReviewState, r.ReviewState)
-	mapNullString(&ld.PublishedOn, r.PublishedOn)
-	mapNullString(&ld.Subtitle, r.Subtitle)
-	mapNullString(&ld.Description, r.Description)
-	mapNullString(&ld.ListingTerms, r.ListingTerms)
-	mapStringWithMapping(&ld.State, r.State, ToListingState)
-	mapNullStringWithMapping(&ld.Share, r.Share, ParseAccountObjectIdentifier)
-	mapNullStringWithMapping(&ld.ApplicationPackage, r.ApplicationPackage, ParseAccountObjectIdentifier)
-	mapNullString(&ld.BusinessNeeds, r.BusinessNeeds)
-	mapNullString(&ld.UsageExamples, r.UsageExamples)
-	mapNullString(&ld.DataAttributes, r.DataAttributes)
-	mapNullString(&ld.Categories, r.Categories)
-	mapNullString(&ld.Resources, r.Resources)
-	mapNullString(&ld.Profile, r.Profile)
-	mapNullString(&ld.CustomizedContactInfo, r.CustomizedContactInfo)
-	mapNullString(&ld.DataDictionary, r.DataDictionary)
-	mapNullString(&ld.DataPreview, r.DataPreview)
-	mapNullString(&ld.Comment, r.Comment)
-	mapNullString(&ld.TargetAccounts, r.TargetAccounts)
-	mapNullString(&ld.Regions, r.Regions)
-	mapNullString(&ld.RefreshSchedule, r.RefreshSchedule)
-	mapNullString(&ld.RefreshType, r.RefreshType)
-	mapNullString(&ld.RejectionReason, r.RejectionReason)
-	mapNullString(&ld.UnpublishedByAdminReasons, r.UnpublishedByAdminReasons)
-	mapNullBool(&ld.IsLimitedTrial, r.IsLimitedTrial)
-	mapNullBool(&ld.IsByRequest, r.IsByRequest)
-	mapNullString(&ld.LimitedTrialPlan, r.LimitedTrialPlan)
-	mapNullString(&ld.RetriedOn, r.RetriedOn)
-	mapNullString(&ld.ScheduledDropTime, r.ScheduledDropTime)
-	mapNullString(&ld.Distribution, r.Distribution)
-	mapNullBool(&ld.IsMountlessQueryable, r.IsMountlessQueryable)
-	mapNullString(&ld.OrganizationProfileName, r.OrganizationProfileName)
-	mapNullString(&ld.UniformListingLocator, r.UniformListingLocator)
-	mapNullString(&ld.TrialDetails, r.TrialDetails)
-	mapNullString(&ld.ApproverContact, r.ApproverContact)
-	mapNullString(&ld.SupportContact, r.SupportContact)
-	mapNullString(&ld.LiveVersionUri, r.LiveVersionUri)
-	mapNullString(&ld.LastCommittedVersionUri, r.LastCommittedVersionUri)
-	mapNullString(&ld.LastCommittedVersionName, r.LastCommittedVersionName)
-	mapNullString(&ld.LastCommittedVersionAlias, r.LastCommittedVersionAlias)
-	mapNullString(&ld.PublishedVersionUri, r.PublishedVersionUri)
-	mapNullString(&ld.PublishedVersionName, r.PublishedVersionName)
-	mapNullString(&ld.PublishedVersionAlias, r.PublishedVersionAlias)
-	mapNullBool(&ld.IsShare, r.IsShare)
-	mapNullString(&ld.RequestApprovalType, r.RequestApprovalType)
-	mapNullString(&ld.MonetizationDisplayOrder, r.MonetizationDisplayOrder)
-	mapNullString(&ld.LegacyUniformListingLocators, r.LegacyUniformListingLocators)
-
-	return ld, nil
+	mapNullString(&result.PublishedOn, r.PublishedOn)
+	mapNullString(&result.Subtitle, r.Subtitle)
+	mapNullString(&result.Description, r.Description)
+	mapNullString(&result.ListingTerms, r.ListingTerms)
+	mapStringWithMapping(&result.State, r.State, ToListingState)
+	mapNullStringWithMapping(&result.Share, r.Share, ParseAccountObjectIdentifier)
+	mapNullStringWithMapping(&result.ApplicationPackage, r.ApplicationPackage, ParseAccountObjectIdentifier)
+	mapNullString(&result.BusinessNeeds, r.BusinessNeeds)
+	mapNullString(&result.UsageExamples, r.UsageExamples)
+	mapNullString(&result.DataAttributes, r.DataAttributes)
+	mapNullString(&result.Categories, r.Categories)
+	mapNullString(&result.Resources, r.Resources)
+	mapNullString(&result.Profile, r.Profile)
+	mapNullString(&result.CustomizedContactInfo, r.CustomizedContactInfo)
+	mapNullString(&result.DataDictionary, r.DataDictionary)
+	mapNullString(&result.DataPreview, r.DataPreview)
+	mapNullString(&result.Comment, r.Comment)
+	mapNullString(&result.TargetAccounts, r.TargetAccounts)
+	mapNullString(&result.Regions, r.Regions)
+	mapNullString(&result.RefreshSchedule, r.RefreshSchedule)
+	mapNullString(&result.RefreshType, r.RefreshType)
+	mapNullString(&result.ReviewState, r.ReviewState)
+	mapNullString(&result.RejectionReason, r.RejectionReason)
+	mapNullString(&result.UnpublishedByAdminReasons, r.UnpublishedByAdminReasons)
+	mapNullBool(&result.IsLimitedTrial, r.IsLimitedTrial)
+	mapNullBool(&result.IsByRequest, r.IsByRequest)
+	mapNullString(&result.LimitedTrialPlan, r.LimitedTrialPlan)
+	mapNullString(&result.RetriedOn, r.RetriedOn)
+	mapNullString(&result.ScheduledDropTime, r.ScheduledDropTime)
+	mapNullString(&result.Distribution, r.Distribution)
+	mapNullBool(&result.IsMountlessQueryable, r.IsMountlessQueryable)
+	mapNullString(&result.OrganizationProfileName, r.OrganizationProfileName)
+	mapNullString(&result.UniformListingLocator, r.UniformListingLocator)
+	mapNullString(&result.TrialDetails, r.TrialDetails)
+	mapNullString(&result.ApproverContact, r.ApproverContact)
+	mapNullString(&result.SupportContact, r.SupportContact)
+	mapNullString(&result.LiveVersionUri, r.LiveVersionUri)
+	mapNullString(&result.LastCommittedVersionUri, r.LastCommittedVersionUri)
+	mapNullString(&result.LastCommittedVersionName, r.LastCommittedVersionName)
+	mapNullString(&result.LastCommittedVersionAlias, r.LastCommittedVersionAlias)
+	mapNullString(&result.PublishedVersionUri, r.PublishedVersionUri)
+	mapNullString(&result.PublishedVersionName, r.PublishedVersionName)
+	mapNullString(&result.PublishedVersionAlias, r.PublishedVersionAlias)
+	mapNullBool(&result.IsShare, r.IsShare)
+	mapNullString(&result.RequestApprovalType, r.RequestApprovalType)
+	mapNullString(&result.MonetizationDisplayOrder, r.MonetizationDisplayOrder)
+	mapNullString(&result.LegacyUniformListingLocators, r.LegacyUniformListingLocators)
+	return result, nil
 }
 
 func (r *ShowVersionsListingRequest) toOpts() *ShowVersionsListingOptions {
@@ -284,8 +268,7 @@ func (r *ShowVersionsListingRequest) toOpts() *ShowVersionsListingOptions {
 }
 
 func (r listingVersionDBRow) convert() (*ListingVersion, error) {
-	// added manually
-	lv := &ListingVersion{
+	result := &ListingVersion{
 		CreatedOn:         r.CreatedOn,
 		Name:              r.Name,
 		LocationUrl:       r.LocationUrl,
@@ -295,10 +278,8 @@ func (r listingVersionDBRow) convert() (*ListingVersion, error) {
 		IsLast:            r.IsLast,
 		SourceLocationUrl: r.SourceLocationUrl,
 	}
-
-	mapNullString(&lv.Alias, r.Alias)
-	mapNullString(&lv.Comment, r.Comment)
-	mapNullString(&lv.GitCommitHash, r.GitCommitHash)
-
-	return lv, nil
+	mapNullString(&result.Alias, r.Alias)
+	mapNullString(&result.Comment, r.Comment)
+	mapNullString(&result.GitCommitHash, r.GitCommitHash)
+	return result, nil
 }

--- a/pkg/sdk/mapping_helpers.go
+++ b/pkg/sdk/mapping_helpers.go
@@ -27,7 +27,7 @@ func mapNullString(stringField **string, sqlValue sql.NullString) {
 // mapNullStringWithMapping maps a sql.NullString to a pointer of type T using a provided mapper function.
 // Be careful with the sensitive values as the mapper function can return an error, which is then logged by this function.
 func mapNullStringWithMapping[T any](stringField **T, sqlValue sql.NullString, mapper func(string) (T, error)) {
-	if sqlValue.Valid {
+	if sqlValue.Valid && sqlValue.String != "" {
 		if mappedValue, err := mapper(sqlValue.String); err == nil {
 			*stringField = &mappedValue
 		} else {

--- a/pkg/sdk/network_rules_impl_gen.go
+++ b/pkg/sdk/network_rules_impl_gen.go
@@ -2,10 +2,8 @@
 
 package sdk
 
-// imports adjusted manually
 import (
 	"context"
-	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
@@ -126,20 +124,19 @@ func (r *ShowNetworkRuleRequest) toOpts() *ShowNetworkRuleOptions {
 }
 
 func (r ShowNetworkRulesRow) convert() (*NetworkRule, error) {
-	// adjusted manually
-	return &NetworkRule{
-		CreatedOn:    r.CreatedOn,
-		Name:         r.Name,
-		DatabaseName: r.DatabaseName,
-		SchemaName:   r.SchemaName,
-		Owner:        r.Owner,
-		Comment:      r.Comment,
-		// TODO [SNOW-3108659]: use enum mapping instead
-		Type:               NetworkRuleType(r.Type),
-		Mode:               NetworkRuleMode(r.Mode),
+	result := &NetworkRule{
+		CreatedOn:          r.CreatedOn,
+		Name:               r.Name,
+		DatabaseName:       r.DatabaseName,
+		SchemaName:         r.SchemaName,
+		Owner:              r.Owner,
+		Comment:            r.Comment,
 		EntriesInValueList: r.EntriesInValuelist,
 		OwnerRoleType:      r.OwnerRoleType,
-	}, nil
+	}
+	mapStringWithMapping(&result.Type, r.Type, ToNetworkRuleType)
+	mapStringWithMapping(&result.Mode, r.Mode, ToNetworkRuleMode)
+	return result, nil
 }
 
 func (r *DescribeNetworkRuleRequest) toOpts() *DescribeNetworkRuleOptions {
@@ -150,20 +147,16 @@ func (r *DescribeNetworkRuleRequest) toOpts() *DescribeNetworkRuleOptions {
 }
 
 func (r DescNetworkRulesRow) convert() (*NetworkRuleDetails, error) {
-	// adjusted manually
-	valueList := strings.Split(r.ValueList, ",")
-	if len(valueList) == 1 && valueList[0] == "" {
-		valueList = []string{}
-	}
-	return &NetworkRuleDetails{
+	result := &NetworkRuleDetails{
 		CreatedOn:    r.CreatedOn,
 		Name:         r.Name,
 		DatabaseName: r.DatabaseName,
 		SchemaName:   r.SchemaName,
 		Owner:        r.Owner,
 		Comment:      r.Comment,
-		Type:         NetworkRuleType(r.Type),
-		Mode:         NetworkRuleMode(r.Mode),
-		ValueList:    valueList,
-	}, nil
+	}
+	mapStringWithMapping(&result.Type, r.Type, ToNetworkRuleType)
+	mapStringWithMapping(&result.Mode, r.Mode, ToNetworkRuleMode)
+	result.ValueList = ParseCommaSeparatedStringArray(r.ValueList, false)
+	return result, nil
 }

--- a/pkg/sdk/organization_accounts_impl_gen.go
+++ b/pkg/sdk/organization_accounts_impl_gen.go
@@ -110,8 +110,7 @@ func (r *ShowOrganizationAccountRequest) toOpts() *ShowOrganizationAccountOption
 }
 
 func (r organizationAccountDbRow) convert() (*OrganizationAccount, error) {
-	// adjusted manually
-	oa := &OrganizationAccount{
+	result := &OrganizationAccount{
 		OrganizationName:             r.OrganizationName,
 		AccountName:                  r.AccountName,
 		SnowflakeRegion:              r.SnowflakeRegion,
@@ -125,15 +124,15 @@ func (r organizationAccountDbRow) convert() (*OrganizationAccount, error) {
 		IsEventsAccount:              r.IsEventsAccount,
 		IsOrganizationAccount:        r.IsOrganizationAccount,
 	}
-	mapStringWithMapping(&oa.Edition, r.Edition, ToOrganizationAccountEdition)
-	mapNullString(&oa.Comment, r.Comment)
-	mapNullString(&oa.MarketplaceConsumerBillingEntityName, r.MarketplaceConsumerBillingEntityName)
-	mapNullString(&oa.MarketplaceProviderBillingEntityName, r.MarketplaceProviderBillingEntityName)
-	mapNullString(&oa.OldAccountUrl, r.OldAccountUrl)
-	mapNullString(&oa.AccountOldUrlSavedOn, r.AccountOldUrlSavedOn)
-	mapNullString(&oa.AccountOldUrlLastUsed, r.AccountOldUrlLastUsed)
-	mapNullString(&oa.OrganizationOldUrl, r.OrganizationOldUrl)
-	mapNullString(&oa.OrganizationOldUrlSavedOn, r.OrganizationOldUrlSavedOn)
-	mapNullString(&oa.OrganizationOldUrlLastUsed, r.OrganizationOldUrlLastUsed)
-	return oa, nil
+	mapStringWithMapping(&result.Edition, r.Edition, ToOrganizationAccountEdition)
+	mapNullString(&result.Comment, r.Comment)
+	mapNullString(&result.MarketplaceConsumerBillingEntityName, r.MarketplaceConsumerBillingEntityName)
+	mapNullString(&result.MarketplaceProviderBillingEntityName, r.MarketplaceProviderBillingEntityName)
+	mapNullString(&result.OldAccountUrl, r.OldAccountUrl)
+	mapNullString(&result.AccountOldUrlSavedOn, r.AccountOldUrlSavedOn)
+	mapNullString(&result.AccountOldUrlLastUsed, r.AccountOldUrlLastUsed)
+	mapNullString(&result.OrganizationOldUrl, r.OrganizationOldUrl)
+	mapNullString(&result.OrganizationOldUrlSavedOn, r.OrganizationOldUrlSavedOn)
+	mapNullString(&result.OrganizationOldUrlLastUsed, r.OrganizationOldUrlLastUsed)
+	return result, nil
 }

--- a/pkg/sdk/stages_impl_gen.go
+++ b/pkg/sdk/stages_impl_gen.go
@@ -4,7 +4,6 @@ package sdk
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
@@ -513,15 +512,14 @@ func (r *DescribeStageRequest) toOpts() *DescribeStageOptions {
 }
 
 func (r stageDescRow) convert() (*StageProperty, error) {
-	// adjusted manually
-	stageProp := &StageProperty{
+	result := &StageProperty{
 		Parent:  r.ParentProperty,
 		Name:    r.Property,
 		Type:    r.PropertyType,
 		Value:   r.PropertyValue,
 		Default: r.PropertyDefault,
 	}
-	return stageProp, nil
+	return result, nil
 }
 
 func (r *ShowStageRequest) toOpts() *ShowStageOptions {
@@ -533,8 +531,7 @@ func (r *ShowStageRequest) toOpts() *ShowStageOptions {
 }
 
 func (r stageShowRow) convert() (*Stage, error) {
-	// adjusted manually
-	stage := &Stage{
+	result := &Stage{
 		CreatedOn:        r.CreatedOn,
 		Name:             r.Name,
 		DatabaseName:     r.DatabaseName,
@@ -546,33 +543,11 @@ func (r stageShowRow) convert() (*Stage, error) {
 		Comment:          r.Comment,
 		DirectoryEnabled: r.DirectoryEnabled == "Y",
 	}
-	stageType, err := ToStageType(r.Type)
-	if err != nil {
-		return nil, err
-	}
-	stage.Type = stageType
-	if r.Region.Valid {
-		stage.Region = &r.Region.String
-	}
-	if r.Cloud.Valid {
-		cloud, err := ToStageCloud(r.Cloud.String)
-		if err != nil {
-			return nil, err
-		}
-		stage.Cloud = &cloud
-	}
-	if r.StorageIntegration.Valid {
-		id, err := ParseAccountObjectIdentifier(r.StorageIntegration.String)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse storage integration: %w", err)
-		}
-		stage.StorageIntegration = &id
-	}
-	if r.Endpoint.Valid {
-		stage.Endpoint = &r.Endpoint.String
-	}
-	if r.OwnerRoleType.Valid {
-		stage.OwnerRoleType = &r.OwnerRoleType.String
-	}
-	return stage, nil
+	mapNullString(&result.Region, r.Region)
+	mapStringWithMapping(&result.Type, r.Type, ToStageType)
+	mapNullStringWithMapping(&result.Cloud, r.Cloud, ToStageCloud)
+	mapNullStringWithMapping(&result.StorageIntegration, r.StorageIntegration, ParseAccountObjectIdentifier)
+	mapNullString(&result.Endpoint, r.Endpoint)
+	mapNullString(&result.OwnerRoleType, r.OwnerRoleType)
+	return result, nil
 }

--- a/pkg/sdk/testint/listings_integration_test.go
+++ b/pkg/sdk/testint/listings_integration_test.go
@@ -537,7 +537,7 @@ func TestInt_Listings(t *testing.T) {
 }`, *listingDetails.ListingTerms)
 		assert.Equal(t, sdk.ListingStateDraft, listingDetails.State)
 		assert.Equal(t, share.ID().Name(), listingDetails.Share.Name())
-		assert.Empty(t, listingDetails.ApplicationPackage.Name()) // Application package is returned even if listing is not associated with one, but it is empty in that case
+		assert.Nil(t, listingDetails.ApplicationPackage)
 		assert.Nil(t, listingDetails.BusinessNeeds)
 		assert.Nil(t, listingDetails.UsageExamples)
 		assert.Nil(t, listingDetails.DataAttributes)

--- a/pkg/sdk/user_programmatic_access_tokens_impl_gen.go
+++ b/pkg/sdk/user_programmatic_access_tokens_impl_gen.go
@@ -2,10 +2,8 @@
 
 package sdk
 
-// imports adjusted manually
 import (
 	"context"
-	"fmt"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
@@ -88,11 +86,11 @@ func (r *AddUserProgrammaticAccessTokenRequest) toOpts() *AddUserProgrammaticAcc
 }
 
 func (r addProgrammaticAccessTokenResultDBRow) convert() (*AddProgrammaticAccessTokenResult, error) {
-	// adjusted manually
-	return &AddProgrammaticAccessTokenResult{
+	result := &AddProgrammaticAccessTokenResult{
 		TokenName:   r.TokenName,
 		TokenSecret: r.TokenSecret,
-	}, nil
+	}
+	return result, nil
 }
 
 func (r *ModifyUserProgrammaticAccessTokenRequest) toOpts() *ModifyUserProgrammaticAccessTokenOptions {
@@ -130,12 +128,12 @@ func (r *RotateUserProgrammaticAccessTokenRequest) toOpts() *RotateUserProgramma
 }
 
 func (r rotateProgrammaticAccessTokenResultDBRow) convert() (*RotateProgrammaticAccessTokenResult, error) {
-	// adjusted manually
-	return &RotateProgrammaticAccessTokenResult{
+	result := &RotateProgrammaticAccessTokenResult{
 		TokenName:        r.TokenName,
 		TokenSecret:      r.TokenSecret,
 		RotatedTokenName: r.RotatedTokenName,
-	}, nil
+	}
+	return result, nil
 }
 
 func (r *RemoveUserProgrammaticAccessTokenRequest) toOpts() *RemoveUserProgrammaticAccessTokenOptions {
@@ -155,40 +153,17 @@ func (r *ShowUserProgrammaticAccessTokenRequest) toOpts() *ShowUserProgrammaticA
 }
 
 func (r programmaticAccessTokenResultDBRow) convert() (*ProgrammaticAccessToken, error) {
-	// adjusted manually
-	token := &ProgrammaticAccessToken{
+	result := &ProgrammaticAccessToken{
 		Name:      r.Name,
 		ExpiresAt: r.ExpiresAt,
 		CreatedOn: r.CreatedOn,
 		CreatedBy: r.CreatedBy,
 	}
-	userName, err := ParseAccountObjectIdentifier(r.UserName)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing user name: %w", err)
-	} else {
-		token.UserName = userName
-	}
-	if r.RoleRestriction.Valid && r.RoleRestriction.String != "" {
-		roleRestriction, err := ParseAccountObjectIdentifier(r.RoleRestriction.String)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing role restriction: %w", err)
-		}
-		token.RoleRestriction = &roleRestriction
-	}
-	status, err := ToProgrammaticAccessTokenStatus(r.Status)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing programmatic access token status: %w", err)
-	} else {
-		token.Status = status
-	}
-	if r.Comment.Valid {
-		token.Comment = &r.Comment.String
-	}
-	if r.MinsToBypassNetworkPolicyRequirement.Valid {
-		token.MinsToBypassNetworkPolicyRequirement = Pointer(int(r.MinsToBypassNetworkPolicyRequirement.Int64))
-	}
-	if r.RotatedTo.Valid {
-		token.RotatedTo = &r.RotatedTo.String
-	}
-	return token, nil
+	mapStringWithMapping(&result.UserName, r.UserName, ParseAccountObjectIdentifier)
+	mapNullStringWithMapping(&result.RoleRestriction, r.RoleRestriction, ParseAccountObjectIdentifier)
+	mapStringWithMapping(&result.Status, r.Status, ToProgrammaticAccessTokenStatus)
+	mapNullString(&result.Comment, r.Comment)
+	mapNullInt(&result.MinsToBypassNetworkPolicyRequirement, r.MinsToBypassNetworkPolicyRequirement)
+	mapNullString(&result.RotatedTo, r.RotatedTo)
+	return result, nil
 }


### PR DESCRIPTION
Continuation of https://github.com/snowflakedb/terraform-provider-snowflake/pull/4740.                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  Fixes the remaining `PlainField(col, EnumType)` blockers in 5 defs and enables `WithConvertGeneration()` on them, producing generated `convert()` bodies for image_repositories, listings, network_rules, organization_accounts, stages, and user_programmatic_access_tokens.

  Follow-ups:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
  - Continue with generating convert for other objects
  - Handle errors properly for all converts      