### PR TITLE
chore: Add CreateFromIcebergFiles SDK operation

### DIFF
--- a/pkg/sdk/common_types_test.go
+++ b/pkg/sdk/common_types_test.go
@@ -203,8 +203,8 @@ func TestToStorageSerializationPolicy(t *testing.T) {
 	}{
 		{Input: string(StorageSerializationPolicyOptimized), Expected: StorageSerializationPolicyOptimized},
 		{Input: string(StorageSerializationPolicyCompatible), Expected: StorageSerializationPolicyCompatible},
-		{Name: "validation: incorrect storage serialization policy", Input: "incorrect", Error: "unknown storage serialization policy: incorrect"},
-		{Name: "validation: empty input", Input: "", Error: "unknown storage serialization policy: "},
+		{Name: "validation: incorrect storage serialization policy", Input: "incorrect", Error: "invalid storage serialization policy: INCORRECT"},
+		{Name: "validation: empty input", Input: "", Error: "invalid storage serialization policy: "},
 		{Name: "validation: lower case input", Input: "optimized", Expected: StorageSerializationPolicyOptimized},
 	}
 

--- a/pkg/sdk/databases.go
+++ b/pkg/sdk/databases.go
@@ -156,29 +156,6 @@ func (row databaseRow) convert() (*Database, error) {
 	return database, nil
 }
 
-type StorageSerializationPolicy string
-
-const (
-	StorageSerializationPolicyCompatible StorageSerializationPolicy = "COMPATIBLE"
-	StorageSerializationPolicyOptimized  StorageSerializationPolicy = "OPTIMIZED"
-)
-
-func ToStorageSerializationPolicy(value string) (StorageSerializationPolicy, error) {
-	switch strings.ToUpper(value) {
-	case string(StorageSerializationPolicyCompatible):
-		return StorageSerializationPolicyCompatible, nil
-	case string(StorageSerializationPolicyOptimized):
-		return StorageSerializationPolicyOptimized, nil
-	default:
-		return "", fmt.Errorf("unknown storage serialization policy: %s", value)
-	}
-}
-
-var AllStorageSerializationPolicies = []StorageSerializationPolicy{
-	StorageSerializationPolicyCompatible,
-	StorageSerializationPolicyOptimized,
-}
-
 // CreateDatabaseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-database.
 type CreateDatabaseOptions struct {
 	create      bool                    `ddl:"static" sql:"CREATE"`

--- a/pkg/sdk/generator/defs/iceberg_tables_def.go
+++ b/pkg/sdk/generator/defs/iceberg_tables_def.go
@@ -31,6 +31,10 @@ var (
 		"IcebergTableCatalog", "IcebergTableCatalogs",
 		"SNOWFLAKE",
 	)
+	StorageSerializationPolicyEnumDef = g.NewEnum(
+		"StorageSerializationPolicy", "StorageSerializationPolicies",
+		"COMPATIBLE", "OPTIMIZED",
+	)
 )
 
 var icebergTableColumn = g.NewQueryStruct("IcebergTableColumn").
