### PR TITLE
chore: Extract manual validation blocks from SDK validations gen files

### DIFF
--- a/pkg/sdk/api_integrations_ext.go
+++ b/pkg/sdk/api_integrations_ext.go
@@ -1,5 +1,12 @@
 package sdk
 
+func (s *ApiIntegrationSet) additionalValidations() error {
+	if moreThanOneValueSet(s.AwsParams, s.AzureParams, s.GoogleParams) {
+		return errMoreThanOneOf("AlterApiIntegrationOptions.Set", "AwsParams", "AzureParams", "GoogleParams")
+	}
+	return nil
+}
+
 func (r *CreateApiIntegrationRequest) GetName() AccountObjectIdentifier {
 	return r.name
 }

--- a/pkg/sdk/api_integrations_validations_gen.go
+++ b/pkg/sdk/api_integrations_validations_gen.go
@@ -45,10 +45,7 @@ func (opts *AlterApiIntegrationOptions) validate() error {
 		errs = append(errs, errExactlyOneOf("AlterApiIntegrationOptions", "Set", "Unset", "SetTags", "UnsetTags"))
 	}
 	if valueSet(opts.Set) {
-		// Edited manually
-		if moreThanOneValueSet(opts.Set.AwsParams, opts.Set.AzureParams, opts.Set.GoogleParams) {
-			errs = append(errs, errMoreThanOneOf("AlterApiIntegrationOptions.Set", "AwsParams", "AzureParams", "GoogleParams"))
-		}
+		errs = append(errs, opts.Set.additionalValidations()) // invocation added manually
 		if !anyValueSet(opts.Set.AwsParams, opts.Set.AzureParams, opts.Set.GoogleParams, opts.Set.Enabled, opts.Set.ApiAllowedPrefixes, opts.Set.ApiBlockedPrefixes, opts.Set.Comment) {
 			errs = append(errs, errAtLeastOneOf("AlterApiIntegrationOptions.Set", "AwsParams", "AzureParams", "GoogleParams", "Enabled", "ApiAllowedPrefixes", "ApiBlockedPrefixes", "Comment"))
 		}

--- a/pkg/sdk/applications_ext.go
+++ b/pkg/sdk/applications_ext.go
@@ -1,0 +1,17 @@
+package sdk
+
+func (opts *CreateApplicationOptions) additionalValidations() error {
+	if valueSet(opts.DebugMode) && !valueSet(opts.Version) {
+		return NewError("CreateApplicationOptions.DebugMode can be set only when CreateApplicationOptions.Version is set")
+	}
+	return nil
+}
+
+func (opts *AlterApplicationOptions) additionalValidations() error {
+	if valueSet(opts.IfExists) {
+		if !valueSet(opts.Set) && !valueSet(opts.Unset) {
+			return NewError("AlterApplicationOptions.IfExists can be set only when AlterApplicationOptions.Set or AlterApplicationOptions.Unset is set")
+		}
+	}
+	return nil
+}

--- a/pkg/sdk/applications_validations_gen.go
+++ b/pkg/sdk/applications_validations_gen.go
@@ -26,10 +26,7 @@ func (opts *CreateApplicationOptions) validate() error {
 			errs = append(errs, errExactlyOneOf("CreateApplicationOptions.Version", "VersionDirectory", "VersionAndPatch"))
 		}
 	}
-	// Added manually
-	if valueSet(opts.DebugMode) && !valueSet(opts.Version) {
-		errs = append(errs, NewError("CreateApplicationOptions.DebugMode can be set only when CreateApplicationOptions.Version is set"))
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 
@@ -60,12 +57,7 @@ func (opts *AlterApplicationOptions) validate() error {
 			errs = append(errs, errExactlyOneOf("AlterApplicationOptions.UpgradeVersion", "VersionDirectory", "VersionAndPatch"))
 		}
 	}
