### PR TITLE
chore: Generate convert for more SDK objects - part 4

### DIFF
--- a/pkg/sdk/compute_pools_impl_gen.go
+++ b/pkg/sdk/compute_pools_impl_gen.go
@@ -2,7 +2,6 @@
 
 package sdk
 
-// imports adjusted manually
 import (
 	"context"
 	"fmt"
@@ -145,8 +144,7 @@ func (r *ShowComputePoolRequest) toOpts() *ShowComputePoolOptions {
 }
 
 func (r computePoolsRow) convert() (*ComputePool, error) {
-	// Added manually
-	cp := &ComputePool{
+	result := &ComputePool{
 		Name:            r.Name,
 		MinNodes:        r.MinNodes,
 		MaxNodes:        r.MaxNodes,
@@ -163,30 +161,15 @@ func (r computePoolsRow) convert() (*ComputePool, error) {
 		Owner:           r.Owner,
 		IsExclusive:     r.IsExclusive,
 	}
-	if r.Comment.Valid {
-		cp.Comment = &r.Comment.String
-	}
-	if r.Application.Valid {
-		id, err := ParseAccountObjectIdentifier(r.Application.String)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse application in compute pool: %w", err)
-		} else {
-			cp.Application = &id
-		}
-	}
-	instanceFamily, err := ToComputePoolInstanceFamily(r.InstanceFamily)
-	if err != nil {
-		return nil, fmt.Errorf("error converting compute pool instance family: %w", err)
+	mapStringWithMapping(&result.State, r.State, ToComputePoolState)
+	if v, err := ToComputePoolInstanceFamily(r.InstanceFamily); err == nil {
+		result.InstanceFamily = v
 	} else {
-		cp.InstanceFamily = instanceFamily
+		return nil, fmt.Errorf("parsing compute pool instance family: %w", err)
 	}
-	state, err := ToComputePoolState(r.State)
-	if err != nil {
-		return nil, fmt.Errorf("error converting compute pool state: %w", err)
-	} else {
-		cp.State = state
-	}
-	return cp, err
+	mapNullString(&result.Comment, r.Comment)
+	mapNullStringWithMapping(&result.Application, r.Application, ParseAccountObjectIdentifier)
+	return result, nil
 }
 
 func (r *DescribeComputePoolRequest) toOpts() *DescribeComputePoolOptions {
@@ -197,8 +180,7 @@ func (r *DescribeComputePoolRequest) toOpts() *DescribeComputePoolOptions {
 }
 
 func (r computePoolDescRow) convert() (*ComputePoolDetails, error) {
-	// Added manually
-	cp := &ComputePoolDetails{
+	result := &ComputePoolDetails{
 		Name:            r.Name,
 		MinNodes:        r.MinNodes,
 		MaxNodes:        r.MaxNodes,
@@ -217,28 +199,13 @@ func (r computePoolDescRow) convert() (*ComputePoolDetails, error) {
 		ErrorCode:       r.ErrorCode,
 		StatusMessage:   r.StatusMessage,
 	}
-	if r.Comment.Valid {
-		cp.Comment = &r.Comment.String
-	}
-	if r.Application.Valid {
-		id, err := ParseAccountObjectIdentifier(r.Application.String)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse application in compute pool: %w", err)
-		} else {
-			cp.Application = &id
-		}
-	}
-	instanceFamily, err := ToComputePoolInstanceFamily(r.InstanceFamily)
-	if err != nil {
-		return nil, fmt.Errorf(" error converting compute pool instance family: %w", err)
+	mapStringWithMapping(&result.State, r.State, ToComputePoolState)
+	if v, err := ToComputePoolInstanceFamily(r.InstanceFamily); err == nil {
+		result.InstanceFamily = v
 	} else {
-		cp.InstanceFamily = instanceFamily
+		return nil, fmt.Errorf("parsing compute pool instance family: %w", err)
 	}
-	state, err := ToComputePoolState(r.State)
-	if err != nil {
-		return nil, fmt.Errorf("error converting compute pool state: %w", err)
-	} else {
-		cp.State = state
-	}
-	return cp, err
+	mapNullString(&result.Comment, r.Comment)
+	mapNullStringWithMapping(&result.Application, r.Application, ParseAccountObjectIdentifier)
+	return result, nil
 }

--- a/pkg/sdk/connections_impl_gen.go
+++ b/pkg/sdk/connections_impl_gen.go
@@ -122,40 +122,28 @@ func (r *ShowConnectionRequest) toOpts() *ShowConnectionOptions {
 }
 
 func (r connectionRow) convert() (*Connection, error) {
-	// added manually
-	c := &Connection{
-		SnowflakeRegion:  r.SnowflakeRegion,
-		CreatedOn:        r.CreatedOn,
-		AccountName:      r.AccountName,
-		Name:             r.Name,
+	result := &Connection{
+		SnowflakeRegion: r.SnowflakeRegion,
+		CreatedOn:       r.CreatedOn,
+		AccountName:     r.AccountName,
+		Name:            r.Name,
+		// IsPrimary:        r.IsPrimary == "Y", // removed manually
 		ConnectionUrl:    r.ConnectionUrl,
 		OrganizationName: r.OrganizationName,
 		AccountLocator:   r.AccountLocator,
 	}
-
+	// added manually
 	parsedIsPrimary, err := strconv.ParseBool(r.IsPrimary)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse bool is_primary for connection: %w", err)
 	} else {
-		c.IsPrimary = parsedIsPrimary
+		result.IsPrimary = parsedIsPrimary
 	}
-
-	primaryExternalId, err := ParseExternalObjectIdentifier(r.Primary)
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse primary connection external identifier: %w", err)
-	} else {
-		c.Primary = primaryExternalId
+	mapNullString(&result.RegionGroup, r.RegionGroup)
+	mapNullString(&result.Comment, r.Comment)
+	mapStringWithMapping(&result.Primary, r.Primary, ParseExternalObjectIdentifier)
+	if ids, err := ParseCommaSeparatedAccountIdentifierArray(r.FailoverAllowedToAccounts); err == nil {
+		result.FailoverAllowedToAccounts = ids
 	}
-
-	if allowedToAccounts, err := ParseCommaSeparatedAccountIdentifierArray(r.FailoverAllowedToAccounts); err != nil {
-		return nil, fmt.Errorf("unable to parse account identifier list for enable failover to accounts: %w", err)
-	} else {
-		c.FailoverAllowedToAccounts = allowedToAccounts
-	}
-
-	if r.Comment.Valid {
-		c.Comment = String(r.Comment.String)
-	}
-
-	return c, nil
+	return result, nil
 }

--- a/pkg/sdk/connections_impl_gen.go
+++ b/pkg/sdk/connections_impl_gen.go
@@ -2,11 +2,8 @@
 
 package sdk
 
-// imports adjusted manually
 import (
 	"context"
-	"fmt"
-	"strconv"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
@@ -123,24 +120,17 @@ func (r *ShowConnectionRequest) toOpts() *ShowConnectionOptions {
 
 func (r connectionRow) convert() (*Connection, error) {
 	result := &Connection{
-		SnowflakeRegion: r.SnowflakeRegion,
-		CreatedOn:       r.CreatedOn,
-		AccountName:     r.AccountName,
-		Name:            r.Name,
-		// IsPrimary:        r.IsPrimary == "Y", // removed manually
+		SnowflakeRegion:  r.SnowflakeRegion,
+		CreatedOn:        r.CreatedOn,
+		AccountName:      r.AccountName,
+		Name:             r.Name,
 		ConnectionUrl:    r.ConnectionUrl,
 		OrganizationName: r.OrganizationName,
 		AccountLocator:   r.AccountLocator,
 	}
-	// added manually
-	parsedIsPrimary, err := strconv.ParseBool(r.IsPrimary)
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse bool is_primary for connection: %w", err)
-	} else {
-		result.IsPrimary = parsedIsPrimary
-	}
 	mapNullString(&result.RegionGroup, r.RegionGroup)
 	mapNullString(&result.Comment, r.Comment)
+	mapStringToBoolParsed(&result.IsPrimary, r.IsPrimary)
 	mapStringWithMapping(&result.Primary, r.Primary, ParseExternalObjectIdentifier)
 	if ids, err := ParseCommaSeparatedAccountIdentifierArray(r.FailoverAllowedToAccounts); err == nil {
 		result.FailoverAllowedToAccounts = ids

--- a/pkg/sdk/generator/defs/compute_pools_def.go
+++ b/pkg/sdk/generator/defs/compute_pools_def.go
@@ -89,7 +89,7 @@ var computePoolsDef = g.NewInterface(
 		Enum("state", ComputePoolStateEnumDef).
 		Number("min_nodes").
 		Number("max_nodes").
-		PlainField("instance_family", "ComputePoolInstanceFamily").
+		PlainField("instance_family", "ComputePoolInstanceFamily", g.WithCustomParser("ToComputePoolInstanceFamily")).
 		Number("num_services").
 		Number("num_jobs").
 		Number("auto_suspend_secs").
@@ -103,7 +103,8 @@ var computePoolsDef = g.NewInterface(
 		Text("owner").
 		OptionalText("comment").
 		Bool("is_exclusive").
-		Field("application", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("Application")),
+		Field("application", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("Application")).
+		WithConvertGeneration(),
 	g.NewQueryStruct("ShowComputePools").
 		Show().
 		SQL("COMPUTE POOLS").
@@ -118,7 +119,7 @@ var computePoolsDef = g.NewInterface(
 		Enum("state", ComputePoolStateEnumDef).
 		Number("min_nodes").
 		Number("max_nodes").
-		PlainField("instance_family", "ComputePoolInstanceFamily").
+		PlainField("instance_family", "ComputePoolInstanceFamily", g.WithCustomParser("ToComputePoolInstanceFamily")).
 		Number("num_services").
 		Number("num_jobs").
 		Number("auto_suspend_secs").
@@ -134,7 +135,8 @@ var computePoolsDef = g.NewInterface(
 		Bool("is_exclusive").
 		Field("application", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("Application")).
 		Text("error_code").
-		Text("status_message"),
+		Text("status_message").
+		WithConvertGeneration(),
 	g.NewQueryStruct("DescComputePool").
 		Describe().
 		SQL("COMPUTE POOL").

--- a/pkg/sdk/generator/defs/connections_def.go
+++ b/pkg/sdk/generator/defs/connections_def.go
@@ -84,10 +84,11 @@ var connectionsDef = g.NewInterface(
 		OptionalText("comment").
 		Field("is_primary", "string", "bool").
 		Field("primary", "string", "ExternalObjectIdentifier").
-		Field("failover_allowed_to_accounts", "string", "[]AccountIdentifier").
+		AccountIdentifierArray("failover_allowed_to_accounts").
 		Text("connection_url").
 		Text("organization_name").
-		Text("account_locator"),
+		Text("account_locator").
+		WithConvertGeneration(),
 	g.NewQueryStruct("ShowConnections").
 		Show().
 		SQL("CONNECTIONS").

--- a/pkg/sdk/generator/defs/connections_def.go
+++ b/pkg/sdk/generator/defs/connections_def.go
@@ -82,7 +82,7 @@ var connectionsDef = g.NewInterface(
 		Text("account_name").
 		Text("name").
 		OptionalText("comment").
-		Field("is_primary", "string", "bool").
+		Field("is_primary", "string", "bool", g.WithBoolParsed()).
 		Field("primary", "string", "ExternalObjectIdentifier").
 		AccountIdentifierArray("failover_allowed_to_accounts").
 		Text("connection_url").

--- a/pkg/sdk/generator/defs/iceberg_tables_def.go
+++ b/pkg/sdk/generator/defs/iceberg_tables_def.go
@@ -324,7 +324,7 @@ var icebergTablesDef = g.NewInterface(
 		OptionalText("owner").
 		OptionalAccountObjectIdentifier("external_volume_name", g.WithPlainFieldName("ExternalVolumeName")).
 		OptionalAccountObjectIdentifier("catalog_name", g.WithPlainFieldName("CatalogName")).
-		PlainField("iceberg_table_type", IcebergTableTypeEnumDef.Kind()).
+		Enum("iceberg_table_type", IcebergTableTypeEnumDef).
 		OptionalText("catalog_table_name").
 		OptionalText("catalog_namespace").
 		Text("base_location").

--- a/pkg/sdk/generator/defs/materialized_views_def.go
+++ b/pkg/sdk/generator/defs/materialized_views_def.go
@@ -78,7 +78,8 @@ var materializedViewDetailsPairs = g.StructPair("materializedViewDetailsRow", "M
 	Field("unique key", "string", "bool", g.WithPlainFieldName("IsUnique")).
 	Field("check", "sql.NullString", "*bool").
 	OptionalText("expression").
-	OptionalText("comment")
+	OptionalText("comment").
+	WithConvertGeneration()
 
 var materializedViewsDef = g.NewInterface(
 	"MaterializedViews",

--- a/pkg/sdk/generator/defs/materialized_views_def.go
+++ b/pkg/sdk/generator/defs/materialized_views_def.go
@@ -63,7 +63,7 @@ var materializedViewPairs = g.StructPair("materializedViewDBRow", "MaterializedV
 	OptionalText("comment", g.WithRequiredInPlain()).
 	Text("text").
 	Bool("is_secure").
-	Field("automatic_clustering", "string", "bool").
+	Field("automatic_clustering", "string", "bool", g.WithBoolTrueValue("ON")).
 	OptionalText("owner_role_type", g.WithRequiredInPlain()).
 	OptionalText("budget", g.WithRequiredInPlain()).
 	WithConvertGeneration()

--- a/pkg/sdk/generator/defs/openflow_connectors_def.go
+++ b/pkg/sdk/generator/defs/openflow_connectors_def.go
@@ -75,7 +75,7 @@ var openflowConnectorsDef = g.NewInterface(
 	"TODO: add link when public docs are available",
 	g.StructPair("openflowConnectorRow", "OpenflowConnector").
 		Text("name").
-		PlainField("status", OpenflowConnectorStatusEnumDef.Kind()).
+		Enum("status", OpenflowConnectorStatusEnumDef).
 		Text("runtime").
 		OptionalText("connector_definition").
 		OptionalText("display_name").
@@ -90,7 +90,8 @@ var openflowConnectorsDef = g.NewInterface(
 		OptionalText("live_version_location_uri").
 		OptionalText("comment").
 		Time("created_on").
-		Time("updated_on"),
+		Time("updated_on").
+		WithConvertGeneration(),
 	g.NewQueryStruct("ShowOpenflowConnectors").
 		Show().
 		SQL("OPENFLOW CONNECTORS").
@@ -103,7 +104,7 @@ var openflowConnectorsDef = g.NewInterface(
 	"TODO: add link when public docs are available",
 	g.StructPair("openflowConnectorDetailsRow", "OpenflowConnectorDetails").
 		Text("name").
-		PlainField("status", OpenflowConnectorStatusEnumDef.Kind()).
+		Enum("status", OpenflowConnectorStatusEnumDef).
 		Text("runtime").
 		OptionalText("connector_definition").
 		OptionalText("definition_version_name").
@@ -128,7 +129,8 @@ var openflowConnectorsDef = g.NewInterface(
 		Time("created_on").
 		Time("updated_on").
 		OptionalText("error_code").
-		OptionalText("status_message"),
+		OptionalText("status_message").
+		WithConvertGeneration(),
 	g.NewQueryStruct("DescribeOpenflowConnector").
 		Describe().
 		SQL("OPENFLOW CONNECTOR").

--- a/pkg/sdk/generator/defs/openflow_deployments_def.go
+++ b/pkg/sdk/generator/defs/openflow_deployments_def.go
@@ -84,16 +84,17 @@ var openflowDeploymentsDef = g.NewInterface(
 	"TODO: add link when public docs are available",
 	g.StructPair("openflowDeploymentRow", "OpenflowDeployment").
 		Text("name").
-		Field("type", "string", OpenflowDeploymentTypeEnumDef.Kind(), g.WithDbFieldName("DeploymentType")).
-		PlainField("status", OpenflowDeploymentStatusEnumDef.Kind()).
-		Field("vpc_type", "sql.NullString", OpenflowVpcTypeEnumDef.KindPtr()).
+		Enum("type", OpenflowDeploymentTypeEnumDef, g.WithDbFieldName("DeploymentType")).
+		Enum("status", OpenflowDeploymentStatusEnumDef).
+		OptionalEnum("vpc_type", OpenflowVpcTypeEnumDef).
 		OptionalText("display_name").
 		Bool("use_private_link").
 		Bool("use_user_auth_over_private_link").
 		OptionalText("custom_ingress_hostname").
 		OptionalText("openflow_key").
 		Text("owner").
-		OptionalText("comment"),
+		OptionalText("comment").
+		WithConvertGeneration(),
 	g.NewQueryStruct("ShowOpenflowDeployments").
 		Show().
 		SQL("OPENFLOW DEPLOYMENTS").
@@ -104,9 +105,9 @@ var openflowDeploymentsDef = g.NewInterface(
 	"TODO: add link when public docs are available",
 	g.StructPair("openflowDeploymentDetailsRow", "OpenflowDeploymentDetails").
 		Text("name").
-		Field("type", "string", OpenflowDeploymentTypeEnumDef.Kind(), g.WithDbFieldName("DeploymentType")).
-		PlainField("status", OpenflowDeploymentStatusEnumDef.Kind()).
-		Field("vpc_type", "sql.NullString", OpenflowVpcTypeEnumDef.KindPtr()).
+		Enum("type", OpenflowDeploymentTypeEnumDef, g.WithDbFieldName("DeploymentType")).
+		Enum("status", OpenflowDeploymentStatusEnumDef).
+		OptionalEnum("vpc_type", OpenflowVpcTypeEnumDef).
 		OptionalText("display_name").
 		Bool("use_private_link").
 		Bool("use_user_auth_over_private_link").
@@ -117,7 +118,8 @@ var openflowDeploymentsDef = g.NewInterface(
 		Time("created_on").
 		Time("updated_on").
 		OptionalText("error_code").
-		OptionalText("status_message"),
+		OptionalText("status_message").
+		WithConvertGeneration(),
 	g.NewQueryStruct("DescribeOpenflowDeployment").
 		Describe().
 		SQL("OPENFLOW DEPLOYMENT").

--- a/pkg/sdk/generator/defs/openflow_runtimes_def.go
+++ b/pkg/sdk/generator/defs/openflow_runtimes_def.go
@@ -99,11 +99,11 @@ var openflowRuntimesDef = g.NewInterface(
 	"TODO: add link when public docs are available",
 	g.StructPair("openflowRuntimeRow", "OpenflowRuntime").
 		Text("name").
-		PlainField("status", OpenflowRuntimeStatusEnumDef.Kind()).
+		Enum("status", OpenflowRuntimeStatusEnumDef).
 		Text("deployment").
 		Number("min_nodes").
 		Number("max_nodes").
-		PlainField("node_type", OpenflowRuntimeNodeTypeEnumDef.Kind()).
+		Enum("node_type", OpenflowRuntimeNodeTypeEnumDef).
 		OptionalText("display_name").
 		Field("external_access_integrations", "sql.NullString", "[]AccountObjectIdentifier").
 		Bool("initially_suspended").
@@ -111,7 +111,8 @@ var openflowRuntimesDef = g.NewInterface(
 		Text("owner").
 		OptionalText("comment").
 		Time("created_on").
-		Time("updated_on"),
+		Time("updated_on").
+		WithConvertGeneration(),
 	g.NewQueryStruct("ShowOpenflowRuntimes").
 		Show().
 		SQL("OPENFLOW RUNTIMES").
@@ -124,11 +125,11 @@ var openflowRuntimesDef = g.NewInterface(
 	"TODO: add link when public docs are available",
 	g.StructPair("openflowRuntimeDetailsRow", "OpenflowRuntimeDetails").
 		Text("name").
-		PlainField("status", OpenflowRuntimeStatusEnumDef.Kind()).
+		Enum("status", OpenflowRuntimeStatusEnumDef).
 		Text("deployment").
 		Number("min_nodes").
 		Number("max_nodes").
-		PlainField("node_type", OpenflowRuntimeNodeTypeEnumDef.Kind()).
+		Enum("node_type", OpenflowRuntimeNodeTypeEnumDef).
 		OptionalText("display_name").
 		Field("external_access_integrations", "sql.NullString", "[]AccountObjectIdentifier").
 		Bool("initially_suspended").
@@ -139,7 +140,8 @@ var openflowRuntimesDef = g.NewInterface(
 		Time("created_on").
 		Time("updated_on").
 		OptionalText("error_code").
-		OptionalText("status_message"),
+		OptionalText("status_message").
+		WithConvertGeneration(),
 	g.NewQueryStruct("DescribeOpenflowRuntime").
 		Describe().
 		SQL("OPENFLOW RUNTIME").

--- a/pkg/sdk/generator/defs/row_access_policies_def.go
+++ b/pkg/sdk/generator/defs/row_access_policies_def.go
@@ -86,9 +86,10 @@ var rowAccessPoliciesDef = g.NewInterface(
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-row-access-policy",
 		g.StructPair("describeRowAccessPolicyDBRow", "RowAccessPolicyDescription").
 			Text("name").
-			Field("signature", "string", "[]TableColumnSignature").
+			Field("signature", "string", "[]TableColumnSignature", g.WithCustomParser("ParseTableColumnSignature")).
 			Text("return_type").
-			Text("body"),
+			Text("body").
+			WithConvertGeneration(),
 		g.NewQueryStruct("DescribeRowAccessPolicy").
 			Describe().
 			SQL("ROW ACCESS POLICY").

--- a/pkg/sdk/generator/defs/secrets_def.go
+++ b/pkg/sdk/generator/defs/secrets_def.go
@@ -17,7 +17,8 @@ var secretPairs = g.StructPair("secretDBRow", "Secret").
 	OptionalText("comment").
 	Text("secret_type").
 	Field("oauth_scopes", "sql.NullString", "[]string").
-	Text("owner_role_type")
+	Text("owner_role_type").
+	WithConvertGeneration()
 
 var secretDetailsPairs = g.StructPair("secretDetailsDBRow", "SecretDetails").
 	Time("created_on").
@@ -31,7 +32,8 @@ var secretDetailsPairs = g.StructPair("secretDetailsDBRow", "SecretDetails").
 	Field("oauth_access_token_expiry_time", "*time.Time", "*time.Time").
 	Field("oauth_refresh_token_expiry_time", "*time.Time", "*time.Time").
 	Field("oauth_scopes", "sql.NullString", "[]string").
-	OptionalText("integration_name")
+	OptionalText("integration_name").
+	WithConvertGeneration()
 
 var secretsApiIntegrationScopeDef = g.NewQueryStruct("ApiIntegrationScope").
 	Text("Scope", g.KeywordOptions().SingleQuotes().Required())

--- a/pkg/sdk/generator/defs/security_integrations_def.go
+++ b/pkg/sdk/generator/defs/security_integrations_def.go
@@ -646,7 +646,8 @@ var securityIntegrationsDef = g.NewInterface(
 			Text("property", g.WithPlainFieldName("Name")).
 			Text("property_type", g.WithPlainFieldName("Type")).
 			Text("property_value", g.WithPlainFieldName("Value")).
-			Text("property_default", g.WithPlainFieldName("Default")),
+			Text("property_default", g.WithPlainFieldName("Default")).
+			WithConvertGeneration(),
 		g.NewQueryStruct("DescSecurityIntegration").
 			Describe().
 			SQL("SECURITY INTEGRATION").
@@ -661,7 +662,8 @@ var securityIntegrationsDef = g.NewInterface(
 			Text("category").
 			Bool("enabled").
 			OptionalText("comment", g.WithRequiredInPlain()).
-			Time("created_on"),
+			Time("created_on").
+			WithConvertGeneration(),
 		g.NewQueryStruct("ShowSecurityIntegrations").
 			Show().
 			SQL("SECURITY INTEGRATIONS").

--- a/pkg/sdk/generator/defs/services_def.go
+++ b/pkg/sdk/generator/defs/services_def.go
@@ -178,7 +178,8 @@ var servicesDef = g.NewInterface(
 		Text("spec_digest").
 		Bool("is_upgrading").
 		OptionalText("managing_object_domain").
-		OptionalText("managing_object_name"),
+		OptionalText("managing_object_name").
+		WithConvertGeneration(),
 	g.NewQueryStruct("ShowServices").
 		Show().
 		OptionalSQL("JOB").
@@ -223,7 +224,8 @@ var servicesDef = g.NewInterface(
 		Text("spec_digest").
 		Bool("is_upgrading").
 		OptionalText("managing_object_domain").
-		OptionalText("managing_object_name"),
+		OptionalText("managing_object_name").
+		WithConvertGeneration(),
 	g.NewQueryStruct("DescService").
 		Describe().
 		SQL("SERVICE").

--- a/pkg/sdk/generator/defs/storage_integrations_def.go
+++ b/pkg/sdk/generator/defs/storage_integrations_def.go
@@ -142,7 +142,8 @@ var storageIntegrationsDef = g.NewInterface(
 			Text("category").
 			Bool("enabled").
 			OptionalText("comment", g.WithRequiredInPlain()).
-			Time("created_on"),
+			Time("created_on").
+			WithConvertGeneration(),
 		g.NewQueryStruct("ShowStorageIntegrations").
 			Show().
 			SQL("STORAGE INTEGRATIONS").
@@ -155,7 +156,8 @@ var storageIntegrationsDef = g.NewInterface(
 			Text("property", g.WithPlainFieldName("Name")).
 			Text("property_type", g.WithPlainFieldName("Type")).
 			Text("property_value", g.WithPlainFieldName("Value")).
-			Text("property_default", g.WithPlainFieldName("Default")),
+			Text("property_default", g.WithPlainFieldName("Default")).
+			WithConvertGeneration(),
 		g.NewQueryStruct("DescribeStorageIntegration").
 			Describe().
 			SQL("STORAGE INTEGRATION").

--- a/pkg/sdk/generator/defs/streams_def.go
+++ b/pkg/sdk/generator/defs/streams_def.go
@@ -40,15 +40,16 @@ var (
 			Text("schema_name").
 			OptionalText("owner").
 			OptionalText("comment").
-			OptionalText("table_name").
+			OptionalSchemaObjectIdentifier("table_name", g.WithPlainFieldName("TableName")).
 			OptionalEnum("source_type", StreamSourceTypeEnumDef).
-			Field("base_tables", "sql.NullString", "[]string").
+			NullableSchemaObjectIdentifierArray("base_tables").
 			OptionalText("type").
 			Field("stale", "string", "bool").
 			OptionalEnum("mode", StreamModeEnumDef).
 			OptionalTime("stale_after").
 			OptionalText("invalid_reason").
-			OptionalText("owner_role_type")
+			OptionalText("owner_role_type").
+			WithConvertGeneration()
 
 	streamsDef = g.NewInterface(
 		"Streams",

--- a/pkg/sdk/generator/defs/streams_def.go
+++ b/pkg/sdk/generator/defs/streams_def.go
@@ -44,7 +44,7 @@ var (
 			OptionalEnum("source_type", StreamSourceTypeEnumDef).
 			NullableSchemaObjectIdentifierArray("base_tables").
 			OptionalText("type").
-			Field("stale", "string", "bool").
+			Field("stale", "string", "bool", g.WithBoolTrueValue("true")).
 			OptionalEnum("mode", StreamModeEnumDef).
 			OptionalTime("stale_after").
 			OptionalText("invalid_reason").

--- a/pkg/sdk/generator/defs/tasks_def.go
+++ b/pkg/sdk/generator/defs/tasks_def.go
@@ -17,17 +17,17 @@ var taskPairs = g.StructPair("taskDBRow", "Task").
 	Field("warehouse", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("Warehouse")).
 	OptionalText("schedule", g.WithRequiredInPlain()).
 	Field("predecessors", "string", "[]SchemaObjectIdentifier").
-	PlainField("state", "TaskState").
+	PlainField("state", "TaskState", g.WithCustomParser("ToTaskState")).
 	Text("definition").
 	OptionalText("condition", g.WithRequiredInPlain()).
-	Field("allow_overlapping_execution", "string", "bool").
+	Field("allow_overlapping_execution", "string", "bool", g.WithBoolTrueValue("true")).
 	Field("error_integration", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("ErrorIntegration")).
 	OptionalText("last_committed_on", g.WithRequiredInPlain()).
 	OptionalText("last_suspended_on", g.WithRequiredInPlain()).
 	Text("owner_role_type").
 	OptionalText("config", g.WithRequiredInPlain()).
 	OptionalText("budget", g.WithRequiredInPlain()).
-	PlainField("task_relations", "TaskRelations").
+	PlainField("task_relations", "TaskRelations", g.WithCustomParser("ToTaskRelations")).
 	OptionalText("last_suspended_reason", g.WithRequiredInPlain()).
 	Field("target_completion_interval", "sql.NullString", "*TaskTargetCompletionInterval", g.WithPlainFieldName("TargetCompletionInterval"))
 

--- a/pkg/sdk/generator/defs/views_def.go
+++ b/pkg/sdk/generator/defs/views_def.go
@@ -24,7 +24,8 @@ var viewPairs = g.StructPair("viewDBRow", "View").
 	OptionalBool("is_secure", g.WithRequiredInPlain()).
 	OptionalBool("is_materialized", g.WithRequiredInPlain()).
 	OptionalText("owner_role_type", g.WithRequiredInPlain()).
-	OptionalText("change_tracking", g.WithRequiredInPlain())
+	OptionalText("change_tracking", g.WithRequiredInPlain()).
+	WithConvertGeneration()
 
 // TODO [SNOW-965322]: extract common type for describe
 var viewDetailsPairs = g.StructPair("viewDetailsRow", "ViewDetails").
@@ -39,7 +40,8 @@ var viewDetailsPairs = g.StructPair("viewDetailsRow", "ViewDetails").
 	OptionalText("expression").
 	OptionalText("comment").
 	OptionalText("policy name", g.WithPlainFieldName("PolicyName")).
-	OptionalText("privacy domain", g.WithPlainFieldName("PrivacyDomain"))
+	OptionalText("privacy domain", g.WithPlainFieldName("PrivacyDomain")).
+	WithConvertGeneration()
 
 var columnDef = g.NewQueryStruct("Column").
 	Text("Value", g.KeywordOptions().Required().DoubleQuotes())

--- a/pkg/sdk/generator/gen/field_pair.go
+++ b/pkg/sdk/generator/gen/field_pair.go
@@ -1,6 +1,8 @@
 package gen
 
 import (
+	"strings"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/genhelpers"
 )
 
@@ -19,19 +21,20 @@ type FieldPair struct {
 type AssignmentKind string
 
 const (
-	AssignmentKindDirect                       AssignmentKind = "Direct"
-	AssignmentKindStringToBool                 AssignmentKind = "StringToBool"
-	AssignmentKindStringToStringArray          AssignmentKind = "StringToStringArray"
-	AssignmentKindStringToEnum                 AssignmentKind = "StringToEnum"
-	AssignmentKindStringToJson                 AssignmentKind = "StringToJson"
-	AssignmentKindStringToIdentifier           AssignmentKind = "StringToIdentifier"
-	AssignmentKindNullableToNullable           AssignmentKind = "NullableToNullable"
-	AssignmentKindNullableToRequired           AssignmentKind = "NullableToRequired"
-	AssignmentKindNullableToIdentifier         AssignmentKind = "NullableToIdentifier"
-	AssignmentKindNullableToEnum               AssignmentKind = "NullableToEnum"
-	AssignmentKindNullableToStringArray        AssignmentKind = "NullableToStringArray"
-	AssignmentKindNullableStringToNullableBool AssignmentKind = "NullableStringToNullableBool"
-	AssignmentKindUnsupported                  AssignmentKind = "Unsupported"
+	AssignmentKindDirect                          AssignmentKind = "Direct"
+	AssignmentKindStringToBool                    AssignmentKind = "StringToBool"
+	AssignmentKindStringToStringArray             AssignmentKind = "StringToStringArray"
+	AssignmentKindStringToEnum                    AssignmentKind = "StringToEnum"
+	AssignmentKindStringToJson                    AssignmentKind = "StringToJson"
+	AssignmentKindStringToIdentifier              AssignmentKind = "StringToIdentifier"
+	AssignmentKindNullableToNullable              AssignmentKind = "NullableToNullable"
+	AssignmentKindNullableToRequired              AssignmentKind = "NullableToRequired"
+	AssignmentKindNullableToIdentifier            AssignmentKind = "NullableToIdentifier"
+	AssignmentKindNullableToEnum                  AssignmentKind = "NullableToEnum"
+	AssignmentKindNullableToStringArray           AssignmentKind = "NullableToStringArray"
+	AssignmentKindNullableStringToNullableBool    AssignmentKind = "NullableStringToNullableBool"
+	AssignmentKindNullableStringToIdentifierArray AssignmentKind = "NullableStringToIdentifierArray"
+	AssignmentKindUnsupported                     AssignmentKind = "Unsupported"
 )
 
 func (fp FieldPair) AssignmentKindDirect() bool {
@@ -82,6 +85,16 @@ func (fp FieldPair) AssignmentKindNullableStringToNullableBool() bool {
 	return fp.AssignmentKind() == AssignmentKindNullableStringToNullableBool
 }
 
+func (fp FieldPair) AssignmentKindNullableStringToIdentifierArray() bool {
+	return fp.AssignmentKind() == AssignmentKindNullableStringToIdentifierArray
+}
+
+// IdentifierArrayElementType returns the element type name for NullableStringToIdentifierArray fields.
+// E.g., for []SchemaObjectIdentifier it returns "SchemaObjectIdentifier".
+func (fp FieldPair) IdentifierArrayElementType() string {
+	return genhelpers.TypeWithoutPointer(strings.TrimPrefix(fp.PlainKind, "[]"))
+}
+
 // AssignmentKind returns the conversion strategy for this field pair.
 // The returned value is used as a discriminator via the boolean predicate methods below.
 func (fp FieldPair) AssignmentKind() AssignmentKind {
@@ -114,6 +127,8 @@ func (fp FieldPair) AssignmentKind() AssignmentKind {
 			return AssignmentKindNullableToStringArray
 		case fp.PlainKind == "*bool":
 			return AssignmentKindNullableStringToNullableBool
+		case strings.HasPrefix(fp.PlainKind, "[]") && genhelpers.IsIdentifierType(strings.TrimPrefix(fp.PlainKind, "[]")):
+			return AssignmentKindNullableStringToIdentifierArray
 		case fp.IsEnum:
 			return AssignmentKindNullableToEnum
 		case genhelpers.IsIdentifierType(fp.PlainKind):

--- a/pkg/sdk/generator/gen/field_pair.go
+++ b/pkg/sdk/generator/gen/field_pair.go
@@ -19,18 +19,19 @@ type FieldPair struct {
 type AssignmentKind string
 
 const (
-	AssignmentKindDirect                AssignmentKind = "Direct"
-	AssignmentKindStringToBool          AssignmentKind = "StringToBool"
-	AssignmentKindStringToStringArray   AssignmentKind = "StringToStringArray"
-	AssignmentKindStringToEnum          AssignmentKind = "StringToEnum"
-	AssignmentKindStringToJson          AssignmentKind = "StringToJson"
-	AssignmentKindStringToIdentifier    AssignmentKind = "StringToIdentifier"
-	AssignmentKindNullableToNullable    AssignmentKind = "NullableToNullable"
-	AssignmentKindNullableToRequired    AssignmentKind = "NullableToRequired"
-	AssignmentKindNullableToIdentifier  AssignmentKind = "NullableToIdentifier"
-	AssignmentKindNullableToEnum        AssignmentKind = "NullableToEnum"
-	AssignmentKindNullableToStringArray AssignmentKind = "NullableToStringArray"
-	AssignmentKindUnsupported           AssignmentKind = "Unsupported"
+	AssignmentKindDirect                       AssignmentKind = "Direct"
+	AssignmentKindStringToBool                 AssignmentKind = "StringToBool"
+	AssignmentKindStringToStringArray          AssignmentKind = "StringToStringArray"
+	AssignmentKindStringToEnum                 AssignmentKind = "StringToEnum"
+	AssignmentKindStringToJson                 AssignmentKind = "StringToJson"
+	AssignmentKindStringToIdentifier           AssignmentKind = "StringToIdentifier"
+	AssignmentKindNullableToNullable           AssignmentKind = "NullableToNullable"
+	AssignmentKindNullableToRequired           AssignmentKind = "NullableToRequired"
+	AssignmentKindNullableToIdentifier         AssignmentKind = "NullableToIdentifier"
+	AssignmentKindNullableToEnum               AssignmentKind = "NullableToEnum"
+	AssignmentKindNullableToStringArray        AssignmentKind = "NullableToStringArray"
+	AssignmentKindNullableStringToNullableBool AssignmentKind = "NullableStringToNullableBool"
+	AssignmentKindUnsupported                  AssignmentKind = "Unsupported"
 )
 
 func (fp FieldPair) AssignmentKindDirect() bool {
@@ -77,6 +78,10 @@ func (fp FieldPair) AssignmentKindNullableToStringArray() bool {
 	return fp.AssignmentKind() == AssignmentKindNullableToStringArray
 }
 
+func (fp FieldPair) AssignmentKindNullableStringToNullableBool() bool {
+	return fp.AssignmentKind() == AssignmentKindNullableStringToNullableBool
+}
+
 // AssignmentKind returns the conversion strategy for this field pair.
 // The returned value is used as a discriminator via the boolean predicate methods below.
 func (fp FieldPair) AssignmentKind() AssignmentKind {
@@ -107,6 +112,8 @@ func (fp FieldPair) AssignmentKind() AssignmentKind {
 			return AssignmentKindNullableToRequired
 		case fp.PlainKind == "[]string":
 			return AssignmentKindNullableToStringArray
+		case fp.PlainKind == "*bool":
+			return AssignmentKindNullableStringToNullableBool
 		case fp.IsEnum:
 			return AssignmentKindNullableToEnum
 		case genhelpers.IsIdentifierType(fp.PlainKind):

--- a/pkg/sdk/generator/gen/field_pair.go
+++ b/pkg/sdk/generator/gen/field_pair.go
@@ -15,6 +15,7 @@ type FieldPair struct {
 	PlainKind      string
 	IsEnum         bool
 	IsJson         bool
+	CustomParser   string
 }
 
 // AssignmentKind is the conversion strategy discriminator used in convert.tmpl.
@@ -27,6 +28,8 @@ const (
 	AssignmentKindStringToEnum                    AssignmentKind = "StringToEnum"
 	AssignmentKindStringToJson                    AssignmentKind = "StringToJson"
 	AssignmentKindStringToIdentifier              AssignmentKind = "StringToIdentifier"
+	AssignmentKindStringToIdentifierArray         AssignmentKind = "StringToIdentifierArray"
+	AssignmentKindCustom                          AssignmentKind = "Custom"
 	AssignmentKindNullableToNullable              AssignmentKind = "NullableToNullable"
 	AssignmentKindNullableToRequired              AssignmentKind = "NullableToRequired"
 	AssignmentKindNullableToIdentifier            AssignmentKind = "NullableToIdentifier"
@@ -59,6 +62,14 @@ func (fp FieldPair) AssignmentKindStringToJson() bool {
 
 func (fp FieldPair) AssignmentKindStringToIdentifier() bool {
 	return fp.AssignmentKind() == AssignmentKindStringToIdentifier
+}
+
+func (fp FieldPair) AssignmentKindStringToIdentifierArray() bool {
+	return fp.AssignmentKind() == AssignmentKindStringToIdentifierArray
+}
+
+func (fp FieldPair) AssignmentKindCustom() bool {
+	return fp.AssignmentKind() == AssignmentKindCustom
 }
 
 func (fp FieldPair) AssignmentKindNullableToNullable() bool {
@@ -98,6 +109,10 @@ func (fp FieldPair) IdentifierArrayElementType() string {
 // AssignmentKind returns the conversion strategy for this field pair.
 // The returned value is used as a discriminator via the boolean predicate methods below.
 func (fp FieldPair) AssignmentKind() AssignmentKind {
+	if fp.CustomParser != "" {
+		return AssignmentKindCustom
+	}
+
 	if fp.DbKind == fp.PlainKind {
 		return AssignmentKindDirect
 	}
@@ -115,6 +130,8 @@ func (fp FieldPair) AssignmentKind() AssignmentKind {
 			return AssignmentKindStringToJson
 		case genhelpers.IsIdentifierType(fp.PlainKind):
 			return AssignmentKindStringToIdentifier
+		case strings.HasPrefix(fp.PlainKind, "[]") && genhelpers.IsIdentifierType(strings.TrimPrefix(fp.PlainKind, "[]")):
+			return AssignmentKindStringToIdentifierArray
 		}
 
 	case "sql.NullString":

--- a/pkg/sdk/generator/gen/field_pair.go
+++ b/pkg/sdk/generator/gen/field_pair.go
@@ -16,28 +16,37 @@ type FieldPair struct {
 	IsEnum         bool
 	IsJson         bool
 	CustomParser   string
+	BoolTrueValue  string
+	BoolParsed     bool
 }
 
 // AssignmentKind is the conversion strategy discriminator used in convert.tmpl.
 type AssignmentKind string
 
 const (
-	AssignmentKindDirect                          AssignmentKind = "Direct"
-	AssignmentKindStringToBool                    AssignmentKind = "StringToBool"
-	AssignmentKindStringToStringArray             AssignmentKind = "StringToStringArray"
-	AssignmentKindStringToEnum                    AssignmentKind = "StringToEnum"
-	AssignmentKindStringToJson                    AssignmentKind = "StringToJson"
-	AssignmentKindStringToIdentifier              AssignmentKind = "StringToIdentifier"
-	AssignmentKindStringToIdentifierArray         AssignmentKind = "StringToIdentifierArray"
-	AssignmentKindCustom                          AssignmentKind = "Custom"
-	AssignmentKindNullableToNullable              AssignmentKind = "NullableToNullable"
-	AssignmentKindNullableToRequired              AssignmentKind = "NullableToRequired"
-	AssignmentKindNullableToIdentifier            AssignmentKind = "NullableToIdentifier"
-	AssignmentKindNullableToEnum                  AssignmentKind = "NullableToEnum"
-	AssignmentKindNullableToStringArray           AssignmentKind = "NullableToStringArray"
-	AssignmentKindNullableStringToNullableBool    AssignmentKind = "NullableStringToNullableBool"
-	AssignmentKindNullableStringToIdentifierArray AssignmentKind = "NullableStringToIdentifierArray"
-	AssignmentKindUnsupported                     AssignmentKind = "Unsupported"
+	AssignmentKindDirect                             AssignmentKind = "Direct"
+	AssignmentKindStringToBool                       AssignmentKind = "StringToBool"
+	AssignmentKindStringToBoolValue                  AssignmentKind = "StringToBoolValue"
+	AssignmentKindStringToBoolParsed                 AssignmentKind = "StringToBoolParsed"
+	AssignmentKindStringToStringArray                AssignmentKind = "StringToStringArray"
+	AssignmentKindStringToEnum                       AssignmentKind = "StringToEnum"
+	AssignmentKindStringToJson                       AssignmentKind = "StringToJson"
+	AssignmentKindStringToIdentifier                 AssignmentKind = "StringToIdentifier"
+	AssignmentKindStringToIdentifierArray            AssignmentKind = "StringToIdentifierArray"
+	AssignmentKindCustom                             AssignmentKind = "Custom"
+	AssignmentKindNullableToNullable                 AssignmentKind = "NullableToNullable"
+	AssignmentKindNullableToRequired                 AssignmentKind = "NullableToRequired"
+	AssignmentKindNullableToIdentifier               AssignmentKind = "NullableToIdentifier"
+	AssignmentKindNullableToEnum                     AssignmentKind = "NullableToEnum"
+	AssignmentKindNullableToStringArray              AssignmentKind = "NullableToStringArray"
+	AssignmentKindNullableStringToNullableBool       AssignmentKind = "NullableStringToNullableBool"
+	AssignmentKindNullableStringToNullableBoolValue  AssignmentKind = "NullableStringToNullableBoolValue"
+	AssignmentKindNullableStringToNullableBoolParsed AssignmentKind = "NullableStringToNullableBoolParsed"
+	AssignmentKindNullableStringToRequiredBool       AssignmentKind = "NullableStringToRequiredBool"
+	AssignmentKindNullableStringToRequiredBoolValue  AssignmentKind = "NullableStringToRequiredBoolValue"
+	AssignmentKindNullableStringToRequiredBoolParsed AssignmentKind = "NullableStringToRequiredBoolParsed"
+	AssignmentKindNullableStringToIdentifierArray    AssignmentKind = "NullableStringToIdentifierArray"
+	AssignmentKindUnsupported                        AssignmentKind = "Unsupported"
 )
 
 func (fp FieldPair) AssignmentKindDirect() bool {
@@ -46,6 +55,14 @@ func (fp FieldPair) AssignmentKindDirect() bool {
 
 func (fp FieldPair) AssignmentKindStringToBool() bool {
 	return fp.AssignmentKind() == AssignmentKindStringToBool
+}
+
+func (fp FieldPair) AssignmentKindStringToBoolValue() bool {
+	return fp.AssignmentKind() == AssignmentKindStringToBoolValue
+}
+
+func (fp FieldPair) AssignmentKindStringToBoolParsed() bool {
+	return fp.AssignmentKind() == AssignmentKindStringToBoolParsed
 }
 
 func (fp FieldPair) AssignmentKindStringToStringArray() bool {
@@ -96,6 +113,26 @@ func (fp FieldPair) AssignmentKindNullableStringToNullableBool() bool {
 	return fp.AssignmentKind() == AssignmentKindNullableStringToNullableBool
 }
 
+func (fp FieldPair) AssignmentKindNullableStringToNullableBoolValue() bool {
+	return fp.AssignmentKind() == AssignmentKindNullableStringToNullableBoolValue
+}
+
+func (fp FieldPair) AssignmentKindNullableStringToNullableBoolParsed() bool {
+	return fp.AssignmentKind() == AssignmentKindNullableStringToNullableBoolParsed
+}
+
+func (fp FieldPair) AssignmentKindNullableStringToRequiredBool() bool {
+	return fp.AssignmentKind() == AssignmentKindNullableStringToRequiredBool
+}
+
+func (fp FieldPair) AssignmentKindNullableStringToRequiredBoolValue() bool {
+	return fp.AssignmentKind() == AssignmentKindNullableStringToRequiredBoolValue
+}
+
+func (fp FieldPair) AssignmentKindNullableStringToRequiredBoolParsed() bool {
+	return fp.AssignmentKind() == AssignmentKindNullableStringToRequiredBoolParsed
+}
+
 func (fp FieldPair) AssignmentKindNullableStringToIdentifierArray() bool {
 	return fp.AssignmentKind() == AssignmentKindNullableStringToIdentifierArray
 }
@@ -120,6 +157,10 @@ func (fp FieldPair) AssignmentKind() AssignmentKind {
 	switch fp.DbKind {
 	case "string":
 		switch {
+		case fp.PlainKind == "bool" && fp.BoolParsed:
+			return AssignmentKindStringToBoolParsed
+		case fp.PlainKind == "bool" && fp.BoolTrueValue != "":
+			return AssignmentKindStringToBoolValue
 		case fp.PlainKind == "bool":
 			return AssignmentKindStringToBool
 		case fp.PlainKind == "[]string":
@@ -142,8 +183,18 @@ func (fp FieldPair) AssignmentKind() AssignmentKind {
 			return AssignmentKindNullableToRequired
 		case fp.PlainKind == "[]string":
 			return AssignmentKindNullableToStringArray
+		case fp.PlainKind == "*bool" && fp.BoolParsed:
+			return AssignmentKindNullableStringToNullableBoolParsed
+		case fp.PlainKind == "*bool" && fp.BoolTrueValue != "":
+			return AssignmentKindNullableStringToNullableBoolValue
 		case fp.PlainKind == "*bool":
 			return AssignmentKindNullableStringToNullableBool
+		case fp.PlainKind == "bool" && fp.BoolParsed:
+			return AssignmentKindNullableStringToRequiredBoolParsed
+		case fp.PlainKind == "bool" && fp.BoolTrueValue != "":
+			return AssignmentKindNullableStringToRequiredBoolValue
+		case fp.PlainKind == "bool":
+			return AssignmentKindNullableStringToRequiredBool
 		case strings.HasPrefix(fp.PlainKind, "[]") && genhelpers.IsIdentifierType(strings.TrimPrefix(fp.PlainKind, "[]")):
 			return AssignmentKindNullableStringToIdentifierArray
 		case fp.IsEnum:

--- a/pkg/sdk/generator/gen/paired_struct.go
+++ b/pkg/sdk/generator/gen/paired_struct.go
@@ -57,6 +57,30 @@ func WithCustomParser(funcName string) PairedFieldOption {
 	}
 }
 
+// WithBoolTrueValue overrides the truthy string compared against the db field for string → bool conversions.
+// The default is "Y". Use this when Snowflake returns a different truthy value, e.g. "true" or "ON".
+// Example:
+//
+//	Field("automatic_clustering", "string", "bool", WithBoolTrueValue("ON"))
+//	// plain: AutomaticClustering = r.AutomaticClustering == "ON"
+func WithBoolTrueValue(v string) PairedFieldOption {
+	return func(f *pairedField) {
+		f.boolTrueValue = v
+	}
+}
+
+// WithBoolParsed routes string → bool or sql.NullString → bool conversions through strconv.ParseBool
+// instead of a fixed string comparison. Use when the db column returns "true"/"false" and robust
+// parsing is preferred over a hard-coded truthy value.
+// Example:
+//
+//	Field("is_primary", "string", "bool", WithBoolParsed())
+func WithBoolParsed() PairedFieldOption {
+	return func(f *pairedField) {
+		f.boolParsed = true
+	}
+}
+
 // pairedField holds the definition for a single field in both the DB row struct and the plain SDK struct.
 type pairedField struct {
 	// dbColumnName is the snake_case column name used for the db: tag and to auto-derive the field names.
@@ -75,6 +99,10 @@ type pairedField struct {
 	isJson bool
 	// customParser is the name of a custom parse function to use for conversion.
 	customParser string
+	// boolTrueValue overrides the default "Y" comparison for string/NullString → bool conversions.
+	boolTrueValue string
+	// boolParsed routes string/NullString → bool conversions through strconv.ParseBool.
+	boolParsed bool
 }
 
 // resolvedPlainFieldName returns the explicit override or the CamelCase conversion of dbColumnName.
@@ -387,6 +415,8 @@ func (p *PairedStructs) toFieldPairs() []FieldPair {
 			IsEnum:         f.isEnum,
 			IsJson:         f.isJson,
 			CustomParser:   f.customParser,
+			BoolTrueValue:  f.boolTrueValue,
+			BoolParsed:     f.boolParsed,
 		}
 	}
 	return pairs

--- a/pkg/sdk/generator/gen/paired_struct.go
+++ b/pkg/sdk/generator/gen/paired_struct.go
@@ -46,6 +46,17 @@ func WithRequiredInPlain() PairedFieldOption {
 	}
 }
 
+// WithCustomParser sets a custom parse function name to use when converting the db field to the plain field.
+// The function must have signature func(string) (T, error) where T matches the plain kind.
+// Example:
+//
+//	Field("signature", "string", "[]TableColumnSignature", WithCustomParser("ParseTableColumnSignature"))
+func WithCustomParser(funcName string) PairedFieldOption {
+	return func(f *pairedField) {
+		f.customParser = funcName
+	}
+}
+
 // pairedField holds the definition for a single field in both the DB row struct and the plain SDK struct.
 type pairedField struct {
 	// dbColumnName is the snake_case column name used for the db: tag and to auto-derive the field names.
@@ -62,6 +73,8 @@ type pairedField struct {
 	isEnum bool
 	// isJson marks that the db string column should be JSON-unmarshaled into the plain field.
 	isJson bool
+	// customParser is the name of a custom parse function to use for conversion.
+	customParser string
 }
 
 // resolvedPlainFieldName returns the explicit override or the CamelCase conversion of dbColumnName.
@@ -270,6 +283,15 @@ func (p *PairedStructs) NullableSchemaObjectIdentifierArray(dbColumnName string,
 	return p.addField(dbColumnName, "sql.NullString", "[]SchemaObjectIdentifier", opts)
 }
 
+// AccountIdentifierArray adds a required AccountIdentifier slice field. The db kind is string and the
+// plain kind is []AccountIdentifier.
+//
+//	db:    <FieldName> string `db:"<dbColumnName>"`
+//	plain: <FieldName> []AccountIdentifier
+func (p *PairedStructs) AccountIdentifierArray(dbColumnName string, opts ...PairedFieldOption) *PairedStructs {
+	return p.addField(dbColumnName, "string", "[]AccountIdentifier", opts)
+}
+
 // SchemaObjectIdentifierWithArguments adds a SchemaObjectIdentifierWithArguments field. The db kind is string and the plain kind
 // is SchemaObjectIdentifierWithArguments. The plain field name defaults to "Id", but can be overridden with WithPlainFieldName.
 //
@@ -364,6 +386,7 @@ func (p *PairedStructs) toFieldPairs() []FieldPair {
 			PlainKind:      f.plainKind,
 			IsEnum:         f.isEnum,
 			IsJson:         f.isJson,
+			CustomParser:   f.customParser,
 		}
 	}
 	return pairs

--- a/pkg/sdk/generator/gen/paired_struct.go
+++ b/pkg/sdk/generator/gen/paired_struct.go
@@ -260,6 +260,16 @@ func (p *PairedStructs) OptionalSchemaObjectIdentifier(dbColumnName string, opts
 	return p.addField(dbColumnName, "sql.NullString", "*SchemaObjectIdentifier", allOpts)
 }
 
+// NullableSchemaObjectIdentifierArray adds a nullable SchemaObjectIdentifier slice field. The db kind is
+// sql.NullString and the plain kind is []SchemaObjectIdentifier. The plain field name defaults to the
+// camel-cased column name unless overridden with WithPlainFieldName.
+//
+//	db:    <FieldName> sql.NullString `db:"<dbColumnName>"`
+//	plain: <FieldName> []SchemaObjectIdentifier
+func (p *PairedStructs) NullableSchemaObjectIdentifierArray(dbColumnName string, opts ...PairedFieldOption) *PairedStructs {
+	return p.addField(dbColumnName, "sql.NullString", "[]SchemaObjectIdentifier", opts)
+}
+
 // SchemaObjectIdentifierWithArguments adds a SchemaObjectIdentifierWithArguments field. The db kind is string and the plain kind
 // is SchemaObjectIdentifierWithArguments. The plain field name defaults to "Id", but can be overridden with WithPlainFieldName.
 //

--- a/pkg/sdk/generator/gen/templates.go
+++ b/pkg/sdk/generator/gen/templates.go
@@ -109,13 +109,16 @@ var (
 
 func init() {
 	subTemplates := template.New("subTemplates").Funcs(template.FuncMap{
-		"describe_mapping_deref":     deref[DescriptionMappingKind],
-		"show_mapping_deref":         deref[ShowMappingKind],
-		"instance_method_kind_deref": deref[InstanceMethodKind],
-		"TypeWithoutPointer":         genhelpers.TypeWithoutPointer,
+		"describe_mapping_deref":        deref[DescriptionMappingKind],
+		"show_mapping_deref":            deref[ShowMappingKind],
+		"instance_method_kind_deref":    deref[InstanceMethodKind],
+		"TypeWithoutPointer":            genhelpers.TypeWithoutPointer,
+		"TypeWithoutPointerAndBrackets": genhelpers.TypeWithoutPointerAndBrackets,
 	})
 	subTemplates, _ = subTemplates.New("toOptsMapping").Parse(toOptsMappingTemplateContent)
-	subTemplates, _ = subTemplates.New("convert").Parse(convertTemplateContent)
+	subTemplates, _ = subTemplates.New("convert").Funcs(genhelpers.BuildTemplateFuncMap(
+		genhelpers.CamelToWords,
+	)).Parse(convertTemplateContent)
 	subTemplates, _ = subTemplates.New("convertGuard").Parse(convertGuardTemplateContent)
 	subTemplates, _ = subTemplates.New("convertGuards").Parse(convertGuardsTemplateContent)
 	subTemplates, _ = subTemplates.New("implementationMappings").Parse(implementationMappingsTemplateContent)

--- a/pkg/sdk/generator/gen/templates/sub_templates/convert.tmpl
+++ b/pkg/sdk/generator/gen/templates/sub_templates/convert.tmpl
@@ -36,6 +36,8 @@ func (r {{ .From.Name }}) {{ .MappingFuncName }}() (*{{ .To.KindNoPtr }}, error)
             if r.{{ .DbFieldName }}.Valid {
             	result.{{ .PlainFieldName }} = ParseCommaSeparatedStringArray(r.{{ .DbFieldName }}.String, false)
             }
+        {{- else if .AssignmentKindNullableStringToNullableBool }}
+            mapNullStringToBool(&result.{{ .PlainFieldName }}, r.{{ .DbFieldName }})
         {{- else }}
             // TODO: Mapping for {{ .PlainFieldName }} ({{ .DbKind }} -> {{ .PlainKind }})
         {{- end }}

--- a/pkg/sdk/generator/gen/templates/sub_templates/convert.tmpl
+++ b/pkg/sdk/generator/gen/templates/sub_templates/convert.tmpl
@@ -25,6 +25,8 @@ func (r {{ .From.Name }}) {{ .MappingFuncName }}() (*{{ .To.KindNoPtr }}, error)
         {{- else if .AssignmentKindCustom }}
             if v, err := {{ .CustomParser }}(r.{{ .DbFieldName }}); err == nil {
             	result.{{ .PlainFieldName }} = v
+            } else {
+                return nil, fmt.Errorf("parsing {{ CamelToWords (TypeWithoutPointerAndBrackets .PlainKind) }}: %w", err)
             }
         {{- else if .AssignmentKindStringToEnum }}
             mapStringWithMapping(&result.{{ .PlainFieldName }}, r.{{ .DbFieldName }}, To{{ TypeWithoutPointer .PlainKind }})

--- a/pkg/sdk/generator/gen/templates/sub_templates/convert.tmpl
+++ b/pkg/sdk/generator/gen/templates/sub_templates/convert.tmpl
@@ -18,6 +18,14 @@ func (r {{ .From.Name }}) {{ .MappingFuncName }}() (*{{ .To.KindNoPtr }}, error)
             result.{{ .PlainFieldName }} = ParseCommaSeparatedStringArray(r.{{ .DbFieldName }}, false)
         {{- else if .AssignmentKindStringToIdentifier }}
             mapStringWithMapping(&result.{{ .PlainFieldName }}, r.{{ .DbFieldName }}, Parse{{ TypeWithoutPointer .PlainKind }})
+        {{- else if .AssignmentKindStringToIdentifierArray }}
+            if ids, err := ParseCommaSeparated{{ .IdentifierArrayElementType }}Array(r.{{ .DbFieldName }}); err == nil {
+            	result.{{ .PlainFieldName }} = ids
+            }
+        {{- else if .AssignmentKindCustom }}
+            if v, err := {{ .CustomParser }}(r.{{ .DbFieldName }}); err == nil {
+            	result.{{ .PlainFieldName }} = v
+            }
         {{- else if .AssignmentKindStringToEnum }}
             mapStringWithMapping(&result.{{ .PlainFieldName }}, r.{{ .DbFieldName }}, To{{ TypeWithoutPointer .PlainKind }})
         {{- else if .AssignmentKindStringToJson }}

--- a/pkg/sdk/generator/gen/templates/sub_templates/convert.tmpl
+++ b/pkg/sdk/generator/gen/templates/sub_templates/convert.tmpl
@@ -38,6 +38,12 @@ func (r {{ .From.Name }}) {{ .MappingFuncName }}() (*{{ .To.KindNoPtr }}, error)
             }
         {{- else if .AssignmentKindNullableStringToNullableBool }}
             mapNullStringToBool(&result.{{ .PlainFieldName }}, r.{{ .DbFieldName }})
+        {{- else if .AssignmentKindNullableStringToIdentifierArray }}
+            if r.{{ .DbFieldName }}.Valid {
+            	if ids, err := ParseCommaSeparated{{ .IdentifierArrayElementType }}Array(r.{{ .DbFieldName }}.String); err == nil {
+            		result.{{ .PlainFieldName }} = ids
+            	}
+            }
         {{- else }}
             // TODO: Mapping for {{ .PlainFieldName }} ({{ .DbKind }} -> {{ .PlainKind }})
         {{- end }}

--- a/pkg/sdk/generator/gen/templates/sub_templates/convert.tmpl
+++ b/pkg/sdk/generator/gen/templates/sub_templates/convert.tmpl
@@ -8,12 +8,17 @@ func (r {{ .From.Name }}) {{ .MappingFuncName }}() (*{{ .To.KindNoPtr }}, error)
             {{ .PlainFieldName }}: r.{{ .DbFieldName }},
         {{- else if .AssignmentKindStringToBool }}
             {{ .PlainFieldName }}: r.{{ .DbFieldName }} == "Y",
+        {{- else if .AssignmentKindStringToBoolValue }}
+            {{ .PlainFieldName }}: r.{{ .DbFieldName }} == "{{ .BoolTrueValue }}",
         {{- end }}
     {{- end }}
     }
     {{- range .FieldPairs }}
         {{- if .AssignmentKindDirect }}
         {{- else if .AssignmentKindStringToBool }}
+        {{- else if .AssignmentKindStringToBoolValue }}
+        {{- else if .AssignmentKindStringToBoolParsed }}
+            mapStringToBoolParsed(&result.{{ .PlainFieldName }}, r.{{ .DbFieldName }})
         {{- else if .AssignmentKindStringToStringArray }}
             result.{{ .PlainFieldName }} = ParseCommaSeparatedStringArray(r.{{ .DbFieldName }}, false)
         {{- else if .AssignmentKindStringToIdentifier }}
@@ -48,6 +53,16 @@ func (r {{ .From.Name }}) {{ .MappingFuncName }}() (*{{ .To.KindNoPtr }}, error)
             }
         {{- else if .AssignmentKindNullableStringToNullableBool }}
             mapNullStringToBool(&result.{{ .PlainFieldName }}, r.{{ .DbFieldName }})
+        {{- else if .AssignmentKindNullableStringToNullableBoolValue }}
+            mapNullStringToBoolValue(&result.{{ .PlainFieldName }}, r.{{ .DbFieldName }}, "{{ .BoolTrueValue }}")
+        {{- else if .AssignmentKindNullableStringToNullableBoolParsed }}
+            mapNullStringToBoolParsed(&result.{{ .PlainFieldName }}, r.{{ .DbFieldName }})
+        {{- else if .AssignmentKindNullableStringToRequiredBool }}
+            mapNullStringToRequiredBool(&result.{{ .PlainFieldName }}, r.{{ .DbFieldName }})
+        {{- else if .AssignmentKindNullableStringToRequiredBoolValue }}
+            mapNullStringToRequiredBoolValue(&result.{{ .PlainFieldName }}, r.{{ .DbFieldName }}, "{{ .BoolTrueValue }}")
+        {{- else if .AssignmentKindNullableStringToRequiredBoolParsed }}
+            mapNullStringToRequiredBoolParsed(&result.{{ .PlainFieldName }}, r.{{ .DbFieldName }})
         {{- else if .AssignmentKindNullableStringToIdentifierArray }}
             if r.{{ .DbFieldName }}.Valid {
             	if ids, err := ParseCommaSeparated{{ .IdentifierArrayElementType }}Array(r.{{ .DbFieldName }}.String); err == nil {

--- a/pkg/sdk/hybrid_tables_impl_gen.go
+++ b/pkg/sdk/hybrid_tables_impl_gen.go
@@ -335,11 +335,7 @@ func (r hybridTableIndexRow) convert() (*HybridTableIndex, error) {
 		DatabaseName: r.DatabaseName,
 		SchemaName:   r.SchemaName,
 	}
-	// added manually
-	if r.IsUnique.Valid {
-		v := r.IsUnique.String == "Y"
-		result.IsUnique = &v
-	}
+	mapNullStringToBool(&result.IsUnique, r.IsUnique)
 	mapNullString(&result.Columns, r.Columns)
 	mapNullStringToNonNullableField(&result.IncludedColumns, r.IncludedColumns)
 	mapNullStringToNonNullableField(&result.Owner, r.Owner)

--- a/pkg/sdk/iceberg_tables_impl_gen.go
+++ b/pkg/sdk/iceberg_tables_impl_gen.go
@@ -411,7 +411,7 @@ func (r icebergTableRow) convert() (*IcebergTable, error) {
 	mapNullString(&result.Owner, r.Owner)
 	mapNullStringWithMapping(&result.ExternalVolumeName, r.ExternalVolumeName, ParseAccountObjectIdentifier)
 	mapNullStringWithMapping(&result.CatalogName, r.CatalogName, ParseAccountObjectIdentifier)
-	// TODO: Mapping for IcebergTableType (string -> IcebergTableType)
+	mapStringWithMapping(&result.IcebergTableType, r.IcebergTableType, ToIcebergTableType)
 	mapNullString(&result.CatalogTableName, r.CatalogTableName)
 	mapNullString(&result.CatalogNamespace, r.CatalogNamespace)
 	mapNullString(&result.Comment, r.Comment)

--- a/pkg/sdk/mapping_helpers.go
+++ b/pkg/sdk/mapping_helpers.go
@@ -24,6 +24,13 @@ func mapNullString(stringField **string, sqlValue sql.NullString) {
 	}
 }
 
+func mapNullStringToBool(boolField **bool, sqlValue sql.NullString) {
+	if sqlValue.Valid {
+		v := sqlValue.String == "Y"
+		*boolField = &v
+	}
+}
+
 // mapNullStringWithMapping maps a sql.NullString to a pointer of type T using a provided mapper function.
 // Be careful with the sensitive values as the mapper function can return an error, which is then logged by this function.
 func mapNullStringWithMapping[T any](stringField **T, sqlValue sql.NullString, mapper func(string) (T, error)) {

--- a/pkg/sdk/mapping_helpers.go
+++ b/pkg/sdk/mapping_helpers.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"database/sql"
 	"log"
+	"strconv"
 	"time"
 )
 
@@ -28,6 +29,59 @@ func mapNullStringToBool(boolField **bool, sqlValue sql.NullString) {
 	if sqlValue.Valid {
 		v := sqlValue.String == "Y"
 		*boolField = &v
+	}
+}
+
+// mapNullStringToBoolValue maps a sql.NullString to a *bool by comparing the string to trueValue.
+func mapNullStringToBoolValue(boolField **bool, sqlValue sql.NullString, trueValue string) {
+	if sqlValue.Valid {
+		v := sqlValue.String == trueValue
+		*boolField = &v
+	}
+}
+
+// mapNullStringToBoolParsed maps a sql.NullString to a *bool using strconv.ParseBool.
+func mapNullStringToBoolParsed(boolField **bool, sqlValue sql.NullString) {
+	if sqlValue.Valid {
+		if v, err := strconv.ParseBool(sqlValue.String); err == nil {
+			*boolField = &v
+		} else {
+			log.Printf("[WARN] Failed to parse bool value, err = %s", err)
+		}
+	}
+}
+
+// mapNullStringToRequiredBool maps a sql.NullString to a bool by comparing the string to "Y".
+func mapNullStringToRequiredBool(boolField *bool, sqlValue sql.NullString) {
+	if sqlValue.Valid {
+		*boolField = sqlValue.String == "Y"
+	}
+}
+
+// mapNullStringToRequiredBoolValue maps a sql.NullString to a bool by comparing the string to trueValue.
+func mapNullStringToRequiredBoolValue(boolField *bool, sqlValue sql.NullString, trueValue string) {
+	if sqlValue.Valid {
+		*boolField = sqlValue.String == trueValue
+	}
+}
+
+// mapNullStringToRequiredBoolParsed maps a sql.NullString to a bool using strconv.ParseBool.
+func mapNullStringToRequiredBoolParsed(boolField *bool, sqlValue sql.NullString) {
+	if sqlValue.Valid {
+		if v, err := strconv.ParseBool(sqlValue.String); err == nil {
+			*boolField = v
+		} else {
+			log.Printf("[WARN] Failed to parse bool value, err = %s", err)
+		}
+	}
+}
+
+// mapStringToBoolParsed maps a string to a bool using strconv.ParseBool.
+func mapStringToBoolParsed(boolField *bool, v string) {
+	if parsed, err := strconv.ParseBool(v); err == nil {
+		*boolField = parsed
+	} else {
+		log.Printf("[WARN] Failed to parse bool value, err = %s", err)
 	}
 }
 

--- a/pkg/sdk/mapping_helpers.go
+++ b/pkg/sdk/mapping_helpers.go
@@ -26,10 +26,7 @@ func mapNullString(stringField **string, sqlValue sql.NullString) {
 }
 
 func mapNullStringToBool(boolField **bool, sqlValue sql.NullString) {
-	if sqlValue.Valid {
-		v := sqlValue.String == "Y"
-		*boolField = &v
-	}
+	mapNullStringToBoolValue(boolField, sqlValue, "Y")
 }
 
 // mapNullStringToBoolValue maps a sql.NullString to a *bool by comparing the string to trueValue.
@@ -53,9 +50,7 @@ func mapNullStringToBoolParsed(boolField **bool, sqlValue sql.NullString) {
 
 // mapNullStringToRequiredBool maps a sql.NullString to a bool by comparing the string to "Y".
 func mapNullStringToRequiredBool(boolField *bool, sqlValue sql.NullString) {
-	if sqlValue.Valid {
-		*boolField = sqlValue.String == "Y"
-	}
+	mapNullStringToRequiredBoolValue(boolField, sqlValue, "Y")
 }
 
 // mapNullStringToRequiredBoolValue maps a sql.NullString to a bool by comparing the string to trueValue.
@@ -68,11 +63,7 @@ func mapNullStringToRequiredBoolValue(boolField *bool, sqlValue sql.NullString, 
 // mapNullStringToRequiredBoolParsed maps a sql.NullString to a bool using strconv.ParseBool.
 func mapNullStringToRequiredBoolParsed(boolField *bool, sqlValue sql.NullString) {
 	if sqlValue.Valid {
-		if v, err := strconv.ParseBool(sqlValue.String); err == nil {
-			*boolField = v
-		} else {
-			log.Printf("[WARN] Failed to parse bool value, err = %s", err)
-		}
+		mapStringToBoolParsed(boolField, sqlValue.String)
 	}
 }
 

--- a/pkg/sdk/materialized_views_impl_gen.go
+++ b/pkg/sdk/materialized_views_impl_gen.go
@@ -200,7 +200,7 @@ func (r materializedViewDBRow) convert() (*MaterializedView, error) {
 		BehindBy:            r.BehindBy,
 		Text:                tracking.TrimMetadata(r.Text), // adjusted manually: tracking added
 		IsSecure:            r.IsSecure,
-		AutomaticClustering: r.AutomaticClustering == "ON", // adjusted manually: Y -> ON
+		AutomaticClustering: r.AutomaticClustering == "ON",
 	}
 	mapNullString(&result.Reserved, r.Reserved)
 	mapNullStringToNonNullableField(&result.ClusterBy, r.ClusterBy)

--- a/pkg/sdk/materialized_views_impl_gen.go
+++ b/pkg/sdk/materialized_views_impl_gen.go
@@ -219,8 +219,7 @@ func (r *DescribeMaterializedViewRequest) toOpts() *DescribeMaterializedViewOpti
 }
 
 func (r materializedViewDetailsRow) convert() (*MaterializedViewDetails, error) {
-	// adjusted manually
-	details := &MaterializedViewDetails{
+	result := &MaterializedViewDetails{
 		Name:       r.Name,
 		Type:       r.Type,
 		Kind:       r.Kind,
@@ -228,17 +227,9 @@ func (r materializedViewDetailsRow) convert() (*MaterializedViewDetails, error) 
 		IsPrimary:  r.PrimaryKey == "Y",
 		IsUnique:   r.UniqueKey == "Y",
 	}
-	if r.Default.Valid {
-		details.Default = String(r.Default.String)
-	}
-	if r.Check.Valid {
-		details.Check = Bool(r.Check.String == "Y")
-	}
-	if r.Expression.Valid {
-		details.Expression = String(r.Expression.String)
-	}
-	if r.Comment.Valid {
-		details.Comment = String(r.Comment.String)
-	}
-	return details, nil
+	mapNullString(&result.Default, r.Default)
+	mapNullStringToBool(&result.Check, r.Check)
+	mapNullString(&result.Expression, r.Expression)
+	mapNullString(&result.Comment, r.Comment)
+	return result, nil
 }

--- a/pkg/sdk/openflow_connectors_impl_gen.go
+++ b/pkg/sdk/openflow_connectors_impl_gen.go
@@ -127,8 +127,26 @@ func (r *ShowOpenflowConnectorRequest) toOpts() *ShowOpenflowConnectorOptions {
 }
 
 func (r openflowConnectorRow) convert() (*OpenflowConnector, error) {
-	// TODO: Mapping
-	return &OpenflowConnector{}, nil
+	result := &OpenflowConnector{
+		Name:         r.Name,
+		Runtime:      r.Runtime,
+		DatabaseName: r.DatabaseName,
+		SchemaName:   r.SchemaName,
+		Owner:        r.Owner,
+		CreatedOn:    r.CreatedOn,
+		UpdatedOn:    r.UpdatedOn,
+	}
+	mapStringWithMapping(&result.Status, r.Status, ToOpenflowConnectorStatus)
+	mapNullString(&result.ConnectorDefinition, r.ConnectorDefinition)
+	mapNullString(&result.DisplayName, r.DisplayName)
+	mapNullString(&result.DefaultVersion, r.DefaultVersion)
+	mapNullString(&result.DefaultVersionName, r.DefaultVersionName)
+	mapNullString(&result.DefaultVersionAlias, r.DefaultVersionAlias)
+	mapNullString(&result.DefaultVersionLocationUri, r.DefaultVersionLocationUri)
+	mapNullString(&result.DefaultVersionSourceLocationUri, r.DefaultVersionSourceLocationUri)
+	mapNullString(&result.LiveVersionLocationUri, r.LiveVersionLocationUri)
+	mapNullString(&result.Comment, r.Comment)
+	return result, nil
 }
 
 func (r *DescribeOpenflowConnectorRequest) toOpts() *DescribeOpenflowConnectorOptions {
@@ -139,6 +157,34 @@ func (r *DescribeOpenflowConnectorRequest) toOpts() *DescribeOpenflowConnectorOp
 }
 
 func (r openflowConnectorDetailsRow) convert() (*OpenflowConnectorDetails, error) {
-	// TODO: Mapping
-	return &OpenflowConnectorDetails{}, nil
+	result := &OpenflowConnectorDetails{
+		Name:         r.Name,
+		Runtime:      r.Runtime,
+		DatabaseName: r.DatabaseName,
+		SchemaName:   r.SchemaName,
+		Owner:        r.Owner,
+		CreatedOn:    r.CreatedOn,
+		UpdatedOn:    r.UpdatedOn,
+	}
+	mapStringWithMapping(&result.Status, r.Status, ToOpenflowConnectorStatus)
+	mapNullString(&result.ConnectorDefinition, r.ConnectorDefinition)
+	mapNullString(&result.DefinitionVersionName, r.DefinitionVersionName)
+	mapNullString(&result.Provider, r.Provider)
+	mapNullString(&result.DisplayName, r.DisplayName)
+	mapNullString(&result.DefaultVersion, r.DefaultVersion)
+	mapNullString(&result.DefaultVersionName, r.DefaultVersionName)
+	mapNullString(&result.DefaultVersionAlias, r.DefaultVersionAlias)
+	mapNullString(&result.DefaultVersionLocationUri, r.DefaultVersionLocationUri)
+	mapNullString(&result.DefaultVersionSourceLocationUri, r.DefaultVersionSourceLocationUri)
+	mapNullString(&result.DefaultVersionGitCommitHash, r.DefaultVersionGitCommitHash)
+	mapNullString(&result.LastVersionName, r.LastVersionName)
+	mapNullString(&result.LastVersionAlias, r.LastVersionAlias)
+	mapNullString(&result.LastVersionLocationUri, r.LastVersionLocationUri)
+	mapNullString(&result.LastVersionSourceLocationUri, r.LastVersionSourceLocationUri)
+	mapNullString(&result.LastVersionGitCommitHash, r.LastVersionGitCommitHash)
+	mapNullString(&result.LiveVersionLocationUri, r.LiveVersionLocationUri)
+	mapNullString(&result.Comment, r.Comment)
+	mapNullString(&result.ErrorCode, r.ErrorCode)
+	mapNullString(&result.StatusMessage, r.StatusMessage)
+	return result, nil
 }

--- a/pkg/sdk/openflow_deployments_impl_gen.go
+++ b/pkg/sdk/openflow_deployments_impl_gen.go
@@ -128,8 +128,20 @@ func (r *ShowOpenflowDeploymentRequest) toOpts() *ShowOpenflowDeploymentOptions 
 }
 
 func (r openflowDeploymentRow) convert() (*OpenflowDeployment, error) {
-	// TODO: Mapping
-	return &OpenflowDeployment{}, nil
+	result := &OpenflowDeployment{
+		Name:                       r.Name,
+		UsePrivateLink:             r.UsePrivateLink,
+		UseUserAuthOverPrivateLink: r.UseUserAuthOverPrivateLink,
+		Owner:                      r.Owner,
+	}
+	mapStringWithMapping(&result.Type, r.DeploymentType, ToOpenflowDeploymentType)
+	mapStringWithMapping(&result.Status, r.Status, ToOpenflowDeploymentStatus)
+	mapNullStringWithMapping(&result.VpcType, r.VpcType, ToOpenflowVpcType)
+	mapNullString(&result.DisplayName, r.DisplayName)
+	mapNullString(&result.CustomIngressHostname, r.CustomIngressHostname)
+	mapNullString(&result.OpenflowKey, r.OpenflowKey)
+	mapNullString(&result.Comment, r.Comment)
+	return result, nil
 }
 
 func (r *DescribeOpenflowDeploymentRequest) toOpts() *DescribeOpenflowDeploymentOptions {
@@ -140,6 +152,22 @@ func (r *DescribeOpenflowDeploymentRequest) toOpts() *DescribeOpenflowDeployment
 }
 
 func (r openflowDeploymentDetailsRow) convert() (*OpenflowDeploymentDetails, error) {
-	// TODO: Mapping
-	return &OpenflowDeploymentDetails{}, nil
+	result := &OpenflowDeploymentDetails{
+		Name:                       r.Name,
+		UsePrivateLink:             r.UsePrivateLink,
+		UseUserAuthOverPrivateLink: r.UseUserAuthOverPrivateLink,
+		Owner:                      r.Owner,
+		CreatedOn:                  r.CreatedOn,
+		UpdatedOn:                  r.UpdatedOn,
+	}
+	mapStringWithMapping(&result.Type, r.DeploymentType, ToOpenflowDeploymentType)
+	mapStringWithMapping(&result.Status, r.Status, ToOpenflowDeploymentStatus)
+	mapNullStringWithMapping(&result.VpcType, r.VpcType, ToOpenflowVpcType)
+	mapNullString(&result.DisplayName, r.DisplayName)
+	mapNullString(&result.CustomIngressHostname, r.CustomIngressHostname)
+	mapNullString(&result.OpenflowKey, r.OpenflowKey)
+	mapNullString(&result.Comment, r.Comment)
+	mapNullString(&result.ErrorCode, r.ErrorCode)
+	mapNullString(&result.StatusMessage, r.StatusMessage)
+	return result, nil
 }

--- a/pkg/sdk/openflow_runtimes_impl_gen.go
+++ b/pkg/sdk/openflow_runtimes_impl_gen.go
@@ -149,8 +149,27 @@ func (r *ShowOpenflowRuntimeRequest) toOpts() *ShowOpenflowRuntimeOptions {
 }
 
 func (r openflowRuntimeRow) convert() (*OpenflowRuntime, error) {
-	// TODO: Mapping
-	return &OpenflowRuntime{}, nil
+	result := &OpenflowRuntime{
+		Name:               r.Name,
+		Deployment:         r.Deployment,
+		MinNodes:           r.MinNodes,
+		MaxNodes:           r.MaxNodes,
+		InitiallySuspended: r.InitiallySuspended,
+		ExecuteAsRole:      r.ExecuteAsRole,
+		Owner:              r.Owner,
+		CreatedOn:          r.CreatedOn,
+		UpdatedOn:          r.UpdatedOn,
+	}
+	mapStringWithMapping(&result.Status, r.Status, ToOpenflowRuntimeStatus)
+	mapStringWithMapping(&result.NodeType, r.NodeType, ToOpenflowRuntimeNodeType)
+	mapNullString(&result.DisplayName, r.DisplayName)
+	if r.ExternalAccessIntegrations.Valid {
+		if ids, err := ParseCommaSeparatedAccountObjectIdentifierArray(r.ExternalAccessIntegrations.String); err == nil {
+			result.ExternalAccessIntegrations = ids
+		}
+	}
+	mapNullString(&result.Comment, r.Comment)
+	return result, nil
 }
 
 func (r *DescribeOpenflowRuntimeRequest) toOpts() *DescribeOpenflowRuntimeOptions {
@@ -161,6 +180,28 @@ func (r *DescribeOpenflowRuntimeRequest) toOpts() *DescribeOpenflowRuntimeOption
 }
 
 func (r openflowRuntimeDetailsRow) convert() (*OpenflowRuntimeDetails, error) {
-	// TODO: Mapping
-	return &OpenflowRuntimeDetails{}, nil
+	result := &OpenflowRuntimeDetails{
+		Name:               r.Name,
+		Deployment:         r.Deployment,
+		MinNodes:           r.MinNodes,
+		MaxNodes:           r.MaxNodes,
+		InitiallySuspended: r.InitiallySuspended,
+		ExecuteAsRole:      r.ExecuteAsRole,
+		Owner:              r.Owner,
+		CreatedOn:          r.CreatedOn,
+		UpdatedOn:          r.UpdatedOn,
+	}
+	mapStringWithMapping(&result.Status, r.Status, ToOpenflowRuntimeStatus)
+	mapStringWithMapping(&result.NodeType, r.NodeType, ToOpenflowRuntimeNodeType)
+	mapNullString(&result.DisplayName, r.DisplayName)
+	if r.ExternalAccessIntegrations.Valid {
+		if ids, err := ParseCommaSeparatedAccountObjectIdentifierArray(r.ExternalAccessIntegrations.String); err == nil {
+			result.ExternalAccessIntegrations = ids
+		}
+	}
+	mapNullString(&result.Comment, r.Comment)
+	mapNullString(&result.ServerUrl, r.ServerUrl)
+	mapNullString(&result.ErrorCode, r.ErrorCode)
+	mapNullString(&result.StatusMessage, r.StatusMessage)
+	return result, nil
 }

--- a/pkg/sdk/row_access_policies_impl_gen.go
+++ b/pkg/sdk/row_access_policies_impl_gen.go
@@ -2,7 +2,6 @@
 
 package sdk
 
-// imports adjusted manually
 import (
 	"context"
 	"fmt"
@@ -149,17 +148,15 @@ func (r *DescribeRowAccessPolicyRequest) toOpts() *DescribeRowAccessPolicyOption
 }
 
 func (r describeRowAccessPolicyDBRow) convert() (*RowAccessPolicyDescription, error) {
-	// adjusted manually
-	rowAccessPolicyDescription := &RowAccessPolicyDescription{
+	result := &RowAccessPolicyDescription{
 		Name:       r.Name,
 		ReturnType: r.ReturnType,
 		Body:       r.Body,
 	}
-	signature, err := ParseTableColumnSignature(r.Signature)
-	if err != nil {
-		return nil, fmt.Errorf("parsing table column signature: %w", err)
+	if v, err := ParseTableColumnSignature(r.Signature); err == nil {
+		result.Signature = v
 	} else {
-		rowAccessPolicyDescription.Signature = signature
+		return nil, fmt.Errorf("parsing table column signature: %w", err)
 	}
-	return rowAccessPolicyDescription, nil
+	return result, nil
 }

--- a/pkg/sdk/secrets_impl_gen.go
+++ b/pkg/sdk/secrets_impl_gen.go
@@ -203,8 +203,7 @@ func (r *ShowSecretRequest) toOpts() *ShowSecretOptions {
 }
 
 func (r secretDBRow) convert() (*Secret, error) {
-	// adjusted manually
-	s := &Secret{
+	result := &Secret{
 		CreatedOn:     r.CreatedOn,
 		Name:          r.Name,
 		SchemaName:    r.SchemaName,
@@ -213,13 +212,11 @@ func (r secretDBRow) convert() (*Secret, error) {
 		SecretType:    r.SecretType,
 		OwnerRoleType: r.OwnerRoleType,
 	}
-	if r.Comment.Valid {
-		s.Comment = String(r.Comment.String)
-	}
+	mapNullString(&result.Comment, r.Comment)
 	if r.OauthScopes.Valid {
-		s.OauthScopes = ParseCommaSeparatedStringArray(r.OauthScopes.String, false)
+		result.OauthScopes = ParseCommaSeparatedStringArray(r.OauthScopes.String, false)
 	}
-	return s, nil
+	return result, nil
 }
 
 func (r *DescribeSecretRequest) toOpts() *DescribeSecretOptions {
@@ -230,8 +227,7 @@ func (r *DescribeSecretRequest) toOpts() *DescribeSecretOptions {
 }
 
 func (r secretDetailsDBRow) convert() (*SecretDetails, error) {
-	// adjusted manually
-	s := &SecretDetails{
+	result := &SecretDetails{
 		CreatedOn:                   r.CreatedOn,
 		Name:                        r.Name,
 		SchemaName:                  r.SchemaName,
@@ -241,17 +237,11 @@ func (r secretDetailsDBRow) convert() (*SecretDetails, error) {
 		OauthAccessTokenExpiryTime:  r.OauthAccessTokenExpiryTime,
 		OauthRefreshTokenExpiryTime: r.OauthRefreshTokenExpiryTime,
 	}
-	if r.Username.Valid {
-		s.Username = String(r.Username.String)
-	}
-	if r.Comment.Valid {
-		s.Comment = String(r.Comment.String)
-	}
+	mapNullString(&result.Comment, r.Comment)
+	mapNullString(&result.Username, r.Username)
 	if r.OauthScopes.Valid {
-		s.OauthScopes = ParseCommaSeparatedStringArray(r.OauthScopes.String, false)
+		result.OauthScopes = ParseCommaSeparatedStringArray(r.OauthScopes.String, false)
 	}
-	if r.IntegrationName.Valid {
-		s.IntegrationName = String(r.IntegrationName.String)
-	}
-	return s, nil
+	mapNullString(&result.IntegrationName, r.IntegrationName)
+	return result, nil
 }

--- a/pkg/sdk/security_integrations_impl_gen.go
+++ b/pkg/sdk/security_integrations_impl_gen.go
@@ -2,6 +2,7 @@
 
 package sdk
 
+// imports adjusted manually
 import (
 	"context"
 	"fmt"
@@ -633,13 +634,13 @@ func (r *DescribeSecurityIntegrationRequest) toOpts() *DescribeSecurityIntegrati
 }
 
 func (r securityIntegrationDescRow) convert() (*SecurityIntegrationProperty, error) {
-	// adjusted manually
-	return &SecurityIntegrationProperty{
+	result := &SecurityIntegrationProperty{
 		Name:    r.Property,
 		Type:    r.PropertyType,
 		Value:   r.PropertyValue,
 		Default: r.PropertyDefault,
-	}, nil
+	}
+	return result, nil
 }
 
 func (r *ShowSecurityIntegrationRequest) toOpts() *ShowSecurityIntegrationOptions {
@@ -650,16 +651,13 @@ func (r *ShowSecurityIntegrationRequest) toOpts() *ShowSecurityIntegrationOption
 }
 
 func (r securityIntegrationShowRow) convert() (*SecurityIntegration, error) {
-	// adjusted manually
-	s := &SecurityIntegration{
+	result := &SecurityIntegration{
 		Name:            r.Name,
 		IntegrationType: r.Type,
+		Category:        r.Category,
 		Enabled:         r.Enabled,
 		CreatedOn:       r.CreatedOn,
-		Category:        r.Category,
 	}
-	if r.Comment.Valid {
-		s.Comment = r.Comment.String
-	}
-	return s, nil
+	mapNullStringToNonNullableField(&result.Comment, r.Comment)
+	return result, nil
 }

--- a/pkg/sdk/services_impl_gen.go
+++ b/pkg/sdk/services_impl_gen.go
@@ -2,10 +2,8 @@
 
 package sdk
 
-// imports adjusted manually
 import (
 	"context"
-	"fmt"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
@@ -202,8 +200,7 @@ func (r *ShowServiceRequest) toOpts() *ShowServiceOptions {
 }
 
 func (r servicesRow) convert() (*Service, error) {
-	// adjusted manually
-	service := &Service{
+	result := &Service{
 		Name:              r.Name,
 		DatabaseName:      r.DatabaseName,
 		SchemaName:        r.SchemaName,
@@ -224,50 +221,20 @@ func (r servicesRow) convert() (*Service, error) {
 		SpecDigest:        r.SpecDigest,
 		IsUpgrading:       r.IsUpgrading,
 	}
-	serviceStatus, err := ToServiceStatus(r.Status)
-	if err != nil {
-		return nil, fmt.Errorf("error converting service status: %w", err)
-	} else {
-		service.Status = serviceStatus
-	}
-	if r.Comment.Valid {
-		service.Comment = &r.Comment.String
-	}
-	if r.ManagingObjectDomain.Valid {
-		service.ManagingObjectDomain = &r.ManagingObjectDomain.String
-	}
-	if r.ManagingObjectName.Valid {
-		service.ManagingObjectName = &r.ManagingObjectName.String
-	}
-	computePoolId, err := ParseAccountObjectIdentifier(r.ComputePool)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse compute pool in service: %w", err)
-	} else {
-		service.ComputePool = computePoolId
-	}
-	if r.QueryWarehouse.Valid {
-		id, err := ParseAccountObjectIdentifier(r.QueryWarehouse.String)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse query warehouse in service: %w", err)
-		} else {
-			service.QueryWarehouse = &id
-		}
-	}
-	if r.SuspendedOn.Valid {
-		service.SuspendedOn = &r.SuspendedOn.Time
-	}
-	if r.ResumedOn.Valid {
-		service.ResumedOn = &r.ResumedOn.Time
-	}
+	mapStringWithMapping(&result.Status, r.Status, ToServiceStatus)
+	mapStringWithMapping(&result.ComputePool, r.ComputePool, ParseAccountObjectIdentifier)
 	if r.ExternalAccessIntegrations.Valid {
-		eaiIds, err := ParseCommaSeparatedAccountObjectIdentifierArray(r.ExternalAccessIntegrations.String)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse external access integrations in service: %w", err)
-		} else {
-			service.ExternalAccessIntegrations = eaiIds
+		if ids, err := ParseCommaSeparatedAccountObjectIdentifierArray(r.ExternalAccessIntegrations.String); err == nil {
+			result.ExternalAccessIntegrations = ids
 		}
 	}
-	return service, nil
+	mapNullTime(&result.ResumedOn, r.ResumedOn)
+	mapNullTime(&result.SuspendedOn, r.SuspendedOn)
+	mapNullString(&result.Comment, r.Comment)
+	mapNullStringWithMapping(&result.QueryWarehouse, r.QueryWarehouse, ParseAccountObjectIdentifier)
+	mapNullString(&result.ManagingObjectDomain, r.ManagingObjectDomain)
+	mapNullString(&result.ManagingObjectName, r.ManagingObjectName)
+	return result, nil
 }
 
 func (r *DescribeServiceRequest) toOpts() *DescribeServiceOptions {
@@ -278,8 +245,7 @@ func (r *DescribeServiceRequest) toOpts() *DescribeServiceOptions {
 }
 
 func (r serviceDescRow) convert() (*ServiceDetails, error) {
-	// adjusted manually
-	service := &ServiceDetails{
+	result := &ServiceDetails{
 		Name:              r.Name,
 		DatabaseName:      r.DatabaseName,
 		SchemaName:        r.SchemaName,
@@ -301,50 +267,20 @@ func (r serviceDescRow) convert() (*ServiceDetails, error) {
 		SpecDigest:        r.SpecDigest,
 		IsUpgrading:       r.IsUpgrading,
 	}
-	serviceStatus, err := ToServiceStatus(r.Status)
-	if err != nil {
-		return nil, fmt.Errorf("error converting service status: %w", err)
-	} else {
-		service.Status = serviceStatus
-	}
-	if r.Comment.Valid {
-		service.Comment = &r.Comment.String
-	}
-	if r.ManagingObjectDomain.Valid {
-		service.ManagingObjectDomain = &r.ManagingObjectDomain.String
-	}
-	if r.ManagingObjectName.Valid {
-		service.ManagingObjectName = &r.ManagingObjectName.String
-	}
-	computePoolId, err := ParseAccountObjectIdentifier(r.ComputePool)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse compute pool in service: %w", err)
-	} else {
-		service.ComputePool = computePoolId
-	}
-	if r.QueryWarehouse.Valid {
-		id, err := ParseAccountObjectIdentifier(r.QueryWarehouse.String)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse query warehouse in service: %w", err)
-		} else {
-			service.QueryWarehouse = &id
-		}
-	}
-	if r.SuspendedOn.Valid {
-		service.SuspendedOn = &r.SuspendedOn.Time
-	}
-	if r.ResumedOn.Valid {
-		service.ResumedOn = &r.ResumedOn.Time
-	}
+	mapStringWithMapping(&result.Status, r.Status, ToServiceStatus)
+	mapStringWithMapping(&result.ComputePool, r.ComputePool, ParseAccountObjectIdentifier)
 	if r.ExternalAccessIntegrations.Valid {
-		eaiIds, err := ParseCommaSeparatedAccountObjectIdentifierArray(r.ExternalAccessIntegrations.String)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse external access integrations in service: %w", err)
-		} else {
-			service.ExternalAccessIntegrations = eaiIds
+		if ids, err := ParseCommaSeparatedAccountObjectIdentifierArray(r.ExternalAccessIntegrations.String); err == nil {
+			result.ExternalAccessIntegrations = ids
 		}
 	}
-	return service, nil
+	mapNullTime(&result.ResumedOn, r.ResumedOn)
+	mapNullTime(&result.SuspendedOn, r.SuspendedOn)
+	mapNullString(&result.Comment, r.Comment)
+	mapNullStringWithMapping(&result.QueryWarehouse, r.QueryWarehouse, ParseAccountObjectIdentifier)
+	mapNullString(&result.ManagingObjectDomain, r.ManagingObjectDomain)
+	mapNullString(&result.ManagingObjectName, r.ManagingObjectName)
+	return result, nil
 }
 
 func (r *ExecuteJobServiceRequest) toOpts() *ExecuteJobServiceOptions {

--- a/pkg/sdk/storage_integrations_impl_gen.go
+++ b/pkg/sdk/storage_integrations_impl_gen.go
@@ -170,18 +170,15 @@ func (r *ShowStorageIntegrationRequest) toOpts() *ShowStorageIntegrationOptions 
 }
 
 func (r showStorageIntegrationsDbRow) convert() (*StorageIntegration, error) {
-	// adjusted manually
-	s := &StorageIntegration{
+	result := &StorageIntegration{
 		Name:        r.Name,
 		StorageType: r.Type,
 		Category:    r.Category,
 		Enabled:     r.Enabled,
 		CreatedOn:   r.CreatedOn,
 	}
-	if r.Comment.Valid {
-		s.Comment = r.Comment.String
-	}
-	return s, nil
+	mapNullStringToNonNullableField(&result.Comment, r.Comment)
+	return result, nil
 }
 
 func (r *DescribeStorageIntegrationRequest) toOpts() *DescribeStorageIntegrationOptions {
@@ -192,11 +189,11 @@ func (r *DescribeStorageIntegrationRequest) toOpts() *DescribeStorageIntegration
 }
 
 func (r descStorageIntegrationsDbRow) convert() (*StorageIntegrationProperty, error) {
-	// adjusted manually
-	return &StorageIntegrationProperty{
+	result := &StorageIntegrationProperty{
 		Name:    r.Property,
 		Type:    r.PropertyType,
 		Value:   r.PropertyValue,
 		Default: r.PropertyDefault,
-	}, nil
+	}
+	return result, nil
 }

--- a/pkg/sdk/streams_impl_gen.go
+++ b/pkg/sdk/streams_impl_gen.go
@@ -230,21 +230,16 @@ func (r *ShowStreamRequest) toOpts() *ShowStreamOptions {
 }
 
 func (r showStreamsDbRow) convert() (*Stream, error) {
-	// adjusted manually
-	s := &Stream{
+	result := &Stream{
 		CreatedOn:    r.CreatedOn,
 		Name:         r.Name,
 		DatabaseName: r.DatabaseName,
 		SchemaName:   r.SchemaName,
-		Stale:        r.Stale == "true",
+		Stale:        r.Stale == "true", // "Y" -> "true" adjusted manually
 	}
-	mapNullTime(&s.StaleAfter, r.StaleAfter)
-	mapNullString(&s.Owner, r.Owner)
-	mapNullString(&s.Comment, r.Comment)
-	mapNullString(&s.Type, r.Type)
-	mapNullString(&s.InvalidReason, r.InvalidReason)
-	mapNullString(&s.OwnerRoleType, r.OwnerRoleType)
-
+	mapNullString(&result.Owner, r.Owner)
+	mapNullString(&result.Comment, r.Comment)
+	// manually adjusted
 	if r.TableName.Valid {
 		if strings.Contains(r.TableName.String, "No privilege or table dropped") {
 			return nil, errors.New("the source object is dropped or you don't have permission to access it")
@@ -255,38 +250,20 @@ func (r showStreamsDbRow) convert() (*Stream, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error converting table name in show stream: %w", err)
 		}
-		s.TableName = &tableName
+		result.TableName = &tableName
 	}
-
-	// TODO [SNOW-3108659] Use mapNullStringWithMapping
-	if r.SourceType.Valid {
-		sourceType, err := ToStreamSourceType(r.SourceType.String)
-		if err != nil {
-			return nil, fmt.Errorf("error converting source type in show stream: %w", err)
-		} else {
-			s.SourceType = &sourceType
-		}
-	}
-
+	mapNullStringWithMapping(&result.SourceType, r.SourceType, ToStreamSourceType)
 	if r.BaseTables.Valid {
-		baseTables, err := ParseCommaSeparatedSchemaObjectIdentifierArray(r.BaseTables.String)
-		if err != nil {
-			return nil, fmt.Errorf("error converting base tables in show stream: %w", err)
-		}
-		s.BaseTables = baseTables
-	}
-
-	// TODO [SNOW-3108659] Use mapNullStringWithMapping
-	if r.Mode.Valid {
-		mode, err := ToStreamMode(r.Mode.String)
-		if err != nil {
-			return nil, fmt.Errorf("error converting mode in show stream: %w", err)
-		} else {
-			s.Mode = &mode
+		if ids, err := ParseCommaSeparatedSchemaObjectIdentifierArray(r.BaseTables.String); err == nil {
+			result.BaseTables = ids
 		}
 	}
-
-	return s, nil
+	mapNullString(&result.Type, r.Type)
+	mapNullStringWithMapping(&result.Mode, r.Mode, ToStreamMode)
+	mapNullTime(&result.StaleAfter, r.StaleAfter)
+	mapNullString(&result.InvalidReason, r.InvalidReason)
+	mapNullString(&result.OwnerRoleType, r.OwnerRoleType)
+	return result, nil
 }
 
 func (r *DescribeStreamRequest) toOpts() *DescribeStreamOptions {

--- a/pkg/sdk/streams_impl_gen.go
+++ b/pkg/sdk/streams_impl_gen.go
@@ -235,7 +235,7 @@ func (r showStreamsDbRow) convert() (*Stream, error) {
 		Name:         r.Name,
 		DatabaseName: r.DatabaseName,
 		SchemaName:   r.SchemaName,
-		Stale:        r.Stale == "true", // "Y" -> "true" adjusted manually
+		Stale:        r.Stale == "true",
 	}
 	mapNullString(&result.Owner, r.Owner)
 	mapNullString(&result.Comment, r.Comment)

--- a/pkg/sdk/views_impl_gen.go
+++ b/pkg/sdk/views_impl_gen.go
@@ -264,7 +264,10 @@ func (r viewDBRow) convert() (*View, error) {
 	mapNullStringToNonNullableField(&result.Reserved, r.Reserved)
 	mapNullStringToNonNullableField(&result.Owner, r.Owner)
 	mapNullStringToNonNullableField(&result.Comment, r.Comment)
-	mapNullStringToNonNullableField(&result.Text, r.Text)
+	// TODO [this PR]: allow metadata trimming
+	if r.Text.Valid {
+		result.Text = tracking.TrimMetadata(r.Text.String)
+	}
 	mapNullBoolToNonNullableField(&result.IsSecure, r.IsSecure)
 	mapNullBoolToNonNullableField(&result.IsMaterialized, r.IsMaterialized)
 	mapNullStringToNonNullableField(&result.OwnerRoleType, r.OwnerRoleType)
@@ -289,10 +292,7 @@ func (r viewDetailsRow) convert() (*ViewDetails, error) {
 		IsUnique:   r.UniqueKey == "Y",
 	}
 	mapNullString(&result.Default, r.Default)
-	// TODO: Mapping for Check (sql.NullString -> *bool)
-	if r.Check.Valid {
-		result.Check = Bool(r.Check.String == "Y")
-	}
+	mapNullStringToBool(&result.Check, r.Check)
 	mapNullString(&result.Expression, r.Expression)
 	mapNullString(&result.Comment, r.Comment)
 	mapNullString(&result.PolicyName, r.PolicyName)

--- a/pkg/sdk/views_impl_gen.go
+++ b/pkg/sdk/views_impl_gen.go
@@ -254,41 +254,22 @@ func (r *ShowViewRequest) toOpts() *ShowViewOptions {
 }
 
 func (r viewDBRow) convert() (*View, error) {
-	// adjusted manually
-	view := View{
+	result := &View{
 		CreatedOn:    r.CreatedOn,
 		Name:         r.Name,
 		DatabaseName: r.DatabaseName,
 		SchemaName:   r.SchemaName,
 	}
-	if r.Reserved.Valid {
-		view.Reserved = r.Reserved.String
-	}
-	if r.Owner.Valid {
-		view.Owner = r.Owner.String
-	}
-	if r.Comment.Valid {
-		view.Comment = r.Comment.String
-	}
-	if r.Text.Valid {
-		view.Text = tracking.TrimMetadata(r.Text.String)
-	}
-	if r.Kind.Valid {
-		view.Kind = r.Kind.String
-	}
-	if r.IsSecure.Valid {
-		view.IsSecure = r.IsSecure.Bool
-	}
-	if r.IsMaterialized.Valid {
-		view.IsMaterialized = r.IsMaterialized.Bool
-	}
-	if r.OwnerRoleType.Valid {
-		view.OwnerRoleType = r.OwnerRoleType.String
-	}
-	if r.ChangeTracking.Valid {
-		view.ChangeTracking = r.ChangeTracking.String
-	}
-	return &view, nil
+	mapNullStringToNonNullableField(&result.Kind, r.Kind)
+	mapNullStringToNonNullableField(&result.Reserved, r.Reserved)
+	mapNullStringToNonNullableField(&result.Owner, r.Owner)
+	mapNullStringToNonNullableField(&result.Comment, r.Comment)
+	mapNullStringToNonNullableField(&result.Text, r.Text)
+	mapNullBoolToNonNullableField(&result.IsSecure, r.IsSecure)
+	mapNullBoolToNonNullableField(&result.IsMaterialized, r.IsMaterialized)
+	mapNullStringToNonNullableField(&result.OwnerRoleType, r.OwnerRoleType)
+	mapNullStringToNonNullableField(&result.ChangeTracking, r.ChangeTracking)
+	return result, nil
 }
 
 func (r *DescribeViewRequest) toOpts() *DescribeViewOptions {
@@ -299,8 +280,7 @@ func (r *DescribeViewRequest) toOpts() *DescribeViewOptions {
 }
 
 func (r viewDetailsRow) convert() (*ViewDetails, error) {
-	// adjusted manually
-	details := &ViewDetails{
+	result := &ViewDetails{
 		Name:       r.Name,
 		Type:       r.Type,
 		Kind:       r.Kind,
@@ -308,20 +288,14 @@ func (r viewDetailsRow) convert() (*ViewDetails, error) {
 		IsPrimary:  r.PrimaryKey == "Y",
 		IsUnique:   r.UniqueKey == "Y",
 	}
-	if r.Default.Valid {
-		details.Default = String(r.Default.String)
-	}
+	mapNullString(&result.Default, r.Default)
+	// TODO: Mapping for Check (sql.NullString -> *bool)
 	if r.Check.Valid {
-		details.Check = Bool(r.Check.String == "Y")
+		result.Check = Bool(r.Check.String == "Y")
 	}
-	if r.Expression.Valid {
-		details.Expression = String(r.Expression.String)
-	}
-	if r.Comment.Valid {
-		details.Comment = String(r.Comment.String)
-	}
-	if r.PolicyName.Valid {
-		details.PolicyName = String(r.PolicyName.String)
-	}
-	return details, nil
+	mapNullString(&result.Expression, r.Expression)
+	mapNullString(&result.Comment, r.Comment)
+	mapNullString(&result.PolicyName, r.PolicyName)
+	mapNullString(&result.PrivacyDomain, r.PrivacyDomain)
+	return result, nil
 }


### PR DESCRIPTION
Continuation of: https://github.com/snowflakedb/terraform-provider-snowflake/pull/4771

Configures config generation and regenerates for multiple objects. Note that still some manual changes are necessary, and they will be handled as follow-ups.
Notable changes:
- improved boolean conversions (string comparison, bool parsing)
- custom conversions

Follow-ups:
- Continue with generating convert for other objects
- Address the manual changes present
- Handle errors properly for all converts