@@ -187,7 +191,7 @@ var icebergTablesDef = g.NewInterface(
 		OptionalTextAssignment("BASE_LOCATION", g.ParameterOptions().SingleQuotes()).
 		OptionalAssignment("TARGET_FILE_SIZE", IcebergTableTargetFileSizeEnumDef.KindPtr(), g.ParameterOptions().SingleQuotes()).
 		OptionalTextAssignment("CATALOG_SYNC", g.ParameterOptions().SingleQuotes()).
-		PredefinedQueryStructField("StorageSerializationPolicy", "*StorageSerializationPolicy", g.ParameterOptions().SQL("STORAGE_SERIALIZATION_POLICY")).
+		OptionalAssignment("STORAGE_SERIALIZATION_POLICY", StorageSerializationPolicyEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
 		OptionalNumberAssignment("DATA_RETENTION_TIME_IN_DAYS", g.ParameterOptions()).
 		OptionalNumberAssignment("MAX_DATA_EXTENSION_TIME_IN_DAYS", g.ParameterOptions()).
 		OptionalBooleanAssignment("CHANGE_TRACKING", g.ParameterOptions()).
@@ -204,6 +208,24 @@ var icebergTablesDef = g.NewInterface(
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists").
 		WithAdditionalValidations(),
+).CustomOperation(
+	"CreateFromIcebergFiles",
+	"https://docs.snowflake.com/en/sql-reference/sql/create-iceberg-table-iceberg-files",
+	g.NewQueryStruct("CreateFromIcebergFiles").
+		Create().
+		OrReplace().
+		SQL("ICEBERG TABLE").
+		IfNotExists().
+		Name().
+		OptionalIdentifier("ExternalVolume", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("EXTERNAL_VOLUME")).
+		OptionalIdentifier("Catalog", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("CATALOG")).
+		TextAssignment("METADATA_FILE_PATH", g.ParameterOptions().SingleQuotes().Required()).
+		OptionalBooleanAssignment("REPLACE_INVALID_CHARACTERS", g.ParameterOptions()).
+		OptionalComment().
+		OptionalTags().
+		PredefinedQueryStructField("Contact", "[]TableContact", g.KeywordOptions().Parentheses().SQL("WITH CONTACT")).
+		WithValidation(g.ValidIdentifier, "name").
+		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists"),
 ).AlterOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/alter-iceberg-table",
 	g.NewQueryStruct("AlterIcebergTable").
@@ -374,4 +396,5 @@ var icebergTablesDef = g.NewInterface(
 	IcebergTableLogEventLevelEnumDef,
 	IcebergTableTypeEnumDef,
 	IcebergTableCatalogEnumDef,
+	StorageSerializationPolicyEnumDef,
 )

--- a/pkg/sdk/iceberg_tables_dto_builders_gen.go
+++ b/pkg/sdk/iceberg_tables_dto_builders_gen.go
@@ -813,6 +813,56 @@ func NewIcebergTableAggregationPolicyRequest(
 	return &s
 }
 
+func NewCreateFromIcebergFilesIcebergTableRequest(
+	name SchemaObjectIdentifier,
+	metadataFilePath string,
+) *CreateFromIcebergFilesIcebergTableRequest {
+	s := CreateFromIcebergFilesIcebergTableRequest{}
+	s.name = name
+	s.MetadataFilePath = metadataFilePath
+	return &s
+}
+
+func (s *CreateFromIcebergFilesIcebergTableRequest) WithOrReplace(orReplace bool) *CreateFromIcebergFilesIcebergTableRequest {
+	s.OrReplace = &orReplace
+	return s
+}
+
+func (s *CreateFromIcebergFilesIcebergTableRequest) WithIfNotExists(ifNotExists bool) *CreateFromIcebergFilesIcebergTableRequest {
+	s.IfNotExists = &ifNotExists
+	return s
+}
+
+func (s *CreateFromIcebergFilesIcebergTableRequest) WithExternalVolume(externalVolume AccountObjectIdentifier) *CreateFromIcebergFilesIcebergTableRequest {
+	s.ExternalVolume = &externalVolume
+	return s
+}
+
+func (s *CreateFromIcebergFilesIcebergTableRequest) WithCatalog(catalog AccountObjectIdentifier) *CreateFromIcebergFilesIcebergTableRequest {
+	s.Catalog = &catalog
+	return s
+}
+
+func (s *CreateFromIcebergFilesIcebergTableRequest) WithReplaceInvalidCharacters(replaceInvalidCharacters bool) *CreateFromIcebergFilesIcebergTableRequest {
+	s.ReplaceInvalidCharacters = &replaceInvalidCharacters
+	return s
+}
+
+func (s *CreateFromIcebergFilesIcebergTableRequest) WithComment(comment string) *CreateFromIcebergFilesIcebergTableRequest {
+	s.Comment = &comment
+	return s
+}
+
+func (s *CreateFromIcebergFilesIcebergTableRequest) WithTag(tag []TagAssociation) *CreateFromIcebergFilesIcebergTableRequest {
+	s.Tag = tag
+	return s
+}
+
+func (s *CreateFromIcebergFilesIcebergTableRequest) WithContact(contact []TableContact) *CreateFromIcebergFilesIcebergTableRequest {
+	s.Contact = contact
+	return s
+}
+
 func NewAlterIcebergTableRequest(
 	name SchemaObjectIdentifier,
 ) *AlterIcebergTableRequest {

--- a/pkg/sdk/iceberg_tables_dto_gen.go
+++ b/pkg/sdk/iceberg_tables_dto_gen.go
@@ -5,11 +5,12 @@ package sdk
 import "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 
 var (
-	_ optionsProvider[CreateIcebergTableOptions]   = new(CreateIcebergTableRequest)
-	_ optionsProvider[AlterIcebergTableOptions]    = new(AlterIcebergTableRequest)
-	_ optionsProvider[DropIcebergTableOptions]     = new(DropIcebergTableRequest)
-	_ optionsProvider[ShowIcebergTableOptions]     = new(ShowIcebergTableRequest)
-	_ optionsProvider[DescribeIcebergTableOptions] = new(DescribeIcebergTableRequest)
+	_ optionsProvider[CreateIcebergTableOptions]                 = new(CreateIcebergTableRequest)
+	_ optionsProvider[CreateFromIcebergFilesIcebergTableOptions] = new(CreateFromIcebergFilesIcebergTableRequest)
+	_ optionsProvider[AlterIcebergTableOptions]                  = new(AlterIcebergTableRequest)
+	_ optionsProvider[DropIcebergTableOptions]                   = new(DropIcebergTableRequest)
+	_ optionsProvider[ShowIcebergTableOptions]                   = new(ShowIcebergTableRequest)
+	_ optionsProvider[DescribeIcebergTableOptions]               = new(DescribeIcebergTableRequest)
 )
 
 type CreateIcebergTableRequest struct {
@@ -230,6 +231,19 @@ type IcebergTableRowAccessPolicyRequest struct {
 
 type IcebergTableAggregationPolicyRequest struct {
 	AggregationPolicy SchemaObjectIdentifier // required
+}
+
+type CreateFromIcebergFilesIcebergTableRequest struct {
+	OrReplace                *bool
+	IfNotExists              *bool
+	name                     SchemaObjectIdentifier // required
+	ExternalVolume           *AccountObjectIdentifier
+	Catalog                  *AccountObjectIdentifier
+	MetadataFilePath         string // required
+	ReplaceInvalidCharacters *bool
+	Comment                  *string
+	Tag                      []TagAssociation
+	Contact                  []TableContact
 }
 
 type AlterIcebergTableRequest struct {

--- a/pkg/sdk/iceberg_tables_enums_gen.go
+++ b/pkg/sdk/iceberg_tables_enums_gen.go
@@ -194,3 +194,27 @@ func ToIcebergTableCatalog(s string) (IcebergTableCatalog, error) {
 		return "", fmt.Errorf("invalid iceberg table catalog: %s", s)
 	}
 }
+
+type StorageSerializationPolicy string
+
+const (
+	StorageSerializationPolicyCompatible StorageSerializationPolicy = "COMPATIBLE"
+	StorageSerializationPolicyOptimized  StorageSerializationPolicy = "OPTIMIZED"
+)
+
+var AllStorageSerializationPolicies = []StorageSerializationPolicy{
+	StorageSerializationPolicyCompatible,
+	StorageSerializationPolicyOptimized,
+}
+
+func ToStorageSerializationPolicy(s string) (StorageSerializationPolicy, error) {
+	s = strings.ToUpper(s)
+	switch s {
+	case string(StorageSerializationPolicyCompatible):
+		return StorageSerializationPolicyCompatible, nil
+	case string(StorageSerializationPolicyOptimized):
+		return StorageSerializationPolicyOptimized, nil
+	default:
+		return "", fmt.Errorf("invalid storage serialization policy: %s", s)
+	}
+}

--- a/pkg/sdk/iceberg_tables_ext.go
+++ b/pkg/sdk/iceberg_tables_ext.go
@@ -211,13 +211,13 @@ func (r *CreateIcebergTableRequest) GetName() SchemaObjectIdentifier {
 	return r.name
 }
 
-// icebergTableExternalVolumeQuoted formats an AccountObjectIdentifier for the
-// EXTERNAL_VOLUME clause of CREATE ICEBERG TABLE, which expects a single-quoted
+// icebergTableIdentifierQuoted formats an AccountObjectIdentifier for the
+// EXTERNAL_VOLUME and CATALOG clauses of CREATE ICEBERG TABLE, which expects a single-quoted
 // string literal whose content is the double-quoted volume name (e.g. '"vol1"').
 //
 // TODO(SNOW-2236323): Use a proper generation option instead.
 // We need to use a custom parsing here, see SNOW-1833593 for more details.
-func icebergTableExternalVolumeQuoted(id *AccountObjectIdentifier) *string {
+func icebergTableIdentifierQuoted(id *AccountObjectIdentifier) *string {
 	if id == nil {
 		return nil
 	}

--- a/pkg/sdk/iceberg_tables_gen.go
+++ b/pkg/sdk/iceberg_tables_gen.go
@@ -12,6 +12,7 @@ import (
 
 type IcebergTables interface {
 	Create(ctx context.Context, request *CreateIcebergTableRequest) error
+	CreateFromIcebergFiles(ctx context.Context, request *CreateFromIcebergFilesIcebergTableRequest) error
 	Alter(ctx context.Context, request *AlterIcebergTableRequest) error
 	Drop(ctx context.Context, request *DropIcebergTableRequest) error
 	DropSafely(ctx context.Context, id SchemaObjectIdentifier) error
@@ -257,6 +258,24 @@ type IcebergTableRowAccessPolicy struct {
 
 type IcebergTableAggregationPolicy struct {
 	AggregationPolicy SchemaObjectIdentifier `ddl:"identifier" sql:"AGGREGATION POLICY"`
+}
+
+// CreateFromIcebergFilesIcebergTableOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-iceberg-table-iceberg-files.
+type CreateFromIcebergFilesIcebergTableOptions struct {
+	create       bool                   `ddl:"static" sql:"CREATE"`
+	OrReplace    *bool                  `ddl:"keyword" sql:"OR REPLACE"`
+	icebergTable bool                   `ddl:"static" sql:"ICEBERG TABLE"`
+	IfNotExists  *bool                  `ddl:"keyword" sql:"IF NOT EXISTS"`
+	name         SchemaObjectIdentifier `ddl:"identifier"`
+	// Adjusted manually
+	ExternalVolume *string `ddl:"parameter" sql:"EXTERNAL_VOLUME"`
+	// Adjusted manually
+	Catalog                  *string          `ddl:"parameter" sql:"CATALOG"`
+	MetadataFilePath         string           `ddl:"parameter,single_quotes" sql:"METADATA_FILE_PATH"`
+	ReplaceInvalidCharacters *bool            `ddl:"parameter" sql:"REPLACE_INVALID_CHARACTERS"`
+	Comment                  *string          `ddl:"parameter,single_quotes" sql:"COMMENT"`
+	Tag                      []TagAssociation `ddl:"keyword,parentheses" sql:"TAG"`
+	Contact                  []TableContact   `ddl:"keyword,parentheses" sql:"WITH CONTACT"`
 }
 
 // AlterIcebergTableOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-iceberg-table.

--- a/pkg/sdk/iceberg_tables_gen_test.go
+++ b/pkg/sdk/iceberg_tables_gen_test.go
@@ -13,6 +13,8 @@ func init() {
 	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[TableSearchMethod]{"TableSearchMethod", AllTableSearchMethods, ToTableSearchMethod})
 	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[IcebergTableLogEventLevel]{"IcebergTableLogEventLevel", AllIcebergTableLogEventLevels, ToIcebergTableLogEventLevel})
 	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[IcebergTableType]{"IcebergTableType", AllIcebergTableTypes, ToIcebergTableType})
+	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[IcebergTableCatalog]{"IcebergTableCatalog", AllIcebergTableCatalogs, ToIcebergTableCatalog})
+	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[StorageSerializationPolicy]{"StorageSerializationPolicy", AllStorageSerializationPolicies, ToStorageSerializationPolicy})
 }
 
 func TestIcebergTables_Create(t *testing.T) {
@@ -370,7 +372,7 @@ func TestIcebergTables_Create(t *testing.T) {
 		}
 		opts.PathLayout = new(IcebergTablePathLayoutHierarchical)
 		opts.ClusterBy = []string{`"col1"`, `"col2"`}
-		opts.ExternalVolume = icebergTableExternalVolumeQuoted(new(NewAccountObjectIdentifier("vol1")))
+		opts.ExternalVolume = icebergTableIdentifierQuoted(new(NewAccountObjectIdentifier("vol1")))
 		opts.Catalog = new(IcebergTableCatalogSnowflake)
 		opts.BaseLocation = new("base/loc")
 		opts.TargetFileSize = new(IcebergTableTargetFileSize64mb)
@@ -912,6 +914,81 @@ func TestIcebergTables_Create(t *testing.T) {
 			},
 		}
 		assertOptsInvalidJoinedErrors(t, opts, errOneOf("CreateIcebergTableOptions.ColumnsAndConstraints.OutOfLineConstraint[0].CH", "EnableValidate", "EnableNovalidate"))
+	})
+}
+
+func TestIcebergTables_CreateFromIcebergFiles(t *testing.T) {
+	id := randomSchemaObjectIdentifier()
+	externalVolumeId := NewAccountObjectIdentifier("vol1")
+	catalogId := NewAccountObjectIdentifier("cat1")
+	tagId1 := randomSchemaObjectIdentifier()
+	tagId2 := randomSchemaObjectIdentifier()
+
+	// Minimal valid CreateFromIcebergFilesIcebergTableOptions
+	defaultOpts := func() *CreateFromIcebergFilesIcebergTableOptions {
+		return &CreateFromIcebergFilesIcebergTableOptions{
+			name:             id,
+			MetadataFilePath: "metadata/v1.metadata.json",
+		}
+	}
+
+	t.Run("validation: nil options", func(t *testing.T) {
+		opts := (*CreateFromIcebergFilesIcebergTableOptions)(nil)
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
+	})
+
+	t.Run("validation: valid identifier for [opts.name]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.name = emptySchemaObjectIdentifier
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: conflicting fields for [opts.OrReplace opts.IfNotExists]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.OrReplace = new(true)
+		opts.IfNotExists = new(true)
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("CreateFromIcebergFilesIcebergTableOptions", "OrReplace", "IfNotExists"))
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		opts := defaultOpts()
+		assertOptsValidAndSQLEquals(t, opts, `CREATE ICEBERG TABLE %s METADATA_FILE_PATH = 'metadata/v1.metadata.json'`, id.FullyQualifiedName())
+	})
+
+	t.Run("if not exists", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.IfNotExists = new(true)
+		assertOptsValidAndSQLEquals(t, opts, `CREATE ICEBERG TABLE IF NOT EXISTS %s METADATA_FILE_PATH = 'metadata/v1.metadata.json'`, id.FullyQualifiedName())
+	})
+
+	t.Run("all options", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.OrReplace = new(true)
+		opts.ExternalVolume = icebergTableIdentifierQuoted(&externalVolumeId)
+		opts.Catalog = icebergTableIdentifierQuoted(&catalogId)
+		opts.ReplaceInvalidCharacters = new(true)
+		opts.Comment = new("some comment")
+		opts.Tag = []TagAssociation{
+			{Name: tagId1, Value: "v1"},
+			{Name: tagId2, Value: "v2"},
+		}
+		opts.Contact = []TableContact{
+			{Purpose: "SUPPORT", Contact: "support_team"},
+		}
+		assertOptsValidAndSQLEquals(t, opts,
+			`CREATE OR REPLACE ICEBERG TABLE %s `+
+				`EXTERNAL_VOLUME = '%s' `+
+				`CATALOG = '%s' `+
+				`METADATA_FILE_PATH = 'metadata/v1.metadata.json' `+
+				`REPLACE_INVALID_CHARACTERS = true `+
+				`COMMENT = 'some comment' `+
+				`TAG (%s = 'v1', %s = 'v2') `+
+				`WITH CONTACT (SUPPORT = 'support_team')`,
+			id.FullyQualifiedName(),
+			externalVolumeId.FullyQualifiedName(),
+			catalogId.FullyQualifiedName(),
+			tagId1.FullyQualifiedName(), tagId2.FullyQualifiedName(),
+		)
 	})
 }
 

