### PR TITLE
chore: Generate convert for more SDK objects - part 5

### DIFF
--- a/pkg/acceptance/bettertestspoc/assert/objectassert/procedure_snowflake_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/procedure_snowflake_ext.go
@@ -9,41 +9,41 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 )
 
-func (a *ProcedureAssert) HasCreatedOnNotEmpty() *ProcedureAssert {
-	a.AddAssertion(func(t *testing.T, o *sdk.Procedure) error {
+func (p *ProcedureAssert) HasCreatedOnNotEmpty() *ProcedureAssert {
+	p.AddAssertion(func(t *testing.T, o *sdk.Procedure) error {
 		t.Helper()
 		if o.CreatedOn == "" {
 			return fmt.Errorf("expected created_on to be not empty")
 		}
 		return nil
 	})
-	return a
+	return p
 }
 
-func (a *ProcedureAssert) HasExternalAccessIntegrationsNil() *ProcedureAssert {
-	a.AddAssertion(func(t *testing.T, o *sdk.Procedure) error {
+func (p *ProcedureAssert) HasExternalAccessIntegrationsNil() *ProcedureAssert {
+	p.AddAssertion(func(t *testing.T, o *sdk.Procedure) error {
 		t.Helper()
 		if o.ExternalAccessIntegrations != nil {
 			return fmt.Errorf("expected external_access_integrations to be nil but was: %v", *o.ExternalAccessIntegrations)
 		}
 		return nil
 	})
-	return a
+	return p
 }
 
-func (a *ProcedureAssert) HasSecretsNil() *ProcedureAssert {
-	a.AddAssertion(func(t *testing.T, o *sdk.Procedure) error {
+func (p *ProcedureAssert) HasSecretsNil() *ProcedureAssert {
+	p.AddAssertion(func(t *testing.T, o *sdk.Procedure) error {
 		t.Helper()
 		if o.Secrets != nil {
 			return fmt.Errorf("expected secrets to be nil but was: %v", *o.Secrets)
 		}
 		return nil
 	})
-	return a
+	return p
 }
 
-func (f *ProcedureAssert) HasExactlyExternalAccessIntegrations(integrations ...sdk.AccountObjectIdentifier) *ProcedureAssert {
-	f.AddAssertion(func(t *testing.T, o *sdk.Procedure) error {
+func (p *ProcedureAssert) HasExactlyExternalAccessIntegrations(integrations ...sdk.AccountObjectIdentifier) *ProcedureAssert {
+	p.AddAssertion(func(t *testing.T, o *sdk.Procedure) error {
 		t.Helper()
 		if o.ExternalAccessIntegrations == nil {
 			return fmt.Errorf("expected external access integrations to have value; got: nil")
@@ -55,7 +55,26 @@ func (f *ProcedureAssert) HasExactlyExternalAccessIntegrations(integrations ...s
 		}
 		return nil
 	})
-	return f
+	return p
+}
+
+func (p *ProcedureAssert) HasExactlySecrets(expectedSecrets map[string]sdk.SchemaObjectIdentifier) *ProcedureAssert {
+	p.AddAssertion(func(t *testing.T, o *sdk.Procedure) error {
+		t.Helper()
+		if o.Secrets == nil {
+			return fmt.Errorf("expected secrets to have value; got: nil")
+		}
+		var parts []string
+		for k, v := range expectedSecrets {
+			parts = append(parts, fmt.Sprintf(`"%s":"\"%s\".\"%s\".%s"`, k, v.DatabaseName(), v.SchemaName(), v.Name()))
+		}
+		expected := fmt.Sprintf(`{%s}`, strings.Join(parts, ","))
+		if *o.Secrets != expected {
+			return fmt.Errorf("expected secrets: %v; got: %v", expected, *o.Secrets)
+		}
+		return nil
+	})
+	return p
 }
 
 func (p *ProcedureAssert) HasArgumentsRawContains(substring string) *ProcedureAssert {

--- a/pkg/sdk/external_functions_ext.go
+++ b/pkg/sdk/external_functions_ext.go
@@ -1,5 +1,31 @@
 package sdk
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
+)
+
 func (v *ExternalFunction) ID() SchemaObjectIdentifierWithArguments {
 	return NewSchemaObjectIdentifierWithArguments(v.CatalogName, v.SchemaName, v.Name, v.Arguments...)
+}
+
+func (r externalFunctionRow) additionalConvert(result *ExternalFunction) error {
+	if r.SchemaName.Valid {
+		result.SchemaName = strings.Trim(r.SchemaName.String, `"`)
+	}
+	if r.CatalogName.Valid {
+		result.CatalogName = strings.Trim(r.CatalogName.String, `"`)
+	}
+	arguments := strings.TrimLeft(r.Arguments, r.Name)
+	returnIndex := strings.Index(arguments, ") RETURN ")
+	parsedArguments, err := ParseFunctionAndProcedureArguments(arguments[:returnIndex+1])
+	if err != nil {
+		return fmt.Errorf("failed to parse external function arguments: %w", err)
+	}
+	result.Arguments = collections.Map(parsedArguments, func(a ParsedArgument) DataType {
+		return DataType(a.ArgType)
+	})
+	return nil
 }

--- a/pkg/sdk/external_functions_gen.go
+++ b/pkg/sdk/external_functions_gen.go
@@ -122,7 +122,7 @@ type ExternalFunction struct {
 	IsAnsi             bool
 	MinNumArguments    int
 	MaxNumArguments    int
-	Arguments          []DataType
+	Arguments          []DataType // added manually
 	ArgumentsRaw       string
 	Description        string
 	CatalogName        string

--- a/pkg/sdk/external_functions_impl_gen.go
+++ b/pkg/sdk/external_functions_impl_gen.go
@@ -2,11 +2,8 @@
 
 package sdk
 
-// imports adjusted manually
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
@@ -90,24 +87,29 @@ func (r *CreateExternalFunctionRequest) toOpts() *CreateExternalFunctionOptions 
 	if r.Arguments != nil {
 		s := make([]ExternalFunctionArgument, len(r.Arguments))
 		for i, v := range r.Arguments {
-			// adjusted manually
-			s[i] = ExternalFunctionArgument(v)
+			s[i] = ExternalFunctionArgument{
+				ArgName:     v.ArgName,
+				ArgDataType: v.ArgDataType,
+			}
 		}
 		opts.Arguments = s
 	}
 	if r.Headers != nil {
 		s := make([]ExternalFunctionHeader, len(r.Headers))
 		for i, v := range r.Headers {
-			// adjusted manually
-			s[i] = ExternalFunctionHeader(v)
+			s[i] = ExternalFunctionHeader{
+				Name:  v.Name,
+				Value: v.Value,
+			}
 		}
 		opts.Headers = s
 	}
 	if r.ContextHeaders != nil {
 		s := make([]ExternalFunctionContextHeader, len(r.ContextHeaders))
 		for i, v := range r.ContextHeaders {
-			// adjusted manually
-			s[i] = ExternalFunctionContextHeader(v)
+			s[i] = ExternalFunctionContextHeader{
+				ContextFunction: v.ContextFunction,
+			}
 		}
 		opts.ContextHeaders = s
 	}
@@ -130,16 +132,19 @@ func (r *AlterExternalFunctionRequest) toOpts() *AlterExternalFunctionOptions {
 		if r.Set.Headers != nil {
 			s := make([]ExternalFunctionHeader, len(r.Set.Headers))
 			for i, v := range r.Set.Headers {
-				// adjusted manually
-				s[i] = ExternalFunctionHeader(v)
+				s[i] = ExternalFunctionHeader{
+					Name:  v.Name,
+					Value: v.Value,
+				}
 			}
 			opts.Set.Headers = s
 		}
 		if r.Set.ContextHeaders != nil {
 			s := make([]ExternalFunctionContextHeader, len(r.Set.ContextHeaders))
 			for i, v := range r.Set.ContextHeaders {
-				// adjusted manually
-				s[i] = ExternalFunctionContextHeader(v)
+				s[i] = ExternalFunctionContextHeader{
+					ContextFunction: v.ContextFunction,
+				}
 			}
 			opts.Set.ContextHeaders = s
 		}
@@ -168,8 +173,7 @@ func (r *ShowExternalFunctionRequest) toOpts() *ShowExternalFunctionOptions {
 }
 
 func (r externalFunctionRow) convert() (*ExternalFunction, error) {
-	// adjusted manually
-	e := &ExternalFunction{
+	result := &ExternalFunction{
 		CreatedOn:          r.CreatedOn,
 		Name:               r.Name,
 		IsBuiltin:          r.IsBuiltin == "Y",
@@ -184,32 +188,13 @@ func (r externalFunctionRow) convert() (*ExternalFunction, error) {
 		IsExternalFunction: r.IsExternalFunction == "Y",
 		Language:           r.Language,
 	}
-	arguments := strings.TrimLeft(r.Arguments, r.Name)
-	returnIndex := strings.Index(arguments, ") RETURN ")
-	parsedArguments, err := ParseFunctionAndProcedureArguments(arguments[:returnIndex+1])
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse external function arguments: %w", err)
-	} else {
-		e.Arguments = collections.Map(parsedArguments, func(a ParsedArgument) DataType {
-			return DataType(a.ArgType)
-		})
+	mapNullStringToRequiredBool(&result.IsSecure, r.IsSecure)
+	mapNullStringToRequiredBool(&result.IsMemoizable, r.IsMemoizable)
+	mapNullStringToRequiredBool(&result.IsDataMetric, r.IsDataMetric)
+	if err := r.additionalConvert(result); err != nil {
+		return nil, err
 	}
-	if r.SchemaName.Valid {
-		e.SchemaName = strings.Trim(r.SchemaName.String, `"`)
-	}
-	if r.CatalogName.Valid {
-		e.CatalogName = strings.Trim(r.CatalogName.String, `"`)
-	}
-	if r.IsSecure.Valid {
-		e.IsSecure = r.IsSecure.String == "Y"
-	}
-	if r.IsMemoizable.Valid {
-		e.IsMemoizable = r.IsMemoizable.String == "Y"
-	}
-	if r.IsDataMetric.Valid {
-		e.IsDataMetric = r.IsDataMetric.String == "Y"
-	}
-	return e, nil
+	return result, nil
 }
 
 func (r *DescribeExternalFunctionRequest) toOpts() *DescribeExternalFunctionOptions {
@@ -220,9 +205,9 @@ func (r *DescribeExternalFunctionRequest) toOpts() *DescribeExternalFunctionOpti
 }
 
 func (r externalFunctionPropertyRow) convert() (*ExternalFunctionProperty, error) {
-	// adjusted manually
-	return &ExternalFunctionProperty{
+	result := &ExternalFunctionProperty{
 		Property: r.Property,
 		Value:    r.Value,
-	}, nil
+	}
+	return result, nil
 }

--- a/pkg/sdk/functions_ext.go
+++ b/pkg/sdk/functions_ext.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 )
 
@@ -311,4 +313,27 @@ func NewCreateForJavascriptFunctionRequestDefinitionWrapped(
 	s.Returns = returns
 	s.FunctionDefinition = fmt.Sprintf(`$$%s$$`, functionDefinition)
 	return &s
+}
+
+func (r functionRow) additionalConvert(result *Function) error {
+	result.SchemaName = strings.Trim(r.SchemaName, `"`)
+	result.CatalogName = strings.Trim(r.CatalogName, `"`)
+	arguments := strings.TrimLeft(r.Arguments, r.Name)
+	returnIndex := strings.Index(arguments, ") RETURN ")
+	result.ReturnTypeOld = DataType(arguments[returnIndex+len(") RETURN "):])
+	parsedArguments, err := ParseFunctionAndProcedureArguments(arguments[:returnIndex+1])
+	if err != nil {
+		return fmt.Errorf("failed to parse function arguments: %w", err)
+	}
+	result.ArgumentsOld = collections.Map(parsedArguments, func(a ParsedArgument) DataType {
+		return DataType(a.ArgType)
+	})
+	return nil
+}
+
+func (r functionDetailRow) additionalConvert(result *FunctionDetail) error {
+	if r.Value.Valid && r.Value.String != "null" {
+		result.Value = String(r.Value.String)
+	}
+	return nil
 }

--- a/pkg/sdk/functions_gen.go
+++ b/pkg/sdk/functions_gen.go
@@ -290,8 +290,8 @@ type Function struct {
 	IsAnsi                     bool
 	MinNumArguments            int
 	MaxNumArguments            int
-	ArgumentsOld               []DataType
-	ReturnTypeOld              DataType
+	ArgumentsOld               []DataType // added manually
+	ReturnTypeOld              DataType   // added manually
 	ArgumentsRaw               string
 	Description                string
 	CatalogName                string

--- a/pkg/sdk/functions_impl_gen.go
+++ b/pkg/sdk/functions_impl_gen.go
@@ -2,11 +2,8 @@
 
 package sdk
 
-// imports adjusted manually
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
@@ -472,11 +469,9 @@ func (r *ShowFunctionRequest) toOpts() *ShowFunctionOptions {
 }
 
 func (r functionRow) convert() (*Function, error) {
-	// adjusted manually
-	e := &Function{
+	result := &Function{
 		CreatedOn:          r.CreatedOn,
 		Name:               r.Name,
-		SchemaName:         strings.Trim(r.SchemaName, `"`),
 		IsBuiltin:          r.IsBuiltin == "Y",
 		IsAggregate:        r.IsAggregate == "Y",
 		IsAnsi:             r.IsAnsi == "Y",
@@ -484,40 +479,20 @@ func (r functionRow) convert() (*Function, error) {
 		MaxNumArguments:    r.MaxNumArguments,
 		ArgumentsRaw:       r.Arguments,
 		Description:        r.Description,
-		CatalogName:        strings.Trim(r.CatalogName, `"`),
 		IsTableFunction:    r.IsTableFunction == "Y",
 		ValidForClustering: r.ValidForClustering == "Y",
 		IsExternalFunction: r.IsExternalFunction == "Y",
 		Language:           r.Language,
 	}
-	arguments := strings.TrimLeft(r.Arguments, r.Name)
-	returnIndex := strings.Index(arguments, ") RETURN ")
-	e.ReturnTypeOld = DataType(arguments[returnIndex+len(") RETURN "):])
-	parsedArguments, err := ParseFunctionAndProcedureArguments(arguments[:returnIndex+1])
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse function arguments: %w", err)
-	} else {
-		e.ArgumentsOld = collections.Map(parsedArguments, func(a ParsedArgument) DataType {
-			return DataType(a.ArgType)
-		})
+	mapNullStringToRequiredBool(&result.IsSecure, r.IsSecure)
+	mapNullString(&result.Secrets, r.Secrets)
+	mapNullString(&result.ExternalAccessIntegrations, r.ExternalAccessIntegrations)
+	mapNullStringToRequiredBool(&result.IsMemoizable, r.IsMemoizable)
+	mapNullStringToRequiredBool(&result.IsDataMetric, r.IsDataMetric)
+	if err := r.additionalConvert(result); err != nil {
+		return nil, err
 	}
-
-	if r.IsSecure.Valid {
-		e.IsSecure = r.IsSecure.String == "Y"
-	}
-	if r.Secrets.Valid {
-		e.Secrets = String(r.Secrets.String)
-	}
-	if r.ExternalAccessIntegrations.Valid {
-		e.ExternalAccessIntegrations = String(r.ExternalAccessIntegrations.String)
-	}
-	if r.IsMemoizable.Valid {
-		e.IsMemoizable = r.IsMemoizable.String == "Y"
-	}
-	if r.IsDataMetric.Valid {
-		e.IsDataMetric = r.IsDataMetric.String == "Y"
-	}
-	return e, nil
+	return result, nil
 }
 
 func (r *DescribeFunctionRequest) toOpts() *DescribeFunctionOptions {
@@ -528,12 +503,11 @@ func (r *DescribeFunctionRequest) toOpts() *DescribeFunctionOptions {
 }
 
 func (r functionDetailRow) convert() (*FunctionDetail, error) {
-	// adjusted manually
-	e := &FunctionDetail{
+	result := &FunctionDetail{
 		Property: r.Property,
 	}
-	if r.Value.Valid && r.Value.String != "null" {
-		e.Value = String(r.Value.String)
+	if err := r.additionalConvert(result); err != nil {
+		return nil, err
 	}
-	return e, nil
+	return result, nil
 }

--- a/pkg/sdk/generator/defs/external_functions_def.go
+++ b/pkg/sdk/generator/defs/external_functions_def.go
@@ -45,6 +45,33 @@ var externalFunctionUnset = g.NewQueryStruct("ExternalFunctionUnset").
 	OptionalSQL("RESPONSE_TRANSLATOR").
 	WithValidation(g.AtLeastOneValueSet, "Comment", "Headers", "ContextHeaders", "MaxBatchRows", "Compression", "Secure", "RequestTranslator", "ResponseTranslator")
 
+// TODO [next PRs]: support adding a field only in plain struct (in this case: `Arguments`)
+var externalFunctionPairs = g.StructPair("externalFunctionRow", "ExternalFunction").
+	Text("created_on").
+	Text("name").
+	OptionalText("schema_name", g.WithManualConvert(), g.WithRequiredInPlain()).
+	BoolFromText("is_builtin").
+	BoolFromText("is_aggregate").
+	BoolFromText("is_ansi").
+	Number("min_num_arguments").
+	Number("max_num_arguments").
+	Text("arguments", g.WithPlainFieldName("ArgumentsRaw")).
+	Text("description").
+	Field("catalog_name", "sql.NullString", "string", g.WithManualConvert()).
+	BoolFromText("is_table_function").
+	BoolFromText("valid_for_clustering").
+	OptionalBoolFromText("is_secure", g.WithRequiredInPlain()).
+	BoolFromText("is_external_function").
+	Text("language").
+	OptionalBoolFromText("is_memoizable", g.WithRequiredInPlain()).
+	OptionalBoolFromText("is_data_metric", g.WithRequiredInPlain()).
+	WithConvertGeneration()
+
+var externalFunctionPropertyPairs = g.StructPair("externalFunctionPropertyRow", "ExternalFunctionProperty").
+	Text("property").
+	Text("value").
+	WithConvertGeneration()
+
 // TODO [SNOW-2048276]: Add dedicated external Drop and DropSafely functions
 var externalFunctionsDef = g.NewInterface(
 	"ExternalFunctions",
@@ -107,47 +134,9 @@ var externalFunctionsDef = g.NewInterface(
 		).
 		WithValidation(g.ExactlyOneValueSet, "Set", "Unset").
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-external-functions",
-	g.DbStruct("externalFunctionRow").
-		Field("created_on", "string").
-		Field("name", "string").
-		Field("schema_name", "sql.NullString").
-		Field("is_builtin", "string").
-		Field("is_aggregate", "string").
-		Field("is_ansi", "string").
-		Field("min_num_arguments", "int").
-		Field("max_num_arguments", "int").
-		Field("arguments", "string").
-		Field("description", "string").
-		Field("catalog_name", "sql.NullString").
-		Field("is_table_function", "string").
-		Field("valid_for_clustering", "string").
-		Field("is_secure", "sql.NullString").
-		Field("is_external_function", "string").
-		Field("language", "string").
-		Field("is_memoizable", "sql.NullString").
-		Field("is_data_metric", "sql.NullString"),
-	g.PlainStruct("ExternalFunction").
-		Field("CreatedOn", "string").
-		Field("Name", "string").
-		Field("SchemaName", "string").
-		Field("IsBuiltin", "bool").
-		Field("IsAggregate", "bool").
-		Field("IsAnsi", "bool").
-		Field("MinNumArguments", "int").
-		Field("MaxNumArguments", "int").
-		Field("Arguments", "[]DataType").
-		Field("ArgumentsRaw", "string").
-		Field("Description", "string").
-		Field("CatalogName", "string").
-		Field("IsTableFunction", "bool").
-		Field("ValidForClustering", "bool").
-		Field("IsSecure", "bool").
-		Field("IsExternalFunction", "bool").
-		Field("Language", "string").
-		Field("IsMemoizable", "bool").
-		Field("IsDataMetric", "bool"),
+	externalFunctionPairs,
 	g.NewQueryStruct("ShowFunctions").
 		Show().
 		SQL("EXTERNAL FUNCTIONS").
@@ -155,15 +144,10 @@ var externalFunctionsDef = g.NewInterface(
 		OptionalIn(),
 	g.ShowByIDInFiltering,
 	g.ShowByIDLikeFiltering,
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSlice,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-function",
-	g.DbStruct("externalFunctionPropertyRow").
-		Field("property", "string").
-		Field("value", "string"),
-	g.PlainStruct("ExternalFunctionProperty").
-		Field("Property", "string").
-		Field("Value", "string"),
+	externalFunctionPropertyPairs,
 	g.NewQueryStruct("DescribeExternalFunction").
 		Describe().
 		SQL("FUNCTION").

--- a/pkg/sdk/generator/defs/functions_def.go
+++ b/pkg/sdk/generator/defs/functions_def.go
@@ -55,6 +55,35 @@ var (
 					List("SecretsList", "SecretReference", g.ListOptions().Required().MustParentheses())
 )
 
+// TODO [next PRs]: support adding a field only in plain struct (in this case: `ArgumentsOld` and `ReturnTypeOld`)
+var functionPairs = g.StructPair("functionRow", "Function").
+	Text("created_on").
+	Text("name").
+	Text("schema_name", g.WithManualConvert()).
+	BoolFromText("is_builtin").
+	BoolFromText("is_aggregate").
+	BoolFromText("is_ansi").
+	Number("min_num_arguments").
+	Number("max_num_arguments").
+	Text("arguments", g.WithPlainFieldName("ArgumentsRaw")).
+	Text("description").
+	Text("catalog_name", g.WithManualConvert()).
+	BoolFromText("is_table_function").
+	BoolFromText("valid_for_clustering").
+	OptionalBoolFromText("is_secure", g.WithRequiredInPlain()).
+	OptionalText("secrets").
+	OptionalText("external_access_integrations").
+	BoolFromText("is_external_function").
+	Text("language").
+	OptionalBoolFromText("is_memoizable", g.WithRequiredInPlain()).
+	OptionalBoolFromText("is_data_metric", g.WithRequiredInPlain()).
+	WithConvertGeneration()
+
+var functionDetailPairs = g.StructPair("functionDetailRow", "FunctionDetail").
+	Text("property").
+	OptionalText("value", g.WithManualConvert()).
+	WithConvertGeneration()
+
 var functionsDef = g.NewInterface(
 	"Functions",
 	"Function",
@@ -324,52 +353,9 @@ var functionsDef = g.NewInterface(
 		IfExists().
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-user-functions",
-	g.DbStruct("functionRow").
-		Field("created_on", "string").
-		Field("name", "string").
-		Field("schema_name", "string").
-		Field("is_builtin", "string").
-		Field("is_aggregate", "string").
-		Field("is_ansi", "string").
-		Field("min_num_arguments", "int").
-		Field("max_num_arguments", "int").
-		Field("arguments", "string").
-		Field("description", "string").
-		Field("catalog_name", "string").
-		Field("is_table_function", "string").
-		Field("valid_for_clustering", "string").
-		Field("is_secure", "sql.NullString").
-		OptionalText("secrets").
-		OptionalText("external_access_integrations").
-		Field("is_external_function", "string").
-		Field("language", "string").
-		Field("is_memoizable", "sql.NullString").
-		Field("is_data_metric", "sql.NullString"),
-	g.PlainStruct("Function").
-		Field("CreatedOn", "string").
-		Field("Name", "string").
-		Field("SchemaName", "string").
-		Field("IsBuiltin", "bool").
-		Field("IsAggregate", "bool").
-		Field("IsAnsi", "bool").
-		Field("MinNumArguments", "int").
-		Field("MaxNumArguments", "int").
-		Field("ArgumentsOld", "[]DataType").
-		Field("ReturnTypeOld", "DataType").
-		Field("ArgumentsRaw", "string").
-		Field("Description", "string").
-		Field("CatalogName", "string").
-		Field("IsTableFunction", "bool").
-		Field("ValidForClustering", "bool").
-		Field("IsSecure", "bool").
-		OptionalText("Secrets").
-		OptionalText("ExternalAccessIntegrations").
-		Field("IsExternalFunction", "bool").
-		Field("Language", "string").
-		Field("IsMemoizable", "bool").
-		Field("IsDataMetric", "bool"),
+	functionPairs,
 	g.NewQueryStruct("ShowFunctions").
 		Show().
 		SQL("USER FUNCTIONS").
@@ -377,15 +363,10 @@ var functionsDef = g.NewInterface(
 		OptionalExtendedIn(),
 	g.ShowByIDExtendedInFiltering,
 	g.ShowByIDLikeFiltering,
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSlice,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-function",
-	g.DbStruct("functionDetailRow").
-		Field("property", "string").
-		Field("value", "sql.NullString"),
-	g.PlainStruct("FunctionDetail").
-		Text("Property").
-		OptionalText("Value"),
+	functionDetailPairs,
 	g.NewQueryStruct("DescribeFunction").
 		Describe().
 		SQL("FUNCTION").

--- a/pkg/sdk/generator/defs/postgres_instances_def.go
+++ b/pkg/sdk/generator/defs/postgres_instances_def.go
@@ -22,6 +22,32 @@ var (
 	)
 )
 
+var postgresInstancesPairs = g.StructPair("postgresInstancesRow", "PostgresInstance").
+	Text("name").
+	Text("owner").
+	Text("owner_role_type").
+	Time("created_on").
+	Time("updated_on").
+	Text("type").
+	OptionalText("origin").
+	OptionalText("host").
+	OptionalText("privatelink_service_identifier").
+	Text("compute_family").
+	Text("authentication_authority").
+	Number("storage_size").
+	Text("postgres_version").
+	OptionalText("postgres_settings").
+	BoolFromText("is_ha", g.WithBoolTrueValue("true")).
+	Number("retention_time").
+	Enum("state", PostgresInstanceStateEnumDef).
+	OptionalText("comment").
+	WithConvertGeneration()
+
+var postgresInstanceDetailPairs = g.StructPair("postgresInstanceDetailsRow", "PostgresInstanceProperty").
+	Text("property").
+	OptionalText("value", g.WithRequiredInPlain()).
+	WithConvertGeneration()
+
 var postgresInstancesDef = g.NewInterface(
 	"PostgresInstances",
 	"PostgresInstance",
@@ -145,61 +171,19 @@ var postgresInstancesDef = g.NewInterface(
 		IfExists().
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-postgres-instances",
-	g.DbStruct("postgresInstancesRow").
-		Text("name").
-		Text("owner").
-		Text("owner_role_type").
-		Time("created_on").
-		Time("updated_on").
-		Text("type").
-		OptionalText("origin").
-		OptionalText("host").
-		OptionalText("privatelink_service_identifier").
-		Text("compute_family").
-		Text("authentication_authority").
-		Number("storage_size").
-		Text("postgres_version").
-		OptionalText("postgres_settings").
-		Text("is_ha").
-		Number("retention_time").
-		Text("state").
-		OptionalText("comment"),
-	g.PlainStruct("PostgresInstance").
-		Text("Name").
-		Text("Owner").
-		Text("OwnerRoleType").
-		Time("CreatedOn").
-		Time("UpdatedOn").
-		Text("Type").
-		OptionalText("Origin").
-		OptionalText("Host").
-		OptionalText("PrivatelinkServiceIdentifier").
-		Text("ComputeFamily").
-		Text("AuthenticationAuthority").
-		Number("StorageSize").
-		Text("PostgresVersion").
-		OptionalText("PostgresSettings").
-		Bool("IsHa").
-		Number("RetentionTime").
-		Enum("State", PostgresInstanceStateEnumDef).
-		OptionalText("Comment"),
+	postgresInstancesPairs,
 	g.NewQueryStruct("ShowPostgresInstances").
 		Show().
 		SQL("POSTGRES INSTANCES").
 		OptionalLike().
 		OptionalStartsWith().
 		OptionalLimitFrom(),
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSlice,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-postgres-instance",
-	g.DbStruct("postgresInstanceDetailsRow").
-		Text("property").
-		OptionalText("value"),
-	g.PlainStruct("PostgresInstanceProperty").
-		Text("Property").
-		Text("Value"),
+	postgresInstanceDetailPairs,
 	g.NewQueryStruct("DescribePostgresInstance").
 		Describe().
 		SQL("POSTGRES INSTANCE").

--- a/pkg/sdk/generator/defs/procedures_def.go
+++ b/pkg/sdk/generator/defs/procedures_def.go
@@ -84,6 +84,31 @@ var procedureWithClause = g.NewQueryStruct("ProcedureWithClause").
 	PredefinedQueryStructField("CteColumns", "[]string", g.KeywordOptions().Parentheses()).
 	PredefinedQueryStructField("Statement", "string", g.ParameterOptions().NoEquals().NoQuotes().SQL("AS").Required())
 
+// TODO [next PRs]: support adding a field only in plain struct (in this case: `ArgumentsOld` and `ReturnTypeOld`)
+var procedurePairs = g.StructPair("procedureRow", "Procedure").
+	Text("created_on").
+	Text("name").
+	Text("schema_name", g.WithManualConvert()).
+	BoolFromText("is_builtin").
+	BoolFromText("is_aggregate").
+	BoolFromText("is_ansi").
+	Number("min_num_arguments").
+	Number("max_num_arguments").
+	Text("arguments", g.WithPlainFieldName("ArgumentsRaw")).
+	Text("description").
+	Text("catalog_name", g.WithManualConvert()).
+	BoolFromText("is_table_function").
+	BoolFromText("valid_for_clustering").
+	OptionalBoolFromText("is_secure", g.WithRequiredInPlain()).
+	OptionalText("secrets").
+	OptionalText("external_access_integrations").
+	WithConvertGeneration()
+
+var procedureDetailPairs = g.StructPair("procedureDetailRow", "ProcedureDetail").
+	Text("property").
+	OptionalText("value", g.WithManualConvert()).
+	WithConvertGeneration()
+
 var proceduresDef = g.NewInterface(
 	"Procedures",
 	"Procedure",
@@ -334,44 +359,9 @@ var proceduresDef = g.NewInterface(
 		IfExists().
 		Name().
 		WithValidation(g.ValidIdentifier, "name"),
-).ShowOperation(
+).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-procedures",
-	g.DbStruct("procedureRow").
-		Field("created_on", "string").
-		Field("name", "string").
-		Field("schema_name", "string").
-		Field("is_builtin", "string").
-		Field("is_aggregate", "string").
-		Field("is_ansi", "string").
-		Field("min_num_arguments", "int").
-		Field("max_num_arguments", "int").
-		Field("arguments", "string").
-		Field("description", "string").
-		Field("catalog_name", "string").
-		Field("is_table_function", "string").
-		Field("valid_for_clustering", "string").
-		Field("is_secure", "sql.NullString").
-		OptionalText("secrets").
-		OptionalText("external_access_integrations"),
-	g.PlainStruct("Procedure").
-		Field("CreatedOn", "string").
-		Field("Name", "string").
-		Field("SchemaName", "string").
-		Field("IsBuiltin", "bool").
-		Field("IsAggregate", "bool").
-		Field("IsAnsi", "bool").
-		Field("MinNumArguments", "int").
-		Field("MaxNumArguments", "int").
-		Field("ArgumentsOld", "[]DataType").
-		Field("ReturnTypeOld", "DataType").
-		Field("ArgumentsRaw", "string").
-		Field("Description", "string").
-		Field("CatalogName", "string").
-		Field("IsTableFunction", "bool").
-		Field("ValidForClustering", "bool").
-		Field("IsSecure", "bool").
-		OptionalText("Secrets").
-		OptionalText("ExternalAccessIntegrations"),
+	procedurePairs,
 	g.NewQueryStruct("ShowProcedures").
 		Show().
 		SQL("PROCEDURES").
@@ -379,15 +369,10 @@ var proceduresDef = g.NewInterface(
 		OptionalExtendedIn(),
 	g.ShowByIDInFiltering,
 	g.ShowByIDLikeFiltering,
-).DescribeOperation(
+).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSlice,
 	"https://docs.snowflake.com/en/sql-reference/sql/desc-procedure",
-	g.DbStruct("procedureDetailRow").
-		Field("property", "string").
-		Field("value", "sql.NullString"),
-	g.PlainStruct("ProcedureDetail").
-		Field("Property", "string").
-		OptionalText("Value"),
+	procedureDetailPairs,
 	g.NewQueryStruct("DescribeProcedure").
 		Describe().
 		SQL("PROCEDURE").

--- a/pkg/sdk/generator/defs/tasks_def.go
+++ b/pkg/sdk/generator/defs/tasks_def.go
@@ -17,7 +17,7 @@ var taskPairs = g.StructPair("taskDBRow", "Task").
 	Field("warehouse", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("Warehouse"), g.WithManualConvert()).
 	OptionalText("schedule", g.WithRequiredInPlain()).
 	Field("predecessors", "string", "[]SchemaObjectIdentifier", g.WithManualConvert()).
-	PlainField("state", "TaskState", g.WithCustomParser("ToTaskState")).
+	PlainField("state", "TaskState", g.WithManualConvert()).
 	Text("definition").
 	OptionalText("condition", g.WithRequiredInPlain()).
 	Field("allow_overlapping_execution", "string", "bool", g.WithBoolTrueValue("true")).

--- a/pkg/sdk/generator/defs/tasks_def.go
+++ b/pkg/sdk/generator/defs/tasks_def.go
@@ -14,14 +14,14 @@ var taskPairs = g.StructPair("taskDBRow", "Task").
 	Text("schema_name").
 	Text("owner").
 	OptionalText("comment", g.WithRequiredInPlain()).
-	Field("warehouse", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("Warehouse")).
+	Field("warehouse", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("Warehouse"), g.WithManualConvert()).
 	OptionalText("schedule", g.WithRequiredInPlain()).
-	Field("predecessors", "string", "[]SchemaObjectIdentifier").
+	Field("predecessors", "string", "[]SchemaObjectIdentifier", g.WithManualConvert()).
 	PlainField("state", "TaskState", g.WithCustomParser("ToTaskState")).
 	Text("definition").
 	OptionalText("condition", g.WithRequiredInPlain()).
 	Field("allow_overlapping_execution", "string", "bool", g.WithBoolTrueValue("true")).
-	Field("error_integration", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("ErrorIntegration")).
+	Field("error_integration", "sql.NullString", "*AccountObjectIdentifier", g.WithPlainFieldName("ErrorIntegration"), g.WithManualConvert()).
 	OptionalText("last_committed_on", g.WithRequiredInPlain()).
 	OptionalText("last_suspended_on", g.WithRequiredInPlain()).
 	Text("owner_role_type").
@@ -29,7 +29,8 @@ var taskPairs = g.StructPair("taskDBRow", "Task").
 	OptionalText("budget", g.WithRequiredInPlain()).
 	PlainField("task_relations", "TaskRelations", g.WithCustomParser("ToTaskRelations")).
 	OptionalText("last_suspended_reason", g.WithRequiredInPlain()).
-	Field("target_completion_interval", "sql.NullString", "*TaskTargetCompletionInterval", g.WithPlainFieldName("TargetCompletionInterval"))
+	Field("target_completion_interval", "sql.NullString", "*TaskTargetCompletionInterval", g.WithPlainFieldName("TargetCompletionInterval"), g.WithManualConvert()).
+	WithConvertGeneration()
 
 var taskCreateWarehouse = g.NewQueryStruct("CreateTaskWarehouse").
 	OptionalIdentifier("Warehouse", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().Equals().SQL("WAREHOUSE")).

--- a/pkg/sdk/generator/gen/field_pair.go
+++ b/pkg/sdk/generator/gen/field_pair.go
@@ -18,12 +18,15 @@ type FieldPair struct {
 	CustomParser   string
 	BoolTrueValue  string
 	BoolParsed     bool
+
+	manualConvert bool
 }
 
 // AssignmentKind is the conversion strategy discriminator used in convert.tmpl.
 type AssignmentKind string
 
 const (
+	AssignmentKindManual                             AssignmentKind = "Manual"
 	AssignmentKindDirect                             AssignmentKind = "Direct"
 	AssignmentKindStringToBool                       AssignmentKind = "StringToBool"
 	AssignmentKindStringToBoolValue                  AssignmentKind = "StringToBoolValue"
@@ -48,6 +51,10 @@ const (
 	AssignmentKindNullableStringToIdentifierArray    AssignmentKind = "NullableStringToIdentifierArray"
 	AssignmentKindUnsupported                        AssignmentKind = "Unsupported"
 )
+
+func (fp FieldPair) AssignmentKindManual() bool {
+	return fp.AssignmentKind() == AssignmentKindManual
+}
 
 func (fp FieldPair) AssignmentKindDirect() bool {
 	return fp.AssignmentKind() == AssignmentKindDirect
@@ -146,6 +153,10 @@ func (fp FieldPair) IdentifierArrayElementType() string {
 // AssignmentKind returns the conversion strategy for this field pair.
 // The returned value is used as a discriminator via the boolean predicate methods below.
 func (fp FieldPair) AssignmentKind() AssignmentKind {
+	if fp.manualConvert {
+		return AssignmentKindManual
+	}
+
 	if fp.CustomParser != "" {
 		return AssignmentKindCustom
 	}

--- a/pkg/sdk/generator/gen/operation.go
+++ b/pkg/sdk/generator/gen/operation.go
@@ -89,6 +89,17 @@ type Mapping struct {
 	FieldPairs []FieldPair
 }
 
+// HasManualConvert reports whether any field in this Mapping is marked as manual convert.
+// When true, the generated convert() will call r.additionalConvert(result) after all generated mappings.
+func (m *Mapping) HasManualConvert() bool {
+	for _, f := range m.FieldPairs {
+		if f.manualConvert {
+			return true
+		}
+	}
+	return false
+}
+
 func newOperation(kind string, doc string) *Operation {
 	return &Operation{
 		Name:          kind,

--- a/pkg/sdk/generator/gen/paired_struct.go
+++ b/pkg/sdk/generator/gen/paired_struct.go
@@ -69,6 +69,18 @@ func WithBoolTrueValue(v string) PairedFieldOption {
 	}
 }
 
+// WithManualConvert marks this field to be skipped in the generated convert() body.
+// Use this when the field's conversion requires logic that cannot be expressed by the generator
+// (e.g. row-context-dependent parsing, non-standard null exclusion strings).
+// The field must then be handled manually inside the additionalConvert() method.
+// When any field carries WithManualConvert(), the generated convert() automatically emits
+// a call to r.additionalConvert(result) — no separate WithConvertHook() is needed.
+func WithManualConvert() PairedFieldOption {
+	return func(f *pairedField) {
+		f.manualConvert = true
+	}
+}
+
 // WithBoolParsed routes string → bool or sql.NullString → bool conversions through strconv.ParseBool
 // instead of a fixed string comparison. Use when the db column returns "true"/"false" and robust
 // parsing is preferred over a hard-coded truthy value.
@@ -103,6 +115,8 @@ type pairedField struct {
 	boolTrueValue string
 	// boolParsed routes string/NullString → bool conversions through strconv.ParseBool.
 	boolParsed bool
+	// manualConvert marks this field to be skipped in generated convert code.
+	manualConvert bool
 }
 
 // resolvedPlainFieldName returns the explicit override or the CamelCase conversion of dbColumnName.
@@ -427,6 +441,7 @@ func (p *PairedStructs) toFieldPairs() []FieldPair {
 			CustomParser:   f.customParser,
 			BoolTrueValue:  f.boolTrueValue,
 			BoolParsed:     f.boolParsed,
+			manualConvert:  f.manualConvert,
 		}
 	}
 	return pairs

--- a/pkg/sdk/generator/gen/paired_struct.go
+++ b/pkg/sdk/generator/gen/paired_struct.go
@@ -208,6 +208,22 @@ func (p *PairedStructs) OptionalBool(dbColumnName string, opts ...PairedFieldOpt
 	return p.addField(dbColumnName, "sql.NullBool", "*bool", opts)
 }
 
+// BoolFromText adds a non-nullable boolean field to the plain struct converted from non-nullable string value ("Y" by default).
+//
+//	db:    <FieldName> string `db:"<dbColumnName>"`
+//	plain: <FieldName> bool
+func (p *PairedStructs) BoolFromText(dbColumnName string, opts ...PairedFieldOption) *PairedStructs {
+	return p.addField(dbColumnName, "string", "bool", opts)
+}
+
+// OptionalBoolFromText adds a nullable boolean field to the plain struct converted from nullable string value ("Y" by default).
+//
+//	db:    <FieldName> sql.NullString `db:"<dbColumnName>"`
+//	plain: <FieldName> *bool
+func (p *PairedStructs) OptionalBoolFromText(dbColumnName string, opts ...PairedFieldOption) *PairedStructs {
+	return p.addField(dbColumnName, "sql.NullString", "*bool", opts)
+}
+
 // Number adds a non-nullable integer field to both the db row struct and the plain struct.
 //
 //	db:    <FieldName> int `db:"<dbColumnName>"`

--- a/pkg/sdk/generator/gen/templates/sub_templates/convert.tmpl
+++ b/pkg/sdk/generator/gen/templates/sub_templates/convert.tmpl
@@ -10,6 +10,7 @@ func (r {{ .From.Name }}) {{ .MappingFuncName }}() (*{{ .To.KindNoPtr }}, error)
             {{ .PlainFieldName }}: r.{{ .DbFieldName }} == "Y",
         {{- else if .AssignmentKindStringToBoolValue }}
             {{ .PlainFieldName }}: r.{{ .DbFieldName }} == "{{ .BoolTrueValue }}",
+        {{- else if .AssignmentKindManual }}
         {{- end }}
     {{- end }}
     }
@@ -69,9 +70,15 @@ func (r {{ .From.Name }}) {{ .MappingFuncName }}() (*{{ .To.KindNoPtr }}, error)
             		result.{{ .PlainFieldName }} = ids
             	}
             }
+        {{- else if .AssignmentKindManual }}
         {{- else }}
             // TODO: Mapping for {{ .PlainFieldName }} ({{ .DbKind }} -> {{ .PlainKind }})
         {{- end }}
+    {{- end }}
+    {{- if .HasManualConvert }}
+        if err := r.additionalConvert(result); err != nil {
+            return nil, err
+        }
     {{- end }}
     return result, nil
 {{- else }}

--- a/pkg/sdk/postgres_instances_ext.go
+++ b/pkg/sdk/postgres_instances_ext.go
@@ -3,34 +3,3 @@ package sdk
 func (r *CreatePostgresInstanceRequest) GetName() AccountObjectIdentifier {
 	return r.name
 }
-
-func (r postgresInstancesRow) convert() (*PostgresInstance, error) {
-	pi := &PostgresInstance{
-		Name:                    r.Name,
-		Owner:                   r.Owner,
-		OwnerRoleType:           r.OwnerRoleType,
-		CreatedOn:               r.CreatedOn,
-		UpdatedOn:               r.UpdatedOn,
-		Type:                    r.Type,
-		ComputeFamily:           r.ComputeFamily,
-		AuthenticationAuthority: r.AuthenticationAuthority,
-		StorageSize:             r.StorageSize,
-		PostgresVersion:         r.PostgresVersion,
-		IsHa:                    r.IsHa == "true",
-		RetentionTime:           r.RetentionTime,
-	}
-	mapNullString(&pi.Origin, r.Origin)
-	mapNullString(&pi.Host, r.Host)
-	mapNullString(&pi.PrivatelinkServiceIdentifier, r.PrivatelinkServiceIdentifier)
-	mapNullString(&pi.PostgresSettings, r.PostgresSettings)
-	mapNullString(&pi.Comment, r.Comment)
-	mapStringWithMapping(&pi.State, r.State, ToPostgresInstanceState)
-	return pi, nil
-}
-
-func (r postgresInstanceDetailsRow) convert() (*PostgresInstanceProperty, error) {
-	return &PostgresInstanceProperty{
-		Property: r.Property,
-		Value:    r.Value.String,
-	}, nil
-}

--- a/pkg/sdk/postgres_instances_gen.go
+++ b/pkg/sdk/postgres_instances_gen.go
@@ -42,9 +42,9 @@ type ForkPostgresInstanceOptions struct {
 	create           bool                        `ddl:"static" sql:"CREATE"`
 	postgresInstance bool                        `ddl:"static" sql:"POSTGRES INSTANCE"`
 	name             AccountObjectIdentifier     `ddl:"identifier"`
-	Fork             AccountObjectIdentifier     `ddl:"identifier,required" sql:"FORK"`
-	At               *PostgresInstanceForkAt     `ddl:"list,parentheses,no_comma" sql:"AT"`
-	Before           *PostgresInstanceForkBefore `ddl:"list,parentheses,no_comma" sql:"BEFORE"`
+	Fork             AccountObjectIdentifier     `ddl:"identifier,required" sql:"FORK"`         // adjusted manually - adjust def
+	At               *PostgresInstanceForkAt     `ddl:"list,parentheses,no_comma" sql:"AT"`     // adjusted manually - adjust def
+	Before           *PostgresInstanceForkBefore `ddl:"list,parentheses,no_comma" sql:"BEFORE"` // adjusted manually - adjust def
 	ComputeFamily    *string                     `ddl:"parameter,single_quotes" sql:"COMPUTE_FAMILY"`
 	StorageSizeGb    *int                        `ddl:"parameter" sql:"STORAGE_SIZE_GB"`
 	HighAvailability *bool                       `ddl:"parameter" sql:"HIGH_AVAILABILITY"`
@@ -95,7 +95,7 @@ type PostgresInstanceSet struct {
 
 type PostgresInstanceApply struct {
 	Immediately *bool   `ddl:"keyword" sql:"IMMEDIATELY"`
-	On          *string `ddl:"parameter,single_quotes,no_equals" sql:"ON"`
+	On          *string `ddl:"parameter,single_quotes,no_equals" sql:"ON"` // adjusted manually - adjust def
 }
 
 type PostgresInstanceUnset struct {
@@ -107,7 +107,7 @@ type PostgresInstanceUnset struct {
 }
 
 type PostgresInstanceResetAccess struct {
-	For PostgresInstanceResetAccessRole `ddl:"parameter,single_quotes,no_equals" sql:"FOR"`
+	For PostgresInstanceResetAccessRole `ddl:"parameter,single_quotes,no_equals" sql:"FOR"` // adjusted manually - adjust def
 }
 
 // DropPostgresInstanceOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-postgres-instance.

--- a/pkg/sdk/postgres_instances_impl_gen.go
+++ b/pkg/sdk/postgres_instances_impl_gen.go
@@ -184,9 +184,41 @@ func (r *ShowPostgresInstanceRequest) toOpts() *ShowPostgresInstanceOptions {
 	return opts
 }
 
+func (r postgresInstancesRow) convert() (*PostgresInstance, error) {
+	result := &PostgresInstance{
+		Name:                    r.Name,
+		Owner:                   r.Owner,
+		OwnerRoleType:           r.OwnerRoleType,
+		CreatedOn:               r.CreatedOn,
+		UpdatedOn:               r.UpdatedOn,
+		Type:                    r.Type,
+		ComputeFamily:           r.ComputeFamily,
+		AuthenticationAuthority: r.AuthenticationAuthority,
+		StorageSize:             r.StorageSize,
+		PostgresVersion:         r.PostgresVersion,
+		IsHa:                    r.IsHa == "true",
+		RetentionTime:           r.RetentionTime,
+	}
+	mapNullString(&result.Origin, r.Origin)
+	mapNullString(&result.Host, r.Host)
+	mapNullString(&result.PrivatelinkServiceIdentifier, r.PrivatelinkServiceIdentifier)
+	mapNullString(&result.PostgresSettings, r.PostgresSettings)
+	mapStringWithMapping(&result.State, r.State, ToPostgresInstanceState)
+	mapNullString(&result.Comment, r.Comment)
+	return result, nil
+}
+
 func (r *DescribePostgresInstanceRequest) toOpts() *DescribePostgresInstanceOptions {
 	opts := &DescribePostgresInstanceOptions{
 		name: r.name,
 	}
 	return opts
+}
+
+func (r postgresInstanceDetailsRow) convert() (*PostgresInstanceProperty, error) {
+	result := &PostgresInstanceProperty{
+		Property: r.Property,
+	}
+	mapNullStringToNonNullableField(&result.Value, r.Value)
+	return result, nil
 }

--- a/pkg/sdk/procedures_ext.go
+++ b/pkg/sdk/procedures_ext.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 )
 
@@ -417,4 +418,27 @@ func (t *ProcedureReturnsTable) additionalValidations() error {
 		}
 	}
 	return JoinErrors(errs...)
+}
+
+func (r procedureRow) additionalConvert(result *Procedure) error {
+	result.SchemaName = strings.Trim(r.SchemaName, `"`)
+	result.CatalogName = strings.Trim(r.CatalogName, `"`)
+	arguments := strings.TrimLeft(r.Arguments, r.Name)
+	returnIndex := strings.Index(arguments, ") RETURN ")
+	result.ReturnTypeOld = DataType(arguments[returnIndex+len(") RETURN "):])
+	parsedArguments, err := ParseFunctionAndProcedureArguments(arguments[:returnIndex+1])
+	if err != nil {
+		return fmt.Errorf("failed to parse procedure arguments: %w", err)
+	}
+	result.ArgumentsOld = collections.Map(parsedArguments, func(a ParsedArgument) DataType {
+		return DataType(a.ArgType)
+	})
+	return nil
+}
+
+func (r procedureDetailRow) additionalConvert(result *ProcedureDetail) error {
+	if r.Value.Valid && r.Value.String != "null" {
+		result.Value = String(r.Value.String)
+	}
+	return nil
 }

--- a/pkg/sdk/procedures_gen.go
+++ b/pkg/sdk/procedures_gen.go
@@ -272,8 +272,8 @@ type Procedure struct {
 	IsAnsi                     bool
 	MinNumArguments            int
 	MaxNumArguments            int
-	ArgumentsOld               []DataType
-	ReturnTypeOld              DataType
+	ArgumentsOld               []DataType // added manually
+	ReturnTypeOld              DataType   // added manually
 	ArgumentsRaw               string
 	Description                string
 	CatalogName                string

--- a/pkg/sdk/procedures_impl_gen.go
+++ b/pkg/sdk/procedures_impl_gen.go
@@ -2,11 +2,8 @@
 
 package sdk
 
-// imports adjusted manually
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
@@ -487,11 +484,9 @@ func (r *ShowProcedureRequest) toOpts() *ShowProcedureOptions {
 }
 
 func (r procedureRow) convert() (*Procedure, error) {
-	// adjusted manually
-	e := &Procedure{
+	result := &Procedure{
 		CreatedOn:          r.CreatedOn,
 		Name:               r.Name,
-		SchemaName:         strings.Trim(r.SchemaName, `"`),
 		IsBuiltin:          r.IsBuiltin == "Y",
 		IsAggregate:        r.IsAggregate == "Y",
 		IsAnsi:             r.IsAnsi == "Y",
@@ -499,25 +494,16 @@ func (r procedureRow) convert() (*Procedure, error) {
 		MaxNumArguments:    r.MaxNumArguments,
 		ArgumentsRaw:       r.Arguments,
 		Description:        r.Description,
-		CatalogName:        strings.Trim(r.CatalogName, `"`),
 		IsTableFunction:    r.IsTableFunction == "Y",
 		ValidForClustering: r.ValidForClustering == "Y",
 	}
-	arguments := strings.TrimLeft(r.Arguments, r.Name)
-	returnIndex := strings.Index(arguments, ") RETURN ")
-	e.ReturnTypeOld = DataType(arguments[returnIndex+len(") RETURN "):])
-	parsedArguments, err := ParseFunctionAndProcedureArguments(arguments[:returnIndex+1])
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse procedure arguments: %w", err)
-	} else {
-		e.ArgumentsOld = collections.Map(parsedArguments, func(a ParsedArgument) DataType {
-			return DataType(a.ArgType)
-		})
+	mapNullStringToRequiredBool(&result.IsSecure, r.IsSecure)
+	mapNullString(&result.Secrets, r.Secrets)
+	mapNullString(&result.ExternalAccessIntegrations, r.ExternalAccessIntegrations)
+	if err := r.additionalConvert(result); err != nil {
+		return nil, err
 	}
-	if r.IsSecure.Valid {
-		e.IsSecure = r.IsSecure.String == "Y"
-	}
-	return e, nil
+	return result, nil
 }
 
 func (r *DescribeProcedureRequest) toOpts() *DescribeProcedureOptions {
@@ -528,14 +514,13 @@ func (r *DescribeProcedureRequest) toOpts() *DescribeProcedureOptions {
 }
 
 func (r procedureDetailRow) convert() (*ProcedureDetail, error) {
-	// adjusted manually
-	e := &ProcedureDetail{
+	result := &ProcedureDetail{
 		Property: r.Property,
 	}
-	if r.Value.Valid && r.Value.String != "null" {
-		e.Value = String(r.Value.String)
+	if err := r.additionalConvert(result); err != nil {
+		return nil, err
 	}
-	return e, nil
+	return result, nil
 }
 
 func (r *CallProcedureRequest) toOpts() *CallProcedureOptions {

--- a/pkg/sdk/tasks_ext.go
+++ b/pkg/sdk/tasks_ext.go
@@ -349,6 +349,14 @@ func (r taskDBRow) additionalConvert(result *Task) error {
 		}
 		result.Warehouse = &id
 	}
+	if len(r.State) > 0 {
+		taskState, err := ToTaskState(r.State)
+		if err != nil {
+			return fmt.Errorf("failed to convert to task state: %w", err)
+		} else {
+			result.State = taskState
+		}
+	}
 	if len(r.Predecessors) > 0 {
 		names, err := getPredecessors(r.Predecessors)
 		ids := make([]SchemaObjectIdentifier, len(names))

--- a/pkg/sdk/tasks_ext.go
+++ b/pkg/sdk/tasks_ext.go
@@ -313,3 +313,67 @@ func parseTargetCompletionInterval(interval string) (*TaskTargetCompletionInterv
 		return nil, fmt.Errorf("invalid task target completion interval unit: %s", unit)
 	}
 }
+
+// getPredecessors parses the JSON-encoded predecessors string returned by Snowflake.
+// Since 2022_03, Snowflake returns this as a JSON array (even when empty).
+// The list is formatted, e.g.:
+// `[\n  \"\\\"qgb)Z1KcNWJ(\\\".\\\"glN@JtR=7dzP$7\\\".\\\"_XEL(7N_F?@frgT5>dQS>V|vSy,J\\\"\"\n]`.
+func getPredecessors(predecessors string) ([]string, error) {
+	predecessorNames := make([]string, 0)
+	err := json.Unmarshal([]byte(predecessors), &predecessorNames)
+	if err == nil {
+		for i, predecessorName := range predecessorNames {
+			formattedName := strings.Trim(predecessorName, "\\\"")
+			idx := strings.LastIndex(formattedName, "\"") + 1
+			// -1 because of not found +1 is 0
+			if idx == 0 {
+				idx = strings.LastIndex(formattedName, ".") + 1
+			} else if strings.LastIndex(formattedName, ".\"")+2 < idx {
+				idx++
+			}
+			formattedName = formattedName[idx:]
+			predecessorNames[i] = formattedName
+		}
+	}
+	return predecessorNames, err
+}
+
+// additionalConvert handles the four fields in taskDBRow that cannot be expressed
+// by the generator: predecessors (JSON + row context), warehouse / error_integration
+// ("null" string exclusion), and target_completion_interval (custom parser).
+func (r taskDBRow) additionalConvert(result *Task) error {
+	if r.Warehouse.Valid && r.Warehouse.String != "null" {
+		id, err := ParseAccountObjectIdentifier(r.Warehouse.String)
+		if err != nil {
+			return fmt.Errorf("failed to parse warehouse: %w", err)
+		}
+		result.Warehouse = &id
+	}
+	if len(r.Predecessors) > 0 {
+		names, err := getPredecessors(r.Predecessors)
+		ids := make([]SchemaObjectIdentifier, len(names))
+		if err == nil {
+			for i, name := range names {
+				ids[i] = NewSchemaObjectIdentifier(r.DatabaseName, r.SchemaName, name)
+			}
+		}
+		result.Predecessors = ids
+	} else {
+		result.Predecessors = make([]SchemaObjectIdentifier, 0)
+	}
+	if r.ErrorIntegration.Valid && r.ErrorIntegration.String != "null" {
+		id, err := ParseAccountObjectIdentifier(r.ErrorIntegration.String)
+		if err != nil {
+			return fmt.Errorf("failed to parse error_integration: %w", err)
+		}
+		result.ErrorIntegration = &id
+	}
+	if r.TargetCompletionInterval.Valid {
+		targetCompletionInterval, err := parseTargetCompletionInterval(r.TargetCompletionInterval.String)
+		if err != nil {
+			return fmt.Errorf("failed to parse target completion interval: %w", err)
+		}
+		result.TargetCompletionInterval = targetCompletionInterval
+	}
+	return nil
+}

--- a/pkg/sdk/tasks_impl_gen.go
+++ b/pkg/sdk/tasks_impl_gen.go
@@ -2,12 +2,9 @@
 
 package sdk
 
-// imports adjusted manually
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
@@ -253,11 +250,10 @@ func (r *ShowTaskRequest) toOpts() *ShowTaskOptions {
 }
 
 func (r taskDBRow) convert() (*Task, error) {
-	// adjusted manually
-	task := Task{
+	result := &Task{
 		CreatedOn:                 r.CreatedOn,
-		Id:                        r.Id,
 		Name:                      r.Name,
+		Id:                        r.Id,
 		DatabaseName:              r.DatabaseName,
 		SchemaName:                r.SchemaName,
 		Owner:                     r.Owner,
@@ -265,107 +261,28 @@ func (r taskDBRow) convert() (*Task, error) {
 		AllowOverlappingExecution: r.AllowOverlappingExecution == "true",
 		OwnerRoleType:             r.OwnerRoleType,
 	}
-	if r.TaskRelations != "" {
-		taskRelations, err := ToTaskRelations(r.TaskRelations)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert task relations: %w", err)
-		} else {
-			task.TaskRelations = taskRelations
-		}
-	}
-	if r.Comment.Valid {
-		task.Comment = r.Comment.String
-	}
-	if r.Warehouse.Valid && r.Warehouse.String != "null" {
-		id, err := ParseAccountObjectIdentifier(r.Warehouse.String)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse warehouse: %w", err)
-		} else {
-			task.Warehouse = &id
-		}
-	}
-	if r.Schedule.Valid {
-		task.Schedule = r.Schedule.String
-	}
-	if len(r.Predecessors) > 0 {
-		names, err := getPredecessors(r.Predecessors)
-		ids := make([]SchemaObjectIdentifier, len(names))
-		if err == nil {
-			for i, name := range names {
-				ids[i] = NewSchemaObjectIdentifier(r.DatabaseName, r.SchemaName, name)
-			}
-		}
-		task.Predecessors = ids
+	mapNullStringToNonNullableField(&result.Comment, r.Comment)
+	mapNullStringToNonNullableField(&result.Schedule, r.Schedule)
+	if v, err := ToTaskState(r.State); err == nil {
+		result.State = v
 	} else {
-		task.Predecessors = make([]SchemaObjectIdentifier, 0)
+		return nil, fmt.Errorf("parsing task state: %w", err)
 	}
-	if len(r.State) > 0 {
-		taskState, err := ToTaskState(r.State)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert to task state: %w", err)
-		} else {
-			task.State = taskState
-		}
+	mapNullStringToNonNullableField(&result.Condition, r.Condition)
+	mapNullStringToNonNullableField(&result.LastCommittedOn, r.LastCommittedOn)
+	mapNullStringToNonNullableField(&result.LastSuspendedOn, r.LastSuspendedOn)
+	mapNullStringToNonNullableField(&result.Config, r.Config)
+	mapNullStringToNonNullableField(&result.Budget, r.Budget)
+	if v, err := ToTaskRelations(r.TaskRelations); err == nil {
+		result.TaskRelations = v
+	} else {
+		return nil, fmt.Errorf("parsing task relations: %w", err)
 	}
-	if r.Condition.Valid {
-		task.Condition = r.Condition.String
+	mapNullStringToNonNullableField(&result.LastSuspendedReason, r.LastSuspendedReason)
+	if err := r.additionalConvert(result); err != nil {
+		return nil, err
 	}
-	if r.ErrorIntegration.Valid && r.ErrorIntegration.String != "null" {
-		id, err := ParseAccountObjectIdentifier(r.ErrorIntegration.String)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse error_integration: %w", err)
-		} else {
-			task.ErrorIntegration = &id
-		}
-	}
-	if r.LastCommittedOn.Valid {
-		task.LastCommittedOn = r.LastCommittedOn.String
-	}
-	if r.LastSuspendedOn.Valid {
-		task.LastSuspendedOn = r.LastSuspendedOn.String
-	}
-	if r.Config.Valid {
-		task.Config = r.Config.String
-	}
-	if r.Budget.Valid {
-		task.Budget = r.Budget.String
-	}
-	if r.LastSuspendedReason.Valid {
-		task.LastSuspendedReason = r.LastSuspendedReason.String
-	}
-	if r.TargetCompletionInterval.Valid {
-		targetCompletionInterval, err := parseTargetCompletionInterval(r.TargetCompletionInterval.String)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse target completion interval: %w", err)
-		} else {
-			task.TargetCompletionInterval = targetCompletionInterval
-		}
-	}
-	return &task, nil
-}
-
-// added manually
-func getPredecessors(predecessors string) ([]string, error) {
-	// Since 2022_03, Snowflake returns this as a JSON array (even empty)
-	// The list is formatted, e.g.:
-	// e.g. `[\n  \"\\\"qgb)Z1KcNWJ(\\\".\\\"glN@JtR=7dzP$7\\\".\\\"_XEL(7N_F?@frgT5>dQS>V|vSy,J\\\"\"\n]`.
-	predecessorNames := make([]string, 0)
-	err := json.Unmarshal([]byte(predecessors), &predecessorNames)
-	if err == nil {
-		for i, predecessorName := range predecessorNames {
-			formattedName := strings.Trim(predecessorName, "\\\"")
-			idx := strings.LastIndex(formattedName, "\"") + 1
-			// -1 because of not found +1 is 0
-			if idx == 0 {
-				idx = strings.LastIndex(formattedName, ".") + 1
-			} else if strings.LastIndex(formattedName, ".\"")+2 < idx {
-				idx++
-			}
-			formattedName = formattedName[idx:]
-			predecessorNames[i] = formattedName
-		}
-	}
-	return predecessorNames, err
+	return result, nil
 }
 
 func (r *DescribeTaskRequest) toOpts() *DescribeTaskOptions {

--- a/pkg/sdk/tasks_impl_gen.go
+++ b/pkg/sdk/tasks_impl_gen.go
@@ -263,11 +263,6 @@ func (r taskDBRow) convert() (*Task, error) {
 	}
 	mapNullStringToNonNullableField(&result.Comment, r.Comment)
 	mapNullStringToNonNullableField(&result.Schedule, r.Schedule)
-	if v, err := ToTaskState(r.State); err == nil {
-		result.State = v
-	} else {
-		return nil, fmt.Errorf("parsing task state: %w", err)
-	}
 	mapNullStringToNonNullableField(&result.Condition, r.Condition)
 	mapNullStringToNonNullableField(&result.LastCommittedOn, r.LastCommittedOn)
 	mapNullStringToNonNullableField(&result.LastSuspendedOn, r.LastSuspendedOn)

--- a/pkg/sdk/testint/procedures_integration_test.go
+++ b/pkg/sdk/testint/procedures_integration_test.go
@@ -96,8 +96,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExternalAccessIntegrations("").
+			HasSecrets(""),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, procedure.ID()).
@@ -169,10 +169,10 @@ func TestInt_Procedures(t *testing.T) {
 		t.Cleanup(testClientHelper().Procedure.DropProcedureFunc(t, id))
 		t.Cleanup(testClientHelper().Stage.RemoveFromUserStageFunc(t, jarName))
 
-		function, err := client.Procedures.ShowByID(ctx, id)
+		proc, err := client.Procedures.ShowByID(ctx, id)
 		require.NoError(t, err)
 
-		assertThatObject(t, objectassert.ProcedureFromObject(t, function).
+		assertThatObject(t, objectassert.ProcedureFromObject(t, proc).
 			HasCreatedOnNotEmpty().
 			HasName(id.Name()).
 			HasSchemaName(id.SchemaName()).
@@ -183,18 +183,17 @@ func TestInt_Procedures(t *testing.T) {
 			HasMaxNumArguments(1).
 			HasArgumentsOld(sdk.LegacyDataTypeFrom(dataType)).
 			HasReturnTypeOld(sdk.LegacyDataTypeFrom(dataType)).
-			HasArgumentsRaw(fmt.Sprintf(`%[1]s(%[2]s) RETURN %[2]s`, function.ID().Name(), dataType.ToLegacyDataTypeSql())).
+			HasArgumentsRaw(fmt.Sprintf(`%[1]s(%[2]s) RETURN %[2]s`, proc.ID().Name(), dataType.ToLegacyDataTypeSql())).
 			HasDescription("comment").
 			HasCatalogName(id.DatabaseName()).
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			// TODO [SNOW-1850370]: apparently external access integrations and secrets are not filled out correctly for procedures
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
+			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}),
 		)
 
-		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
+		assertThatObject(t, objectassert.ProcedureDetails(t, proc.ID()).
 			HasSignature(fmt.Sprintf(`(%s %s)`, argName, dataType.ToLegacyDataTypeSql())).
 			HasReturns(fmt.Sprintf(`%s NOT NULL`, dataType.ToSql())).
 			HasReturnDataType(dataType).
@@ -271,8 +270,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExternalAccessIntegrations("").
+			HasSecrets(""),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -358,8 +357,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
+			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -507,8 +506,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExternalAccessIntegrations("").
+			HasSecrets(""),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -581,8 +580,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExternalAccessIntegrations("").
+			HasSecrets(""),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -655,8 +654,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExternalAccessIntegrations("").
+			HasSecrets(""),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -743,8 +742,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
+			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -820,8 +819,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExternalAccessIntegrations("").
+			HasSecrets(""),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -907,8 +906,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
+			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -988,8 +987,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExternalAccessIntegrations("").
+			HasSecrets(""),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -1083,8 +1082,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
+			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -1161,8 +1160,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExternalAccessIntegrations("").
+			HasSecrets(""),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -1250,8 +1249,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExactlyExternalAccessIntegrations(externalAccessIntegration).
+			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -1324,8 +1323,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExternalAccessIntegrations("").
+			HasSecrets(""),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -1429,8 +1428,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExternalAccessIntegrations("").
+			HasSecrets(""),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -1497,8 +1496,8 @@ func TestInt_Procedures(t *testing.T) {
 			HasIsTableFunction(false).
 			HasValidForClustering(false).
 			HasIsSecure(false).
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExternalAccessIntegrations("").
+			HasSecrets(""),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, function.ID()).
@@ -1956,9 +1955,8 @@ def filter_by_role(session, table_name, role):
 		assertThatObject(t, objectassert.Procedure(t, id).
 			HasName(id.Name()).
 			HasDescription(sdk.DefaultProcedureComment).
-			// both nil, because they are always nil in SHOW for procedures
-			HasExternalAccessIntegrationsNil().
-			HasSecretsNil(),
+			HasExactlyExternalAccessIntegrations().
+			HasExactlySecrets(map[string]sdk.SchemaObjectIdentifier{"abc": secretId}),
 		)
 
 		assertThatObject(t, objectassert.ProcedureDetails(t, id).


### PR DESCRIPTION
Continuation of https://github.com/snowflakedb/terraform-provider-snowflake/pull/4780

- Add the manual conversion for unsupported conversions (similar to additional validations)
  - if there is any manual conversion, then the block is added automatically
- Adjust all functions, procedures, external functions, and tasks definitions (db/plain struct -> pairedStruct)
  - note that fields existing in a sibgle struct only are still edited manually - it will be addressed in the next PR
- Fix procedure tests (note that earlier there was no mapping for external integrations and secretc for show procedures)