### PR TITLE
chore: Check for manual changes in generated SDK validations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,9 @@ mod-check: ## check if there are any missing/unused modules
 	# -diff causes a non-zero exit status to be returned if changes to go.mod or go.sum are detected (source: https://go.dev/ref/mod#go-mod-tidy)
 	go mod tidy -compat=1.26.3 -diff
 
-pre-push: generate-all-config-model-builders mod fmt generate-docs-additional-files docs lint-fix test-architecture generate-sdk-validations-check ## Run a few checks and generators. It should be used only locally because it modifies or fixes the code.
+pre-push: generate-all-config-model-builders generate-sdk-validations mod fmt generate-docs-additional-files docs lint-fix test-architecture ## Run a few checks and generators. It should be used only locally because it modifies or fixes the code.
 
-pre-push-check: generate-all-config-model-builders-check mod-check fmt-check generate-docs-additional-files-check docs-check lint test-architecture generate-sdk-validations-check ## Run checks before pushing a change (docs, fmt, mod, etc.)
+pre-push-check: generate-all-config-model-builders-check generate-sdk-validations-check mod-check fmt-check generate-docs-additional-files-check docs-check lint test-architecture ## Run checks before pushing a change (docs, fmt, mod, etc.)
 
 sweep: ## destroy the whole architecture; USE ONLY FOR DEVELOPMENT ACCOUNTS
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
@@ -152,8 +152,10 @@ generate-dto-%: ./pkg/sdk/%_dto.go ## Generate DTO for given SDK interface
 generate-sdk: ## Generate all SDK objects
 	go generate ./pkg/sdk/generate.go
 
-generate-sdk-validations-check: ## check that SDK validations are up-to-date
+generate-sdk-validations: ## check that SDK validations are up-to-date
 	make generate-sdk SF_TF_GENERATOR_ARGS='--filter-generation-part-names=validations'
+
+generate-sdk-validations-check: generate-sdk-validations ## check that SDK validations are up-to-date
 	$(call GIT_DIFF_CHECK,pkg/sdk/*_validations_gen.go)
 
 clean-generated-sdk: ## Clean all generated SDK objects

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,9 @@ mod-check: ## check if there are any missing/unused modules
 	# -diff causes a non-zero exit status to be returned if changes to go.mod or go.sum are detected (source: https://go.dev/ref/mod#go-mod-tidy)
 	go mod tidy -compat=1.26.3 -diff
 
-pre-push: generate-all-config-model-builders mod fmt generate-docs-additional-files docs lint-fix test-architecture ## Run a few checks and generators. It should be used only locally because it modifies or fixes the code.
+pre-push: generate-all-config-model-builders mod fmt generate-docs-additional-files docs lint-fix test-architecture generate-sdk-validations-check ## Run a few checks and generators. It should be used only locally because it modifies or fixes the code.
 
-pre-push-check: generate-all-config-model-builders-check mod-check fmt-check generate-docs-additional-files-check docs-check lint test-architecture ## Run checks before pushing a change (docs, fmt, mod, etc.)
+pre-push-check: generate-all-config-model-builders-check mod-check fmt-check generate-docs-additional-files-check docs-check lint test-architecture generate-sdk-validations-check ## Run checks before pushing a change (docs, fmt, mod, etc.)
 
 sweep: ## destroy the whole architecture; USE ONLY FOR DEVELOPMENT ACCOUNTS
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
@@ -151,6 +151,10 @@ generate-dto-%: ./pkg/sdk/%_dto.go ## Generate DTO for given SDK interface
 
 generate-sdk: ## Generate all SDK objects
 	go generate ./pkg/sdk/generate.go
+
+generate-sdk-validations-check: ## check that SDK validations are up-to-date
+	make generate-sdk SF_TF_GENERATOR_ARGS='--filter-generation-part-names=validations'
+	$(call GIT_DIFF_CHECK,pkg/sdk/*_validations_gen.go)
 
 clean-generated-sdk: ## Clean all generated SDK objects
 	rm -f ./pkg/sdk/*_gen.go
@@ -245,4 +249,4 @@ generate-poc-provider-plugin-framework-model-and-schema: ## Generate model and s
 clean-poc-provider-plugin-framework-model-and-schema: ## Clean generated model and schema for Plugin Framework PoC
 	rm -f ./pkg/testacc/13_plugin_framework_model_and_schema_gen.go
 
-.PHONY: build-local dev-setup dev-cleanup docs docs-check fmt fmt-check fumpt help install lint lint-fix mod mod-check pre-push pre-push-check sweep terraform-fmt terraform-fmt-check test test-acceptance uninstall-tf
+.PHONY: build-local dev-setup dev-cleanup docs docs-check fmt fmt-check fumpt help install lint lint-fix mod mod-check pre-push pre-push-check sweep terraform-fmt terraform-fmt-check test test-acceptance uninstall-tf generate-sdk-validations-check

--- a/pkg/sdk/file_formats_validations_gen.go
+++ b/pkg/sdk/file_formats_validations_gen.go
@@ -10,6 +10,5 @@ func (opts *DummyOperationFileFormatOptions) validate() error {
 	}
 	var errs []error
 	errs = append(errs, opts.additionalValidations())
-	// all file formats validations removed manually
 	return JoinErrors(errs...)
 }

--- a/pkg/sdk/generator/defs/file_formats_def.go
+++ b/pkg/sdk/generator/defs/file_formats_def.go
@@ -173,7 +173,7 @@ var fileFormatsDef = g.NewInterface(
 		"DummyOperation",
 		"not available",
 		g.NewQueryStruct("FileFormatsDummyOperation").
-			OptionalQueryStructField("FileFormat", fileFormatDef(), g.ListOptions().Parentheses().SQL("FILE_FORMAT =")).
+			OptionalQueryStructField("FileFormat", g.RemoveValidations(fileFormatDef()), g.ListOptions().Parentheses().SQL("FILE_FORMAT =")).
 			WithAdditionalValidations(),
 	).
 	WithEnums(

--- a/pkg/sdk/generator/gen/tmp.go
+++ b/pkg/sdk/generator/gen/tmp.go
@@ -1,0 +1,19 @@
+package gen
+
+// RemoveValidations removes all validations from the QueryStruct and all nested fields recursively.
+// Currently used, to prevent generation of each validation in reused struct like file formats.
+// Will be removed when the support for reusable structs is added.
+func RemoveValidations(qs *QueryStruct) *QueryStruct {
+	qs.validations = nil
+	for _, f := range qs.fields {
+		removeFieldValidations(f)
+	}
+	return qs
+}
+
+func removeFieldValidations(f *Field) {
+	f.Validations = nil
+	for i := range f.Fields {
+		removeFieldValidations(&f.Fields[i])
+	}
+}


### PR DESCRIPTION
Continuation to https://github.com/snowflakedb/terraform-provider-snowflake/pull/4778.

All unsupported validations are handled by the additionalValidations. The last part (file formats) is currently handled by temporary validations removal (file formats will be reworked; also, there is ongoing effort to have better handling for reusable structs).
The regeneration is validated as part of pre-push to enforce no manual changes in the validations generation part.

Follow-ups:
- handle validations for slices (main case for additionalValidations)