-	// Added manually
-	if valueSet(opts.IfExists) {
-		if !valueSet(opts.Set) && !valueSet(opts.Unset) {
-			errs = append(errs, NewError("AlterApplicationOptions.IfExists can be set only when AlterApplicationOptions.Set or AlterApplicationOptions.Unset is set"))
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 

--- a/pkg/sdk/compute_pools_ext.go
+++ b/pkg/sdk/compute_pools_ext.go
@@ -1,5 +1,30 @@
 package sdk
 
+func (opts *CreateComputePoolOptions) additionalValidations() error {
+	var errs []error
+	if !validateIntGreaterThan(opts.MinNodes, 0) {
+		errs = append(errs, errIntValue("CreateComputePoolOptions", "MinNodes", IntErrGreater, 0))
+	}
+	if !validateIntGreaterThanOrEqual(opts.MaxNodes, opts.MinNodes) {
+		errs = append(errs, errIntValue("CreateComputePoolOptions", "MaxNodes", IntErrGreaterOrEqual, opts.MinNodes))
+	}
+	return JoinErrors(errs...)
+}
+
+func (s *ComputePoolSet) additionalValidations() error {
+	var errs []error
+	if valueSet(s.MinNodes) && !validateIntGreaterThan(*s.MinNodes, 0) {
+		errs = append(errs, errIntValue("AlterComputePoolOptions", "Set.MinNodes", IntErrGreater, 0))
+	}
+	if valueSet(s.MaxNodes) && !validateIntGreaterThan(*s.MaxNodes, 0) {
+		errs = append(errs, errIntValue("AlterComputePoolOptions", "Set.MaxNodes", IntErrGreater, 0))
+	}
+	if valueSet(s.MinNodes) && valueSet(s.MaxNodes) && !validateIntGreaterThanOrEqual(*s.MaxNodes, *s.MinNodes) {
+		errs = append(errs, errIntValue("AlterComputePoolOptions", "Set.MaxNodes", IntErrGreaterOrEqual, *s.MinNodes))
+	}
+	return JoinErrors(errs...)
+}
+
 func (r *CreateComputePoolRequest) GetName() AccountObjectIdentifier {
 	return r.name
 }

--- a/pkg/sdk/compute_pools_validations_gen.go
+++ b/pkg/sdk/compute_pools_validations_gen.go
@@ -18,14 +18,7 @@ func (opts *CreateComputePoolOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	// Validation added manually.
-	if !validateIntGreaterThan(opts.MinNodes, 0) {
-		errs = append(errs, errIntValue("CreateComputePoolOptions", "MinNodes", IntErrGreater, 0))
-	}
-	// Validation added manually.
-	if !validateIntGreaterThanOrEqual(opts.MaxNodes, opts.MinNodes) {
-		errs = append(errs, errIntValue("CreateComputePoolOptions", "MaxNodes", IntErrGreaterOrEqual, opts.MinNodes))
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 
@@ -41,19 +34,7 @@ func (opts *AlterComputePoolOptions) validate() error {
 		errs = append(errs, errExactlyOneOf("AlterComputePoolOptions", "Resume", "Suspend", "StopAll", "Set", "Unset", "SetTags", "UnsetTags"))
 	}
 	if valueSet(opts.Set) {
-		// Validation added manually.
-		if valueSet(opts.Set.MinNodes) && !validateIntGreaterThan(*opts.Set.MinNodes, 0) {
-			errs = append(errs, errIntValue("AlterComputePoolOptions", "Set.MinNodes", IntErrGreater, 0))
-		}
-		// Validation added manually.
-		if valueSet(opts.Set.MaxNodes) && !validateIntGreaterThan(*opts.Set.MaxNodes, 0) {
-			errs = append(errs, errIntValue("AlterComputePoolOptions", "Set.MaxNodes", IntErrGreater, 0))
-		}
-		// Validation added manually.
-		if valueSet(opts.Set.MinNodes) && valueSet(opts.Set.MaxNodes) && !validateIntGreaterThanOrEqual(*opts.Set.MaxNodes, *opts.Set.MinNodes) {
-			errs = append(errs, errIntValue("AlterComputePoolOptions", "Set.MaxNodes", IntErrGreaterOrEqual, *opts.Set.MinNodes))
-		}
-
+		errs = append(errs, opts.Set.additionalValidations()) // invocation added manually
 		if !anyValueSet(opts.Set.MinNodes, opts.Set.MaxNodes, opts.Set.AutoResume, opts.Set.AutoSuspendSecs, opts.Set.Comment) {
 			errs = append(errs, errAtLeastOneOf("AlterComputePoolOptions.Set", "MinNodes", "MaxNodes", "AutoResume", "AutoSuspendSecs", "Comment"))
 		}

--- a/pkg/sdk/external_volumes_ext.go
+++ b/pkg/sdk/external_volumes_ext.go
@@ -7,6 +7,23 @@ import (
 	"strings"
 )
 
+func (opts *CreateExternalVolumeOptions) additionalValidations() error {
+	var errs []error
+	// Apply errExactlyOneOf to each element in storage locations list
+	for i, storageLocationItem := range opts.StorageLocations {
+		storageLocation := storageLocationItem.ExternalVolumeStorageLocation
+		if !exactlyOneValueSet(storageLocation.S3StorageLocationParams, storageLocation.GCSStorageLocationParams, storageLocation.AzureStorageLocationParams, storageLocation.S3CompatStorageLocationParams) {
+			errs = append(errs, errExactlyOneOf(fmt.Sprintf("CreateExternalVolumeOptions.StorageLocation[%d]", i), "S3StorageLocationParams", "GCSStorageLocationParams", "AzureStorageLocationParams", "S3CompatStorageLocationParams"))
+		}
+	}
+
+	// Check the storage location list is not empty, as at least 1 storage location is required for an external volume
+	if len(opts.StorageLocations) == 0 {
+		errs = append(errs, errNotSet("CreateExternalVolumeOptions", "StorageLocations"))
+	}
+	return JoinErrors(errs...)
+}
+
 // CopySentinelStorageLocationItem creates a copy of the given storage location with a
 // sentinel name used for Terraform provider operations. This is useful for managing
 // storage location state without affecting user-visible names.

--- a/pkg/sdk/external_volumes_validations_gen.go
+++ b/pkg/sdk/external_volumes_validations_gen.go
@@ -2,8 +2,6 @@
 
 package sdk
 
-import "fmt"
-
 var (
 	_ validatable = new(CreateExternalVolumeOptions)
 	_ validatable = new(AlterExternalVolumeOptions)
@@ -24,20 +22,7 @@ func (opts *CreateExternalVolumeOptions) validate() error {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 
-	// Added manually
-
-	// Apply errExactlyOneOf to each element in storage locations list
-	for i, storageLocationItem := range opts.StorageLocations {
-		storageLocation := storageLocationItem.ExternalVolumeStorageLocation
-		if !exactlyOneValueSet(storageLocation.S3StorageLocationParams, storageLocation.GCSStorageLocationParams, storageLocation.AzureStorageLocationParams, storageLocation.S3CompatStorageLocationParams) {
-			errs = append(errs, errExactlyOneOf(fmt.Sprintf("CreateExternalVolumeOptions.StorageLocation[%d]", i), "S3StorageLocationParams", "GCSStorageLocationParams", "AzureStorageLocationParams", "S3CompatStorageLocationParams"))
-		}
-	}
-
-	// Check the storage location list is not empty, as at least 1 storage location is required for an external volume
-	if len(opts.StorageLocations) == 0 {
-		errs = append(errs, errNotSet("CreateExternalVolumeOptions", "StorageLocations"))
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 
 	return JoinErrors(errs...)
 }

--- a/pkg/sdk/file_formats_ext.go
+++ b/pkg/sdk/file_formats_ext.go
@@ -1,5 +1,12 @@
 package sdk
 
+func (opts *DummyOperationFileFormatOptions) additionalValidations() error {
+	if valueSet(opts.FileFormat) {
+		return opts.FileFormat.validate()
+	}
+	return nil
+}
+
 func (opts FileFormatOptions) validate() error {
 	var errs []error
 	if !exactlyOneValueSet(opts.CsvOptions, opts.JsonOptions, opts.AvroOptions, opts.OrcOptions, opts.ParquetOptions, opts.XmlOptions) {

--- a/pkg/sdk/file_formats_validations_gen.go
+++ b/pkg/sdk/file_formats_validations_gen.go
@@ -9,9 +9,6 @@ func (opts *DummyOperationFileFormatOptions) validate() error {
 		return ErrNilOptions
 	}
 	var errs []error
-	// adjusted manually
-	if valueSet(opts.FileFormat) {
-		errs = append(errs, opts.FileFormat.validate())
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }

--- a/pkg/sdk/functions_ext.go
+++ b/pkg/sdk/functions_ext.go
@@ -11,6 +11,99 @@ import (
 
 const DefaultFunctionComment = "user-defined function"
 
+func (opts *CreateForJavaFunctionOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateForJavaFunctionOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	if opts.FunctionDefinition == nil {
+		if opts.TargetPath != nil {
+			errs = append(errs, NewError("TARGET_PATH must be nil when AS is nil"))
+		}
+		if len(opts.Imports) == 0 {
+			errs = append(errs, NewError("IMPORTS must not be empty when AS is nil"))
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateForJavascriptFunctionOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateForJavascriptFunctionOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateForPythonFunctionOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateForPythonFunctionOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	if opts.FunctionDefinition == nil {
+		if len(opts.Imports) == 0 {
+			errs = append(errs, NewError("IMPORTS must not be empty when AS is nil"))
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateForScalaFunctionOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateForScalaFunctionOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	if opts.FunctionDefinition == nil {
+		if opts.TargetPath != nil {
+			errs = append(errs, NewError("TARGET_PATH must be nil when AS is nil"))
+		}
+		if len(opts.Imports) == 0 {
+			errs = append(errs, NewError("IMPORTS must not be empty when AS is nil"))
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateForSQLFunctionOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateForSQLFunctionOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (t *FunctionReturnsTable) additionalValidations() error {
+	var errs []error
+	if valueSet(t.Columns) {
+		for _, col := range t.Columns {
+			if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
+				errs = append(errs, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
 func (v *Function) ID() SchemaObjectIdentifierWithArguments {
 	return NewSchemaObjectIdentifierWithArguments(v.CatalogName, v.SchemaName, v.Name, v.ArgumentsOld...)
 }

--- a/pkg/sdk/functions_validations_gen.go
+++ b/pkg/sdk/functions_validations_gen.go
@@ -28,14 +28,7 @@ func (opts *CreateForJavaFunctionOptions) validate() error {
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateForJavaFunctionOptions", "OrReplace", "IfNotExists"))
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateForJavaFunctionOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForJavaFunctionOptions.Returns", "ResultDataType", "Table"))
@@ -46,23 +39,7 @@ func (opts *CreateForJavaFunctionOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			if valueSet(opts.Returns.Table.Columns) {
-				// modified manually
-				for _, col := range opts.Returns.Table.Columns {
-					if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
-						errs = append(errs, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
-					}
-				}
-			}
-		}
-	}
-	// added manually
-	if opts.FunctionDefinition == nil {
-		if opts.TargetPath != nil {
-			errs = append(errs, NewError("TARGET_PATH must be nil when AS is nil"))
-		}
-		if len(opts.Imports) == 0 {
-			errs = append(errs, NewError("IMPORTS must not be empty when AS is nil"))
+			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
 		}
 	}
 	return JoinErrors(errs...)
@@ -79,14 +56,7 @@ func (opts *CreateForJavascriptFunctionOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateForJavascriptFunctionOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForJavascriptFunctionOptions.Returns", "ResultDataType", "Table"))
@@ -97,14 +67,7 @@ func (opts *CreateForJavascriptFunctionOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			if valueSet(opts.Returns.Table.Columns) {
-				// modified manually
-				for _, col := range opts.Returns.Table.Columns {
-					if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
-						errs = append(errs, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
-					}
-				}
-			}
+			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
 		}
 	}
 	return JoinErrors(errs...)
@@ -127,14 +90,7 @@ func (opts *CreateForPythonFunctionOptions) validate() error {
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateForPythonFunctionOptions", "OrReplace", "IfNotExists"))
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateForPythonFunctionOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForPythonFunctionOptions.Returns", "ResultDataType", "Table"))
@@ -145,20 +101,7 @@ func (opts *CreateForPythonFunctionOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			if valueSet(opts.Returns.Table.Columns) {
-				// modified manually
-				for _, col := range opts.Returns.Table.Columns {
-					if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
-						errs = append(errs, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
-					}
-				}
-			}
-		}
-	}
-	// added manually
-	if opts.FunctionDefinition == nil {
-		if len(opts.Imports) == 0 {
-			errs = append(errs, NewError("IMPORTS must not be empty when AS is nil"))
+			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
 		}
 	}
 	return JoinErrors(errs...)
@@ -181,23 +124,7 @@ func (opts *CreateForScalaFunctionOptions) validate() error {
 	if !exactlyOneValueSet(opts.ResultDataTypeOld, opts.ResultDataType) {
 		errs = append(errs, errExactlyOneOf("CreateForScalaFunctionOptions", "ResultDataTypeOld", "ResultDataType"))
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateForScalaFunctionOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
-	// added manually
-	if opts.FunctionDefinition == nil {
-		if opts.TargetPath != nil {
-			errs = append(errs, NewError("TARGET_PATH must be nil when AS is nil"))
-		}
-		if len(opts.Imports) == 0 {
-			errs = append(errs, NewError("IMPORTS must not be empty when AS is nil"))
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 
@@ -212,14 +139,7 @@ func (opts *CreateForSQLFunctionOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateForSQLFunctionOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForSQLFunctionOptions.Returns", "ResultDataType", "Table"))
@@ -230,14 +150,7 @@ func (opts *CreateForSQLFunctionOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			if valueSet(opts.Returns.Table.Columns) {
-				// modified manually
-				for _, col := range opts.Returns.Table.Columns {
-					if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
-						errs = append(errs, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
-					}
-				}
-			}
+			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
 		}
 	}
 	return JoinErrors(errs...)

--- a/pkg/sdk/hybrid_tables_ext.go
+++ b/pkg/sdk/hybrid_tables_ext.go
@@ -1,0 +1,11 @@
+package sdk
+
+func (opts *AlterHybridTableOptions) additionalValidations() error {
+	var errs []error
+	for _, action := range opts.AlterColumnAction {
+		if !exactlyOneValueSet(action.DropDefault, action.SetDefault, action.Type, action.Comment, action.UnsetComment) {
+			errs = append(errs, errExactlyOneOf("AlterHybridTableOptions.AlterColumnAction", "DropDefault", "SetDefault", "Type", "Comment", "UnsetComment"))
+		}
+	}
+	return JoinErrors(errs...)
+}

--- a/pkg/sdk/hybrid_tables_validations_gen.go
+++ b/pkg/sdk/hybrid_tables_validations_gen.go
@@ -51,13 +51,7 @@ func (opts *AlterHybridTableOptions) validate() error {
 			}
 		}
 	}
-	if valueSet(opts.AlterColumnAction) {
-		for _, action := range opts.AlterColumnAction {
-			if !exactlyOneValueSet(action.DropDefault, action.SetDefault, action.Type, action.Comment, action.UnsetComment) {
-				errs = append(errs, errExactlyOneOf("AlterHybridTableOptions.AlterColumnAction", "DropDefault", "SetDefault", "Type", "Comment", "UnsetComment"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.ClusteringAction) {
 		if !exactlyOneValueSet(opts.ClusteringAction.ClusterBy, opts.ClusteringAction.Recluster, opts.ClusteringAction.ChangeReclusterState, opts.ClusteringAction.DropClusteringKey) {
 			errs = append(errs, errExactlyOneOf("AlterHybridTableOptions.ClusteringAction", "ClusterBy", "Recluster", "ChangeReclusterState", "DropClusteringKey"))

--- a/pkg/sdk/iceberg_tables_ext.go
+++ b/pkg/sdk/iceberg_tables_ext.go
@@ -2,6 +2,39 @@ package sdk
 
 import "fmt"
 
+func (opts *CreateIcebergTableOptions) additionalValidations() error {
+	var errs []error
+	// PartitionBy is a slice, validate each element
+	for i, p := range opts.PartitionBy {
+		if !exactlyOneValueSet(p.Identity, p.Bucket, p.Truncate, p.Year, p.Month, p.Day, p.Hour) {
+			errs = append(errs, errExactlyOneOf(fmt.Sprintf("CreateIcebergTableOptions.PartitionBy[%d]", i), "Identity", "Bucket", "Truncate", "Year", "Month", "Day", "Hour"))
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *AlterIcebergTableOptions) additionalValidations() error {
+	var errs []error
+	// AlterColumnAction is a slice, validate each element
+	for i, col := range opts.AlterColumnAction {
+		if !exactlyOneValueSet(col.SetNotNull, col.DropNotNull, col.DataType, col.Comment, col.UnsetComment, col.SetWriteDefault, col.DropWriteDefault) {
+			errs = append(errs, errExactlyOneOf(fmt.Sprintf("AlterIcebergTableOptions.AlterColumnAction[%d]", i), "SetNotNull", "DropNotNull", "DataType", "Comment", "UnsetComment", "SetWriteDefault", "DropWriteDefault"))
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (d *TableDropSearchOptimization) additionalValidations() error {
+	var errs []error
+	// each Drop.On entry must have exactly one of SearchMethodWithTarget, ColumnName, or ExpressionId set.
+	for _, on := range d.On {
+		if !exactlyOneValueSet(on.SearchMethodWithTarget, on.ColumnName, on.ExpressionId) {
+			errs = append(errs, errExactlyOneOf("AlterIcebergTableOptions.SearchOptimizationAction.Drop.On", "SearchMethodWithTarget", "ColumnName", "ExpressionId"))
+		}
+	}
+	return JoinErrors(errs...)
+}
+
 // icebergTableExternalVolumeQuoted formats an AccountObjectIdentifier for the
 // EXTERNAL_VOLUME clause of CREATE ICEBERG TABLE, which expects a single-quoted
 // string literal whose content is the double-quoted volume name (e.g. '"vol1"').

--- a/pkg/sdk/iceberg_tables_validations_gen.go
+++ b/pkg/sdk/iceberg_tables_validations_gen.go
@@ -2,8 +2,6 @@
 
 package sdk
 
-import "fmt"
-
 var (
 	_ validatable = new(CreateIcebergTableOptions)
 	_ validatable = new(AlterIcebergTableOptions)
@@ -23,12 +21,7 @@ func (opts *CreateIcebergTableOptions) validate() error {
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateIcebergTableOptions", "OrReplace", "IfNotExists"))
 	}
-	// Adjusted manually: PartitionBy is a slice, validate each element
-	for i, p := range opts.PartitionBy {
-		if !exactlyOneValueSet(p.Identity, p.Bucket, p.Truncate, p.Year, p.Month, p.Day, p.Hour) {
-			errs = append(errs, errExactlyOneOf(fmt.Sprintf("CreateIcebergTableOptions.PartitionBy[%d]", i), "Identity", "Bucket", "Truncate", "Year", "Month", "Day", "Hour"))
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.RowAccessPolicy) {
 		if !ValidObjectIdentifier(opts.RowAccessPolicy.Name) {
 			errs = append(errs, ErrInvalidObjectIdentifier)
@@ -53,12 +46,7 @@ func (opts *AlterIcebergTableOptions) validate() error {
 	if !exactlyOneValueSet(opts.AddColumnAction, opts.DropColumnAction, opts.RenameColumnAction, opts.AlterColumnAction, opts.SetMaskingPolicyOnColumn, opts.UnsetMaskingPolicyOnColumn, opts.SetProjectionPolicyOnColumn, opts.UnsetProjectionPolicyOnColumn, opts.SetTagsOnColumn, opts.UnsetTagsOnColumn, opts.ClusteringAction, opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags, opts.AddRowAccessPolicy, opts.DropRowAccessPolicy, opts.DropAndAddRowAccessPolicy, opts.DropAllRowAccessPolicies, opts.SetAggregationPolicy, opts.UnsetAggregationPolicy, opts.SetJoinPolicy, opts.UnsetJoinPolicy, opts.SearchOptimizationAction) {
 		errs = append(errs, errExactlyOneOf("AlterIcebergTableOptions", "AddColumnAction", "DropColumnAction", "RenameColumnAction", "AlterColumnAction", "SetMaskingPolicyOnColumn", "UnsetMaskingPolicyOnColumn", "SetProjectionPolicyOnColumn", "UnsetProjectionPolicyOnColumn", "SetTagsOnColumn", "UnsetTagsOnColumn", "ClusteringAction", "Set", "Unset", "SetTags", "UnsetTags", "AddRowAccessPolicy", "DropRowAccessPolicy", "DropAndAddRowAccessPolicy", "DropAllRowAccessPolicies", "SetAggregationPolicy", "UnsetAggregationPolicy", "SetJoinPolicy", "UnsetJoinPolicy", "SearchOptimizationAction"))
 	}
-	// Adjusted manually: AlterColumnAction is a slice, validate each element
-	for i, col := range opts.AlterColumnAction {
-		if !exactlyOneValueSet(col.SetNotNull, col.DropNotNull, col.DataType, col.Comment, col.UnsetComment, col.SetWriteDefault, col.DropWriteDefault) {
-			errs = append(errs, errExactlyOneOf(fmt.Sprintf("AlterIcebergTableOptions.AlterColumnAction[%d]", i), "SetNotNull", "DropNotNull", "DataType", "Comment", "UnsetComment", "SetWriteDefault", "DropWriteDefault"))
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.ClusteringAction) {
 		if !exactlyOneValueSet(opts.ClusteringAction.ClusterBy, opts.ClusteringAction.ChangeReclusterState, opts.ClusteringAction.DropClusteringKey) {
 			errs = append(errs, errExactlyOneOf("AlterIcebergTableOptions.ClusteringAction", "ClusterBy", "ChangeReclusterState", "DropClusteringKey"))
@@ -88,13 +76,8 @@ func (opts *AlterIcebergTableOptions) validate() error {
 		if !exactlyOneValueSet(opts.SearchOptimizationAction.Add, opts.SearchOptimizationAction.Drop) {
 			errs = append(errs, errExactlyOneOf("AlterIcebergTableOptions.SearchOptimizationAction", "Add", "Drop"))
 		}
-		// Adjusted manually: each Drop.On entry must have exactly one of SearchMethodWithTarget, ColumnName, or ExpressionId set.
 		if valueSet(opts.SearchOptimizationAction.Drop) {
-			for _, on := range opts.SearchOptimizationAction.Drop.On {
-				if !exactlyOneValueSet(on.SearchMethodWithTarget, on.ColumnName, on.ExpressionId) {
-					errs = append(errs, errExactlyOneOf("AlterIcebergTableOptions.SearchOptimizationAction.Drop.On", "SearchMethodWithTarget", "ColumnName", "ExpressionId"))
-				}
-			}
+			errs = append(errs, opts.SearchOptimizationAction.Drop.additionalValidations()) // invocation added manually
 		}
 	}
 	return JoinErrors(errs...)

--- a/pkg/sdk/notebooks_ext.go
+++ b/pkg/sdk/notebooks_ext.go
@@ -1,5 +1,38 @@
 package sdk
 
+func (opts *CreateNotebookOptions) additionalValidations() error {
+	var errs []error
+	if opts.IdleAutoShutdownTimeSeconds != nil && !validateIntGreaterThan(*opts.IdleAutoShutdownTimeSeconds, 0) {
+		errs = append(errs, errIntValue("CreateNotebookOptions", "IdleAutoShutdownTimeSeconds", IntErrGreater, 0))
+	}
+	if opts.ExternalAccessIntegrations != nil {
+		for _, integration := range opts.ExternalAccessIntegrations {
+			if !ValidObjectIdentifier(integration) {
+				errs = append(errs, ErrInvalidObjectIdentifier)
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (s *NotebookSet) additionalValidations() error {
+	var errs []error
+	if !anyValueSet(s.Comment, s.QueryWarehouse, s.IdleAutoShutdownTimeSeconds, s.Secrets, s.MainFile, s.Warehouse, s.RuntimeName, s.ComputePool, s.ExternalAccessIntegrations, s.RuntimeEnvironmentVersion) {
+		errs = append(errs, errAtLeastOneOf("AlterNotebookOptions.Set", "Comment", "QueryWarehouse", "IdleAutoShutdownTimeSeconds", "Secrets", "MainFile", "Warehouse", "RuntimeName", "ComputePool", "ExternalAccessIntegrations", "RuntimeEnvironmentVersion"))
+	}
+	if s.IdleAutoShutdownTimeSeconds != nil && !validateIntGreaterThan(*s.IdleAutoShutdownTimeSeconds, 0) {
+		errs = append(errs, errIntValue("AlterNotebookOptions", "IdleAutoShutdownTimeSeconds", IntErrGreater, 0))
+	}
+	if s.ExternalAccessIntegrations != nil {
+		for _, integration := range s.ExternalAccessIntegrations {
+			if !ValidObjectIdentifier(integration) {
+				errs = append(errs, ErrInvalidObjectIdentifier)
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
 func (r *CreateNotebookRequest) GetName() SchemaObjectIdentifier {
 	return r.name
 }

--- a/pkg/sdk/notebooks_validations_gen.go
+++ b/pkg/sdk/notebooks_validations_gen.go
@@ -30,18 +30,7 @@ func (opts *CreateNotebookOptions) validate() error {
 	if opts.ComputePool != nil && !ValidObjectIdentifier(opts.ComputePool) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	// Validation added manually.
-	if opts.IdleAutoShutdownTimeSeconds != nil && !validateIntGreaterThan(*opts.IdleAutoShutdownTimeSeconds, 0) {
-		errs = append(errs, errIntValue("CreateNotebookOptions", "IdleAutoShutdownTimeSeconds", IntErrGreater, 0))
-	}
-	// Validation added manually.
-	if opts.ExternalAccessIntegrations != nil {
-		for _, integration := range opts.ExternalAccessIntegrations {
-			if !ValidObjectIdentifier(integration) {
-				errs = append(errs, ErrInvalidObjectIdentifier)
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 
@@ -69,23 +58,7 @@ func (opts *AlterNotebookOptions) validate() error {
 		if opts.Set.ComputePool != nil && !ValidObjectIdentifier(opts.Set.ComputePool) {
 			errs = append(errs, ErrInvalidObjectIdentifier)
 		}
-		// adjusted manually
-		if !anyValueSet(opts.Set.Comment, opts.Set.QueryWarehouse, opts.Set.IdleAutoShutdownTimeSeconds, opts.Set.Secrets, opts.Set.MainFile, opts.Set.Warehouse, opts.Set.RuntimeName, opts.Set.ComputePool, opts.Set.ExternalAccessIntegrations, opts.Set.RuntimeEnvironmentVersion) {
-			// adjusted manually
-			errs = append(errs, errAtLeastOneOf("AlterNotebookOptions.Set", "Comment", "QueryWarehouse", "IdleAutoShutdownTimeSeconds", "Secrets", "MainFile", "Warehouse", "RuntimeName", "ComputePool", "ExternalAccessIntegrations", "RuntimeEnvironmentVersion"))
-		}
-		// Validation added manually.
-		if opts.Set.IdleAutoShutdownTimeSeconds != nil && !validateIntGreaterThan(*opts.Set.IdleAutoShutdownTimeSeconds, 0) {
-			errs = append(errs, errIntValue("AlterNotebookOptions", "IdleAutoShutdownTimeSeconds", IntErrGreater, 0))
-		}
-		// Validation added manually.
-		if opts.Set.ExternalAccessIntegrations != nil {
-			for _, integration := range opts.Set.ExternalAccessIntegrations {
-				if !ValidObjectIdentifier(integration) {
-					errs = append(errs, ErrInvalidObjectIdentifier)
-				}
-			}
-		}
+		errs = append(errs, opts.Set.additionalValidations()) // invocation added manually
 	}
 	if valueSet(opts.Unset) {
 		if !anyValueSet(opts.Unset.Comment, opts.Unset.QueryWarehouse, opts.Unset.Secrets, opts.Unset.Warehouse, opts.Unset.RuntimeName, opts.Unset.ComputePool, opts.Unset.ExternalAccessIntegrations, opts.Unset.RuntimeEnvironmentVersion) {

--- a/pkg/sdk/notification_integrations_ext.go
+++ b/pkg/sdk/notification_integrations_ext.go
@@ -1,5 +1,13 @@
 package sdk
 
+func (s *NotificationIntegrationSet) additionalValidations() error {
+	// TODO [next PR]: this validation type will be added (conflicting fields currently works only for 2 fields)
+	if moreThanOneValueSet(s.SetPushParams, s.SetEmailParams, s.SetWebhookParams) {
+		return errOneOf("AlterNotificationIntegrationOptions.Set", "SetPushParams", "SetEmailParams", "SetWebhookParams")
+	}
+	return nil
+}
+
 func (r *CreateNotificationIntegrationRequest) GetName() AccountObjectIdentifier {
 	return r.name
 }

--- a/pkg/sdk/notification_integrations_validations_gen.go
+++ b/pkg/sdk/notification_integrations_validations_gen.go
@@ -49,10 +49,7 @@ func (opts *AlterNotificationIntegrationOptions) validate() error {
 		errs = append(errs, errExactlyOneOf("AlterNotificationIntegrationOptions", "Set", "UnsetEmailParams", "UnsetWebhookParams", "SetTags", "UnsetTags"))
 	}
 	if valueSet(opts.Set) {
-		// Adjusted manually: moreThanOneValueSet for 3+ conflicting fields (generator produces everyValueSet which only catches all-three-set)
-		if moreThanOneValueSet(opts.Set.SetPushParams, opts.Set.SetEmailParams, opts.Set.SetWebhookParams) {
-			errs = append(errs, errOneOf("AlterNotificationIntegrationOptions.Set", "SetPushParams", "SetEmailParams", "SetWebhookParams"))
-		}
+		errs = append(errs, opts.Set.additionalValidations()) // invocation added manually
 		if !anyValueSet(opts.Set.Enabled, opts.Set.SetPushParams, opts.Set.SetEmailParams, opts.Set.SetWebhookParams, opts.Set.Comment) {
 			errs = append(errs, errAtLeastOneOf("AlterNotificationIntegrationOptions.Set", "Enabled", "SetPushParams", "SetEmailParams", "SetWebhookParams", "Comment"))
 		}

--- a/pkg/sdk/postgres_instances_validations_gen.go
+++ b/pkg/sdk/postgres_instances_validations_gen.go
@@ -33,6 +33,9 @@ func (opts *ForkPostgresInstanceOptions) validate() error {
 	if !ValidObjectIdentifier(opts.Fork) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
+	if everyValueSet(opts.At, opts.Before) {
+		errs = append(errs, errOneOf("ForkPostgresInstanceOptions", "At", "Before"))
+	}
 	if valueSet(opts.At) {
 		if !exactlyOneValueSet(opts.At.Timestamp, opts.At.Offset) {
 			errs = append(errs, errExactlyOneOf("ForkPostgresInstanceOptions.At", "Timestamp", "Offset"))
@@ -42,9 +45,6 @@ func (opts *ForkPostgresInstanceOptions) validate() error {
 		if !exactlyOneValueSet(opts.Before.Timestamp, opts.Before.Offset) {
 			errs = append(errs, errExactlyOneOf("ForkPostgresInstanceOptions.Before", "Timestamp", "Offset"))
 		}
-	}
-	if everyValueSet(opts.At, opts.Before) {
-		errs = append(errs, errOneOf("ForkPostgresInstanceOptions", "At", "Before"))
 	}
 	return JoinErrors(errs...)
 }

--- a/pkg/sdk/procedures_ext.go
+++ b/pkg/sdk/procedures_ext.go
@@ -265,3 +265,156 @@ func NewCreateForJavaScriptProcedureRequestDefinitionWrapped(
 	s.ProcedureDefinition = fmt.Sprintf(`$$%s$$`, procedureDefinition)
 	return &s
 }
+
+func (opts *CreateForJavaProcedureOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateForJavaProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	if opts.ProcedureDefinition == nil && opts.TargetPath != nil {
+		errs = append(errs, NewError("TARGET_PATH must be nil when AS is nil"))
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateForJavaScriptProcedureOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateForJavaScriptProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateForPythonProcedureOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateForPythonProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateForScalaProcedureOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateForScalaProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	if opts.ProcedureDefinition == nil && opts.TargetPath != nil {
+		errs = append(errs, NewError("TARGET_PATH must be nil when AS is nil"))
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateForSQLProcedureOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateForSQLProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateAndCallForJavaProcedureOptions) additionalValidations() error {
+	var errs []error
+	if !ValidObjectIdentifier(opts.ProcedureName) {
+		errs = append(errs, errInvalidIdentifier("CreateAndCallForJavaProcedureOptions", "ProcedureName"))
+	}
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateAndCallForJavaProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateAndCallForScalaProcedureOptions) additionalValidations() error {
+	var errs []error
+	if !ValidObjectIdentifier(opts.ProcedureName) {
+		errs = append(errs, errInvalidIdentifier("CreateAndCallForScalaProcedureOptions", "ProcedureName"))
+	}
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateAndCallForScalaProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateAndCallForJavaScriptProcedureOptions) additionalValidations() error {
+	var errs []error
+	if !ValidObjectIdentifier(opts.ProcedureName) {
+		errs = append(errs, errInvalidIdentifier("CreateAndCallForJavaScriptProcedureOptions", "ProcedureName"))
+	}
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateAndCallForJavaScriptProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateAndCallForPythonProcedureOptions) additionalValidations() error {
+	var errs []error
+	if !ValidObjectIdentifier(opts.ProcedureName) {
+		errs = append(errs, errInvalidIdentifier("CreateAndCallForPythonProcedureOptions", "ProcedureName"))
+	}
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateAndCallForPythonProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateAndCallForSQLProcedureOptions) additionalValidations() error {
+	var errs []error
+	if !ValidObjectIdentifier(opts.ProcedureName) {
+		errs = append(errs, errInvalidIdentifier("CreateAndCallForSQLProcedureOptions", "ProcedureName"))
+	}
+	if valueSet(opts.Arguments) {
+		for _, arg := range opts.Arguments {
+			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
+				errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (t *ProcedureReturnsTable) additionalValidations() error {
+	var errs []error
+	if valueSet(t.Columns) {
+		for _, col := range t.Columns {
+			if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
+				errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}

--- a/pkg/sdk/procedures_validations_gen.go
+++ b/pkg/sdk/procedures_validations_gen.go
@@ -37,14 +37,7 @@ func (opts *CreateForJavaProcedureOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateForJavaProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForJavaProcedureOptions.Returns", "ResultDataType", "Table"))
@@ -55,19 +48,8 @@ func (opts *CreateForJavaProcedureOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			if valueSet(opts.Returns.Table.Columns) {
-				// modified manually
-				for _, col := range opts.Returns.Table.Columns {
-					if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
-						errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
-					}
-				}
-			}
+			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
 		}
-	}
-	// added manually
-	if opts.ProcedureDefinition == nil && opts.TargetPath != nil {
-		errs = append(errs, NewError("TARGET_PATH must be nil when AS is nil"))
 	}
 	return JoinErrors(errs...)
 }
@@ -86,14 +68,7 @@ func (opts *CreateForJavaScriptProcedureOptions) validate() error {
 	if !exactlyOneValueSet(opts.ResultDataTypeOld, opts.ResultDataType) {
 		errs = append(errs, errExactlyOneOf("CreateForJavaScriptProcedureOptions", "ResultDataTypeOld", "ResultDataType"))
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateForJavaScriptProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 
@@ -114,14 +89,7 @@ func (opts *CreateForPythonProcedureOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateForPythonProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForPythonProcedureOptions.Returns", "ResultDataType", "Table"))
@@ -132,14 +100,7 @@ func (opts *CreateForPythonProcedureOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			if valueSet(opts.Returns.Table.Columns) {
-				// modified manually
-				for _, col := range opts.Returns.Table.Columns {
-					if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
-						errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
-					}
-				}
-			}
+			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
 		}
 	}
 	return JoinErrors(errs...)
@@ -162,14 +123,7 @@ func (opts *CreateForScalaProcedureOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateForScalaProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForScalaProcedureOptions.Returns", "ResultDataType", "Table"))
@@ -180,19 +134,8 @@ func (opts *CreateForScalaProcedureOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			if valueSet(opts.Returns.Table.Columns) {
-				// modified manually
-				for _, col := range opts.Returns.Table.Columns {
-					if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
-						errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
-					}
-				}
-			}
+			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
 		}
-	}
-	// added manually
-	if opts.ProcedureDefinition == nil && opts.TargetPath != nil {
-		errs = append(errs, NewError("TARGET_PATH must be nil when AS is nil"))
 	}
 	return JoinErrors(errs...)
 }
@@ -208,14 +151,7 @@ func (opts *CreateForSQLProcedureOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateForSQLProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForSQLProcedureOptions.Returns", "ResultDataType", "Table"))
@@ -321,21 +257,10 @@ func (opts *CreateAndCallForJavaProcedureOptions) validate() error {
 	if !valueSet(opts.Handler) {
 		errs = append(errs, errNotSet("CreateAndCallForJavaProcedureOptions", "Handler"))
 	}
-	if !ValidObjectIdentifier(opts.ProcedureName) {
-		// altered manually
-		errs = append(errs, errInvalidIdentifier("CreateAndCallForJavaProcedureOptions", "ProcedureName"))
-	}
 	if !ValidObjectIdentifier(opts.Name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateAndCallForJavaProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateAndCallForJavaProcedureOptions.Returns", "ResultDataType", "Table"))
@@ -346,14 +271,7 @@ func (opts *CreateAndCallForJavaProcedureOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			if valueSet(opts.Returns.Table.Columns) {
-				// modified manually
-				for _, col := range opts.Returns.Table.Columns {
-					if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
-						errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
-					}
-				}
-			}
+			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
 		}
 	}
 	return JoinErrors(errs...)
@@ -373,21 +291,10 @@ func (opts *CreateAndCallForScalaProcedureOptions) validate() error {
 	if !valueSet(opts.Handler) {
 		errs = append(errs, errNotSet("CreateAndCallForScalaProcedureOptions", "Handler"))
 	}
-	if !ValidObjectIdentifier(opts.ProcedureName) {
-		// altered manually
-		errs = append(errs, errInvalidIdentifier("CreateAndCallForScalaProcedureOptions", "ProcedureName"))
-	}
 	if !ValidObjectIdentifier(opts.Name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateAndCallForScalaProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateAndCallForScalaProcedureOptions.Returns", "ResultDataType", "Table"))
@@ -398,14 +305,7 @@ func (opts *CreateAndCallForScalaProcedureOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			if valueSet(opts.Returns.Table.Columns) {
-				// modified manually
-				for _, col := range opts.Returns.Table.Columns {
-					if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
-						errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
-					}
-				}
-			}
+			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
 		}
 	}
 	return JoinErrors(errs...)
@@ -422,21 +322,10 @@ func (opts *CreateAndCallForJavaScriptProcedureOptions) validate() error {
 	if !exactlyOneValueSet(opts.ResultDataTypeOld, opts.ResultDataType) {
 		errs = append(errs, errExactlyOneOf("CreateAndCallForJavaScriptProcedureOptions", "ResultDataTypeOld", "ResultDataType"))
 	}
-	if !ValidObjectIdentifier(opts.ProcedureName) {
-		// altered manually
-		errs = append(errs, errInvalidIdentifier("CreateAndCallForJavaScriptProcedureOptions", "ProcedureName"))
-	}
 	if !ValidObjectIdentifier(opts.Name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateAndCallForJavaScriptProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 
@@ -454,21 +343,10 @@ func (opts *CreateAndCallForPythonProcedureOptions) validate() error {
 	if !valueSet(opts.Handler) {
 		errs = append(errs, errNotSet("CreateAndCallForPythonProcedureOptions", "Handler"))
 	}
-	if !ValidObjectIdentifier(opts.ProcedureName) {
-		// altered manually
-		errs = append(errs, errInvalidIdentifier("CreateAndCallForPythonProcedureOptions", "ProcedureName"))
-	}
 	if !ValidObjectIdentifier(opts.Name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateAndCallForPythonProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateAndCallForPythonProcedureOptions.Returns", "ResultDataType", "Table"))
@@ -479,14 +357,7 @@ func (opts *CreateAndCallForPythonProcedureOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			if valueSet(opts.Returns.Table.Columns) {
-				// modified manually
-				for _, col := range opts.Returns.Table.Columns {
-					if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
-						errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
-					}
-				}
-			}
+			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
 		}
 	}
 	return JoinErrors(errs...)
@@ -500,21 +371,10 @@ func (opts *CreateAndCallForSQLProcedureOptions) validate() error {
 	if !valueSet(opts.ProcedureDefinition) {
 		errs = append(errs, errNotSet("CreateAndCallForSQLProcedureOptions", "ProcedureDefinition"))
 	}
-	if !ValidObjectIdentifier(opts.ProcedureName) {
-		// altered manually
-		errs = append(errs, errInvalidIdentifier("CreateAndCallForSQLProcedureOptions", "ProcedureName"))
-	}
 	if !ValidObjectIdentifier(opts.Name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if valueSet(opts.Arguments) {
-		// modified manually
-		for _, arg := range opts.Arguments {
-			if !exactlyOneValueSet(arg.ArgDataTypeOld, arg.ArgDataType) {
-				errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Arguments", "ArgDataTypeOld", "ArgDataType"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns", "ResultDataType", "Table"))
@@ -525,14 +385,7 @@ func (opts *CreateAndCallForSQLProcedureOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			if valueSet(opts.Returns.Table.Columns) {
-				// modified manually
-				for _, col := range opts.Returns.Table.Columns {
-					if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
-						errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
-					}
-				}
-			}
+			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
 		}
 	}
 	return JoinErrors(errs...)

--- a/pkg/sdk/security_integrations_ext.go
+++ b/pkg/sdk/security_integrations_ext.go
@@ -5,6 +5,20 @@ import (
 	"strings"
 )
 
+func (opts *CreateOauthForPartnerApplicationsSecurityIntegrationOptions) additionalValidations() error {
+	if opts.OauthClient == OauthSecurityIntegrationClientOptionLooker && opts.OauthRedirectUri == nil {
+		return NewError("OauthRedirectUri is required when OauthClient is LOOKER")
+	}
+	return nil
+}
+
+func (opts *CreateScimSecurityIntegrationOptions) additionalValidations() error {
+	if opts.ScimClient == ScimSecurityIntegrationScimClientOptionAzure && opts.SyncPassword != nil {
+		return NewError("SyncPassword is not supported for Azure scim client")
+	}
+	return nil
+}
+
 func (r *CreateApiAuthenticationWithClientCredentialsFlowSecurityIntegrationRequest) GetName() AccountObjectIdentifier {
 	return r.name
 }

--- a/pkg/sdk/security_integrations_validations_gen.go
+++ b/pkg/sdk/security_integrations_validations_gen.go
@@ -100,10 +100,7 @@ func (opts *CreateOauthForPartnerApplicationsSecurityIntegrationOptions) validat
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateOauthForPartnerApplicationsSecurityIntegrationOptions", "OrReplace", "IfNotExists"))
 	}
-	// Adjusted manually.
-	if opts.OauthClient == OauthSecurityIntegrationClientOptionLooker && opts.OauthRedirectUri == nil {
-		errs = append(errs, NewError("OauthRedirectUri is required when OauthClient is LOOKER"))
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 
@@ -146,10 +143,7 @@ func (opts *CreateScimSecurityIntegrationOptions) validate() error {
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateScimSecurityIntegrationOptions", "OrReplace", "IfNotExists"))
 	}
-	// Adjusted manually.
-	if opts.ScimClient == ScimSecurityIntegrationScimClientOptionAzure && opts.SyncPassword != nil {
-		errs = append(errs, NewError("SyncPassword is not supported for Azure scim client"))
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 

--- a/pkg/sdk/semantic_views_ext.go
+++ b/pkg/sdk/semantic_views_ext.go
@@ -67,6 +67,28 @@ type SemanticViewDescribeDetails struct {
 	DescribeRowCount int
 }
 
+func (opts *CreateSemanticViewOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.semanticViewRelationships) {
+		for _, v := range opts.semanticViewRelationships {
+			if !exactlyOneValueSet(v.tableNameOrAlias.RelationshipTableName, v.tableNameOrAlias.RelationshipTableAlias) {
+				errs = append(errs, errExactlyOneOf("CreateSemanticViewOptions.semanticViewRelationships.tableNameOrAlias", "RelationshipTableName", "RelationshipTableAlias"))
+			}
+			if !exactlyOneValueSet(v.refTableNameOrAlias.RelationshipTableName, v.refTableNameOrAlias.RelationshipTableAlias) {
+				errs = append(errs, errExactlyOneOf("CreateSemanticViewOptions.semanticViewRelationships.refTableNameOrAlias", "RelationshipTableName", "RelationshipTableAlias"))
+			}
+		}
+	}
+	if valueSet(opts.semanticViewMetrics) {
+		for _, v := range opts.semanticViewMetrics {
+			if !exactlyOneValueSet(v.semanticExpression, v.windowFunctionMetricDefinition) {
+				errs = append(errs, errExactlyOneOf("CreateSemanticViewOptions.semanticViewMetrics", "semanticExpression", "windowFunctionMetricDefinition"))
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
+
 func (s *CreateSemanticViewRequest) GetName() SchemaObjectIdentifier {
 	return s.name
 }

--- a/pkg/sdk/semantic_views_validations_gen.go
+++ b/pkg/sdk/semantic_views_validations_gen.go
@@ -21,25 +21,7 @@ func (opts *CreateSemanticViewOptions) validate() error {
 	if everyValueSet(opts.IfNotExists, opts.OrReplace) {
 		errs = append(errs, errOneOf("CreateSemanticViewOptions", "IfNotExists", "OrReplace"))
 	}
-	// Adjusted manually
-	if valueSet(opts.semanticViewRelationships) {
-		for _, v := range opts.semanticViewRelationships {
-			if !exactlyOneValueSet(v.tableNameOrAlias.RelationshipTableName, v.tableNameOrAlias.RelationshipTableAlias) {
-				errs = append(errs, errExactlyOneOf("CreateSemanticViewOptions.semanticViewRelationships.tableNameOrAlias", "RelationshipTableName", "RelationshipTableAlias"))
-			}
-			if !exactlyOneValueSet(v.refTableNameOrAlias.RelationshipTableName, v.refTableNameOrAlias.RelationshipTableAlias) {
-				errs = append(errs, errExactlyOneOf("CreateSemanticViewOptions.semanticViewRelationships.refTableNameOrAlias", "RelationshipTableName", "RelationshipTableAlias"))
-			}
-		}
-	}
-	// adjusted manually
-	if valueSet(opts.semanticViewMetrics) {
-		for _, v := range opts.semanticViewMetrics {
-			if !exactlyOneValueSet(v.semanticExpression, v.windowFunctionMetricDefinition) {
-				errs = append(errs, errExactlyOneOf("CreateSemanticViewOptions.semanticViewMetrics", "semanticExpression", "windowFunctionMetricDefinition"))
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 

--- a/pkg/sdk/services_ext.go
+++ b/pkg/sdk/services_ext.go
@@ -6,6 +6,70 @@ import (
 	"strings"
 )
 
+func (opts *CreateServiceOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.MinReadyInstances) {
+		if !validateIntGreaterThan(*opts.MinReadyInstances, 0) {
+			errs = append(errs, errIntValue("CreateServiceOptions", "MinReadyInstances", IntErrGreater, 0))
+		}
+		if valueSet(opts.MinInstances) && !validateIntGreaterThanOrEqual(*opts.MinInstances, *opts.MinReadyInstances) {
+			errs = append(errs, errIntValue("CreateServiceOptions", "MinInstances", IntErrGreaterOrEqual, *opts.MinReadyInstances))
+		}
+		if valueSet(opts.MaxInstances) && !validateIntGreaterThanOrEqual(*opts.MaxInstances, *opts.MinReadyInstances) {
+			errs = append(errs, errIntValue("CreateServiceOptions", "MaxInstances", IntErrGreaterOrEqual, *opts.MinReadyInstances))
+		}
+	}
+	if valueSet(opts.MinInstances) {
+		if !validateIntGreaterThan(*opts.MinInstances, 0) {
+			errs = append(errs, errIntValue("CreateServiceOptions", "MinInstances", IntErrGreater, 0))
+		}
+		if valueSet(opts.MaxInstances) && !validateIntGreaterThanOrEqual(*opts.MaxInstances, *opts.MinInstances) {
+			errs = append(errs, errIntValue("CreateServiceOptions", "MaxInstances", IntErrGreaterOrEqual, *opts.MinInstances))
+		}
+	}
+	if valueSet(opts.MaxInstances) {
+		if !validateIntGreaterThan(*opts.MaxInstances, 0) {
+			errs = append(errs, errIntValue("CreateServiceOptions", "MaxInstances", IntErrGreater, 0))
+		}
+	}
+	if valueSet(opts.AutoSuspendSecs) && !validateIntGreaterThanOrEqual(*opts.AutoSuspendSecs, 0) {
+		errs = append(errs, errIntValue("CreateServiceOptions", "AutoSuspendSecs", IntErrGreaterOrEqual, 0))
+	}
+	return JoinErrors(errs...)
+}
+
+func (s *ServiceSet) additionalValidations() error {
+	var errs []error
+	if valueSet(s.MinReadyInstances) {
+		if !validateIntGreaterThan(*s.MinReadyInstances, 0) {
+			errs = append(errs, errIntValue("AlterServiceOptions.Set", "MinReadyInstances", IntErrGreater, 0))
+		}
+		if valueSet(s.MinInstances) && !validateIntGreaterThanOrEqual(*s.MinInstances, *s.MinReadyInstances) {
+			errs = append(errs, errIntValue("AlterServiceOptions.Set", "MinInstances", IntErrGreaterOrEqual, *s.MinReadyInstances))
+		}
+		if valueSet(s.MaxInstances) && !validateIntGreaterThanOrEqual(*s.MaxInstances, *s.MinReadyInstances) {
+			errs = append(errs, errIntValue("AlterServiceOptions.Set", "MaxInstances", IntErrGreaterOrEqual, *s.MinReadyInstances))
+		}
+	}
+	if valueSet(s.MinInstances) {
+		if !validateIntGreaterThan(*s.MinInstances, 0) {
+			errs = append(errs, errIntValue("AlterServiceOptions.Set", "MinInstances", IntErrGreater, 0))
+		}
+		if valueSet(s.MaxInstances) && !validateIntGreaterThanOrEqual(*s.MaxInstances, *s.MinInstances) {
+			errs = append(errs, errIntValue("AlterServiceOptions.Set", "MaxInstances", IntErrGreaterOrEqual, *s.MinInstances))
+		}
+	}
+	if valueSet(s.MaxInstances) {
+		if !validateIntGreaterThan(*s.MaxInstances, 0) {
+			errs = append(errs, errIntValue("AlterServiceOptions.Set", "MaxInstances", IntErrGreater, 0))
+		}
+	}
+	if valueSet(s.AutoSuspendSecs) && !validateIntGreaterThanOrEqual(*s.AutoSuspendSecs, 0) {
+		errs = append(errs, errIntValue("AlterServiceOptions.Set", "AutoSuspendSecs", IntErrGreaterOrEqual, 0))
+	}
+	return JoinErrors(errs...)
+}
+
 func (s *CreateServiceRequest) GetName() SchemaObjectIdentifier {
 	return s.name
 }

--- a/pkg/sdk/services_validations_gen.go
+++ b/pkg/sdk/services_validations_gen.go
@@ -41,37 +41,7 @@ func (opts *CreateServiceOptions) validate() error {
 			errs = append(errs, errOneOf("CreateServiceOptions.FromSpecificationTemplate", "Location", "SpecificationTemplate"))
 		}
 	}
-	// Validation added manually.
-	if valueSet(opts.MinReadyInstances) {
-		if !validateIntGreaterThan(*opts.MinReadyInstances, 0) {
-			errs = append(errs, errIntValue("CreateServiceOptions", "MinReadyInstances", IntErrGreater, 0))
-		}
-		if valueSet(opts.MinInstances) && !validateIntGreaterThanOrEqual(*opts.MinInstances, *opts.MinReadyInstances) {
-			errs = append(errs, errIntValue("CreateServiceOptions", "MinInstances", IntErrGreaterOrEqual, *opts.MinReadyInstances))
-		}
-		if valueSet(opts.MaxInstances) && !validateIntGreaterThanOrEqual(*opts.MaxInstances, *opts.MinReadyInstances) {
-			errs = append(errs, errIntValue("CreateServiceOptions", "MaxInstances", IntErrGreaterOrEqual, *opts.MinReadyInstances))
-		}
-	}
-	// Validation added manually.
-	if valueSet(opts.MinInstances) {
-		if !validateIntGreaterThan(*opts.MinInstances, 0) {
-			errs = append(errs, errIntValue("CreateServiceOptions", "MinInstances", IntErrGreater, 0))
-		}
-		if valueSet(opts.MaxInstances) && !validateIntGreaterThanOrEqual(*opts.MaxInstances, *opts.MinInstances) {
-			errs = append(errs, errIntValue("CreateServiceOptions", "MaxInstances", IntErrGreaterOrEqual, *opts.MinInstances))
-		}
-	}
-	// Validation added manually.
-	if valueSet(opts.MaxInstances) {
-		if !validateIntGreaterThan(*opts.MaxInstances, 0) {
-			errs = append(errs, errIntValue("CreateServiceOptions", "MaxInstances", IntErrGreater, 0))
-		}
-	}
-	// Validation added manually.
-	if valueSet(opts.AutoSuspendSecs) && !validateIntGreaterThanOrEqual(*opts.AutoSuspendSecs, 0) {
-		errs = append(errs, errIntValue("CreateServiceOptions", "AutoSuspendSecs", IntErrGreaterOrEqual, 0))
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 
 	return JoinErrors(errs...)
 }
@@ -115,37 +85,7 @@ func (opts *AlterServiceOptions) validate() error {
 		if !anyValueSet(opts.Set.MinInstances, opts.Set.MaxInstances, opts.Set.AutoSuspendSecs, opts.Set.MinReadyInstances, opts.Set.QueryWarehouse, opts.Set.AutoResume, opts.Set.ExternalAccessIntegrations, opts.Set.Comment) {
 			errs = append(errs, errAtLeastOneOf("AlterServiceOptions.Set", "MinInstances", "MaxInstances", "AutoSuspendSecs", "MinReadyInstances", "QueryWarehouse", "AutoResume", "ExternalAccessIntegrations", "Comment"))
 		}
-		// Validation added manually.
-		if valueSet(opts.Set.MinReadyInstances) {
-			if !validateIntGreaterThan(*opts.Set.MinReadyInstances, 0) {
-				errs = append(errs, errIntValue("AlterServiceOptions.Set", "MinReadyInstances", IntErrGreater, 0))
-			}
-			if valueSet(opts.Set.MinInstances) && !validateIntGreaterThanOrEqual(*opts.Set.MinInstances, *opts.Set.MinReadyInstances) {
-				errs = append(errs, errIntValue("AlterServiceOptions.Set", "MinInstances", IntErrGreaterOrEqual, *opts.Set.MinReadyInstances))
-			}
-			if valueSet(opts.Set.MaxInstances) && !validateIntGreaterThanOrEqual(*opts.Set.MaxInstances, *opts.Set.MinReadyInstances) {
-				errs = append(errs, errIntValue("AlterServiceOptions.Set", "MaxInstances", IntErrGreaterOrEqual, *opts.Set.MinReadyInstances))
-			}
-		}
-		// Validation added manually.
-		if valueSet(opts.Set.MinInstances) {
-			if !validateIntGreaterThan(*opts.Set.MinInstances, 0) {
-				errs = append(errs, errIntValue("AlterServiceOptions.Set", "MinInstances", IntErrGreater, 0))
-			}
-			if valueSet(opts.Set.MaxInstances) && !validateIntGreaterThanOrEqual(*opts.Set.MaxInstances, *opts.Set.MinInstances) {
-				errs = append(errs, errIntValue("AlterServiceOptions.Set", "MaxInstances", IntErrGreaterOrEqual, *opts.Set.MinInstances))
-			}
-		}
-		// Validation added manually.
-		if valueSet(opts.Set.MaxInstances) {
-			if !validateIntGreaterThan(*opts.Set.MaxInstances, 0) {
-				errs = append(errs, errIntValue("AlterServiceOptions.Set", "MaxInstances", IntErrGreater, 0))
-			}
-		}
-		// Validation added manually.
-		if valueSet(opts.Set.AutoSuspendSecs) && !validateIntGreaterThanOrEqual(*opts.Set.AutoSuspendSecs, 0) {
-			errs = append(errs, errIntValue("AlterServiceOptions.Set", "AutoSuspendSecs", IntErrGreaterOrEqual, 0))
-		}
+		errs = append(errs, opts.Set.additionalValidations()) // invocation added manually
 	}
 	if valueSet(opts.Unset) {
 		if !anyValueSet(opts.Unset.MinInstances, opts.Unset.AutoSuspendSecs, opts.Unset.MaxInstances, opts.Unset.MinReadyInstances, opts.Unset.QueryWarehouse, opts.Unset.AutoResume, opts.Unset.ExternalAccessIntegrations, opts.Unset.Comment) {

--- a/pkg/sdk/stages_ext.go
+++ b/pkg/sdk/stages_ext.go
@@ -7,6 +7,16 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
 
+func (f *StageFileFormat) additionalValidations() error {
+	if f == nil {
+		return nil
+	}
+	if valueSet(f.FileFormatOptions) {
+		return f.FileFormatOptions.validate()
+	}
+	return nil
+}
+
 var AcceptableStageTypes = map[StageType][]StageType{
 	StageTypeInternal: {StageTypeInternal, StageTypeInternalNoCse},
 	StageTypeExternal: {StageTypeExternal},

--- a/pkg/sdk/stages_validations_gen.go
+++ b/pkg/sdk/stages_validations_gen.go
@@ -36,10 +36,7 @@ func (opts *CreateInternalStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("CreateInternalStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		// adjusted manually
-		if valueSet(opts.FileFormat.FileFormatOptions) {
-			errs = append(errs, opts.FileFormat.FileFormatOptions.validate())
-		}
+		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
 	}
 	return JoinErrors(errs...)
 }
@@ -80,10 +77,7 @@ func (opts *CreateOnS3StageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("CreateOnS3StageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		// adjusted manually
-		if valueSet(opts.FileFormat.FileFormatOptions) {
-			errs = append(errs, opts.FileFormat.FileFormatOptions.validate())
-		}
+		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
 	}
 	return JoinErrors(errs...)
 }
@@ -107,10 +101,7 @@ func (opts *CreateOnGCSStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("CreateOnGCSStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		// adjusted manually
-		if valueSet(opts.FileFormat.FileFormatOptions) {
-			errs = append(errs, opts.FileFormat.FileFormatOptions.validate())
-		}
+		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
 	}
 	return JoinErrors(errs...)
 }
@@ -140,10 +131,7 @@ func (opts *CreateOnAzureStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("CreateOnAzureStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		// adjusted manually
-		if valueSet(opts.FileFormat.FileFormatOptions) {
-			errs = append(errs, opts.FileFormat.FileFormatOptions.validate())
-		}
+		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
 	}
 	return JoinErrors(errs...)
 }
@@ -160,10 +148,7 @@ func (opts *CreateOnS3CompatibleStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("CreateOnS3CompatibleStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		// adjusted manually
-		if valueSet(opts.FileFormat.FileFormatOptions) {
-			errs = append(errs, opts.FileFormat.FileFormatOptions.validate())
-		}
+		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
 	}
 	return JoinErrors(errs...)
 }
@@ -197,10 +182,7 @@ func (opts *AlterInternalStageStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("AlterInternalStageStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		// adjusted manually
-		if valueSet(opts.FileFormat.FileFormatOptions) {
-			errs = append(errs, opts.FileFormat.FileFormatOptions.validate())
-		}
+		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
 	}
 	return JoinErrors(errs...)
 }
@@ -241,10 +223,7 @@ func (opts *AlterExternalS3StageStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("AlterExternalS3StageStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		// adjusted manually
-		if valueSet(opts.FileFormat.FileFormatOptions) {
-			errs = append(errs, opts.FileFormat.FileFormatOptions.validate())
-		}
+		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
 	}
 	return JoinErrors(errs...)
 }
@@ -268,10 +247,7 @@ func (opts *AlterExternalGCSStageStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("AlterExternalGCSStageStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		// adjusted manually
-		if valueSet(opts.FileFormat.FileFormatOptions) {
-			errs = append(errs, opts.FileFormat.FileFormatOptions.validate())
-		}
+		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
 	}
 	return JoinErrors(errs...)
 }
@@ -301,10 +277,7 @@ func (opts *AlterExternalAzureStageStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("AlterExternalAzureStageStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		// adjusted manually
-		if valueSet(opts.FileFormat.FileFormatOptions) {
-			errs = append(errs, opts.FileFormat.FileFormatOptions.validate())
-		}
+		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
 	}
 	return JoinErrors(errs...)
 }

--- a/pkg/sdk/streamlits_ext.go
+++ b/pkg/sdk/streamlits_ext.go
@@ -1,0 +1,8 @@
+package sdk
+
+func (opts *ShowStreamlitOptions) additionalValidations() error {
+	if valueSet(opts.Like) && !valueSet(opts.Like.Pattern) {
+		return ErrPatternRequiredForLikeKeyword
+	}
+	return nil
+}

--- a/pkg/sdk/streamlits_validations_gen.go
+++ b/pkg/sdk/streamlits_validations_gen.go
@@ -73,10 +73,7 @@ func (opts *ShowStreamlitOptions) validate() error {
 		return ErrNilOptions
 	}
 	var errs []error
-	// validation added manually
-	if valueSet(opts.Like) && !valueSet(opts.Like.Pattern) {
-		errs = append(errs, ErrPatternRequiredForLikeKeyword)
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 

--- a/pkg/sdk/tasks_ext.go
+++ b/pkg/sdk/tasks_ext.go
@@ -13,6 +13,50 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
 
+func (opts *CreateTaskOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.SessionParameters) {
+		if err := opts.SessionParameters.validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if valueSet(opts.Warehouse) {
+		if !exactlyOneValueSet(opts.Warehouse.Warehouse, opts.Warehouse.UserTaskManagedInitialWarehouseSize) {
+			errs = append(errs, errExactlyOneOf("CreateTaskOptions.Warehouse", "Warehouse", "UserTaskManagedInitialWarehouseSize"))
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateOrAlterTaskOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.SessionParameters) {
+		if err := opts.SessionParameters.validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if valueSet(opts.Warehouse) {
+		if !exactlyOneValueSet(opts.Warehouse.Warehouse, opts.Warehouse.UserTaskManagedInitialWarehouseSize) {
+			errs = append(errs, errExactlyOneOf("CreateOrAlterTaskOptions.CreateTaskWarehouse", "Warehouse", "UserTaskManagedInitialWarehouseSize"))
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (s *TaskSet) additionalValidations() error {
+	if valueSet(s.SessionParameters) {
+		return s.SessionParameters.validate()
+	}
+	return nil
+}
+
+func (s *TaskUnset) additionalValidations() error {
+	if valueSet(s.SessionParametersUnset) {
+		return s.SessionParametersUnset.validate()
+	}
+	return nil
+}
+
 type TaskRelationsRepresentation struct {
 	Predecessors      []string `json:"Predecessors"`
 	FinalizerTask     string   `json:"FinalizerTask"`

--- a/pkg/sdk/tasks_validations_gen.go
+++ b/pkg/sdk/tasks_validations_gen.go
@@ -18,18 +18,7 @@ func (opts *CreateTaskOptions) validate() error {
 		return ErrNilOptions
 	}
 	var errs []error
-	// adjusted manually
-	if valueSet(opts.SessionParameters) {
-		if err := opts.SessionParameters.validate(); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	// added manually
-	if valueSet(opts.Warehouse) {
-		if !exactlyOneValueSet(opts.Warehouse.Warehouse, opts.Warehouse.UserTaskManagedInitialWarehouseSize) {
-			errs = append(errs, errExactlyOneOf("CreateTaskOptions.Warehouse", "Warehouse", "UserTaskManagedInitialWarehouseSize"))
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
@@ -47,18 +36,7 @@ func (opts *CreateOrAlterTaskOptions) validate() error {
 		return ErrNilOptions
 	}
 	var errs []error
-	// adjusted manually
-	if valueSet(opts.SessionParameters) {
-		if err := opts.SessionParameters.validate(); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	// added manually
-	if valueSet(opts.Warehouse) {
-		if !exactlyOneValueSet(opts.Warehouse.Warehouse, opts.Warehouse.UserTaskManagedInitialWarehouseSize) {
-			errs = append(errs, errExactlyOneOf("CreateOrAlterTaskOptions.CreateTaskWarehouse", "Warehouse", "UserTaskManagedInitialWarehouseSize"))
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
@@ -94,12 +72,7 @@ func (opts *AlterTaskOptions) validate() error {
 		errs = append(errs, errExactlyOneOf("AlterTaskOptions", "Resume", "Suspend", "RemoveAfter", "AddAfter", "Set", "Unset", "SetTags", "UnsetTags", "SetFinalize", "UnsetFinalize", "ModifyAs", "ModifyWhen", "RemoveWhen"))
 	}
 	if valueSet(opts.Set) {
-		// adjusted manually
-		if valueSet(opts.Set.SessionParameters) {
-			if err := opts.Set.SessionParameters.validate(); err != nil {
-				errs = append(errs, err)
-			}
-		}
+		errs = append(errs, opts.Set.additionalValidations()) // invocation added manually
 		if !anyValueSet(opts.Set.Warehouse, opts.Set.UserTaskManagedInitialWarehouseSize, opts.Set.Schedule, opts.Set.Config, opts.Set.AllowOverlappingExecution, opts.Set.UserTaskTimeoutMs, opts.Set.SuspendTaskAfterNumFailures, opts.Set.ErrorIntegration, opts.Set.Comment, opts.Set.SessionParameters, opts.Set.TaskAutoRetryAttempts, opts.Set.UserTaskMinimumTriggerIntervalInSeconds, opts.Set.TargetCompletionInterval, opts.Set.ServerlessTaskMinStatementSize, opts.Set.ServerlessTaskMaxStatementSize) {
 			errs = append(errs, errAtLeastOneOf("AlterTaskOptions.Set", "Warehouse", "UserTaskManagedInitialWarehouseSize", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParameters", "TaskAutoRetryAttempts", "UserTaskMinimumTriggerIntervalInSeconds", "TargetCompletionInterval", "ServerlessTaskMinStatementSize", "ServerlessTaskMaxStatementSize"))
 		}
@@ -111,12 +84,7 @@ func (opts *AlterTaskOptions) validate() error {
 		}
 	}
 	if valueSet(opts.Unset) {
-		// adjusted manually
-		if valueSet(opts.Unset.SessionParametersUnset) {
-			if err := opts.Unset.SessionParametersUnset.validate(); err != nil {
-				errs = append(errs, err)
-			}
-		}
+		errs = append(errs, opts.Unset.additionalValidations()) // invocation added manually
 		if !anyValueSet(opts.Unset.Warehouse, opts.Unset.UserTaskManagedInitialWarehouseSize, opts.Unset.Schedule, opts.Unset.Config, opts.Unset.AllowOverlappingExecution, opts.Unset.UserTaskTimeoutMs, opts.Unset.SuspendTaskAfterNumFailures, opts.Unset.ErrorIntegration, opts.Unset.Comment, opts.Unset.SessionParametersUnset, opts.Unset.TaskAutoRetryAttempts, opts.Unset.UserTaskMinimumTriggerIntervalInSeconds, opts.Unset.TargetCompletionInterval, opts.Unset.ServerlessTaskMinStatementSize, opts.Unset.ServerlessTaskMaxStatementSize) {
 			errs = append(errs, errAtLeastOneOf("AlterTaskOptions.Unset", "Warehouse", "UserTaskManagedInitialWarehouseSize", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParametersUnset", "TaskAutoRetryAttempts", "UserTaskMinimumTriggerIntervalInSeconds", "TargetCompletionInterval", "ServerlessTaskMinStatementSize", "ServerlessTaskMaxStatementSize"))
 		}

--- a/pkg/sdk/user_programmatic_access_tokens_ext.go
+++ b/pkg/sdk/user_programmatic_access_tokens_ext.go
@@ -2,6 +2,57 @@ package sdk
 
 import "context"
 
+func (opts *AddUserProgrammaticAccessTokenOptions) additionalValidations() error {
+	var errs []error
+	if !ValidObjectIdentifier(opts.UserName) {
+		errs = append(errs, errInvalidIdentifier("AddUserProgrammaticAccessTokenOptions", "UserName"))
+	}
+	if valueSet(opts.DaysToExpiry) {
+		if !validateIntGreaterThanOrEqual(*opts.DaysToExpiry, 1) {
+			errs = append(errs, errIntValue("AddUserProgrammaticAccessTokenOptions", "DaysToExpiry", IntErrGreaterOrEqual, 1))
+		}
+	}
+	if valueSet(opts.MinsToBypassNetworkPolicyRequirement) {
+		if !validateIntGreaterThanOrEqual(*opts.MinsToBypassNetworkPolicyRequirement, 1) {
+			errs = append(errs, errIntValue("AddUserProgrammaticAccessTokenOptions", "MinsToBypassNetworkPolicyRequirement", IntErrGreaterOrEqual, 1))
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *ModifyUserProgrammaticAccessTokenOptions) additionalValidations() error {
+	var errs []error
+	if !ValidObjectIdentifier(opts.UserName) {
+		errs = append(errs, errInvalidIdentifier("ModifyUserProgrammaticAccessTokenOptions", "UserName"))
+	}
+	if valueSet(opts.Set) && valueSet(opts.Set.MinsToBypassNetworkPolicyRequirement) {
+		if !validateIntGreaterThanOrEqual(*opts.Set.MinsToBypassNetworkPolicyRequirement, 1) {
+			errs = append(errs, errIntValue("ModifyUserProgrammaticAccessTokenOptions", "Set.MinsToBypassNetworkPolicyRequirement", IntErrGreaterOrEqual, 1))
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *RotateUserProgrammaticAccessTokenOptions) additionalValidations() error {
+	var errs []error
+	if !ValidObjectIdentifier(opts.UserName) {
+		errs = append(errs, errInvalidIdentifier("RotateUserProgrammaticAccessTokenOptions", "UserName"))
+	}
+	if valueSet(opts.ExpireRotatedTokenAfterHours) {
+		if !validateIntGreaterThanOrEqual(*opts.ExpireRotatedTokenAfterHours, 0) {
+			errs = append(errs, errIntValue("RotateUserProgrammaticAccessTokenOptions", "ExpireRotatedTokenAfterHours", IntErrGreaterOrEqual, 0))
+		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *RemoveUserProgrammaticAccessTokenOptions) additionalValidations() error {
+	if !ValidObjectIdentifier(opts.UserName) {
+		return errInvalidIdentifier("RemoveUserProgrammaticAccessTokenOptions", "UserName")
+	}
+	return nil
+}
+
 func (r *AddProgrammaticAccessTokenResult) ID() AccountObjectIdentifier {
 	return NewAccountObjectIdentifier(r.TokenName)
 }

--- a/pkg/sdk/user_programmatic_access_tokens_validations_gen.go
+++ b/pkg/sdk/user_programmatic_access_tokens_validations_gen.go
@@ -18,22 +18,7 @@ func (opts *AddUserProgrammaticAccessTokenOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	// adjusted manually
-	if !ValidObjectIdentifier(opts.UserName) {
-		errs = append(errs, errInvalidIdentifier("AddUserProgrammaticAccessTokenOptions", "UserName"))
-	}
-	// adjusted manually
-	if valueSet(opts.DaysToExpiry) {
-		if !validateIntGreaterThanOrEqual(*opts.DaysToExpiry, 1) {
-			errs = append(errs, errIntValue("AddUserProgrammaticAccessTokenOptions", "DaysToExpiry", IntErrGreaterOrEqual, 1))
-		}
-	}
-	// adjusted manually
-	if valueSet(opts.MinsToBypassNetworkPolicyRequirement) {
-		if !validateIntGreaterThanOrEqual(*opts.MinsToBypassNetworkPolicyRequirement, 1) {
-			errs = append(errs, errIntValue("AddUserProgrammaticAccessTokenOptions", "MinsToBypassNetworkPolicyRequirement", IntErrGreaterOrEqual, 1))
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if opts.RoleRestriction != nil && !ValidObjectIdentifier(opts.RoleRestriction) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
@@ -48,16 +33,7 @@ func (opts *ModifyUserProgrammaticAccessTokenOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	// adjusted manually
-	if !ValidObjectIdentifier(opts.UserName) {
-		errs = append(errs, errInvalidIdentifier("ModifyUserProgrammaticAccessTokenOptions", "UserName"))
-	}
-	// adjusted manually
-	if valueSet(opts.Set) && valueSet(opts.Set.MinsToBypassNetworkPolicyRequirement) {
-		if !validateIntGreaterThanOrEqual(*opts.Set.MinsToBypassNetworkPolicyRequirement, 1) {
-			errs = append(errs, errIntValue("ModifyUserProgrammaticAccessTokenOptions", "Set.MinsToBypassNetworkPolicyRequirement", IntErrGreaterOrEqual, 1))
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if !exactlyOneValueSet(opts.Set, opts.Unset, opts.RenameTo) {
 		errs = append(errs, errExactlyOneOf("ModifyUserProgrammaticAccessTokenOptions", "Set", "Unset", "RenameTo"))
 	}
@@ -72,16 +48,7 @@ func (opts *RotateUserProgrammaticAccessTokenOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	// adjusted manually
-	if !ValidObjectIdentifier(opts.UserName) {
-		errs = append(errs, errInvalidIdentifier("RotateUserProgrammaticAccessTokenOptions", "UserName"))
-	}
-	// adjusted manually
-	if valueSet(opts.ExpireRotatedTokenAfterHours) {
-		if !validateIntGreaterThanOrEqual(*opts.ExpireRotatedTokenAfterHours, 0) {
-			errs = append(errs, errIntValue("RotateUserProgrammaticAccessTokenOptions", "ExpireRotatedTokenAfterHours", IntErrGreaterOrEqual, 0))
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 
@@ -93,10 +60,7 @@ func (opts *RemoveUserProgrammaticAccessTokenOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	// adjusted manually
-	if !ValidObjectIdentifier(opts.UserName) {
-		errs = append(errs, errInvalidIdentifier("RemoveUserProgrammaticAccessTokenOptions", "UserName"))
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 

--- a/pkg/sdk/views_ext.go
+++ b/pkg/sdk/views_ext.go
@@ -1,6 +1,42 @@
 package sdk
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
+
+func (p *ViewRowAccessPolicy) additionalValidations() error {
+	if !valueSet(p.On) {
+		return errNotSet("CreateViewOptions.RowAccessPolicy", "On")
+	}
+	return nil
+}
+
+func (p *ViewAddRowAccessPolicy) additionalValidations() error {
+	if !valueSet(p.On) {
+		return errNotSet("AlterViewOptions.AddRowAccessPolicy", "On")
+	}
+	return nil
+}
+
+func (opts *CreateViewOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.Columns) {
+		for i, columnOption := range opts.Columns {
+			if valueSet(columnOption.MaskingPolicy) {
+				if !ValidObjectIdentifier(columnOption.MaskingPolicy.MaskingPolicy) {
+					errs = append(errs, errInvalidIdentifier(fmt.Sprintf("CreateViewOptions.Columns[%d]", i), "MaskingPolicy"))
+				}
+			}
+			if valueSet(columnOption.ProjectionPolicy) {
+				if !ValidObjectIdentifier(columnOption.ProjectionPolicy.ProjectionPolicy) {
+					errs = append(errs, errInvalidIdentifier(fmt.Sprintf("CreateViewOptions.Columns[%d]", i), "ProjectionPolicy"))
+				}
+			}
+		}
+	}
+	return JoinErrors(errs...)
+}
 
 var AllViewDataMetricScheduleMinutes = []int{5, 15, 30, 60, 720, 1440}
 

--- a/pkg/sdk/views_validations_gen.go
+++ b/pkg/sdk/views_validations_gen.go
@@ -2,9 +2,6 @@
 
 package sdk
 
-// imports adjusted manually
-import "fmt"
-
 var (
 	_ validatable = new(CreateViewOptions)
 	_ validatable = new(AlterViewOptions)
@@ -28,31 +25,14 @@ func (opts *CreateViewOptions) validate() error {
 		if !ValidObjectIdentifier(opts.RowAccessPolicy.RowAccessPolicy) {
 			errs = append(errs, ErrInvalidObjectIdentifier)
 		}
-		// added manually
-		if !valueSet(opts.RowAccessPolicy.On) {
-			errs = append(errs, errNotSet("CreateViewOptions.RowAccessPolicy", "On"))
-		}
+		errs = append(errs, opts.RowAccessPolicy.additionalValidations()) // invocation added manually
 	}
 	if valueSet(opts.AggregationPolicy) {
 		if !ValidObjectIdentifier(opts.AggregationPolicy.AggregationPolicy) {
 			errs = append(errs, ErrInvalidObjectIdentifier)
 		}
 	}
-	// added manually
-	if valueSet(opts.Columns) {
-		for i, columnOption := range opts.Columns {
-			if valueSet(columnOption.MaskingPolicy) {
-				if !ValidObjectIdentifier(columnOption.MaskingPolicy.MaskingPolicy) {
-					errs = append(errs, errInvalidIdentifier(fmt.Sprintf("CreateViewOptions.Columns[%d]", i), "MaskingPolicy"))
-				}
-			}
-			if valueSet(columnOption.ProjectionPolicy) {
-				if !ValidObjectIdentifier(columnOption.ProjectionPolicy.ProjectionPolicy) {
-					errs = append(errs, errInvalidIdentifier(fmt.Sprintf("CreateViewOptions.Columns[%d]", i), "ProjectionPolicy"))
-				}
-			}
-		}
-	}
+	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 
@@ -77,10 +57,7 @@ func (opts *AlterViewOptions) validate() error {
 		if !ValidObjectIdentifier(opts.AddRowAccessPolicy.RowAccessPolicy) {
 			errs = append(errs, ErrInvalidObjectIdentifier)
 		}
-		// added manually
-		if !valueSet(opts.AddRowAccessPolicy.On) {
-			errs = append(errs, errNotSet("AlterViewOptions.AddRowAccessPolicy", "On"))
-		}
+		errs = append(errs, opts.AddRowAccessPolicy.additionalValidations()) // invocation added manually
 	}
 	if valueSet(opts.DropRowAccessPolicy) {
 		if !ValidObjectIdentifier(opts.DropRowAccessPolicy.RowAccessPolicy) {
@@ -97,10 +74,7 @@ func (opts *AlterViewOptions) validate() error {
 			if !ValidObjectIdentifier(opts.DropAndAddRowAccessPolicy.Add.RowAccessPolicy) {
 				errs = append(errs, ErrInvalidObjectIdentifier)
 			}
-			// added manually
-			if !valueSet(opts.DropAndAddRowAccessPolicy.Add.On) {
-				errs = append(errs, errNotSet("AlterViewOptions.DropAndAddRowAccessPolicy.Add", "On"))
-			}
+			errs = append(errs, opts.DropAndAddRowAccessPolicy.Add.additionalValidations()) // invocation added manually
 		}
 	}
 	if valueSet(opts.SetAggregationPolicy) {


### PR DESCRIPTION
Part of the ongoing effort to reduce manual changes in SDK generation.

The `*_validations_gen.go` files are code-generated but historically accumulated manually-added validation blocks (marked with comments like `// added manually`, `// modified manually`, `// adjusted manually`, etc.). These blocks are invisible to the generator and are lost or corrupted on regeneration (as demonstrated by hybrid tables, where a slice-iteration loop was replaced with incorrect direct field access).                                                                              

This change extracts all manually-marked validation blocks from `*_validations_gen.go` files into `additionalValidations()` methods in the corresponding `*_ext.go files`, replacing the inline code with a single invocation:
```go
  errs = append(errs, opts.additionalValidations()) // invocation added manually                                                                                                                                                                                                                                                                                                                                                                                                                        
```
The next step is to add an option to the SDK generator to emit these invocation lines automatically. This will eliminate the need to manually re-add validation logic after regeneration and will allow missing validations to be added directly to `*_ext.go` files in a discoverable, maintainable way. Later, the validations will be iteratively added to SDK generator if they are repeatable.

Affected objects: tasks, services, compute pools, stages, views, notebooks, security integrations, notification integrations, semantic views, applications, streamlits, iceberg tables, api integrations, user programmatic access tokens, external volumes, file formats, functions, procedures, hybrid tables. 