### PR TITLE
chore: Fix integration tests

### DIFF
--- a/pkg/sdk/testint/api_integrations_gen_integration_test.go
+++ b/pkg/sdk/testint/api_integrations_gen_integration_test.go
@@ -55,7 +55,7 @@ func TestInt_ApiIntegrations(t *testing.T) {
 		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
 
 		return sdk.NewCreateApiIntegrationRequest(id, prefixes(awsPrefix), true).
-			WithAwsApiProviderParams(*sdk.NewAwsApiParamsRequest(sdk.ApiIntegrationAwsApiGateway, apiAwsRoleArn))
+			WithAwsApiProviderParams(*sdk.NewAwsApiParamsRequest(sdk.ApiIntegrationAwsApiProviderTypeAwsApiGateway, apiAwsRoleArn))
 	}
 
 	createApiIntegrationAzureRequest := func(t *testing.T) *sdk.CreateApiIntegrationRequest {
@@ -212,7 +212,7 @@ func TestInt_ApiIntegrations(t *testing.T) {
 		unsetRequest := sdk.NewAlterApiIntegrationRequest(integration.ID()).
 			WithUnset(
 				*sdk.NewApiIntegrationUnsetRequest().
-					WithApiKey(true).
+					WithAwsParams(*sdk.NewUnsetAwsApiParamsRequest().WithApiKey(true)).
 					WithEnabled(true).
 					WithApiBlockedPrefixes(true).
 					WithComment(true),
@@ -260,7 +260,7 @@ func TestInt_ApiIntegrations(t *testing.T) {
 		unsetRequest := sdk.NewAlterApiIntegrationRequest(integration.ID()).
 			WithUnset(
 				*sdk.NewApiIntegrationUnsetRequest().
-					WithApiKey(true).
+					WithAzureParams(*sdk.NewUnsetAzureApiParamsRequest().WithApiKey(true)).
 					WithEnabled(true).
 					WithApiBlockedPrefixes(true).
 					WithComment(true),
@@ -318,7 +318,8 @@ func TestInt_ApiIntegrations(t *testing.T) {
 		unsetRequest := sdk.NewAlterApiIntegrationRequest(integration.ID()).
 			WithUnset(
 				*sdk.NewApiIntegrationUnsetRequest().
-					WithApiKey(true).
+					// TODO (next PR): add Google params unset
+					WithAwsParams(*sdk.NewUnsetAwsApiParamsRequest().WithApiKey(true)).
 					WithEnabled(true).
 					WithApiBlockedPrefixes(true).
 					WithComment(true),
@@ -405,7 +406,7 @@ func TestInt_ApiIntegrations(t *testing.T) {
 
 		assert.Contains(t, details, sdk.ApiIntegrationProperty{Name: "ENABLED", Type: "Boolean", Value: "true", Default: "true"})
 		assert.Contains(t, details, sdk.ApiIntegrationProperty{Name: "API_KEY", Type: "String", Value: "", Default: ""})
-		assert.Contains(t, details, sdk.ApiIntegrationProperty{Name: "API_PROVIDER", Type: "String", Value: strings.ToUpper(string(sdk.ApiIntegrationAwsApiGateway)), Default: ""})
+		assert.Contains(t, details, sdk.ApiIntegrationProperty{Name: "API_PROVIDER", Type: "String", Value: strings.ToUpper(string(sdk.ApiIntegrationAwsApiProviderTypeAwsApiGateway)), Default: ""})
 		assert.Contains(t, details, sdk.ApiIntegrationProperty{Name: "API_AWS_ROLE_ARN", Type: "String", Value: apiAwsRoleArn, Default: ""})
 		assert.Contains(t, details, sdk.ApiIntegrationProperty{Name: "API_ALLOWED_PREFIXES", Type: "List", Value: awsPrefix, Default: "[]"})
 		assert.Contains(t, details, sdk.ApiIntegrationProperty{Name: "API_BLOCKED_PREFIXES", Type: "List", Value: "", Default: "[]"})


### PR DESCRIPTION
## Summary

- Fix API integration test to use renamed enum constant `ApiIntegrationAwsApiProviderTypeAwsApiGateway` (was `ApiIntegrationAwsApiGateway`)
- Fix AWS and Azure unset params to use the correct nested request builders (`WithAwsParams`/`WithAzureParams` instead of top-level `WithApiKey`)
- Add TODO comment for Google params unset (to be addressed in a follow-up PR)