--- a/pkg/sdk/iceberg_tables_impl_gen.go
+++ b/pkg/sdk/iceberg_tables_impl_gen.go
@@ -25,6 +25,11 @@ func (v *icebergTables) Create(ctx context.Context, request *CreateIcebergTableR
 	return validateAndExec(v.client, ctx, opts)
 }
 
+func (v *icebergTables) CreateFromIcebergFiles(ctx context.Context, request *CreateFromIcebergFilesIcebergTableRequest) error {
+	opts := request.toOpts()
+	return validateAndExec(v.client, ctx, opts)
+}
+
 func (v *icebergTables) Alter(ctx context.Context, request *AlterIcebergTableRequest) error {
 	opts := request.toOpts()
 	return validateAndExec(v.client, ctx, opts)
@@ -83,7 +88,7 @@ func (r *CreateIcebergTableRequest) toOpts() *CreateIcebergTableOptions {
 		PathLayout:  r.PathLayout,
 		ClusterBy:   r.ClusterBy,
 		// Adjusted manually
-		ExternalVolume:             icebergTableExternalVolumeQuoted(r.ExternalVolume),
+		ExternalVolume:             icebergTableIdentifierQuoted(r.ExternalVolume),
 		Catalog:                    r.Catalog,
 		BaseLocation:               r.BaseLocation,
 		TargetFileSize:             r.TargetFileSize,
@@ -179,6 +184,22 @@ func (r *CreateIcebergTableRequest) toOpts() *CreateIcebergTableOptions {
 		opts.AggregationPolicy = &IcebergTableAggregationPolicy{
 			AggregationPolicy: r.AggregationPolicy.AggregationPolicy,
 		}
+	}
+	return opts
+}
+
+func (r *CreateFromIcebergFilesIcebergTableRequest) toOpts() *CreateFromIcebergFilesIcebergTableOptions {
+	opts := &CreateFromIcebergFilesIcebergTableOptions{
+		OrReplace:                r.OrReplace,
+		IfNotExists:              r.IfNotExists,
+		name:                     r.name,
+		ExternalVolume:           icebergTableIdentifierQuoted(r.ExternalVolume),
+		Catalog:                  icebergTableIdentifierQuoted(r.Catalog),
+		MetadataFilePath:         r.MetadataFilePath,
+		ReplaceInvalidCharacters: r.ReplaceInvalidCharacters,
+		Comment:                  r.Comment,
+		Tag:                      r.Tag,
+		Contact:                  r.Contact,
 	}
 	return opts
 }

--- a/pkg/sdk/iceberg_tables_validations_gen.go
+++ b/pkg/sdk/iceberg_tables_validations_gen.go
@@ -4,6 +4,7 @@ package sdk
 
 var (
 	_ validatable = new(CreateIcebergTableOptions)
+	_ validatable = new(CreateFromIcebergFilesIcebergTableOptions)
 	_ validatable = new(AlterIcebergTableOptions)
 	_ validatable = new(DropIcebergTableOptions)
 	_ validatable = new(ShowIcebergTableOptions)
@@ -38,6 +39,20 @@ func (opts *CreateIcebergTableOptions) validate() error {
 		if !ValidObjectIdentifier(opts.AggregationPolicy.AggregationPolicy) {
 			errs = append(errs, ErrInvalidObjectIdentifier)
 		}
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateFromIcebergFilesIcebergTableOptions) validate() error {
+	if opts == nil {
+		return ErrNilOptions
+	}
+	var errs []error
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
+		errs = append(errs, errOneOf("CreateFromIcebergFilesIcebergTableOptions", "OrReplace", "IfNotExists"))
 	}
 	return JoinErrors(errs...)
 }

--- a/pkg/testacc/resource_shared_database_acceptance_test.go
+++ b/pkg/testacc/resource_shared_database_acceptance_test.go
@@ -232,7 +232,7 @@ func TestAcc_CreateSharedDatabase_InvalidValues(t *testing.T) {
 				Config: accconfig.FromModels(t, sharedDatabaseModelInvalid),
 				ExpectError: regexp.MustCompile(`(unknown log level: invalid_value)|` +
 					`(unknown trace level: invalid_value)|` +
-					`(unknown storage serialization policy: invalid_value)|` +
+					`(invalid storage serialization policy: INVALID_VALUE)|` +
 					`(invalid warehouse size:)`),
 			},
 		},


### PR DESCRIPTION
## Summary

- Adds `CreateFromIcebergFiles` SDK operation for `CREATE ICEBERG TABLE … METADATA_FILE_PATH = …` (the Iceberg Files catalog variant), including options struct, DTO, builder, impl, and validations following the existing generator pattern
- Migrates `StorageSerializationPolicy` type, constants, and converter from `databases.go` into `iceberg_tables_enums_gen.go` so it is code-generated alongside the other iceberg enums; error message format updated from `unknown … lowercase` to `invalid … UPPERCASE` to match the rest
- Unifies `icebergTableExternalVolumeQuoted` and `icebergTableCatalogQuoted` into a single `icebergTableIdentifierQuoted` helper (both shared the same TODO ticket SNOW-2236323)
- Adds unit tests for the new operation and for the `StorageSerializationPolicy` / `IcebergTableCatalog` enum converters
- Updates acceptance test regex to match the new error message format