### PR TITLE
chore: Adjust the show warehouse experiment documentation

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1598,9 +1598,7 @@ In this version we introduce a new attribute on the provider level: [`experiment
 
 We treat the available values as experiments, that may become stable feature/behavior in the future provider releases if successful.
 
-Currently, the only available experiment is `WAREHOUSE_SHOW_IMPROVED_PERFORMANCE`. When enabled, it uses a slightly different SHOW query to read warehouse details. It's meant to improve the performance for accounts with many warehouses.
-
-**Important**: to benefit from this improvement, you need to have it enabled also on your Snowflake account. To do this, please reach out to us through your Snowflake Account Manager.
+In this version, the only available experiment is `WAREHOUSE_SHOW_IMPROVED_PERFORMANCE`. When enabled, it uses a slightly different SHOW query to read warehouse details. It's meant to improve the performance for accounts with many warehouses.
 
 Details:
 - The query after enabling the experiment should look like this: `SHOW WAREHOUSES LIKE '<identifier>' STARTS WITH '<identifier>' LIMIT 1`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -930,7 +930,7 @@ It's meant to improve the performance for accounts with many warehouses.
 
 When enabled, it uses a slightly different SHOW query to read warehouse details (`SHOW WAREHOUSES LIKE '<identifier>' STARTS WITH '<identifier>' LIMIT 1`).
 
-**Important**: to benefit from this improvement, you need to have it enabled also on your Snowflake account. To do this, please reach out to us through your Snowflake Account Manager.
+This feature is enabled by default on the Snowflake side.
 
 #### GRANTS_STRICT_PRIVILEGE_MANAGEMENT
 The new `strict_privilege_management` flag was added to the `snowflake_grant_privileges_to_account_role` resource.

--- a/examples/additional/experimental_features.MD
+++ b/examples/additional/experimental_features.MD
@@ -9,7 +9,7 @@ It's meant to improve the performance for accounts with many warehouses.
 
 When enabled, it uses a slightly different SHOW query to read warehouse details (`SHOW WAREHOUSES LIKE '<identifier>' STARTS WITH '<identifier>' LIMIT 1`).
 
-**Important**: to benefit from this improvement, you need to have it enabled also on your Snowflake account. To do this, please reach out to us through your Snowflake Account Manager.
+This feature is enabled by default on the Snowflake side.
 
 #### GRANTS_STRICT_PRIVILEGE_MANAGEMENT
 The new `strict_privilege_management` flag was added to the `snowflake_grant_privileges_to_account_role` resource.

--- a/pkg/provider/experimentalfeatures/experimental_features.go
+++ b/pkg/provider/experimentalfeatures/experimental_features.go
@@ -54,7 +54,7 @@ var allExperiments = []Experiment{
 		joinWithDoubleNewline(
 			"It's meant to improve the performance for accounts with many warehouses.",
 			"When enabled, it uses a slightly different SHOW query to read warehouse details (`SHOW WAREHOUSES LIKE '<identifier>' STARTS WITH '<identifier>' LIMIT 1`).",
-			"**Important**: to benefit from this improvement, you need to have it enabled also on your Snowflake account. To do this, please reach out to us through your Snowflake Account Manager.",
+			"This feature is enabled by default on the Snowflake side.",
 		),
 	},
 	{


### PR DESCRIPTION
This feature is already enabled by default in Snowflake and doesn't require any action from an Account Manager. This change adjusts the documentation to reflect this. We are still leaving the section about giving feedback on this feature.