### PR TITLE
chore: Generate additional validations invocation

### DIFF
--- a/pkg/sdk/api_integrations_validations_gen.go
+++ b/pkg/sdk/api_integrations_validations_gen.go
@@ -45,7 +45,7 @@ func (opts *AlterApiIntegrationOptions) validate() error {
 		errs = append(errs, errExactlyOneOf("AlterApiIntegrationOptions", "Set", "Unset", "SetTags", "UnsetTags"))
 	}
 	if valueSet(opts.Set) {
-		errs = append(errs, opts.Set.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.Set.additionalValidations())
 		if !anyValueSet(opts.Set.AwsParams, opts.Set.AzureParams, opts.Set.GoogleParams, opts.Set.Enabled, opts.Set.ApiAllowedPrefixes, opts.Set.ApiBlockedPrefixes, opts.Set.Comment) {
 			errs = append(errs, errAtLeastOneOf("AlterApiIntegrationOptions.Set", "AwsParams", "AzureParams", "GoogleParams", "Enabled", "ApiAllowedPrefixes", "ApiBlockedPrefixes", "Comment"))
 		}

--- a/pkg/sdk/applications_validations_gen.go
+++ b/pkg/sdk/applications_validations_gen.go
@@ -21,12 +21,12 @@ func (opts *CreateApplicationOptions) validate() error {
 	if !ValidObjectIdentifier(opts.PackageName) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Version) {
 		if !exactlyOneValueSet(opts.Version.VersionDirectory, opts.Version.VersionAndPatch) {
 			errs = append(errs, errExactlyOneOf("CreateApplicationOptions.Version", "VersionDirectory", "VersionAndPatch"))
 		}
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 
@@ -52,12 +52,12 @@ func (opts *AlterApplicationOptions) validate() error {
 	if !exactlyOneValueSet(opts.Set, opts.Unset, opts.Upgrade, opts.UpgradeVersion, opts.UnsetReferences, opts.SetTags, opts.UnsetTags) {
 		errs = append(errs, errExactlyOneOf("AlterApplicationOptions", "Set", "Unset", "Upgrade", "UpgradeVersion", "UnsetReferences", "SetTags", "UnsetTags"))
 	}
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.UpgradeVersion) {
 		if !exactlyOneValueSet(opts.UpgradeVersion.VersionDirectory, opts.UpgradeVersion.VersionAndPatch) {
 			errs = append(errs, errExactlyOneOf("AlterApplicationOptions.UpgradeVersion", "VersionDirectory", "VersionAndPatch"))
 		}
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 

--- a/pkg/sdk/compute_pools_validations_gen.go
+++ b/pkg/sdk/compute_pools_validations_gen.go
@@ -18,7 +18,7 @@ func (opts *CreateComputePoolOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	return JoinErrors(errs...)
 }
 
@@ -34,7 +34,7 @@ func (opts *AlterComputePoolOptions) validate() error {
 		errs = append(errs, errExactlyOneOf("AlterComputePoolOptions", "Resume", "Suspend", "StopAll", "Set", "Unset", "SetTags", "UnsetTags"))
 	}
 	if valueSet(opts.Set) {
-		errs = append(errs, opts.Set.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.Set.additionalValidations())
 		if !anyValueSet(opts.Set.MinNodes, opts.Set.MaxNodes, opts.Set.AutoResume, opts.Set.AutoSuspendSecs, opts.Set.Comment) {
 			errs = append(errs, errAtLeastOneOf("AlterComputePoolOptions.Set", "MinNodes", "MaxNodes", "AutoResume", "AutoSuspendSecs", "Comment"))
 		}

--- a/pkg/sdk/external_volumes_validations_gen.go
+++ b/pkg/sdk/external_volumes_validations_gen.go
@@ -21,9 +21,7 @@ func (opts *CreateExternalVolumeOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
-
+	errs = append(errs, opts.additionalValidations())
 	return JoinErrors(errs...)
 }
 

--- a/pkg/sdk/file_formats_validations_gen.go
+++ b/pkg/sdk/file_formats_validations_gen.go
@@ -9,6 +9,7 @@ func (opts *DummyOperationFileFormatOptions) validate() error {
 		return ErrNilOptions
 	}
 	var errs []error
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
+	// all file formats validations removed manually
 	return JoinErrors(errs...)
 }

--- a/pkg/sdk/functions_gen_test.go
+++ b/pkg/sdk/functions_gen_test.go
@@ -101,7 +101,7 @@ func TestFunctions_CreateForJava(t *testing.T) {
 		opts.Returns = FunctionReturns{
 			ResultDataType: &FunctionReturnsResultDataType{},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForJavaFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.ResultDataType.ResultDataTypeOld opts.Returns.ResultDataType.ResultDataType] should be present - two present", func(t *testing.T) {
@@ -112,7 +112,7 @@ func TestFunctions_CreateForJava(t *testing.T) {
 				ResultDataType:    dataTypeFloat,
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForJavaFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.Table.Columns.ColumnDataTypeOld opts.Returns.Table.Columns.ColumnDataType] should be present", func(t *testing.T) {
@@ -374,7 +374,7 @@ func TestFunctions_CreateForJavascript(t *testing.T) {
 		opts.Returns = FunctionReturns{
 			ResultDataType: &FunctionReturnsResultDataType{},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForJavascriptFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.ResultDataType.ResultDataTypeOld opts.Returns.ResultDataType.ResultDataType] should be present - two present", func(t *testing.T) {
@@ -385,7 +385,7 @@ func TestFunctions_CreateForJavascript(t *testing.T) {
 				ResultDataType:    dataTypeFloat,
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForJavascriptFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.Table.Columns.ColumnDataTypeOld opts.Returns.Table.Columns.ColumnDataType] should be present", func(t *testing.T) {
@@ -578,7 +578,7 @@ func TestFunctions_CreateForPython(t *testing.T) {
 		opts.Returns = FunctionReturns{
 			ResultDataType: &FunctionReturnsResultDataType{},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForPythonFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.ResultDataType.ResultDataTypeOld opts.Returns.ResultDataType.ResultDataType] should be present - two present", func(t *testing.T) {
@@ -589,7 +589,7 @@ func TestFunctions_CreateForPython(t *testing.T) {
 				ResultDataType:    dataTypeFloat,
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForPythonFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.Table.Columns.ColumnDataTypeOld opts.Returns.Table.Columns.ColumnDataType] should be present", func(t *testing.T) {

--- a/pkg/sdk/functions_validations_gen.go
+++ b/pkg/sdk/functions_validations_gen.go
@@ -28,18 +28,18 @@ func (opts *CreateForJavaFunctionOptions) validate() error {
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateForJavaFunctionOptions", "OrReplace", "IfNotExists"))
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForJavaFunctionOptions.Returns", "ResultDataType", "Table"))
 		}
 		if valueSet(opts.Returns.ResultDataType) {
 			if !exactlyOneValueSet(opts.Returns.ResultDataType.ResultDataTypeOld, opts.Returns.ResultDataType.ResultDataType) {
-				errs = append(errs, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+				errs = append(errs, errExactlyOneOf("CreateForJavaFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
+			errs = append(errs, opts.Returns.Table.additionalValidations())
 		}
 	}
 	return JoinErrors(errs...)
@@ -56,18 +56,18 @@ func (opts *CreateForJavascriptFunctionOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForJavascriptFunctionOptions.Returns", "ResultDataType", "Table"))
 		}
 		if valueSet(opts.Returns.ResultDataType) {
 			if !exactlyOneValueSet(opts.Returns.ResultDataType.ResultDataTypeOld, opts.Returns.ResultDataType.ResultDataType) {
-				errs = append(errs, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+				errs = append(errs, errExactlyOneOf("CreateForJavascriptFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
+			errs = append(errs, opts.Returns.Table.additionalValidations())
 		}
 	}
 	return JoinErrors(errs...)
@@ -90,18 +90,18 @@ func (opts *CreateForPythonFunctionOptions) validate() error {
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateForPythonFunctionOptions", "OrReplace", "IfNotExists"))
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForPythonFunctionOptions.Returns", "ResultDataType", "Table"))
 		}
 		if valueSet(opts.Returns.ResultDataType) {
 			if !exactlyOneValueSet(opts.Returns.ResultDataType.ResultDataTypeOld, opts.Returns.ResultDataType.ResultDataType) {
-				errs = append(errs, errExactlyOneOf("CreateForSQLFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+				errs = append(errs, errExactlyOneOf("CreateForPythonFunctionOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
+			errs = append(errs, opts.Returns.Table.additionalValidations())
 		}
 	}
 	return JoinErrors(errs...)
@@ -124,7 +124,7 @@ func (opts *CreateForScalaFunctionOptions) validate() error {
 	if !exactlyOneValueSet(opts.ResultDataTypeOld, opts.ResultDataType) {
 		errs = append(errs, errExactlyOneOf("CreateForScalaFunctionOptions", "ResultDataTypeOld", "ResultDataType"))
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	return JoinErrors(errs...)
 }
 
@@ -139,7 +139,7 @@ func (opts *CreateForSQLFunctionOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForSQLFunctionOptions.Returns", "ResultDataType", "Table"))
@@ -150,7 +150,7 @@ func (opts *CreateForSQLFunctionOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
+			errs = append(errs, opts.Returns.Table.additionalValidations())
 		}
 	}
 	return JoinErrors(errs...)

--- a/pkg/sdk/generator/defs/api_integrations_def.go
+++ b/pkg/sdk/generator/defs/api_integrations_def.go
@@ -92,8 +92,7 @@ var apiIntegrationsDef = g.NewInterface(
 					ListAssignment("API_ALLOWED_PREFIXES", "ApiIntegrationEndpointPrefix", g.ParameterOptions().Parentheses()).
 					ListAssignment("API_BLOCKED_PREFIXES", "ApiIntegrationEndpointPrefix", g.ParameterOptions().Parentheses()).
 					OptionalComment().
-					// resulting validation changed to moreThanOneValueSet (not yet supported in the generator)
-					WithValidation(g.ConflictingFields, "AwsParams", "AzureParams", "GoogleParams").
+					WithAdditionalValidations().
 					WithValidation(g.AtLeastOneValueSet, "AwsParams", "AzureParams", "GoogleParams", "Enabled", "ApiAllowedPrefixes", "ApiBlockedPrefixes", "Comment"),
 				g.KeywordOptions().SQL("SET"),
 			).

--- a/pkg/sdk/generator/defs/applications_def.go
+++ b/pkg/sdk/generator/defs/applications_def.go
@@ -58,7 +58,8 @@ var applicationsDef = g.NewInterface(
 		OptionalTextAssignment("COMMENT", g.ParameterOptions().SingleQuotes()).
 		OptionalTags().
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ValidIdentifier, "PackageName"),
+		WithValidation(g.ValidIdentifier, "PackageName").
+		WithAdditionalValidations(),
 ).DropOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/drop-application",
 	g.NewQueryStruct("DropApplication").
@@ -99,7 +100,8 @@ var applicationsDef = g.NewInterface(
 		OptionalSetTags().
 		OptionalUnsetTags().
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ExactlyOneValueSet, "Set", "Unset", "Upgrade", "UpgradeVersion", "UnsetReferences", "SetTags", "UnsetTags"),
+		WithValidation(g.ExactlyOneValueSet, "Set", "Unset", "Upgrade", "UpgradeVersion", "UnsetReferences", "SetTags", "UnsetTags").
+		WithAdditionalValidations(),
 ).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-applications",
 	g.StructPair("applicationRow", "Application").

--- a/pkg/sdk/generator/defs/compute_pools_def.go
+++ b/pkg/sdk/generator/defs/compute_pools_def.go
@@ -37,7 +37,8 @@ var computePoolsDef = g.NewInterface(
 		OptionalNumberAssignment("AUTO_SUSPEND_SECS", g.ParameterOptions()).
 		OptionalTags().
 		OptionalTextAssignment("COMMENT", g.ParameterOptions().SingleQuotes()).
-		WithValidation(g.ValidIdentifier, "name"),
+		WithValidation(g.ValidIdentifier, "name").
+		WithAdditionalValidations(),
 ).AlterOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/alter-compute-pool",
 	g.NewQueryStruct("AlterComputePool").
@@ -56,6 +57,7 @@ var computePoolsDef = g.NewInterface(
 				OptionalBooleanAssignment("AUTO_RESUME", g.ParameterOptions()).
 				OptionalNumberAssignment("AUTO_SUSPEND_SECS", g.ParameterOptions()).
 				OptionalTextAssignment("COMMENT", g.ParameterOptions().SingleQuotes()).
+				WithAdditionalValidations().
 				WithValidation(g.AtLeastOneValueSet, "MinNodes", "MaxNodes", "AutoResume", "AutoSuspendSecs", "Comment"),
 			g.KeywordOptions().SQL("SET"),
 		).

--- a/pkg/sdk/generator/defs/external_volumes_def.go
+++ b/pkg/sdk/generator/defs/external_volumes_def.go
@@ -135,7 +135,8 @@ var externalVolumesDef = g.NewInterface(
 			OptionalBooleanAssignment("ALLOW_WRITES", nil).
 			OptionalComment().
 			WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists").
-			WithValidation(g.ValidIdentifier, "name"),
+			WithValidation(g.ValidIdentifier, "name").
+			WithAdditionalValidations(),
 		storageLocationItemDef,
 	).
 	AlterOperation(

--- a/pkg/sdk/generator/defs/file_formats_def.go
+++ b/pkg/sdk/generator/defs/file_formats_def.go
@@ -173,7 +173,8 @@ var fileFormatsDef = g.NewInterface(
 		"DummyOperation",
 		"not available",
 		g.NewQueryStruct("FileFormatsDummyOperation").
-			OptionalQueryStructField("FileFormat", fileFormatDef(), g.ListOptions().Parentheses().SQL("FILE_FORMAT =")),
+			OptionalQueryStructField("FileFormat", fileFormatDef(), g.ListOptions().Parentheses().SQL("FILE_FORMAT =")).
+			WithAdditionalValidations(),
 	).
 	WithEnums(
 		FileFormatTypeEnumDef,

--- a/pkg/sdk/generator/defs/functions_def.go
+++ b/pkg/sdk/generator/defs/functions_def.go
@@ -6,18 +6,24 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/generator/gen/sdkcommons"
 )
 
-var functionArgument = g.NewQueryStruct("FunctionArgument").
-	Text("ArgName", g.KeywordOptions().DoubleQuotes().Required()).
-	PredefinedQueryStructField("ArgDataTypeOld", "DataType", g.KeywordOptions().NoQuotes()).
-	PredefinedQueryStructField("ArgDataType", "datatypes.DataType", g.ParameterOptions().NoQuotes().NoEquals().Required()).
-	PredefinedQueryStructField("DefaultValue", "*string", g.ParameterOptions().NoEquals().SQL("DEFAULT")).
-	WithValidation(g.ExactlyOneValueSet, "ArgDataTypeOld", "ArgDataType")
+var functionArgument = func() *g.QueryStruct {
+	return g.NewQueryStruct("FunctionArgument").
+		Text("ArgName", g.KeywordOptions().DoubleQuotes().Required()).
+		PredefinedQueryStructField("ArgDataTypeOld", "DataType", g.KeywordOptions().NoQuotes()).
+		PredefinedQueryStructField("ArgDataType", "datatypes.DataType", g.ParameterOptions().NoQuotes().NoEquals().Required()).
+		PredefinedQueryStructField("DefaultValue", "*string", g.ParameterOptions().NoEquals().SQL("DEFAULT"))
+	// TODO [next PR]: validation is not generated properly as this is used as an array; using the additionalValidations above for now
+	// .WithValidation(g.ExactlyOneValueSet, "ArgDataTypeOld", "ArgDataType")
+}
 
-var functionColumn = g.NewQueryStruct("FunctionColumn").
-	Text("ColumnName", g.KeywordOptions().DoubleQuotes().Required()).
-	PredefinedQueryStructField("ColumnDataTypeOld", "DataType", g.KeywordOptions().NoQuotes()).
-	PredefinedQueryStructField("ColumnDataType", "datatypes.DataType", g.ParameterOptions().NoQuotes().NoEquals().Required()).
-	WithValidation(g.ExactlyOneValueSet, "ColumnDataTypeOld", "ColumnDataType")
+var functionColumn = func() *g.QueryStruct {
+	return g.NewQueryStruct("FunctionColumn").
+		Text("ColumnName", g.KeywordOptions().DoubleQuotes().Required()).
+		PredefinedQueryStructField("ColumnDataTypeOld", "DataType", g.KeywordOptions().NoQuotes()).
+		PredefinedQueryStructField("ColumnDataType", "datatypes.DataType", g.ParameterOptions().NoQuotes().NoEquals().Required())
+	// TODO [next PR]: validation is not generated properly as this is used as an array; using the additionalValidations above for now
+	// .WithValidation(g.ExactlyOneValueSet, "ColumnDataTypeOld", "ColumnDataType")
+}
 
 var functionReturns = func() *g.QueryStruct {
 	return g.NewQueryStruct("FunctionReturns").
@@ -34,9 +40,10 @@ var functionReturns = func() *g.QueryStruct {
 			g.NewQueryStruct("FunctionReturnsTable").
 				ListQueryStructField(
 					"Columns",
-					functionColumn,
+					functionColumn(),
 					g.ParameterOptions().Parentheses().NoEquals(),
-				),
+				).
+				WithAdditionalValidations(),
 			g.KeywordOptions().SQL("TABLE"),
 		).WithValidation(g.ExactlyOneValueSet, "ResultDataType", "Table")
 }
@@ -65,7 +72,7 @@ var functionsDef = g.NewInterface(
 		Identifier("name", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Required()).
 		ListQueryStructField(
 			"Arguments",
-			functionArgument,
+			functionArgument(),
 			g.ListOptions().MustParentheses()).
 		OptionalSQL("COPY GRANTS").
 		QueryStructField(
@@ -100,7 +107,8 @@ var functionsDef = g.NewInterface(
 		PredefinedQueryStructField("FunctionDefinition", "*string", g.ParameterOptions().NoEquals().SQL("AS")).
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ValidateValueSet, "Handler").
-		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists"),
+		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists").
+		WithAdditionalValidations(),
 ).CustomOperation(
 	"CreateForJavascript",
 	"https://docs.snowflake.com/en/sql-reference/sql/create-function#javascript-handler",
@@ -113,7 +121,7 @@ var functionsDef = g.NewInterface(
 		Identifier("name", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Required()).
 		ListQueryStructField(
 			"Arguments",
-			functionArgument,
+			functionArgument(),
 			g.ListOptions().MustParentheses()).
 		OptionalSQL("COPY GRANTS").
 		QueryStructField(
@@ -132,7 +140,8 @@ var functionsDef = g.NewInterface(
 		OptionalAssignment("TRACE_LEVEL", g.KindOfTPointer[sdkcommons.TraceLevel](), g.ParameterOptions().SingleQuotes()).
 		PredefinedQueryStructField("FunctionDefinition", "string", g.ParameterOptions().NoEquals().SQL("AS").Required()).
 		WithValidation(g.ValidateValueSet, "FunctionDefinition").
-		WithValidation(g.ValidIdentifier, "name"),
+		WithValidation(g.ValidIdentifier, "name").
+		WithAdditionalValidations(),
 ).CustomOperation(
 	"CreateForPython",
 	"https://docs.snowflake.com/en/sql-reference/sql/create-function#python-handler",
@@ -147,7 +156,7 @@ var functionsDef = g.NewInterface(
 		Identifier("name", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Required()).
 		ListQueryStructField(
 			"Arguments",
-			functionArgument,
+			functionArgument(),
 			g.ListOptions().MustParentheses()).
 		OptionalSQL("COPY GRANTS").
 		QueryStructField(
@@ -182,7 +191,8 @@ var functionsDef = g.NewInterface(
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ValidateValueSet, "RuntimeVersion").
 		WithValidation(g.ValidateValueSet, "Handler").
-		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists"),
+		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists").
+		WithAdditionalValidations(),
 ).CustomOperation(
 	"CreateForScala",
 	"https://docs.snowflake.com/en/sql-reference/sql/create-function#scala-handler",
@@ -196,7 +206,7 @@ var functionsDef = g.NewInterface(
 		Identifier("name", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Required()).
 		ListQueryStructField(
 			"Arguments",
-			functionArgument,
+			functionArgument(),
 			g.ListOptions().MustParentheses()).
 		OptionalSQL("COPY GRANTS").
 		SQL("RETURNS").
@@ -230,7 +240,8 @@ var functionsDef = g.NewInterface(
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ValidateValueSet, "Handler").
 		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists").
-		WithValidation(g.ExactlyOneValueSet, "ResultDataTypeOld", "ResultDataType"),
+		WithValidation(g.ExactlyOneValueSet, "ResultDataTypeOld", "ResultDataType").
+		WithAdditionalValidations(),
 ).CustomOperation(
 	"CreateForSQL",
 	"https://docs.snowflake.com/en/sql-reference/sql/create-function#sql-handler",
@@ -243,7 +254,7 @@ var functionsDef = g.NewInterface(
 		Identifier("name", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Required()).
 		ListQueryStructField(
 			"Arguments",
-			functionArgument,
+			functionArgument(),
 			g.ListOptions().MustParentheses()).
 		OptionalSQL("COPY GRANTS").
 		QueryStructField(
@@ -261,7 +272,8 @@ var functionsDef = g.NewInterface(
 		OptionalAssignment("TRACE_LEVEL", g.KindOfTPointer[sdkcommons.TraceLevel](), g.ParameterOptions().SingleQuotes()).
 		PredefinedQueryStructField("FunctionDefinition", "string", g.ParameterOptions().NoEquals().SQL("AS").Required()).
 		WithValidation(g.ValidateValueSet, "FunctionDefinition").
-		WithValidation(g.ValidIdentifier, "name"),
+		WithValidation(g.ValidIdentifier, "name").
+		WithAdditionalValidations(),
 ).AlterOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/alter-function",
 	g.NewQueryStruct("AlterFunction").

--- a/pkg/sdk/generator/defs/hybrid_tables_def.go
+++ b/pkg/sdk/generator/defs/hybrid_tables_def.go
@@ -86,8 +86,10 @@ var hybridTableAlterColumnAction = g.NewQueryStruct("HybridTableAlterColumnActio
 	WithField(g.OptionalEnumLegacy[sdkcommons.SequenceName]("SetDefault", g.ParameterOptions().NoEquals().SQL("SET DEFAULT"))).
 	PredefinedQueryStructField("Type", "*DataType", g.ParameterOptions().NoEquals().SQL("SET DATA TYPE")).
 	OptionalTextAssignment("COMMENT", g.ParameterOptions().NoEquals().SingleQuotes()).
-	OptionalSQL("UNSET COMMENT").
-	WithValidation(g.ExactlyOneValueSet, "DropDefault", "SetDefault", "Type", "Comment", "UnsetComment")
+	OptionalSQL("UNSET COMMENT")
+
+// TODO [next PR]: validation is not generated properly as this is used as an array; using the additionalValidations above for now
+// .WithValidation(g.ExactlyOneValueSet, "DropDefault", "SetDefault", "Type", "Comment", "UnsetComment")
 
 var hybridTableDropColumnAction = g.NewQueryStruct("HybridTableDropColumnAction").
 	SQL("DROP COLUMN").
@@ -195,7 +197,8 @@ var hybridTablesDef = g.NewInterface(
 			g.KeywordOptions().SQL("SET"),
 		).
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ExactlyOneValueSet, "NewName", "AddColumnAction", "ConstraintAction", "AlterColumnAction", "DropColumnAction", "DropIndexAction", "ClusteringAction", "Set"),
+		WithValidation(g.ExactlyOneValueSet, "NewName", "AddColumnAction", "ConstraintAction", "AlterColumnAction", "DropColumnAction", "DropIndexAction", "ClusteringAction", "Set").
+		WithAdditionalValidations(),
 ).DropOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/drop-table",
 	g.NewQueryStruct("DropHybridTable").

--- a/pkg/sdk/generator/defs/iceberg_tables_def.go
+++ b/pkg/sdk/generator/defs/iceberg_tables_def.go
@@ -48,8 +48,8 @@ var icebergTableColumn = g.NewQueryStruct("IcebergTableColumn").
 var icebergTableColumnsAndConstraints = g.NewQueryStruct("IcebergTableColumnsAndConstraints").
 	ListQueryStructField("Columns", icebergTableColumn, g.KeywordOptions())
 
-	// TODO(next PR): add constraint support
-	// ListQueryStructField("OutOfLineConstraint", icebergTableOutOfLineConstraint, g.KeywordOptions())
+// TODO(next PR): add constraint support
+// ListQueryStructField("OutOfLineConstraint", icebergTableOutOfLineConstraint, g.KeywordOptions())
 
 var icebergTablePartitionBucketArgs = g.NewQueryStruct("IcebergTablePartitionBucketArgs").
 	Number("NumBuckets", g.KeywordOptions().Required()).
@@ -93,8 +93,10 @@ var icebergTablePartitionExpression = g.NewQueryStruct("IcebergTablePartitionExp
 	OptionalQueryStructField("Year", icebergTablePartitionYear, g.KeywordOptions()).
 	OptionalQueryStructField("Month", icebergTablePartitionMonth, g.KeywordOptions()).
 	OptionalQueryStructField("Day", icebergTablePartitionDay, g.KeywordOptions()).
-	OptionalQueryStructField("Hour", icebergTablePartitionHour, g.KeywordOptions()).
-	WithValidation(g.ExactlyOneValueSet, "Identity", "Bucket", "Truncate", "Year", "Month", "Day", "Hour")
+	OptionalQueryStructField("Hour", icebergTablePartitionHour, g.KeywordOptions())
+
+// TODO [next PR]: validation is not generated properly as this is used as an array; using the additionalValidations above for now
+// .WithValidation(g.ExactlyOneValueSet, "Identity", "Bucket", "Truncate", "Year", "Month", "Day", "Hour")
 
 var icebergTableSetProperties = g.NewQueryStruct("IcebergTableSetProperties").
 	OptionalBooleanAssignment("REPLACE_INVALID_CHARACTERS", g.ParameterOptions()).
@@ -145,8 +147,10 @@ var icebergTableAlterColumnAction = g.NewQueryStruct("IcebergTableAlterColumnAct
 	OptionalTextAssignment("COMMENT", g.ParameterOptions().NoEquals().SingleQuotes()).
 	OptionalSQL("UNSET COMMENT").
 	OptionalTextAssignment("SET WRITE DEFAULT", g.ParameterOptions().NoEquals()).
-	OptionalSQL("DROP WRITE DEFAULT").
-	WithValidation(g.ExactlyOneValueSet, "SetNotNull", "DropNotNull", "DataType", "Comment", "UnsetComment", "SetWriteDefault", "DropWriteDefault")
+	OptionalSQL("DROP WRITE DEFAULT")
+
+// TODO [next PR]: validation is not generated properly as this is used as an array; using the additionalValidations above for now
+// .WithValidation(g.ExactlyOneValueSet, "SetNotNull", "DropNotNull", "DataType", "Comment", "UnsetComment", "SetWriteDefault", "DropWriteDefault")
 
 var icebergTableClusteringAction = g.NewQueryStruct("IcebergTableClusteringAction").
 	ListAssignment("CLUSTER BY", "string", g.ParameterOptions().NoEquals().Parentheses()).
@@ -206,7 +210,8 @@ var icebergTablesDef = g.NewInterface(
 		OptionalBooleanAssignment("ENABLE_DATA_COMPACTION", g.ParameterOptions()).
 		PredefinedQueryStructField("Contact", "[]TableContact", g.KeywordOptions().Parentheses().SQL("WITH CONTACT")).
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists"),
+		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists").
+		WithAdditionalValidations(),
 ).AlterOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/alter-iceberg-table",
 	g.NewQueryStruct("AlterIcebergTable").
@@ -296,7 +301,8 @@ var icebergTablesDef = g.NewInterface(
 			g.KeywordOptions(),
 		).
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ExactlyOneValueSet, "AddColumnAction", "DropColumnAction", "RenameColumnAction", "AlterColumnAction", "SetMaskingPolicyOnColumn", "UnsetMaskingPolicyOnColumn", "SetProjectionPolicyOnColumn", "UnsetProjectionPolicyOnColumn", "SetTagsOnColumn", "UnsetTagsOnColumn", "ClusteringAction", "Set", "Unset", "SetTags", "UnsetTags", "AddRowAccessPolicy", "DropRowAccessPolicy", "DropAndAddRowAccessPolicy", "DropAllRowAccessPolicies", "SetAggregationPolicy", "UnsetAggregationPolicy", "SetJoinPolicy", "UnsetJoinPolicy", "SearchOptimizationAction"),
+		WithValidation(g.ExactlyOneValueSet, "AddColumnAction", "DropColumnAction", "RenameColumnAction", "AlterColumnAction", "SetMaskingPolicyOnColumn", "UnsetMaskingPolicyOnColumn", "SetProjectionPolicyOnColumn", "UnsetProjectionPolicyOnColumn", "SetTagsOnColumn", "UnsetTagsOnColumn", "ClusteringAction", "Set", "Unset", "SetTags", "UnsetTags", "AddRowAccessPolicy", "DropRowAccessPolicy", "DropAndAddRowAccessPolicy", "DropAllRowAccessPolicies", "SetAggregationPolicy", "UnsetAggregationPolicy", "SetJoinPolicy", "UnsetJoinPolicy", "SearchOptimizationAction").
+		WithAdditionalValidations(),
 ).DropOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/drop-iceberg-table",
 	g.NewQueryStruct("DropIcebergTable").

--- a/pkg/sdk/generator/defs/notebooks_def.go
+++ b/pkg/sdk/generator/defs/notebooks_def.go
@@ -106,6 +106,7 @@ var notebooksDef = g.NewInterface(
 				WithValidation(g.ValidIdentifierIfSet, "QueryWarehouse").
 				WithValidation(g.ValidIdentifierIfSet, "Warehouse").
 				WithValidation(g.ValidIdentifierIfSet, "ComputePool").
+				WithValidation(g.AtLeastOneValueSet, "Comment", "QueryWarehouse", "IdleAutoShutdownTimeSeconds", "Secrets", "MainFile", "Warehouse", "RuntimeName", "ComputePool", "ExternalAccessIntegrations", "RuntimeEnvironmentVersion").
 				WithAdditionalValidations(),
 			g.KeywordOptions().SQL("SET"),
 		).

--- a/pkg/sdk/generator/defs/notebooks_def.go
+++ b/pkg/sdk/generator/defs/notebooks_def.go
@@ -80,7 +80,8 @@ var notebooksDef = g.NewInterface(
 		WithValidation(g.ValidIdentifierIfSet, "QueryWarehouse").
 		WithValidation(g.ValidIdentifierIfSet, "Warehouse").
 		WithValidation(g.ConflictingFields, "IfNotExists", "OrReplace").
-		WithValidation(g.ValidIdentifierIfSet, "ComputePool"),
+		WithValidation(g.ValidIdentifierIfSet, "ComputePool").
+		WithAdditionalValidations(),
 ).AlterOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/alter-notebook",
 	g.NewQueryStruct("AlterNotebook").
@@ -105,7 +106,7 @@ var notebooksDef = g.NewInterface(
 				WithValidation(g.ValidIdentifierIfSet, "QueryWarehouse").
 				WithValidation(g.ValidIdentifierIfSet, "Warehouse").
 				WithValidation(g.ValidIdentifierIfSet, "ComputePool").
-				WithValidation(g.AtLeastOneValueSet, "Comment", "QueryWarehouse", "IdleAutoShutdownTimeSeconds", "SecretsList", "MainFile", "Warehouse", "RuntimeName", "ComputePool", "ExternalAccessIntegrations", "RuntimeEnvironmentVersion"),
+				WithAdditionalValidations(),
 			g.KeywordOptions().SQL("SET"),
 		).
 		OptionalQueryStructField(

--- a/pkg/sdk/generator/defs/notification_integrations_def.go
+++ b/pkg/sdk/generator/defs/notification_integrations_def.go
@@ -160,7 +160,7 @@ var notificationIntegrationsDef = g.NewInterface(
 						g.KeywordOptions(),
 					).
 					OptionalComment().
-					WithValidation(g.ConflictingFields, "SetPushParams", "SetEmailParams", "SetWebhookParams").
+					WithAdditionalValidations().
 					WithValidation(g.AtLeastOneValueSet, "Enabled", "SetPushParams", "SetEmailParams", "SetWebhookParams", "Comment"),
 				g.KeywordOptions().SQL("SET"),
 			).

--- a/pkg/sdk/generator/defs/procedures_def.go
+++ b/pkg/sdk/generator/defs/procedures_def.go
@@ -6,18 +6,24 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/generator/gen/sdkcommons"
 )
 
-var procedureArgument = g.NewQueryStruct("ProcedureArgument").
-	Text("ArgName", g.KeywordOptions().DoubleQuotes().Required()).
-	PredefinedQueryStructField("ArgDataTypeOld", "DataType", g.KeywordOptions().NoQuotes()).
-	PredefinedQueryStructField("ArgDataType", "datatypes.DataType", g.ParameterOptions().NoQuotes().NoEquals().Required()).
-	PredefinedQueryStructField("DefaultValue", "*string", g.ParameterOptions().NoEquals().SQL("DEFAULT")).
-	WithValidation(g.ExactlyOneValueSet, "ArgDataTypeOld", "ArgDataType")
+var procedureArgument = func() *g.QueryStruct {
+	return g.NewQueryStruct("ProcedureArgument").
+		Text("ArgName", g.KeywordOptions().DoubleQuotes().Required()).
+		PredefinedQueryStructField("ArgDataTypeOld", "DataType", g.KeywordOptions().NoQuotes()).
+		PredefinedQueryStructField("ArgDataType", "datatypes.DataType", g.ParameterOptions().NoQuotes().NoEquals().Required()).
+		PredefinedQueryStructField("DefaultValue", "*string", g.ParameterOptions().NoEquals().SQL("DEFAULT"))
+	// TODO [next PR]: validation is not generated properly as this is used as an array; using the additionalValidations above for now
+	// .WithValidation(g.ExactlyOneValueSet, "ArgDataTypeOld", "ArgDataType")
+}
 
-var procedureColumn = g.NewQueryStruct("ProcedureColumn").
-	Text("ColumnName", g.KeywordOptions().DoubleQuotes().Required()).
-	PredefinedQueryStructField("ColumnDataTypeOld", "DataType", g.KeywordOptions().NoQuotes()).
-	PredefinedQueryStructField("ColumnDataType", "datatypes.DataType", g.ParameterOptions().NoQuotes().NoEquals().Required()).
-	WithValidation(g.ExactlyOneValueSet, "ColumnDataTypeOld", "ColumnDataType")
+var procedureColumn = func() *g.QueryStruct {
+	return g.NewQueryStruct("ProcedureColumn").
+		Text("ColumnName", g.KeywordOptions().DoubleQuotes().Required()).
+		PredefinedQueryStructField("ColumnDataTypeOld", "DataType", g.KeywordOptions().NoQuotes()).
+		PredefinedQueryStructField("ColumnDataType", "datatypes.DataType", g.ParameterOptions().NoQuotes().NoEquals().Required())
+	// TODO [next PR]: validation is not generated properly as this is used as an array; using the additionalValidations above for now
+	// .WithValidation(g.ExactlyOneValueSet, "ColumnDataTypeOld", "ColumnDataType")
+}
 
 var procedureReturns = func() *g.QueryStruct {
 	return g.NewQueryStruct("ProcedureReturns").
@@ -35,9 +41,10 @@ var procedureReturns = func() *g.QueryStruct {
 			g.NewQueryStruct("ProcedureReturnsTable").
 				ListQueryStructField(
 					"Columns",
-					procedureColumn,
+					procedureColumn(),
 					g.ListOptions().MustParentheses(),
-				),
+				).
+				WithAdditionalValidations(),
 			g.KeywordOptions().SQL("TABLE"),
 		).WithValidation(g.ExactlyOneValueSet, "ResultDataType", "Table")
 }
@@ -56,9 +63,10 @@ var procedureSQLReturns = g.NewQueryStruct("ProcedureSQLReturns").
 		g.NewQueryStruct("ProcedureReturnsTable").
 			ListQueryStructField(
 				"Columns",
-				procedureColumn,
+				procedureColumn(),
 				g.ListOptions().MustParentheses(),
-			),
+			).
+			WithAdditionalValidations(),
 		g.KeywordOptions().SQL("TABLE"),
 	).
 	OptionalSQL("NOT NULL").
@@ -91,7 +99,7 @@ var proceduresDef = g.NewInterface(
 		Identifier("name", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Required()).
 		ListQueryStructField(
 			"Arguments",
-			procedureArgument,
+			procedureArgument(),
 			g.ListOptions().MustParentheses(),
 		).
 		OptionalSQL("COPY GRANTS").
@@ -124,7 +132,8 @@ var proceduresDef = g.NewInterface(
 		WithValidation(g.ValidateValueSet, "RuntimeVersion").
 		WithValidation(g.ValidateValueSet, "Packages").
 		WithValidation(g.ValidateValueSet, "Handler").
-		WithValidation(g.ValidIdentifier, "name"),
+		WithValidation(g.ValidIdentifier, "name").
+		WithAdditionalValidations(),
 ).CustomOperation(
 	"CreateForJavaScript",
 	"https://docs.snowflake.com/en/sql-reference/sql/create-procedure#javascript-handler",
@@ -136,7 +145,7 @@ var proceduresDef = g.NewInterface(
 		Identifier("name", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Required()).
 		ListQueryStructField(
 			"Arguments",
-			procedureArgument,
+			procedureArgument(),
 			g.ListOptions().MustParentheses(),
 		).
 		OptionalSQL("COPY GRANTS").
@@ -152,7 +161,8 @@ var proceduresDef = g.NewInterface(
 		PredefinedQueryStructField("ProcedureDefinition", "string", g.ParameterOptions().NoEquals().SQL("AS").Required()).
 		WithValidation(g.ValidateValueSet, "ProcedureDefinition").
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ExactlyOneValueSet, "ResultDataTypeOld", "ResultDataType"),
+		WithValidation(g.ExactlyOneValueSet, "ResultDataTypeOld", "ResultDataType").
+		WithAdditionalValidations(),
 ).CustomOperation(
 	"CreateForPython",
 	"https://docs.snowflake.com/en/sql-reference/sql/create-procedure#python-handler",
@@ -164,7 +174,7 @@ var proceduresDef = g.NewInterface(
 		Identifier("name", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Required()).
 		ListQueryStructField(
 			"Arguments",
-			procedureArgument,
+			procedureArgument(),
 			g.ListOptions().MustParentheses(),
 		).
 		OptionalSQL("COPY GRANTS").
@@ -196,7 +206,8 @@ var proceduresDef = g.NewInterface(
 		WithValidation(g.ValidateValueSet, "RuntimeVersion").
 		WithValidation(g.ValidateValueSet, "Packages").
 		WithValidation(g.ValidateValueSet, "Handler").
-		WithValidation(g.ValidIdentifier, "name"),
+		WithValidation(g.ValidIdentifier, "name").
+		WithAdditionalValidations(),
 ).CustomOperation(
 	"CreateForScala",
 	"https://docs.snowflake.com/en/sql-reference/sql/create-procedure#scala-handler",
@@ -208,7 +219,7 @@ var proceduresDef = g.NewInterface(
 		Identifier("name", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Required()).
 		ListQueryStructField(
 			"Arguments",
-			procedureArgument,
+			procedureArgument(),
 			g.ListOptions().MustParentheses(),
 		).
 		OptionalSQL("COPY GRANTS").
@@ -241,7 +252,8 @@ var proceduresDef = g.NewInterface(
 		WithValidation(g.ValidateValueSet, "RuntimeVersion").
 		WithValidation(g.ValidateValueSet, "Packages").
 		WithValidation(g.ValidateValueSet, "Handler").
-		WithValidation(g.ValidIdentifier, "name"),
+		WithValidation(g.ValidIdentifier, "name").
+		WithAdditionalValidations(),
 ).CustomOperation(
 	"CreateForSQL",
 	"https://docs.snowflake.com/en/sql-reference/sql/create-procedure#snowflake-scripting-handler",
@@ -253,7 +265,7 @@ var proceduresDef = g.NewInterface(
 		Identifier("name", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Required()).
 		ListQueryStructField(
 			"Arguments",
-			procedureArgument,
+			procedureArgument(),
 			g.ListOptions().MustParentheses(),
 		).
 		OptionalSQL("COPY GRANTS").
@@ -269,7 +281,8 @@ var proceduresDef = g.NewInterface(
 		PredefinedQueryStructField("ExecuteAs", "*ExecuteAs", g.ParameterOptions().NoQuotes().NoEquals().SQL("EXECUTE AS")).
 		PredefinedQueryStructField("ProcedureDefinition", "string", g.ParameterOptions().NoEquals().SQL("AS").Required()).
 		WithValidation(g.ValidateValueSet, "ProcedureDefinition").
-		WithValidation(g.ValidIdentifier, "name"),
+		WithValidation(g.ValidIdentifier, "name").
+		WithAdditionalValidations(),
 ).AlterOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/alter-procedure",
 	g.NewQueryStruct("AlterProcedure").
@@ -396,7 +409,7 @@ var proceduresDef = g.NewInterface(
 		SQL("AS PROCEDURE").
 		ListQueryStructField(
 			"Arguments",
-			procedureArgument,
+			procedureArgument(),
 			g.ListOptions().MustParentheses(),
 		).
 		QueryStructField(
@@ -431,8 +444,8 @@ var proceduresDef = g.NewInterface(
 		WithValidation(g.ValidateValueSet, "RuntimeVersion").
 		WithValidation(g.ValidateValueSet, "Packages").
 		WithValidation(g.ValidateValueSet, "Handler").
-		WithValidation(g.ValidIdentifier, "ProcedureName").
-		WithValidation(g.ValidIdentifier, "Name"),
+		WithValidation(g.ValidIdentifier, "Name").
+		WithAdditionalValidations(),
 ).CustomOperation(
 	"CreateAndCallForScala",
 	"https://docs.snowflake.com/en/sql-reference/sql/call-with#java-and-scala",
@@ -442,7 +455,7 @@ var proceduresDef = g.NewInterface(
 		SQL("AS PROCEDURE").
 		ListQueryStructField(
 			"Arguments",
-			procedureArgument,
+			procedureArgument(),
 			g.ListOptions().MustParentheses(),
 		).
 		QueryStructField(
@@ -477,8 +490,8 @@ var proceduresDef = g.NewInterface(
 		WithValidation(g.ValidateValueSet, "RuntimeVersion").
 		WithValidation(g.ValidateValueSet, "Packages").
 		WithValidation(g.ValidateValueSet, "Handler").
-		WithValidation(g.ValidIdentifier, "ProcedureName").
-		WithValidation(g.ValidIdentifier, "Name"),
+		WithValidation(g.ValidIdentifier, "Name").
+		WithAdditionalValidations(),
 ).CustomOperation(
 	"CreateAndCallForJavaScript",
 	"https://docs.snowflake.com/en/sql-reference/sql/call-with#javascript",
@@ -488,7 +501,7 @@ var proceduresDef = g.NewInterface(
 		SQL("AS PROCEDURE").
 		ListQueryStructField(
 			"Arguments",
-			procedureArgument,
+			procedureArgument(),
 			g.ListOptions().MustParentheses(),
 		).
 		SQL("RETURNS").
@@ -509,8 +522,8 @@ var proceduresDef = g.NewInterface(
 		PredefinedQueryStructField("ScriptingVariable", "*string", g.ParameterOptions().NoEquals().NoQuotes().SQL("INTO")).
 		WithValidation(g.ValidateValueSet, "ProcedureDefinition").
 		WithValidation(g.ExactlyOneValueSet, "ResultDataTypeOld", "ResultDataType").
-		WithValidation(g.ValidIdentifier, "ProcedureName").
-		WithValidation(g.ValidIdentifier, "Name"),
+		WithValidation(g.ValidIdentifier, "Name").
+		WithAdditionalValidations(),
 ).CustomOperation(
 	"CreateAndCallForPython",
 	"https://docs.snowflake.com/en/sql-reference/sql/call-with#python",
@@ -520,7 +533,7 @@ var proceduresDef = g.NewInterface(
 		SQL("AS PROCEDURE").
 		ListQueryStructField(
 			"Arguments",
-			procedureArgument,
+			procedureArgument(),
 			g.ListOptions().MustParentheses(),
 		).
 		QueryStructField(
@@ -555,8 +568,8 @@ var proceduresDef = g.NewInterface(
 		WithValidation(g.ValidateValueSet, "RuntimeVersion").
 		WithValidation(g.ValidateValueSet, "Packages").
 		WithValidation(g.ValidateValueSet, "Handler").
-		WithValidation(g.ValidIdentifier, "ProcedureName").
-		WithValidation(g.ValidIdentifier, "Name"),
+		WithValidation(g.ValidIdentifier, "Name").
+		WithAdditionalValidations(),
 ).CustomOperation(
 	"CreateAndCallForSQL",
 	"https://docs.snowflake.com/en/sql-reference/sql/call-with#snowflake-scripting",
@@ -566,7 +579,7 @@ var proceduresDef = g.NewInterface(
 		SQL("AS PROCEDURE").
 		ListQueryStructField(
 			"Arguments",
-			procedureArgument,
+			procedureArgument(),
 			g.ListOptions().MustParentheses(),
 		).
 		QueryStructField(
@@ -587,8 +600,8 @@ var proceduresDef = g.NewInterface(
 		PredefinedQueryStructField("CallArguments", "[]string", g.KeywordOptions().MustParentheses()).
 		PredefinedQueryStructField("ScriptingVariable", "*string", g.ParameterOptions().NoEquals().NoQuotes().SQL("INTO")).
 		WithValidation(g.ValidateValueSet, "ProcedureDefinition").
-		WithValidation(g.ValidIdentifier, "ProcedureName").
-		WithValidation(g.ValidIdentifier, "Name"),
+		WithValidation(g.ValidIdentifier, "Name").
+		WithAdditionalValidations(),
 ).WithCustomInterfaceMethod(
 	"DescribeDetails",
 	"DescribeDetails returns aggregated describe results for the given procedure.",

--- a/pkg/sdk/generator/defs/security_integrations_def.go
+++ b/pkg/sdk/generator/defs/security_integrations_def.go
@@ -431,7 +431,7 @@ var securityIntegrationsDef = g.NewInterface(
 					g.ParameterOptions(),
 				).
 				OptionalQueryStructField("BlockedRolesList", blockedRolesListDef, g.ParameterOptions().SQL("BLOCKED_ROLES_LIST").Parentheses())
-		}),
+		}).WithAdditionalValidations(),
 		preAuthorizedRolesListDef,
 		blockedRolesListDef,
 	).
@@ -507,7 +507,7 @@ var securityIntegrationsDef = g.NewInterface(
 				TextAssignment("RUN_AS_ROLE", g.ParameterOptions().Required().NoQuotes()).
 				OptionalTextAssignment("NETWORK_POLICY", g.ParameterOptions().NoQuotes()).
 				OptionalBooleanAssignment("SYNC_PASSWORD", g.ParameterOptions())
-		}),
+		}).WithAdditionalValidations(),
 	).
 	CustomOperation(
 		"AlterApiAuthenticationWithClientCredentialsFlow",

--- a/pkg/sdk/generator/defs/semantic_views_def.go
+++ b/pkg/sdk/generator/defs/semantic_views_def.go
@@ -46,7 +46,8 @@ var semanticViewsDef = g.NewInterface(
 			OptionalComment().
 			OptionalCopyGrants().
 			WithValidation(g.ValidIdentifier, "name").
-			WithValidation(g.ConflictingFields, "IfNotExists", "OrReplace"),
+			WithValidation(g.ConflictingFields, "IfNotExists", "OrReplace").
+			WithAdditionalValidations(),
 		logicalTable,
 		synonym,
 		semanticViewRelationship,

--- a/pkg/sdk/generator/defs/services_def.go
+++ b/pkg/sdk/generator/defs/services_def.go
@@ -79,7 +79,8 @@ var servicesDef = g.NewInterface(
 		OptionalComment().
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ExactlyOneValueSet, "FromSpecification", "FromSpecificationTemplate").
-		WithValidation(g.ValidIdentifierIfSet, "QueryWarehouse"),
+		WithValidation(g.ValidIdentifierIfSet, "QueryWarehouse").
+		WithAdditionalValidations(),
 	serviceExternalAccessIntegrationsDef,
 	listItemDef,
 	serviceFromSpecificationDef,
@@ -116,7 +117,8 @@ var servicesDef = g.NewInterface(
 				OptionalQueryStructField("ExternalAccessIntegrations", serviceExternalAccessIntegrationsDef, g.ParameterOptions().SQL("EXTERNAL_ACCESS_INTEGRATIONS").Parentheses()).
 				OptionalComment().
 				WithValidation(g.ValidIdentifierIfSet, "QueryWarehouse").
-				WithValidation(g.AtLeastOneValueSet, "MinInstances", "MaxInstances", "AutoSuspendSecs", "MinReadyInstances", "QueryWarehouse", "AutoResume", "ExternalAccessIntegrations", "Comment"),
+				WithValidation(g.AtLeastOneValueSet, "MinInstances", "MaxInstances", "AutoSuspendSecs", "MinReadyInstances", "QueryWarehouse", "AutoResume", "ExternalAccessIntegrations", "Comment").
+				WithAdditionalValidations(),
 			g.KeywordOptions().SQL("SET"),
 		).
 		OptionalQueryStructField(

--- a/pkg/sdk/generator/defs/stages_def.go
+++ b/pkg/sdk/generator/defs/stages_def.go
@@ -52,7 +52,8 @@ func createStageOperation(structName string, apply func(qs *g.QueryStruct) *g.Qu
 			g.NewQueryStruct("StageFileFormat").
 				OptionalIdentifier("FormatName", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("FORMAT_NAME =")).
 				PredefinedQueryStructField("FileFormatOptions", "*FileFormatOptions", g.ListOptions()).
-				WithValidation(g.ExactlyOneValueSet, "FormatName", "FileFormatOptions"),
+				WithValidation(g.ExactlyOneValueSet, "FormatName", "FileFormatOptions").
+				WithAdditionalValidations(),
 			g.ListOptions().Parentheses().NoComma().SQL("FILE_FORMAT ="),
 		).
 		OptionalComment().
@@ -74,7 +75,8 @@ func alterStageOperation(structName string, apply func(qs *g.QueryStruct) *g.Que
 			g.NewQueryStruct("StageFileFormat").
 				OptionalIdentifier("FormatName", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("FORMAT_NAME =")).
 				PredefinedQueryStructField("FileFormatOptions", "*FileFormatOptions", g.ListOptions()).
-				WithValidation(g.ExactlyOneValueSet, "FormatName", "FileFormatOptions"),
+				WithValidation(g.ExactlyOneValueSet, "FormatName", "FileFormatOptions").
+				WithAdditionalValidations(),
 			g.ListOptions().Parentheses().NoComma().SQL("FILE_FORMAT ="),
 		).
 		// TODO(SNOW-3035788): use COMMENT in unset and here use OptionalComment

--- a/pkg/sdk/generator/defs/streamlits_def.go
+++ b/pkg/sdk/generator/defs/streamlits_def.go
@@ -95,7 +95,8 @@ var streamlitsDef = g.NewInterface(
 		SQL("STREAMLITS").
 		OptionalLike().
 		OptionalIn().
-		OptionalLimit(),
+		OptionalLimit().
+		WithAdditionalValidations(),
 	g.ShowByIDLikeFiltering,
 	g.ShowByIDInFiltering,
 ).DescribeOperationWithPairedStructs(

--- a/pkg/sdk/generator/defs/tables_def.go
+++ b/pkg/sdk/generator/defs/tables_def.go
@@ -83,12 +83,15 @@ var tableAddSearchOptimization = g.NewQueryStruct("TableAddSearchOptimization").
 var tableDropSearchOptimizationOn = g.NewQueryStruct("TableDropSearchOptimizationOn").
 	OptionalQueryStructField("SearchMethodWithTarget", newTableSearchMethodWithTarget(), g.KeywordOptions()).
 	OptionalText("ColumnName", g.KeywordOptions()).
-	OptionalText("ExpressionId", g.KeywordOptions()).
-	WithValidation(g.ExactlyOneValueSet, "SearchMethodWithTarget", "ColumnName", "ExpressionId")
+	OptionalText("ExpressionId", g.KeywordOptions())
+
+// TODO [next PR]: validation is not generated properly as this is used as an array; using the additionalValidations above for now
+// .WithValidation(g.ExactlyOneValueSet, "SearchMethodWithTarget", "ColumnName", "ExpressionId")
 
 var tableDropSearchOptimization = g.NewQueryStruct("TableDropSearchOptimization").
 	SQL("DROP SEARCH OPTIMIZATION").
-	ListQueryStructField("On", tableDropSearchOptimizationOn, g.KeywordOptions().SQL("ON"))
+	ListQueryStructField("On", tableDropSearchOptimizationOn, g.KeywordOptions().SQL("ON")).
+	WithAdditionalValidations()
 
 var tableSearchOptimizationAction = g.NewQueryStruct("TableSearchOptimizationAction").
 	OptionalQueryStructField(

--- a/pkg/sdk/generator/defs/tasks_def.go
+++ b/pkg/sdk/generator/defs/tasks_def.go
@@ -53,7 +53,7 @@ var tasksDef = g.NewInterface(
 			OptionalTextAssignment("SCHEDULE", g.ParameterOptions().SingleQuotes()).
 			OptionalTextAssignment("CONFIG", g.ParameterOptions().NoQuotes()).
 			OptionalBooleanAssignment("ALLOW_OVERLAPPING_EXECUTION", nil).
-			OptionalSessionParameters().
+			PredefinedQueryStructField("SessionParameters", "*SessionParameters", g.ListOptions().NoParentheses()).
 			OptionalNumberAssignment("USER_TASK_TIMEOUT_MS", nil).
 			OptionalNumberAssignment("SUSPEND_TASK_AFTER_NUM_FAILURES", nil).
 			OptionalIdentifier("ErrorIntegration", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().Equals().SQL("ERROR_INTEGRATION")).
@@ -69,6 +69,7 @@ var tasksDef = g.NewInterface(
 			OptionalTextAssignment("WHEN", g.ParameterOptions().NoQuotes().NoEquals()).
 			SQL("AS").
 			Text("sql", g.KeywordOptions().NoQuotes().Required()).
+			WithAdditionalValidations().
 			WithValidation(g.ValidIdentifier, "name").
 			WithValidation(g.ValidIdentifierIfSet, "ErrorIntegration").
 			WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists"),
@@ -86,7 +87,7 @@ var tasksDef = g.NewInterface(
 			OptionalTextAssignment("CONFIG", g.ParameterOptions().NoQuotes()).
 			OptionalBooleanAssignment("ALLOW_OVERLAPPING_EXECUTION", nil).
 			OptionalNumberAssignment("USER_TASK_TIMEOUT_MS", nil).
-			OptionalSessionParameters().
+			PredefinedQueryStructField("SessionParameters", "*SessionParameters", g.ListOptions().NoParentheses()).
 			OptionalNumberAssignment("SUSPEND_TASK_AFTER_NUM_FAILURES", nil).
 			OptionalIdentifier("ErrorIntegration", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().Equals().SQL("ERROR_INTEGRATION")).
 			OptionalTextAssignment("COMMENT", g.ParameterOptions().SingleQuotes()).
@@ -96,6 +97,7 @@ var tasksDef = g.NewInterface(
 			OptionalTextAssignment("WHEN", g.ParameterOptions().NoQuotes().NoEquals()).
 			SQL("AS").
 			Text("sql", g.KeywordOptions().NoQuotes().Required()).
+			WithAdditionalValidations().
 			WithValidation(g.ValidIdentifier, "name").
 			WithValidation(g.ValidIdentifierIfSet, "ErrorIntegration"),
 	).
@@ -136,12 +138,13 @@ var tasksDef = g.NewInterface(
 					OptionalNumberAssignment("SUSPEND_TASK_AFTER_NUM_FAILURES", nil).
 					OptionalIdentifier("ErrorIntegration", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().Equals().SQL("ERROR_INTEGRATION")).
 					OptionalTextAssignment("COMMENT", g.ParameterOptions().SingleQuotes()).
-					OptionalSessionParameters().
+					PredefinedQueryStructField("SessionParameters", "*SessionParameters", g.ListOptions().NoParentheses()).
 					OptionalNumberAssignment("TASK_AUTO_RETRY_ATTEMPTS", nil).
 					OptionalNumberAssignment("USER_TASK_MINIMUM_TRIGGER_INTERVAL_IN_SECONDS", nil).
 					OptionalTextAssignment("TARGET_COMPLETION_INTERVAL", g.ParameterOptions().SingleQuotes()).
 					OptionalAssignment("SERVERLESS_TASK_MIN_STATEMENT_SIZE", "WarehouseSize", g.ParameterOptions().SingleQuotes()).
 					OptionalAssignment("SERVERLESS_TASK_MAX_STATEMENT_SIZE", "WarehouseSize", g.ParameterOptions().SingleQuotes()).
+					WithAdditionalValidations().
 					WithValidation(g.AtLeastOneValueSet, "Warehouse", "UserTaskManagedInitialWarehouseSize", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParameters", "TaskAutoRetryAttempts", "UserTaskMinimumTriggerIntervalInSeconds", "TargetCompletionInterval", "ServerlessTaskMinStatementSize", "ServerlessTaskMaxStatementSize").
 					WithValidation(g.ConflictingFields, "Warehouse", "UserTaskManagedInitialWarehouseSize").
 					WithValidation(g.ValidIdentifierIfSet, "ErrorIntegration"),
@@ -164,7 +167,8 @@ var tasksDef = g.NewInterface(
 					OptionalSQL("TARGET_COMPLETION_INTERVAL").
 					OptionalSQL("SERVERLESS_TASK_MIN_STATEMENT_SIZE").
 					OptionalSQL("SERVERLESS_TASK_MAX_STATEMENT_SIZE").
-					OptionalSessionParametersUnset().
+					PredefinedQueryStructField("SessionParametersUnset", "*SessionParametersUnset", g.ListOptions().NoParentheses()).
+					WithAdditionalValidations().
 					WithValidation(g.AtLeastOneValueSet, "Warehouse", "UserTaskManagedInitialWarehouseSize", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParametersUnset", "TaskAutoRetryAttempts", "UserTaskMinimumTriggerIntervalInSeconds", "TargetCompletionInterval", "ServerlessTaskMinStatementSize", "ServerlessTaskMaxStatementSize"),
 				g.ListOptions().SQL("UNSET").NoParentheses(),
 			).

--- a/pkg/sdk/generator/defs/user_programmatic_access_tokens_def.go
+++ b/pkg/sdk/generator/defs/user_programmatic_access_tokens_def.go
@@ -57,7 +57,7 @@ var userProgrammaticAccessTokensDef = g.NewInterface(
 		OptionalNumberAssignment("MINS_TO_BYPASS_NETWORK_POLICY_REQUIREMENT", g.ParameterOptions()).
 		OptionalComment().
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ValidIdentifier, "UserName").
+		WithAdditionalValidations().
 		WithValidation(g.ValidIdentifierIfSet, "RoleRestriction"),
 ).CustomOperation(
 	"Modify",
@@ -87,7 +87,7 @@ var userProgrammaticAccessTokensDef = g.NewInterface(
 		).
 		OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO").NoEquals()).
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ValidIdentifier, "UserName").
+		WithAdditionalValidations().
 		WithValidation(g.ExactlyOneValueSet, "Set", "Unset", "RenameTo"),
 ).CustomShowOperationWithPairedStructs(
 	"Rotate",
@@ -103,7 +103,7 @@ var userProgrammaticAccessTokensDef = g.NewInterface(
 		Name().
 		OptionalNumberAssignment("EXPIRE_ROTATED_TOKEN_AFTER_HOURS", g.ParameterOptions()).
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ValidIdentifier, "UserName"),
+		WithAdditionalValidations(),
 ).CustomOperation(
 	"Remove",
 	"https://docs.snowflake.com/en/sql-reference/sql/alter-user-remove-programmatic-access-token",
@@ -115,7 +115,7 @@ var userProgrammaticAccessTokensDef = g.NewInterface(
 		SQL("REMOVE PROGRAMMATIC ACCESS TOKEN").
 		Name().
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ValidIdentifier, "UserName"),
+		WithAdditionalValidations(),
 ).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-user-programmatic-access-tokens",
 	programmaticAccessTokenPairs,

--- a/pkg/sdk/generator/defs/views_def.go
+++ b/pkg/sdk/generator/defs/views_def.go
@@ -80,7 +80,8 @@ var viewColumnProjectionPolicy = g.NewQueryStruct("ViewColumnProjectionPolicy").
 var viewRowAccessPolicy = g.NewQueryStruct("ViewRowAccessPolicy").
 	Identifier("RowAccessPolicy", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("ROW ACCESS POLICY").Required()).
 	ListAssignment("ON", "Column", g.ParameterOptions().Required().NoEquals().Parentheses()).
-	WithValidation(g.ValidIdentifier, "RowAccessPolicy")
+	WithValidation(g.ValidIdentifier, "RowAccessPolicy").
+	WithAdditionalValidations()
 
 var viewAggregationPolicy = g.NewQueryStruct("ViewAggregationPolicy").
 	Identifier("AggregationPolicy", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("AGGREGATION POLICY").Required()).
@@ -110,7 +111,8 @@ var viewAddRowAccessPolicy = g.NewQueryStruct("ViewAddRowAccessPolicy").
 	SQL("ADD").
 	Identifier("RowAccessPolicy", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("ROW ACCESS POLICY").Required()).
 	ListAssignment("ON", "Column", g.ParameterOptions().Required().NoEquals().Parentheses()).
-	WithValidation(g.ValidIdentifier, "RowAccessPolicy")
+	WithValidation(g.ValidIdentifier, "RowAccessPolicy").
+	WithAdditionalValidations()
 
 var viewDropRowAccessPolicy = g.NewQueryStruct("ViewDropRowAccessPolicy").
 	SQL("DROP").
@@ -209,7 +211,8 @@ var viewsDef = g.NewInterface(
 			SQL("AS").
 			Text("sql", g.KeywordOptions().NoQuotes().Required()).
 			WithValidation(g.ValidIdentifier, "name").
-			WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists"),
+			WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists").
+			WithAdditionalValidations(),
 	).
 	CustomOperation(
 		"Alter",

--- a/pkg/sdk/generator/gen/keyword_builders.go
+++ b/pkg/sdk/generator/gen/keyword_builders.go
@@ -64,16 +64,6 @@ func (v *QueryStruct) OptionalLimitFrom() *QueryStruct {
 	return v.PredefinedQueryStructField("Limit", "*LimitFrom", KeywordOptions().SQL("LIMIT"))
 }
 
-func (v *QueryStruct) OptionalSessionParameters() *QueryStruct {
-	return v.PredefinedQueryStructField("SessionParameters", "*SessionParameters", ListOptions().NoParentheses()).
-		WithValidation(ValidateValue, "SessionParameters")
-}
-
-func (v *QueryStruct) OptionalSessionParametersUnset() *QueryStruct {
-	return v.PredefinedQueryStructField("SessionParametersUnset", "*SessionParametersUnset", ListOptions().NoParentheses()).
-		WithValidation(ValidateValue, "SessionParametersUnset")
-}
-
 func (v *QueryStruct) NamedListWithParens(sqlPrefix string, listItemKind string, transformer *KeywordTransformer) *QueryStruct {
 	if transformer != nil {
 		transformer = transformer.Parentheses().SQL(sqlPrefix)

--- a/pkg/sdk/generator/gen/query_struct.go
+++ b/pkg/sdk/generator/gen/query_struct.go
@@ -32,6 +32,10 @@ func (v *QueryStruct) WithValidation(validationType ValidationType, fieldNames .
 	return v
 }
 
+func (v *QueryStruct) WithAdditionalValidations() *QueryStruct {
+	return v.WithValidation(AdditionalValidations)
+}
+
 func (v *QueryStruct) PredefinedQueryStructField(name string, kind string, transformer FieldTransformer) *QueryStruct {
 	v.fields = append(v.fields, NewField(name, kind, Tags(), transformer))
 	return v

--- a/pkg/sdk/generator/gen/templates/sub_templates/validation_implementation.tmpl
+++ b/pkg/sdk/generator/gen/templates/sub_templates/validation_implementation.tmpl
@@ -2,9 +2,13 @@
 
 {{- $field := . -}}
 {{- range .Validations }}
-    if {{ .Condition $field }} {
-        errs = append(errs, {{ .ReturnedError $field }})
-    }
+    {{- if .IsAdditionalValidations }}
+        errs = append(errs, opts{{ $field.Path }}.additionalValidations())
+    {{- else }}
+        if {{ .Condition $field }} {
+            errs = append(errs, {{ .ReturnedError $field }})
+        }
+    {{- end }}
 {{- end -}}
 {{- range .Fields }}
     {{- if .HasAnyValidationInSubtree }}

--- a/pkg/sdk/generator/gen/validation.go
+++ b/pkg/sdk/generator/gen/validation.go
@@ -14,6 +14,7 @@ import (
 // - at least one value set - present here, put on level containing given fields
 // - validate nested field - present here, used for common structs which have their own validate() methods specified
 // - nested validation conditionally - not present here, handled by putting validations on lower level fields
+// - additional validations invocation - present here, emits a call to additionalValidations() method on the struct
 type ValidationType int64
 
 const (
@@ -24,6 +25,7 @@ const (
 	AtLeastOneValueSet
 	ValidateValue
 	ValidateValueSet
+	AdditionalValidations
 )
 
 type Validation struct {
@@ -36,6 +38,10 @@ func NewValidation(validationType ValidationType, fieldNames ...string) *Validat
 		Type:       validationType,
 		FieldNames: fieldNames,
 	}
+}
+
+func (v *Validation) IsAdditionalValidations() bool {
+	return v.Type == AdditionalValidations
 }
 
 func (v *Validation) paramsQuoted() []string {
@@ -55,6 +61,9 @@ func (v *Validation) fieldsWithPath(field *Field) []string {
 }
 
 func (v *Validation) Condition(field *Field) string {
+	if v.Type == AdditionalValidations {
+		log.Panicf("Condition() must not be called for AdditionalValidations type")
+	}
 	switch v.Type {
 	case ValidIdentifier:
 		return fmt.Sprintf("!ValidObjectIdentifier(%s)", strings.Join(v.fieldsWithPath(field), ","))
@@ -78,6 +87,9 @@ func (v *Validation) Condition(field *Field) string {
 }
 
 func (v *Validation) ReturnedError(field *Field) string {
+	if v.Type == AdditionalValidations {
+		log.Panicf("ReturnedError() must not be called for AdditionalValidations type")
+	}
 	switch v.Type {
 	case ValidIdentifier:
 		return "ErrInvalidObjectIdentifier"
@@ -99,6 +111,8 @@ func (v *Validation) ReturnedError(field *Field) string {
 
 func (v *Validation) TodoComment(field *Field) string {
 	switch v.Type {
+	case AdditionalValidations:
+		return fmt.Sprintf("validation: additional validations for opts%s", field.Path())
 	case ValidIdentifier:
 		return fmt.Sprintf("validation: valid identifier for %v", v.fieldsWithPath(field))
 	case ValidIdentifierIfSet:

--- a/pkg/sdk/generator/gen/validation.go
+++ b/pkg/sdk/generator/gen/validation.go
@@ -61,9 +61,6 @@ func (v *Validation) fieldsWithPath(field *Field) []string {
 }
 
 func (v *Validation) Condition(field *Field) string {
-	if v.Type == AdditionalValidations {
-		log.Panicf("Condition() must not be called for AdditionalValidations type")
-	}
 	switch v.Type {
 	case ValidIdentifier:
 		return fmt.Sprintf("!ValidObjectIdentifier(%s)", strings.Join(v.fieldsWithPath(field), ","))
@@ -82,14 +79,13 @@ func (v *Validation) Condition(field *Field) string {
 			log.Panicf("expected ValidateValue to be called exactly one field, got: %v", v.FieldNames)
 		}
 		return fmt.Sprintf("err := %s.validate(); err != nil", v.fieldsWithPath(field)[0])
+	case AdditionalValidations:
+		log.Panicf("Condition() must not be called for AdditionalValidations type")
 	}
 	panic("condition for validation unknown")
 }
 
 func (v *Validation) ReturnedError(field *Field) string {
-	if v.Type == AdditionalValidations {
-		log.Panicf("ReturnedError() must not be called for AdditionalValidations type")
-	}
 	switch v.Type {
 	case ValidIdentifier:
 		return "ErrInvalidObjectIdentifier"
@@ -105,6 +101,8 @@ func (v *Validation) ReturnedError(field *Field) string {
 		return fmt.Sprintf(`errNotSet("%s", %s)`, field.PathWithRoot(), strings.Join(v.paramsQuoted(), ","))
 	case ValidateValue:
 		return "err"
+	case AdditionalValidations:
+		log.Panicf("ReturnedError() must not be called for AdditionalValidations type")
 	}
 	panic("condition for validation unknown")
 }

--- a/pkg/sdk/hybrid_tables_validations_gen.go
+++ b/pkg/sdk/hybrid_tables_validations_gen.go
@@ -38,6 +38,7 @@ func (opts *AlterHybridTableOptions) validate() error {
 	if !exactlyOneValueSet(opts.NewName, opts.AddColumnAction, opts.ConstraintAction, opts.AlterColumnAction, opts.DropColumnAction, opts.DropIndexAction, opts.ClusteringAction, opts.Set) {
 		errs = append(errs, errExactlyOneOf("AlterHybridTableOptions", "NewName", "AddColumnAction", "ConstraintAction", "AlterColumnAction", "DropColumnAction", "DropIndexAction", "ClusteringAction", "Set"))
 	}
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.ConstraintAction) {
 		if !exactlyOneValueSet(opts.ConstraintAction.Rename, opts.ConstraintAction.Drop) {
 			errs = append(errs, errExactlyOneOf("AlterHybridTableOptions.ConstraintAction", "Rename", "Drop"))
@@ -51,7 +52,6 @@ func (opts *AlterHybridTableOptions) validate() error {
 			}
 		}
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	if valueSet(opts.ClusteringAction) {
 		if !exactlyOneValueSet(opts.ClusteringAction.ClusterBy, opts.ClusteringAction.Recluster, opts.ClusteringAction.ChangeReclusterState, opts.ClusteringAction.DropClusteringKey) {
 			errs = append(errs, errExactlyOneOf("AlterHybridTableOptions.ClusteringAction", "ClusterBy", "Recluster", "ChangeReclusterState", "DropClusteringKey"))

--- a/pkg/sdk/iceberg_tables_validations_gen.go
+++ b/pkg/sdk/iceberg_tables_validations_gen.go
@@ -21,7 +21,7 @@ func (opts *CreateIcebergTableOptions) validate() error {
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateIcebergTableOptions", "OrReplace", "IfNotExists"))
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.RowAccessPolicy) {
 		if !ValidObjectIdentifier(opts.RowAccessPolicy.Name) {
 			errs = append(errs, ErrInvalidObjectIdentifier)
@@ -46,7 +46,7 @@ func (opts *AlterIcebergTableOptions) validate() error {
 	if !exactlyOneValueSet(opts.AddColumnAction, opts.DropColumnAction, opts.RenameColumnAction, opts.AlterColumnAction, opts.SetMaskingPolicyOnColumn, opts.UnsetMaskingPolicyOnColumn, opts.SetProjectionPolicyOnColumn, opts.UnsetProjectionPolicyOnColumn, opts.SetTagsOnColumn, opts.UnsetTagsOnColumn, opts.ClusteringAction, opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags, opts.AddRowAccessPolicy, opts.DropRowAccessPolicy, opts.DropAndAddRowAccessPolicy, opts.DropAllRowAccessPolicies, opts.SetAggregationPolicy, opts.UnsetAggregationPolicy, opts.SetJoinPolicy, opts.UnsetJoinPolicy, opts.SearchOptimizationAction) {
 		errs = append(errs, errExactlyOneOf("AlterIcebergTableOptions", "AddColumnAction", "DropColumnAction", "RenameColumnAction", "AlterColumnAction", "SetMaskingPolicyOnColumn", "UnsetMaskingPolicyOnColumn", "SetProjectionPolicyOnColumn", "UnsetProjectionPolicyOnColumn", "SetTagsOnColumn", "UnsetTagsOnColumn", "ClusteringAction", "Set", "Unset", "SetTags", "UnsetTags", "AddRowAccessPolicy", "DropRowAccessPolicy", "DropAndAddRowAccessPolicy", "DropAllRowAccessPolicies", "SetAggregationPolicy", "UnsetAggregationPolicy", "SetJoinPolicy", "UnsetJoinPolicy", "SearchOptimizationAction"))
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.ClusteringAction) {
 		if !exactlyOneValueSet(opts.ClusteringAction.ClusterBy, opts.ClusteringAction.ChangeReclusterState, opts.ClusteringAction.DropClusteringKey) {
 			errs = append(errs, errExactlyOneOf("AlterIcebergTableOptions.ClusteringAction", "ClusterBy", "ChangeReclusterState", "DropClusteringKey"))
@@ -77,7 +77,7 @@ func (opts *AlterIcebergTableOptions) validate() error {
 			errs = append(errs, errExactlyOneOf("AlterIcebergTableOptions.SearchOptimizationAction", "Add", "Drop"))
 		}
 		if valueSet(opts.SearchOptimizationAction.Drop) {
-			errs = append(errs, opts.SearchOptimizationAction.Drop.additionalValidations()) // invocation added manually
+			errs = append(errs, opts.SearchOptimizationAction.Drop.additionalValidations())
 		}
 	}
 	return JoinErrors(errs...)

--- a/pkg/sdk/notebooks_ext.go
+++ b/pkg/sdk/notebooks_ext.go
@@ -17,9 +17,6 @@ func (opts *CreateNotebookOptions) additionalValidations() error {
 
 func (s *NotebookSet) additionalValidations() error {
 	var errs []error
-	if !anyValueSet(s.Comment, s.QueryWarehouse, s.IdleAutoShutdownTimeSeconds, s.Secrets, s.MainFile, s.Warehouse, s.RuntimeName, s.ComputePool, s.ExternalAccessIntegrations, s.RuntimeEnvironmentVersion) {
-		errs = append(errs, errAtLeastOneOf("AlterNotebookOptions.Set", "Comment", "QueryWarehouse", "IdleAutoShutdownTimeSeconds", "Secrets", "MainFile", "Warehouse", "RuntimeName", "ComputePool", "ExternalAccessIntegrations", "RuntimeEnvironmentVersion"))
-	}
 	if s.IdleAutoShutdownTimeSeconds != nil && !validateIntGreaterThan(*s.IdleAutoShutdownTimeSeconds, 0) {
 		errs = append(errs, errIntValue("AlterNotebookOptions", "IdleAutoShutdownTimeSeconds", IntErrGreater, 0))
 	}

--- a/pkg/sdk/notebooks_validations_gen.go
+++ b/pkg/sdk/notebooks_validations_gen.go
@@ -30,7 +30,7 @@ func (opts *CreateNotebookOptions) validate() error {
 	if opts.ComputePool != nil && !ValidObjectIdentifier(opts.ComputePool) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	return JoinErrors(errs...)
 }
 
@@ -58,7 +58,7 @@ func (opts *AlterNotebookOptions) validate() error {
 		if opts.Set.ComputePool != nil && !ValidObjectIdentifier(opts.Set.ComputePool) {
 			errs = append(errs, ErrInvalidObjectIdentifier)
 		}
-		errs = append(errs, opts.Set.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.Set.additionalValidations())
 	}
 	if valueSet(opts.Unset) {
 		if !anyValueSet(opts.Unset.Comment, opts.Unset.QueryWarehouse, opts.Unset.Secrets, opts.Unset.Warehouse, opts.Unset.RuntimeName, opts.Unset.ComputePool, opts.Unset.ExternalAccessIntegrations, opts.Unset.RuntimeEnvironmentVersion) {

--- a/pkg/sdk/notebooks_validations_gen.go
+++ b/pkg/sdk/notebooks_validations_gen.go
@@ -58,6 +58,9 @@ func (opts *AlterNotebookOptions) validate() error {
 		if opts.Set.ComputePool != nil && !ValidObjectIdentifier(opts.Set.ComputePool) {
 			errs = append(errs, ErrInvalidObjectIdentifier)
 		}
+		if !anyValueSet(opts.Set.Comment, opts.Set.QueryWarehouse, opts.Set.IdleAutoShutdownTimeSeconds, opts.Set.Secrets, opts.Set.MainFile, opts.Set.Warehouse, opts.Set.RuntimeName, opts.Set.ComputePool, opts.Set.ExternalAccessIntegrations, opts.Set.RuntimeEnvironmentVersion) {
+			errs = append(errs, errAtLeastOneOf("AlterNotebookOptions.Set", "Comment", "QueryWarehouse", "IdleAutoShutdownTimeSeconds", "Secrets", "MainFile", "Warehouse", "RuntimeName", "ComputePool", "ExternalAccessIntegrations", "RuntimeEnvironmentVersion"))
+		}
 		errs = append(errs, opts.Set.additionalValidations())
 	}
 	if valueSet(opts.Unset) {

--- a/pkg/sdk/notification_integrations_validations_gen.go
+++ b/pkg/sdk/notification_integrations_validations_gen.go
@@ -49,7 +49,7 @@ func (opts *AlterNotificationIntegrationOptions) validate() error {
 		errs = append(errs, errExactlyOneOf("AlterNotificationIntegrationOptions", "Set", "UnsetEmailParams", "UnsetWebhookParams", "SetTags", "UnsetTags"))
 	}
 	if valueSet(opts.Set) {
-		errs = append(errs, opts.Set.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.Set.additionalValidations())
 		if !anyValueSet(opts.Set.Enabled, opts.Set.SetPushParams, opts.Set.SetEmailParams, opts.Set.SetWebhookParams, opts.Set.Comment) {
 			errs = append(errs, errAtLeastOneOf("AlterNotificationIntegrationOptions.Set", "Enabled", "SetPushParams", "SetEmailParams", "SetWebhookParams", "Comment"))
 		}

--- a/pkg/sdk/procedures_gen_test.go
+++ b/pkg/sdk/procedures_gen_test.go
@@ -103,7 +103,7 @@ func TestProcedures_CreateForJava(t *testing.T) {
 		opts.Returns = ProcedureReturns{
 			ResultDataType: &ProcedureReturnsResultDataType{},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForJavaProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.ResultDataType.ResultDataTypeOld opts.Returns.ResultDataType.ResultDataType] should be present - more present", func(t *testing.T) {
@@ -114,7 +114,7 @@ func TestProcedures_CreateForJava(t *testing.T) {
 				ResultDataType:    dataTypeFloat,
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForJavaProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.Table.Columns.ColumnDataTypeOld opts.Returns.Table.Columns.ColumnDataType] should be present", func(t *testing.T) {
@@ -499,7 +499,7 @@ func TestProcedures_CreateForPython(t *testing.T) {
 		opts.Returns = ProcedureReturns{
 			ResultDataType: &ProcedureReturnsResultDataType{},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForPythonProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.ResultDataType.ResultDataTypeOld opts.Returns.ResultDataType.ResultDataType] should be present - two present", func(t *testing.T) {
@@ -510,7 +510,7 @@ func TestProcedures_CreateForPython(t *testing.T) {
 				ResultDataType:    dataTypeFloat,
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForPythonProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.Table.Columns.ColumnDataTypeOld opts.Returns.Table.Columns.ColumnDataType] should be present", func(t *testing.T) {
@@ -759,7 +759,7 @@ func TestProcedures_CreateForScala(t *testing.T) {
 		opts.Returns = ProcedureReturns{
 			ResultDataType: &ProcedureReturnsResultDataType{},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForScalaProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.ResultDataType.ResultDataTypeOld opts.Returns.ResultDataType.ResultDataType] should be present - two present", func(t *testing.T) {
@@ -770,7 +770,7 @@ func TestProcedures_CreateForScala(t *testing.T) {
 				ResultDataType:    dataTypeFloat,
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForScalaProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.Table.Columns.ColumnDataTypeOld opts.Returns.Table.Columns.ColumnDataType] should be present", func(t *testing.T) {
@@ -1005,7 +1005,7 @@ func TestProcedures_CreateForSQL(t *testing.T) {
 				},
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.Table.Columns.ColumnDataTypeOld opts.Returns.Table.Columns.ColumnDataType] should be present - two present", func(t *testing.T) {
@@ -1017,7 +1017,7 @@ func TestProcedures_CreateForSQL(t *testing.T) {
 				},
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.Table.Columns.ColumnDataTypeOld opts.Returns.Table.Columns.ColumnDataType] should be present - one valid, one invalid", func(t *testing.T) {
@@ -1030,7 +1030,7 @@ func TestProcedures_CreateForSQL(t *testing.T) {
 				},
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
 	})
 
 	// variants added manually
@@ -1463,7 +1463,7 @@ func TestProcedures_CreateAndCallForJava(t *testing.T) {
 		opts.Returns = ProcedureReturns{
 			ResultDataType: &ProcedureReturnsResultDataType{},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForJavaProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.ResultDataType.ResultDataTypeOld opts.Returns.ResultDataType.ResultDataType] should be present - more present", func(t *testing.T) {
@@ -1474,7 +1474,7 @@ func TestProcedures_CreateAndCallForJava(t *testing.T) {
 				ResultDataType:    dataTypeFloat,
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForJavaProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.Table.Columns.ColumnDataTypeOld opts.Returns.Table.Columns.ColumnDataType] should be present", func(t *testing.T) {
@@ -1698,7 +1698,7 @@ func TestProcedures_CreateAndCallForScala(t *testing.T) {
 		opts.Returns = ProcedureReturns{
 			ResultDataType: &ProcedureReturnsResultDataType{},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForScalaProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.ResultDataType.ResultDataTypeOld opts.Returns.ResultDataType.ResultDataType] should be present - more present", func(t *testing.T) {
@@ -1709,7 +1709,7 @@ func TestProcedures_CreateAndCallForScala(t *testing.T) {
 				ResultDataType:    dataTypeFloat,
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForScalaProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.Table.Columns.ColumnDataTypeOld opts.Returns.Table.Columns.ColumnDataType] should be present", func(t *testing.T) {
@@ -2064,7 +2064,7 @@ func TestProcedures_CreateAndCallForPython(t *testing.T) {
 		opts.Returns = ProcedureReturns{
 			ResultDataType: &ProcedureReturnsResultDataType{},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForPythonProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.ResultDataType.ResultDataTypeOld opts.Returns.ResultDataType.ResultDataType] should be present - more present", func(t *testing.T) {
@@ -2075,7 +2075,7 @@ func TestProcedures_CreateAndCallForPython(t *testing.T) {
 				ResultDataType:    dataTypeFloat,
 			},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("CreateAndCallForPythonProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 	})
 
 	t.Run("validation: exactly one field from [opts.Returns.Table.Columns.ColumnDataTypeOld opts.Returns.Table.Columns.ColumnDataType] should be present", func(t *testing.T) {

--- a/pkg/sdk/procedures_validations_gen.go
+++ b/pkg/sdk/procedures_validations_gen.go
@@ -37,18 +37,18 @@ func (opts *CreateForJavaProcedureOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForJavaProcedureOptions.Returns", "ResultDataType", "Table"))
 		}
 		if valueSet(opts.Returns.ResultDataType) {
 			if !exactlyOneValueSet(opts.Returns.ResultDataType.ResultDataTypeOld, opts.Returns.ResultDataType.ResultDataType) {
-				errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+				errs = append(errs, errExactlyOneOf("CreateForJavaProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
+			errs = append(errs, opts.Returns.Table.additionalValidations())
 		}
 	}
 	return JoinErrors(errs...)
@@ -68,7 +68,7 @@ func (opts *CreateForJavaScriptProcedureOptions) validate() error {
 	if !exactlyOneValueSet(opts.ResultDataTypeOld, opts.ResultDataType) {
 		errs = append(errs, errExactlyOneOf("CreateForJavaScriptProcedureOptions", "ResultDataTypeOld", "ResultDataType"))
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	return JoinErrors(errs...)
 }
 
@@ -89,18 +89,18 @@ func (opts *CreateForPythonProcedureOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForPythonProcedureOptions.Returns", "ResultDataType", "Table"))
 		}
 		if valueSet(opts.Returns.ResultDataType) {
 			if !exactlyOneValueSet(opts.Returns.ResultDataType.ResultDataTypeOld, opts.Returns.ResultDataType.ResultDataType) {
-				errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+				errs = append(errs, errExactlyOneOf("CreateForPythonProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
+			errs = append(errs, opts.Returns.Table.additionalValidations())
 		}
 	}
 	return JoinErrors(errs...)
@@ -123,18 +123,18 @@ func (opts *CreateForScalaProcedureOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForScalaProcedureOptions.Returns", "ResultDataType", "Table"))
 		}
 		if valueSet(opts.Returns.ResultDataType) {
 			if !exactlyOneValueSet(opts.Returns.ResultDataType.ResultDataTypeOld, opts.Returns.ResultDataType.ResultDataType) {
-				errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+				errs = append(errs, errExactlyOneOf("CreateForScalaProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
+			errs = append(errs, opts.Returns.Table.additionalValidations())
 		}
 	}
 	return JoinErrors(errs...)
@@ -151,7 +151,7 @@ func (opts *CreateForSQLProcedureOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateForSQLProcedureOptions.Returns", "ResultDataType", "Table"))
@@ -162,14 +162,7 @@ func (opts *CreateForSQLProcedureOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			if valueSet(opts.Returns.Table.Columns) {
-				// modified manually
-				for _, col := range opts.Returns.Table.Columns {
-					if !exactlyOneValueSet(col.ColumnDataTypeOld, col.ColumnDataType) {
-						errs = append(errs, errExactlyOneOf("CreateForSQLProcedureOptions.Returns.Table.Columns", "ColumnDataTypeOld", "ColumnDataType"))
-					}
-				}
-			}
+			errs = append(errs, opts.Returns.Table.additionalValidations())
 		}
 	}
 	return JoinErrors(errs...)
@@ -260,18 +253,18 @@ func (opts *CreateAndCallForJavaProcedureOptions) validate() error {
 	if !ValidObjectIdentifier(opts.Name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateAndCallForJavaProcedureOptions.Returns", "ResultDataType", "Table"))
 		}
 		if valueSet(opts.Returns.ResultDataType) {
 			if !exactlyOneValueSet(opts.Returns.ResultDataType.ResultDataTypeOld, opts.Returns.ResultDataType.ResultDataType) {
-				errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+				errs = append(errs, errExactlyOneOf("CreateAndCallForJavaProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
+			errs = append(errs, opts.Returns.Table.additionalValidations())
 		}
 	}
 	return JoinErrors(errs...)
@@ -294,18 +287,18 @@ func (opts *CreateAndCallForScalaProcedureOptions) validate() error {
 	if !ValidObjectIdentifier(opts.Name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateAndCallForScalaProcedureOptions.Returns", "ResultDataType", "Table"))
 		}
 		if valueSet(opts.Returns.ResultDataType) {
 			if !exactlyOneValueSet(opts.Returns.ResultDataType.ResultDataTypeOld, opts.Returns.ResultDataType.ResultDataType) {
-				errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+				errs = append(errs, errExactlyOneOf("CreateAndCallForScalaProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
+			errs = append(errs, opts.Returns.Table.additionalValidations())
 		}
 	}
 	return JoinErrors(errs...)
@@ -325,7 +318,7 @@ func (opts *CreateAndCallForJavaScriptProcedureOptions) validate() error {
 	if !ValidObjectIdentifier(opts.Name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	return JoinErrors(errs...)
 }
 
@@ -346,18 +339,18 @@ func (opts *CreateAndCallForPythonProcedureOptions) validate() error {
 	if !ValidObjectIdentifier(opts.Name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateAndCallForPythonProcedureOptions.Returns", "ResultDataType", "Table"))
 		}
 		if valueSet(opts.Returns.ResultDataType) {
 			if !exactlyOneValueSet(opts.Returns.ResultDataType.ResultDataTypeOld, opts.Returns.ResultDataType.ResultDataType) {
-				errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
+				errs = append(errs, errExactlyOneOf("CreateAndCallForPythonProcedureOptions.Returns.ResultDataType", "ResultDataTypeOld", "ResultDataType"))
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
+			errs = append(errs, opts.Returns.Table.additionalValidations())
 		}
 	}
 	return JoinErrors(errs...)
@@ -374,7 +367,7 @@ func (opts *CreateAndCallForSQLProcedureOptions) validate() error {
 	if !ValidObjectIdentifier(opts.Name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Returns) {
 		if !exactlyOneValueSet(opts.Returns.ResultDataType, opts.Returns.Table) {
 			errs = append(errs, errExactlyOneOf("CreateAndCallForSQLProcedureOptions.Returns", "ResultDataType", "Table"))
@@ -385,7 +378,7 @@ func (opts *CreateAndCallForSQLProcedureOptions) validate() error {
 			}
 		}
 		if valueSet(opts.Returns.Table) {
-			errs = append(errs, opts.Returns.Table.additionalValidations()) // invocation added manually
+			errs = append(errs, opts.Returns.Table.additionalValidations())
 		}
 	}
 	return JoinErrors(errs...)

--- a/pkg/sdk/security_integrations_validations_gen.go
+++ b/pkg/sdk/security_integrations_validations_gen.go
@@ -100,7 +100,7 @@ func (opts *CreateOauthForPartnerApplicationsSecurityIntegrationOptions) validat
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateOauthForPartnerApplicationsSecurityIntegrationOptions", "OrReplace", "IfNotExists"))
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	return JoinErrors(errs...)
 }
 
@@ -143,7 +143,7 @@ func (opts *CreateScimSecurityIntegrationOptions) validate() error {
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateScimSecurityIntegrationOptions", "OrReplace", "IfNotExists"))
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	return JoinErrors(errs...)
 }
 

--- a/pkg/sdk/semantic_views_validations_gen.go
+++ b/pkg/sdk/semantic_views_validations_gen.go
@@ -21,7 +21,7 @@ func (opts *CreateSemanticViewOptions) validate() error {
 	if everyValueSet(opts.IfNotExists, opts.OrReplace) {
 		errs = append(errs, errOneOf("CreateSemanticViewOptions", "IfNotExists", "OrReplace"))
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	return JoinErrors(errs...)
 }
 

--- a/pkg/sdk/services_validations_gen.go
+++ b/pkg/sdk/services_validations_gen.go
@@ -25,6 +25,7 @@ func (opts *CreateServiceOptions) validate() error {
 	if opts.QueryWarehouse != nil && !ValidObjectIdentifier(opts.QueryWarehouse) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.FromSpecification) {
 		if !exactlyOneValueSet(opts.FromSpecification.SpecificationFile, opts.FromSpecification.Specification) {
 			errs = append(errs, errExactlyOneOf("CreateServiceOptions.FromSpecification", "SpecificationFile", "Specification"))
@@ -41,8 +42,6 @@ func (opts *CreateServiceOptions) validate() error {
 			errs = append(errs, errOneOf("CreateServiceOptions.FromSpecificationTemplate", "Location", "SpecificationTemplate"))
 		}
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
-
 	return JoinErrors(errs...)
 }
 
@@ -85,7 +84,7 @@ func (opts *AlterServiceOptions) validate() error {
 		if !anyValueSet(opts.Set.MinInstances, opts.Set.MaxInstances, opts.Set.AutoSuspendSecs, opts.Set.MinReadyInstances, opts.Set.QueryWarehouse, opts.Set.AutoResume, opts.Set.ExternalAccessIntegrations, opts.Set.Comment) {
 			errs = append(errs, errAtLeastOneOf("AlterServiceOptions.Set", "MinInstances", "MaxInstances", "AutoSuspendSecs", "MinReadyInstances", "QueryWarehouse", "AutoResume", "ExternalAccessIntegrations", "Comment"))
 		}
-		errs = append(errs, opts.Set.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.Set.additionalValidations())
 	}
 	if valueSet(opts.Unset) {
 		if !anyValueSet(opts.Unset.MinInstances, opts.Unset.AutoSuspendSecs, opts.Unset.MaxInstances, opts.Unset.MinReadyInstances, opts.Unset.QueryWarehouse, opts.Unset.AutoResume, opts.Unset.ExternalAccessIntegrations, opts.Unset.Comment) {

--- a/pkg/sdk/stages_validations_gen.go
+++ b/pkg/sdk/stages_validations_gen.go
@@ -36,7 +36,7 @@ func (opts *CreateInternalStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("CreateInternalStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.FileFormat.additionalValidations())
 	}
 	return JoinErrors(errs...)
 }
@@ -77,7 +77,7 @@ func (opts *CreateOnS3StageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("CreateOnS3StageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.FileFormat.additionalValidations())
 	}
 	return JoinErrors(errs...)
 }
@@ -101,7 +101,7 @@ func (opts *CreateOnGCSStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("CreateOnGCSStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.FileFormat.additionalValidations())
 	}
 	return JoinErrors(errs...)
 }
@@ -131,7 +131,7 @@ func (opts *CreateOnAzureStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("CreateOnAzureStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.FileFormat.additionalValidations())
 	}
 	return JoinErrors(errs...)
 }
@@ -148,7 +148,7 @@ func (opts *CreateOnS3CompatibleStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("CreateOnS3CompatibleStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.FileFormat.additionalValidations())
 	}
 	return JoinErrors(errs...)
 }
@@ -182,7 +182,7 @@ func (opts *AlterInternalStageStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("AlterInternalStageStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.FileFormat.additionalValidations())
 	}
 	return JoinErrors(errs...)
 }
@@ -223,7 +223,7 @@ func (opts *AlterExternalS3StageStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("AlterExternalS3StageStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.FileFormat.additionalValidations())
 	}
 	return JoinErrors(errs...)
 }
@@ -247,7 +247,7 @@ func (opts *AlterExternalGCSStageStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("AlterExternalGCSStageStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.FileFormat.additionalValidations())
 	}
 	return JoinErrors(errs...)
 }
@@ -277,7 +277,7 @@ func (opts *AlterExternalAzureStageStageOptions) validate() error {
 		if !exactlyOneValueSet(opts.FileFormat.FormatName, opts.FileFormat.FileFormatOptions) {
 			errs = append(errs, errExactlyOneOf("AlterExternalAzureStageStageOptions.FileFormat", "FormatName", "FileFormatOptions"))
 		}
-		errs = append(errs, opts.FileFormat.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.FileFormat.additionalValidations())
 	}
 	return JoinErrors(errs...)
 }

--- a/pkg/sdk/streamlits_validations_gen.go
+++ b/pkg/sdk/streamlits_validations_gen.go
@@ -73,7 +73,7 @@ func (opts *ShowStreamlitOptions) validate() error {
 		return ErrNilOptions
 	}
 	var errs []error
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	return JoinErrors(errs...)
 }
 

--- a/pkg/sdk/tasks_validations_gen.go
+++ b/pkg/sdk/tasks_validations_gen.go
@@ -18,7 +18,7 @@ func (opts *CreateTaskOptions) validate() error {
 		return ErrNilOptions
 	}
 	var errs []error
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
@@ -36,7 +36,7 @@ func (opts *CreateOrAlterTaskOptions) validate() error {
 		return ErrNilOptions
 	}
 	var errs []error
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
@@ -72,7 +72,7 @@ func (opts *AlterTaskOptions) validate() error {
 		errs = append(errs, errExactlyOneOf("AlterTaskOptions", "Resume", "Suspend", "RemoveAfter", "AddAfter", "Set", "Unset", "SetTags", "UnsetTags", "SetFinalize", "UnsetFinalize", "ModifyAs", "ModifyWhen", "RemoveWhen"))
 	}
 	if valueSet(opts.Set) {
-		errs = append(errs, opts.Set.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.Set.additionalValidations())
 		if !anyValueSet(opts.Set.Warehouse, opts.Set.UserTaskManagedInitialWarehouseSize, opts.Set.Schedule, opts.Set.Config, opts.Set.AllowOverlappingExecution, opts.Set.UserTaskTimeoutMs, opts.Set.SuspendTaskAfterNumFailures, opts.Set.ErrorIntegration, opts.Set.Comment, opts.Set.SessionParameters, opts.Set.TaskAutoRetryAttempts, opts.Set.UserTaskMinimumTriggerIntervalInSeconds, opts.Set.TargetCompletionInterval, opts.Set.ServerlessTaskMinStatementSize, opts.Set.ServerlessTaskMaxStatementSize) {
 			errs = append(errs, errAtLeastOneOf("AlterTaskOptions.Set", "Warehouse", "UserTaskManagedInitialWarehouseSize", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParameters", "TaskAutoRetryAttempts", "UserTaskMinimumTriggerIntervalInSeconds", "TargetCompletionInterval", "ServerlessTaskMinStatementSize", "ServerlessTaskMaxStatementSize"))
 		}
@@ -84,7 +84,7 @@ func (opts *AlterTaskOptions) validate() error {
 		}
 	}
 	if valueSet(opts.Unset) {
-		errs = append(errs, opts.Unset.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.Unset.additionalValidations())
 		if !anyValueSet(opts.Unset.Warehouse, opts.Unset.UserTaskManagedInitialWarehouseSize, opts.Unset.Schedule, opts.Unset.Config, opts.Unset.AllowOverlappingExecution, opts.Unset.UserTaskTimeoutMs, opts.Unset.SuspendTaskAfterNumFailures, opts.Unset.ErrorIntegration, opts.Unset.Comment, opts.Unset.SessionParametersUnset, opts.Unset.TaskAutoRetryAttempts, opts.Unset.UserTaskMinimumTriggerIntervalInSeconds, opts.Unset.TargetCompletionInterval, opts.Unset.ServerlessTaskMinStatementSize, opts.Unset.ServerlessTaskMaxStatementSize) {
 			errs = append(errs, errAtLeastOneOf("AlterTaskOptions.Unset", "Warehouse", "UserTaskManagedInitialWarehouseSize", "Schedule", "Config", "AllowOverlappingExecution", "UserTaskTimeoutMs", "SuspendTaskAfterNumFailures", "ErrorIntegration", "Comment", "SessionParametersUnset", "TaskAutoRetryAttempts", "UserTaskMinimumTriggerIntervalInSeconds", "TargetCompletionInterval", "ServerlessTaskMinStatementSize", "ServerlessTaskMaxStatementSize"))
 		}

--- a/pkg/sdk/user_programmatic_access_tokens_validations_gen.go
+++ b/pkg/sdk/user_programmatic_access_tokens_validations_gen.go
@@ -18,7 +18,7 @@ func (opts *AddUserProgrammaticAccessTokenOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if opts.RoleRestriction != nil && !ValidObjectIdentifier(opts.RoleRestriction) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
@@ -33,7 +33,7 @@ func (opts *ModifyUserProgrammaticAccessTokenOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	if !exactlyOneValueSet(opts.Set, opts.Unset, opts.RenameTo) {
 		errs = append(errs, errExactlyOneOf("ModifyUserProgrammaticAccessTokenOptions", "Set", "Unset", "RenameTo"))
 	}
@@ -48,7 +48,7 @@ func (opts *RotateUserProgrammaticAccessTokenOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	return JoinErrors(errs...)
 }
 
@@ -60,7 +60,7 @@ func (opts *RemoveUserProgrammaticAccessTokenOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
+	errs = append(errs, opts.additionalValidations())
 	return JoinErrors(errs...)
 }
 

--- a/pkg/sdk/views_validations_gen.go
+++ b/pkg/sdk/views_validations_gen.go
@@ -21,18 +21,18 @@ func (opts *CreateViewOptions) validate() error {
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateViewOptions", "OrReplace", "IfNotExists"))
 	}
+	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.RowAccessPolicy) {
 		if !ValidObjectIdentifier(opts.RowAccessPolicy.RowAccessPolicy) {
 			errs = append(errs, ErrInvalidObjectIdentifier)
 		}
-		errs = append(errs, opts.RowAccessPolicy.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.RowAccessPolicy.additionalValidations())
 	}
 	if valueSet(opts.AggregationPolicy) {
 		if !ValidObjectIdentifier(opts.AggregationPolicy.AggregationPolicy) {
 			errs = append(errs, ErrInvalidObjectIdentifier)
 		}
 	}
-	errs = append(errs, opts.additionalValidations()) // invocation added manually
 	return JoinErrors(errs...)
 }
 
@@ -57,7 +57,7 @@ func (opts *AlterViewOptions) validate() error {
 		if !ValidObjectIdentifier(opts.AddRowAccessPolicy.RowAccessPolicy) {
 			errs = append(errs, ErrInvalidObjectIdentifier)
 		}
-		errs = append(errs, opts.AddRowAccessPolicy.additionalValidations()) // invocation added manually
+		errs = append(errs, opts.AddRowAccessPolicy.additionalValidations())
 	}
 	if valueSet(opts.DropRowAccessPolicy) {
 		if !ValidObjectIdentifier(opts.DropRowAccessPolicy.RowAccessPolicy) {
@@ -74,7 +74,7 @@ func (opts *AlterViewOptions) validate() error {
 			if !ValidObjectIdentifier(opts.DropAndAddRowAccessPolicy.Add.RowAccessPolicy) {
 				errs = append(errs, ErrInvalidObjectIdentifier)
 			}
-			errs = append(errs, opts.DropAndAddRowAccessPolicy.Add.additionalValidations()) // invocation added manually
+			errs = append(errs, opts.DropAndAddRowAccessPolicy.Add.additionalValidations())
 		}
 	}
 	if valueSet(opts.SetAggregationPolicy) {


### PR DESCRIPTION
Continuation of https://github.com/snowflakedb/terraform-provider-snowflake/pull/4772.

The validation unsupported by the current SDK gen was moved to ext files and invoked as `additionalValidations()`. This change introduces the option to set this "type" of validation to the definitions. All affected files were regenerated.
Additionally, function and procedure nested struct definitions were fixed.

Follow-ups:
- address file formats regenerations (all validations are generated)
- add `validations` part to `make pre-push` and `make pre-push-check`
- handle validations for slices (currently, developed as additionalValidations instead of normal definition)