### PR TITLE
chore: Generate convert for more SDK objects - part 8

### DIFF
--- a/pkg/sdk/authentication_policies_ext.go
+++ b/pkg/sdk/authentication_policies_ext.go
@@ -7,6 +7,10 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
 
+func (r showAuthenticationPolicyDBRow) excludeFromShow() bool {
+	return !r.DatabaseName.Valid || !r.SchemaName.Valid
+}
+
 func (r showAuthenticationPolicyDBRow) additionalConvert(result *AuthenticationPolicy) error {
 	var errs []error
 	if !r.DatabaseName.Valid {

--- a/pkg/sdk/authentication_policies_impl_gen.go
+++ b/pkg/sdk/authentication_policies_impl_gen.go
@@ -2,7 +2,6 @@
 
 package sdk
 
-// imports adjusted manually
 import (
 	"context"
 	"slices"
@@ -45,10 +44,7 @@ func (v *authenticationPolicies) Show(ctx context.Context, request *ShowAuthenti
 	if err != nil {
 		return nil, err
 	}
-	// adjusted manually
-	dbRows = slices.DeleteFunc(dbRows, func(row showAuthenticationPolicyDBRow) bool {
-		return !row.DatabaseName.Valid || !row.SchemaName.Valid
-	})
+	dbRows = slices.DeleteFunc(dbRows, func(row showAuthenticationPolicyDBRow) bool { return row.excludeFromShow() })
 	return convertRows[showAuthenticationPolicyDBRow, AuthenticationPolicy](dbRows)
 }
 

--- a/pkg/sdk/connections_impl_gen.go
+++ b/pkg/sdk/connections_impl_gen.go
@@ -53,7 +53,6 @@ func (v *connections) ShowByID(ctx context.Context, id AccountObjectIdentifier) 
 		return nil, err
 	}
 	return collections.FindFirst(connections, func(r Connection) bool {
-		// manually adjusted
 		return r.Name == id.Name() && r.AccountLocator == v.client.GetAccountLocator()
 	})
 }

--- a/pkg/sdk/cortex_agents_ext.go
+++ b/pkg/sdk/cortex_agents_ext.go
@@ -18,14 +18,14 @@ type CortexAgentProfile struct {
 }
 
 // UnmarshalCortexAgentProfile parses profile JSON into CortexAgentProfile.
-func UnmarshalCortexAgentProfile(profileAsJson string) (*CortexAgentProfile, error) {
+func UnmarshalCortexAgentProfile(profileAsJson string) (CortexAgentProfile, error) {
 	var profile CortexAgentProfile
 
 	if err := json.Unmarshal([]byte(profileAsJson), &profile); err != nil {
-		return nil, err
+		return profile, err
 	}
 
-	return &profile, nil
+	return profile, nil
 }
 
 // MarshalCortexAgentProfile serializes a CortexAgentProfile to JSON.

--- a/pkg/sdk/cortex_agents_ext_test.go
+++ b/pkg/sdk/cortex_agents_ext_test.go
@@ -11,12 +11,12 @@ func TestUnmarshalCortexAgentProfile(t *testing.T) {
 	validCases := []struct {
 		name     string
 		json     string
-		expected *CortexAgentProfile
+		expected CortexAgentProfile
 	}{
 		{
 			name: "all fields present",
 			json: `{"display_name":"My Assistant","avatar":"assistant.png","color":"blue"}`,
-			expected: &CortexAgentProfile{
+			expected: CortexAgentProfile{
 				DisplayName: String("My Assistant"),
 				Avatar:      String("assistant.png"),
 				Color:       String("blue"),
@@ -25,14 +25,14 @@ func TestUnmarshalCortexAgentProfile(t *testing.T) {
 		{
 			name: "single field present",
 			json: `{"color":"green"}`,
-			expected: &CortexAgentProfile{
+			expected: CortexAgentProfile{
 				Color: String("green"),
 			},
 		},
 		{
 			name:     "empty object",
 			json:     `{}`,
-			expected: &CortexAgentProfile{},
+			expected: CortexAgentProfile{},
 		},
 	}
 
@@ -40,7 +40,6 @@ func TestUnmarshalCortexAgentProfile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			profile, err := UnmarshalCortexAgentProfile(tc.json)
 			require.NoError(t, err)
-			require.NotNil(t, profile)
 			require.True(t, reflect.DeepEqual(tc.expected, profile), "expected %#v; got %#v", tc.expected, profile)
 		})
 	}
@@ -55,7 +54,7 @@ func TestUnmarshalCortexAgentProfile(t *testing.T) {
 		t.Run(profile, func(t *testing.T) {
 			p, err := UnmarshalCortexAgentProfile(profile)
 			require.Error(t, err)
-			require.Nil(t, p)
+			require.Equal(t, CortexAgentProfile{}, p)
 		})
 	}
 }

--- a/pkg/sdk/cortex_agents_impl_gen.go
+++ b/pkg/sdk/cortex_agents_impl_gen.go
@@ -135,8 +135,7 @@ func (r showCortexAgentDBRow) convert() (*CortexAgent, error) {
 		if v, err := UnmarshalCortexAgentProfile(r.Profile.String); err != nil {
 			return nil, fmt.Errorf("parsing cortex agent profile: %w", err)
 		} else {
-			// Adjusted manually - dereference added
-			result.Profile = *v
+			result.Profile = v
 		}
 	}
 	return result, nil
@@ -162,8 +161,7 @@ func (r cortexAgentDetailsRow) convert() (*CortexAgentDetails, error) {
 		if v, err := UnmarshalCortexAgentProfile(r.Profile.String); err != nil {
 			return nil, fmt.Errorf("parsing cortex agent profile: %w", err)
 		} else {
-			// Adjusted manually - dereference added
-			result.Profile = *v
+			result.Profile = v
 		}
 	}
 	if v, err := NormalizeCortexAgentSpecification(r.AgentSpec); err != nil {

--- a/pkg/sdk/external_functions_impl_gen.go
+++ b/pkg/sdk/external_functions_impl_gen.go
@@ -45,7 +45,6 @@ func (v *externalFunctions) ShowByID(ctx context.Context, id SchemaObjectIdentif
 	if err != nil {
 		return nil, err
 	}
-	// adjusted manually
 	return collections.FindFirst(externalFunctions, func(r ExternalFunction) bool { return r.ID().FullyQualifiedName() == id.FullyQualifiedName() })
 }
 

--- a/pkg/sdk/functions_impl_gen.go
+++ b/pkg/sdk/functions_impl_gen.go
@@ -74,7 +74,6 @@ func (v *functions) ShowByID(ctx context.Context, id SchemaObjectIdentifierWithA
 	if err != nil {
 		return nil, err
 	}
-	// adjusted manually
 	return collections.FindFirst(functions, func(r Function) bool { return r.ID().FullyQualifiedName() == id.FullyQualifiedName() })
 }
 

--- a/pkg/sdk/generator/defs/authentication_policies_def.go
+++ b/pkg/sdk/generator/defs/authentication_policies_def.go
@@ -182,7 +182,8 @@ var authenticationPoliciesDef = g.NewInterface(
 			Text("kind").
 			OptionalText("owner", g.WithRequiredInPlain()).
 			OptionalText("owner_role_type", g.WithRequiredInPlain()).
-			Text("options"),
+			Text("options").
+			WithShowResultFilterHook(),
 		g.NewQueryStruct("ShowAuthenticationPolicies").
 			Show().
 			SQL("AUTHENTICATION POLICIES").

--- a/pkg/sdk/generator/defs/connections_def.go
+++ b/pkg/sdk/generator/defs/connections_def.go
@@ -92,4 +92,5 @@ var connectionsDef = g.NewInterface(
 		Show().
 		SQL("CONNECTIONS").
 		OptionalLike(),
-)
+).
+	WithShowByIDFindPredicateKind(g.ShowByIDFindPredicateNameAndLocator)

--- a/pkg/sdk/generator/defs/hybrid_tables_def.go
+++ b/pkg/sdk/generator/defs/hybrid_tables_def.go
@@ -227,7 +227,7 @@ var hybridTablesDef = g.NewInterface(
 		OptionalTableIn().
 		OptionalStartsWith().
 		OptionalLimitFrom(),
-	g.ShowByIDInFiltering,
+	g.ShowByIDTableInFiltering,
 	g.ShowByIDLikeFiltering,
 ).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSlice,

--- a/pkg/sdk/generator/defs/organization_accounts_def.go
+++ b/pkg/sdk/generator/defs/organization_accounts_def.go
@@ -133,4 +133,5 @@ var organizationAccountsDef = g.NewInterface(
 	WithEnums(
 		OrganizationAccountEditionEnumDef,
 	).
-	WithShowObjectType("Account")
+	WithShowObjectType("Account").
+	WithShowByIDFindPredicateKind(g.ShowByIDFindPredicateAccountName)

--- a/pkg/sdk/generator/defs/password_policies_def.go
+++ b/pkg/sdk/generator/defs/password_policies_def.go
@@ -103,7 +103,8 @@ var passwordPoliciesDef = g.NewInterface(
 			OptionalText("owner", g.WithRequiredInPlain()).
 			Text("comment").
 			OptionalText("owner_role_type", g.WithRequiredInPlain()).
-			Text("options"),
+			Text("options").
+			WithShowResultFilterHook(),
 		g.NewQueryStruct("ShowPasswordPolicies").
 			Show().
 			SQL("PASSWORD POLICIES").

--- a/pkg/sdk/generator/defs/procedures_def.go
+++ b/pkg/sdk/generator/defs/procedures_def.go
@@ -358,7 +358,7 @@ var proceduresDef = g.NewInterface(
 		SQL("PROCEDURES").
 		OptionalLike().
 		OptionalExtendedIn(),
-	g.ShowByIDInFiltering,
+	g.ShowByIDExtendedInFiltering,
 	g.ShowByIDLikeFiltering,
 ).DescribeOperationWithPairedStructs(
 	g.DescriptionMappingKindSlice,

--- a/pkg/sdk/generator/gen/interface.go
+++ b/pkg/sdk/generator/gen/interface.go
@@ -15,6 +15,24 @@ const (
 	SchemaObjectIdentifierWithArguments objectIdentifierKind = "SchemaObjectIdentifierWithArguments"
 )
 
+// ShowByIDFindPredicateKind selects the predicate strategy used in the generated ShowByID FindFirst call.
+// Use ResolvedShowByIDFindPredicateKind() to get the fully-resolved value (manual > auto-detect > default).
+type ShowByIDFindPredicateKind string
+
+const (
+	ShowByIDFindPredicateName           ShowByIDFindPredicateKind = "name"
+	ShowByIDFindPredicateFullID         ShowByIDFindPredicateKind = "full_id"
+	ShowByIDFindPredicateAccountName    ShowByIDFindPredicateKind = "account_name"
+	ShowByIDFindPredicateNameAndLocator ShowByIDFindPredicateKind = "name_and_locator"
+)
+
+func (k ShowByIDFindPredicateKind) IsName() bool        { return k == ShowByIDFindPredicateName }
+func (k ShowByIDFindPredicateKind) IsFullID() bool      { return k == ShowByIDFindPredicateFullID }
+func (k ShowByIDFindPredicateKind) IsAccountName() bool { return k == ShowByIDFindPredicateAccountName }
+func (k ShowByIDFindPredicateKind) IsNameAndLocator() bool {
+	return k == ShowByIDFindPredicateNameAndLocator
+}
+
 func ToObjectIdentifierKind(s string) (objectIdentifierKind, error) {
 	switch s {
 	case "AccountObjectIdentifier":
@@ -50,6 +68,8 @@ type Interface struct {
 	ShowObjectTypeName string
 	// ShowObjectName is the name of the main object returned from this interface through Show methods family.
 	ShowObjectName string
+	// ShowByIDFindPredicateKind selects the predicate strategy for the generated ShowByID FindFirst call.
+	ShowByIDFindPredicateKind ShowByIDFindPredicateKind
 
 	*genhelpers.PreambleModel
 	*genhelpers.ObjectGenerationSettings
@@ -99,4 +119,22 @@ func (i *Interface) WithEnums(enums ...*Enum) *Interface {
 func (i *Interface) WithShowObjectType(name string) *Interface {
 	i.ShowObjectTypeName = name
 	return i
+}
+
+// WithShowByIDFindPredicateKind sets the predicate strategy used in the generated ShowByID FindFirst call.
+// All comparison expressions live in the template; this field only selects which one to emit.
+func (i *Interface) WithShowByIDFindPredicateKind(kind ShowByIDFindPredicateKind) *Interface {
+	i.ShowByIDFindPredicateKind = kind
+	return i
+}
+
+// ResolvedShowByIDFindPredicateKind returns the fully-resolved predicate strategy for ShowByID.
+func (i *Interface) ResolvedShowByIDFindPredicateKind() ShowByIDFindPredicateKind {
+	if i.ShowByIDFindPredicateKind != "" {
+		return i.ShowByIDFindPredicateKind
+	}
+	if i.IdentifierKind == string(SchemaObjectIdentifierWithArguments) {
+		return ShowByIDFindPredicateFullID
+	}
+	return ShowByIDFindPredicateName
 }

--- a/pkg/sdk/generator/gen/operation.go
+++ b/pkg/sdk/generator/gen/operation.go
@@ -67,6 +67,10 @@ type Operation struct {
 	InstanceMethodScalarReturnType string
 	// ShowByIDFiltering defines a kind of filterings performed in ShowByID operation
 	ShowByIDFiltering []ShowByIDFiltering
+	// ShowResultFilterHook, when true, inserts a hook call in the generated Show implementation.
+	// It allows filtering the rows by implementing excludeFromShow() method on the given row type.
+	// The implementation should be provided in the _ext.go file.
+	ShowResultFilterHook bool
 
 	// TODO [SNOW-2324252]: Consider splitting the Operation into definition and generation model
 	// new fields used to move the old template executors logic into simpler template generation based on prepared model

--- a/pkg/sdk/generator/gen/paired_struct.go
+++ b/pkg/sdk/generator/gen/paired_struct.go
@@ -157,6 +157,8 @@ type PairedStructs struct {
 	fields    []pairedField
 	// generateConvert controls whether convert() body generation is enabled for this pair. Default: true.
 	generateConvert bool
+	// showResultFilterHook, when true, causes the generated Show() to call hook allowing rows exclusion
+	showResultFilterHook bool
 }
 
 // StructPair creates a new PairedStructs with the given DB row struct name and plain struct name.
@@ -466,6 +468,13 @@ func (p *PairedStructs) WithoutConvertGeneration() *PairedStructs {
 	return p
 }
 
+// WithShowResultFilterHook enables client-side row filtering in the generated Show implementation.
+// Method `func (r <dbRowType>) excludeFromShow() bool` should be implemented in the _ext.go file.
+func (p *PairedStructs) WithShowResultFilterHook() *PairedStructs {
+	p.showResultFilterHook = true
+	return p
+}
+
 // toFieldPairs converts the paired field definitions into a slice of FieldPair values used in conversion generation.
 func (p *PairedStructs) toFieldPairs() []FieldPair {
 	pairs := make([]FieldPair, len(p.fields))
@@ -511,6 +520,7 @@ func (p *PairedStructs) addMappingFunc() func(op *Operation, from, to *Field) {
 		if p.generateConvert {
 			op.ShowMapping.FieldPairs = p.toFieldPairs()
 		}
+		op.ShowResultFilterHook = p.showResultFilterHook
 	}
 }
 

--- a/pkg/sdk/generator/gen/show_by_id_filtering.go
+++ b/pkg/sdk/generator/gen/show_by_id_filtering.go
@@ -13,6 +13,7 @@ const (
 	ShowByIDExtendedInFiltering
 	ShowByIDApplicationNameFiltering
 	ShowByIDServiceInFiltering
+	ShowByIDTableInFiltering
 
 	// ShowByIDNoFiltering causes the auto-generated ShowByID to use no filtering when passed as the sole filtering argument to ShowOperation
 	ShowByIDNoFiltering ShowByIDFilteringKind = 100
@@ -79,6 +80,10 @@ func newShowByIDServiceInFiltering(identifierKind idPrefix) ShowByIDFiltering {
 	return newShowByIDFiltering("In", "ServiceIn", fmt.Sprintf("In: In{%[1]v: id.%[1]vId()}", identifierKind))
 }
 
+func newShowByIDTableInFiltering(identifierKind idPrefix) ShowByIDFiltering {
+	return newShowByIDFiltering("In", "TableIn", fmt.Sprintf("In: In{%[1]v: id.%[1]vId()}", identifierKind))
+}
+
 type showByIDApplicationFilter struct {
 	showByIDFilter
 }
@@ -106,6 +111,8 @@ func (s *Operation) withFiltering(filtering ...ShowByIDFilteringKind) *Operation
 			s.ShowByIDFiltering = append(s.ShowByIDFiltering, newShowByIDExtendedInFiltering(s.ObjectInterface.ObjectIdentifierPrefix()))
 		case ShowByIDServiceInFiltering:
 			s.ShowByIDFiltering = append(s.ShowByIDFiltering, newShowByIDServiceInFiltering(s.ObjectInterface.ObjectIdentifierPrefix()))
+		case ShowByIDTableInFiltering:
+			s.ShowByIDFiltering = append(s.ShowByIDFiltering, newShowByIDTableInFiltering(s.ObjectInterface.ObjectIdentifierPrefix()))
 		case ShowByIDLikeFiltering:
 			s.ShowByIDFiltering = append(s.ShowByIDFiltering, newShowByIDLikeFiltering())
 		case ShowByIDApplicationNameFiltering:

--- a/pkg/sdk/generator/gen/templates/sub_templates/implementation_functions.tmpl
+++ b/pkg/sdk/generator/gen/templates/sub_templates/implementation_functions.tmpl
@@ -38,7 +38,12 @@
             if err != nil {
                 return nil, err
             }
-            return collections.FindFirst({{ $impl }}, func(r {{ .ObjectInterface.ShowObjectName }}) bool { return {{- if .ObjectInterface.ResolvedShowByIDFindPredicateKind.IsFullID }} r.ID().FullyQualifiedName() == id.FullyQualifiedName(){{- else if .ObjectInterface.ResolvedShowByIDFindPredicateKind.IsAccountName }} r.AccountName == id.Name(){{- else if .ObjectInterface.ResolvedShowByIDFindPredicateKind.IsNameAndLocator }} r.Name == id.Name() && r.AccountLocator == v.client.GetAccountLocator(){{- else }} r.Name == id.Name(){{- end }} })
+            return collections.FindFirst({{ $impl }}, func(r {{ .ObjectInterface.ShowObjectName }}) bool { return
+                {{- if .ObjectInterface.ResolvedShowByIDFindPredicateKind.IsFullID }} r.ID().FullyQualifiedName() == id.FullyQualifiedName()
+                {{- else if .ObjectInterface.ResolvedShowByIDFindPredicateKind.IsAccountName }} r.AccountName == id.Name()
+                {{- else if .ObjectInterface.ResolvedShowByIDFindPredicateKind.IsNameAndLocator }} r.Name == id.Name() && r.AccountLocator == v.client.GetAccountLocator()
+                {{- else }} r.Name == id.Name()
+                {{- end }} })
         }
 
         func (v *{{ $impl }}) ShowByIDSafely(ctx context.Context, id {{ .ObjectInterface.IdentifierKind }}) (*{{ .ObjectInterface.ShowObjectName }}, error) {

--- a/pkg/sdk/generator/gen/templates/sub_templates/implementation_functions.tmpl
+++ b/pkg/sdk/generator/gen/templates/sub_templates/implementation_functions.tmpl
@@ -21,6 +21,9 @@
                     if err != nil {
                         return nil, err
                     }
+                    {{- if .ShowResultFilterHook }}
+                    dbRows = slices.DeleteFunc(dbRows, func(row {{ .ShowMapping.From.Name }}) bool { return row.excludeFromShow() })
+                    {{- end }}
                     return convertRows[{{ .ShowMapping.From.Name }}, {{ .ShowMapping.To.Name }}](dbRows)
                 }
             {{ end }}

--- a/pkg/sdk/generator/gen/templates/sub_templates/implementation_functions.tmpl
+++ b/pkg/sdk/generator/gen/templates/sub_templates/implementation_functions.tmpl
@@ -38,7 +38,7 @@
             if err != nil {
                 return nil, err
             }
-            return collections.FindFirst({{ $impl }}, func(r {{ .ObjectInterface.ShowObjectName }}) bool { return r.Name == id.Name() })
+            return collections.FindFirst({{ $impl }}, func(r {{ .ObjectInterface.ShowObjectName }}) bool { return {{- if .ObjectInterface.ResolvedShowByIDFindPredicateKind.IsFullID }} r.ID().FullyQualifiedName() == id.FullyQualifiedName(){{- else if .ObjectInterface.ResolvedShowByIDFindPredicateKind.IsAccountName }} r.AccountName == id.Name(){{- else if .ObjectInterface.ResolvedShowByIDFindPredicateKind.IsNameAndLocator }} r.Name == id.Name() && r.AccountLocator == v.client.GetAccountLocator(){{- else }} r.Name == id.Name(){{- end }} })
         }
 
         func (v *{{ $impl }}) ShowByIDSafely(ctx context.Context, id {{ .ObjectInterface.IdentifierKind }}) (*{{ .ObjectInterface.ShowObjectName }}, error) {

--- a/pkg/sdk/hybrid_tables_impl_gen.go
+++ b/pkg/sdk/hybrid_tables_impl_gen.go
@@ -50,7 +50,6 @@ func (v *hybridTables) Show(ctx context.Context, request *ShowHybridTableRequest
 func (v *hybridTables) ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*HybridTable, error) {
 	request := NewShowHybridTableRequest().
 		WithLike(Like{Pattern: String(id.Name())}).
-		// adjusted manually
 		WithIn(TableIn{In: In{Schema: id.SchemaId()}})
 	hybridTables, err := v.Show(ctx, request)
 	if err != nil {

--- a/pkg/sdk/organization_accounts_impl_gen.go
+++ b/pkg/sdk/organization_accounts_impl_gen.go
@@ -43,7 +43,6 @@ func (v *organizationAccounts) ShowByID(ctx context.Context, id AccountObjectIde
 	if err != nil {
 		return nil, err
 	}
-	// adjusted manually
 	return collections.FindFirst(organizationAccounts, func(r OrganizationAccount) bool { return r.AccountName == id.Name() })
 }
 

--- a/pkg/sdk/password_policies_ext.go
+++ b/pkg/sdk/password_policies_ext.go
@@ -7,6 +7,10 @@ import (
 	"strconv"
 )
 
+func (r passwordPolicyDBRow) excludeFromShow() bool {
+	return !r.DatabaseName.Valid || !r.SchemaName.Valid
+}
+
 func (r passwordPolicyDBRow) additionalConvert(result *PasswordPolicy) error {
 	var errs []error
 	if !r.DatabaseName.Valid {

--- a/pkg/sdk/password_policies_impl_gen.go
+++ b/pkg/sdk/password_policies_impl_gen.go
@@ -2,7 +2,6 @@
 
 package sdk
 
-// imports adjusted manually
 import (
 	"context"
 	"slices"
@@ -45,10 +44,7 @@ func (v *passwordPolicies) Show(ctx context.Context, request *ShowPasswordPolicy
 	if err != nil {
 		return nil, err
 	}
-	// adjusted manually
-	dbRows = slices.DeleteFunc(dbRows, func(row passwordPolicyDBRow) bool {
-		return !row.DatabaseName.Valid || !row.SchemaName.Valid
-	})
+	dbRows = slices.DeleteFunc(dbRows, func(row passwordPolicyDBRow) bool { return row.excludeFromShow() })
 	return convertRows[passwordPolicyDBRow, PasswordPolicy](dbRows)
 }
 

--- a/pkg/sdk/procedures_impl_gen.go
+++ b/pkg/sdk/procedures_impl_gen.go
@@ -74,7 +74,6 @@ func (v *procedures) ShowByID(ctx context.Context, id SchemaObjectIdentifierWith
 	if err != nil {
 		return nil, err
 	}
-	// adjusted manually
 	return collections.FindFirst(procedures, func(r Procedure) bool { return r.ID().FullyQualifiedName() == id.FullyQualifiedName() })
 }
 

--- a/pkg/sdk/procedures_impl_gen.go
+++ b/pkg/sdk/procedures_impl_gen.go
@@ -69,7 +69,6 @@ func (v *procedures) Show(ctx context.Context, request *ShowProcedureRequest) ([
 func (v *procedures) ShowByID(ctx context.Context, id SchemaObjectIdentifierWithArguments) (*Procedure, error) {
 	request := NewShowProcedureRequest().
 		WithLike(Like{Pattern: String(id.Name())}).
-		// adjusted manually
 		WithIn(ExtendedIn{In: In{Schema: id.SchemaId()}})
 	procedures, err := v.Show(ctx, request)
 	if err != nil {


### PR DESCRIPTION
Continuation of https://github.com/snowflakedb/terraform-provider-snowflake/pull/4802

- Change the unmarshal method return type from ptr to struct for the Cortex agent profile
- Add missing show filtering and adjust proper objects
- Add show rows exclusion hook (authentication and password policies)
- Allow setting a different predicate for the ShowByID check