### PR TITLE
chore: Add SDK integration tests for CreateFromDeltaLake iceberg table

### DIFF
--- a/pkg/acceptance/bettertestspoc/assert/objectassert/iceberg_table_desc_snowflake_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/iceberg_table_desc_snowflake_ext.go
@@ -7,7 +7,17 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 )
 
-// Adjusted manually
+func (i *IcebergTableDetailsAssert) HasNoSourceIcebergType() *IcebergTableDetailsAssert {
+	i.AddAssertion(func(t *testing.T, o *sdk.IcebergTableDetails) error {
+		t.Helper()
+		if o.SourceIcebergType != nil {
+			return fmt.Errorf("expected source iceberg type to be nil; got: %s", *o.SourceIcebergType)
+		}
+		return nil
+	})
+	return i
+}
+
 func (i *IcebergTableDetailsAssert) HasNoDefault() *IcebergTableDetailsAssert {
 	i.AddAssertion(func(t *testing.T, o *sdk.IcebergTableDetails) error {
 		t.Helper()
@@ -19,7 +29,6 @@ func (i *IcebergTableDetailsAssert) HasNoDefault() *IcebergTableDetailsAssert {
 	return i
 }
 
-// Adjusted manually
 func (i *IcebergTableDetailsAssert) HasNoCheck() *IcebergTableDetailsAssert {
 	i.AddAssertion(func(t *testing.T, o *sdk.IcebergTableDetails) error {
 		t.Helper()
@@ -31,7 +40,6 @@ func (i *IcebergTableDetailsAssert) HasNoCheck() *IcebergTableDetailsAssert {
 	return i
 }
 
-// Adjusted manually
 func (i *IcebergTableDetailsAssert) HasNoExpression() *IcebergTableDetailsAssert {
 	i.AddAssertion(func(t *testing.T, o *sdk.IcebergTableDetails) error {
 		t.Helper()
@@ -43,7 +51,6 @@ func (i *IcebergTableDetailsAssert) HasNoExpression() *IcebergTableDetailsAssert
 	return i
 }
 
-// Adjusted manually
 func (i *IcebergTableDetailsAssert) HasNoComment() *IcebergTableDetailsAssert {
 	i.AddAssertion(func(t *testing.T, o *sdk.IcebergTableDetails) error {
 		t.Helper()
@@ -55,7 +62,6 @@ func (i *IcebergTableDetailsAssert) HasNoComment() *IcebergTableDetailsAssert {
 	return i
 }
 
-// Adjusted manually
 func (i *IcebergTableDetailsAssert) HasNoPolicyName() *IcebergTableDetailsAssert {
 	i.AddAssertion(func(t *testing.T, o *sdk.IcebergTableDetails) error {
 		t.Helper()
@@ -67,7 +73,6 @@ func (i *IcebergTableDetailsAssert) HasNoPolicyName() *IcebergTableDetailsAssert
 	return i
 }
 
-// Adjusted manually
 func (i *IcebergTableDetailsAssert) HasNoPrivacyDomain() *IcebergTableDetailsAssert {
 	i.AddAssertion(func(t *testing.T, o *sdk.IcebergTableDetails) error {
 		t.Helper()
@@ -79,7 +84,6 @@ func (i *IcebergTableDetailsAssert) HasNoPrivacyDomain() *IcebergTableDetailsAss
 	return i
 }
 
-// Adjusted manually
 func (i *IcebergTableDetailsAssert) HasNoNameMapping() *IcebergTableDetailsAssert {
 	i.AddAssertion(func(t *testing.T, o *sdk.IcebergTableDetails) error {
 		t.Helper()
@@ -91,7 +95,6 @@ func (i *IcebergTableDetailsAssert) HasNoNameMapping() *IcebergTableDetailsAsser
 	return i
 }
 
-// Adjusted manually
 func (i *IcebergTableDetailsAssert) HasNoWriteDefault() *IcebergTableDetailsAssert {
 	i.AddAssertion(func(t *testing.T, o *sdk.IcebergTableDetails) error {
 		t.Helper()

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/iceberg_table_desc_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/iceberg_table_desc_snowflake_gen.go
@@ -50,8 +50,11 @@ func (i *IcebergTableDetailsAssert) HasType(expected datatypes.DataType) *Iceber
 func (i *IcebergTableDetailsAssert) HasSourceIcebergType(expected string) *IcebergTableDetailsAssert {
 	i.AddAssertion(func(t *testing.T, o *sdk.IcebergTableDetails) error {
 		t.Helper()
-		if o.SourceIcebergType != expected {
-			return fmt.Errorf("expected source iceberg type: %v; got: %v", expected, o.SourceIcebergType)
+		if o.SourceIcebergType == nil {
+			return fmt.Errorf("expected source iceberg type to have value; got: nil")
+		}
+		if *o.SourceIcebergType != expected {
+			return fmt.Errorf("expected source iceberg type: %v; got: %v", expected, *o.SourceIcebergType)
 		}
 		return nil
 	})

--- a/pkg/sdk/generator/defs/iceberg_tables_def.go
+++ b/pkg/sdk/generator/defs/iceberg_tables_def.go
@@ -388,7 +388,7 @@ var icebergTablesDef = g.NewInterface(
 	g.StructPair("icebergTableDetailsRow", "IcebergTableDetails").
 		Text("name").
 		DataType("type").
-		Text("source iceberg type").
+		OptionalText("source iceberg type").
 		Text("kind").
 		PlainField("null", "bool", g.WithPlainFieldName("IsNullable")).
 		OptionalText("default").

--- a/pkg/sdk/iceberg_tables_gen.go
+++ b/pkg/sdk/iceberg_tables_gen.go
@@ -581,7 +581,7 @@ type DescribeIcebergTableOptions struct {
 type icebergTableDetailsRow struct {
 	Name              string         `db:"name"`
 	Type              string         `db:"type"`
-	SourceIcebergType string         `db:"source iceberg type"`
+	SourceIcebergType sql.NullString `db:"source iceberg type"`
 	Kind              string         `db:"kind"`
 	Null              string         `db:"null"`
 	Default           sql.NullString `db:"default"`
@@ -599,7 +599,7 @@ type icebergTableDetailsRow struct {
 type IcebergTableDetails struct {
 	Name              string
 	Type              datatypes.DataType
-	SourceIcebergType string
+	SourceIcebergType *string
 	Kind              string
 	IsNullable        bool
 	Default           *string

--- a/pkg/sdk/iceberg_tables_impl_gen.go
+++ b/pkg/sdk/iceberg_tables_impl_gen.go
@@ -650,18 +650,18 @@ func (r *DescribeIcebergTableRequest) toOpts() *DescribeIcebergTableOptions {
 
 func (r icebergTableDetailsRow) convert() (*IcebergTableDetails, error) {
 	result := &IcebergTableDetails{
-		Name:              r.Name,
-		SourceIcebergType: r.SourceIcebergType,
-		Kind:              r.Kind,
-		IsNullable:        r.Null == "Y",
-		PrimaryKey:        r.PrimaryKey == "Y",
-		UniqueKey:         r.UniqueKey == "Y",
+		Name:       r.Name,
+		Kind:       r.Kind,
+		IsNullable: r.Null == "Y",
+		PrimaryKey: r.PrimaryKey == "Y",
+		UniqueKey:  r.UniqueKey == "Y",
 	}
 	if v, err := datatypes.ParseDataType(r.Type); err != nil {
 		return nil, fmt.Errorf("parsing datatypes. data type: %w", err)
 	} else {
 		result.Type = v
 	}
+	mapNullString(&result.SourceIcebergType, r.SourceIcebergType)
 	mapNullString(&result.Default, r.Default)
 	mapNullString(&result.Check, r.Check)
 	mapNullString(&result.Expression, r.Expression)

--- a/pkg/sdk/testint/iceberg_tables_integration_test.go
+++ b/pkg/sdk/testint/iceberg_tables_integration_test.go
@@ -44,6 +44,21 @@ func TestInt_IcebergTables(t *testing.T) {
 	t.Cleanup(dbForIcebergFilesCleanup)
 	schemaIdForIcebergFiles := sdk.NewDatabaseObjectIdentifier(dbForIcebergFiles.ID().Name(), "PUBLIC")
 
+	deltaBaseLocation := "delta_lake_test_table"
+
+	catalogForDeltaLakeId, catalogForDeltaLakeCleanup := testClientHelper().CatalogIntegration.CreateFunc(t,
+		sdk.NewCreateCatalogIntegrationRequest(testClientHelper().Ids.RandomAccountObjectIdentifier(), true).
+			WithObjectStorageCatalogSourceParams(*sdk.NewObjectStorageParamsRequest(sdk.CatalogIntegrationTableFormatDelta)),
+	)
+	t.Cleanup(catalogForDeltaLakeCleanup)
+
+	dbForDeltaLake, dbForDeltaLakeCleanup := testClientHelper().Database.CreateDatabaseWithOptions(t, testClientHelper().Ids.RandomAccountObjectIdentifier(), &sdk.CreateDatabaseOptions{
+		Catalog:        new(catalogForDeltaLakeId),
+		ExternalVolume: new(externalVolumeId),
+	})
+	t.Cleanup(dbForDeltaLakeCleanup)
+	schemaIdForDeltaLake := sdk.NewDatabaseObjectIdentifier(dbForDeltaLake.ID().Name(), "PUBLIC")
+
 	contactId, contactCleanup := testClientHelper().Contact.Create(t)
 	t.Cleanup(contactCleanup)
 
@@ -634,6 +649,106 @@ func TestInt_IcebergTables(t *testing.T) {
 
 		// IF NOT EXISTS should not error when the table already exists.
 		err = client.IcebergTables.CreateFromIcebergFiles(ctx, sdk.NewCreateFromIcebergFilesIcebergTableRequest(id, metadataFilePath).
+			WithIfNotExists(true))
+		require.NoError(t, err)
+	})
+
+	t.Run("create from delta lake: basic", func(t *testing.T) {
+		id := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(schemaIdForDeltaLake)
+
+		err := client.IcebergTables.CreateFromDeltaLake(ctx, sdk.NewCreateFromDeltaLakeIcebergTableRequest(id, deltaBaseLocation))
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().IcebergTable.DropFunc(t, id))
+
+		assertThatObject(t, objectassert.IcebergTable(t, id).
+			HasName(id.Name()).
+			HasDatabaseName(id.DatabaseName()).
+			HasSchemaName(id.SchemaName()).
+			HasOwner("ACCOUNTADMIN").
+			HasExternalVolumeName(externalVolumeId).
+			HasCatalogName(catalogForDeltaLakeId).
+			HasIcebergTableType(sdk.IcebergTableTypeUnmanaged).
+			HasNoCatalogTableName().
+			HasNoCatalogNamespace().
+			HasCanWriteMetadata(true).
+			HasComment("").
+			HasNoNameMapping().
+			HasOwnerRoleType("ROLE").
+			HasCatalogSyncName(""),
+		)
+
+		assertThatObject(t, objectparametersassert.IcebergTableParameters(t, id).
+			HasCatalog(catalogForDeltaLakeId.Name()).
+			HasExternalVolume(externalVolumeId.Name()),
+		)
+
+		details, err := client.IcebergTables.Describe(ctx, id)
+		require.NoError(t, err)
+		require.NotEmpty(t, details)
+	})
+
+	t.Run("create from delta lake: all options", func(t *testing.T) {
+		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
+
+		err := client.IcebergTables.CreateFromDeltaLake(ctx, sdk.NewCreateFromDeltaLakeIcebergTableRequest(id, deltaBaseLocation).
+			WithOrReplace(true).
+			WithExternalVolume(externalVolumeId).
+			WithCatalog(catalogForDeltaLakeId).
+			WithReplaceInvalidCharacters(true).
+			WithAutoRefresh(false).
+			WithComment("integration test").
+			WithContact([]sdk.TableContact{
+				{Purpose: "SUPPORT", Contact: contactId},
+			}))
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().IcebergTable.DropFunc(t, id))
+
+		assertThatObject(t, objectassert.IcebergTable(t, id).
+			HasName(id.Name()).
+			HasDatabaseName(id.DatabaseName()).
+			HasSchemaName(id.SchemaName()).
+			HasOwner("ACCOUNTADMIN").
+			HasExternalVolumeName(externalVolumeId).
+			HasCatalogName(catalogForDeltaLakeId).
+			HasIcebergTableType(sdk.IcebergTableTypeUnmanaged).
+			HasNoCatalogTableName().
+			HasNoCatalogNamespace().
+			HasCanWriteMetadata(true).
+			HasComment("integration test").
+			HasNoNameMapping().
+			HasOwnerRoleType("ROLE").
+			HasCatalogSyncName("").
+			HasAutoRefreshStatus(""),
+		)
+
+		assertThatObject(t, objectparametersassert.IcebergTableParameters(t, id).
+			HasCatalog(catalogForDeltaLakeId.FullyQualifiedName()).
+			HasExternalVolume(externalVolumeId.FullyQualifiedName()).
+			HasReplaceInvalidCharacters(true),
+		)
+
+		details, err := client.IcebergTables.Describe(ctx, id)
+		require.NoError(t, err)
+		require.NotEmpty(t, details)
+		for _, col := range details {
+			assertThatObject(t, objectassert.IcebergTableDetailsFromObject(t, &col).
+				HasKind("COLUMN").
+				HasNoPolicyName().
+				HasNoPrivacyDomain().
+				HasNoWriteDefault(),
+			)
+		}
+	})
+
+	t.Run("create from delta lake: if not exists", func(t *testing.T) {
+		id := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(schemaIdForDeltaLake)
+
+		err := client.IcebergTables.CreateFromDeltaLake(ctx, sdk.NewCreateFromDeltaLakeIcebergTableRequest(id, deltaBaseLocation))
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().IcebergTable.DropFunc(t, id))
+
+		// IF NOT EXISTS should not error when the table already exists.
+		err = client.IcebergTables.CreateFromDeltaLake(ctx, sdk.NewCreateFromDeltaLakeIcebergTableRequest(id, deltaBaseLocation).
 			WithIfNotExists(true))
 		require.NoError(t, err)
 	})

--- a/pkg/sdk/testint/iceberg_tables_integration_test.go
+++ b/pkg/sdk/testint/iceberg_tables_integration_test.go
@@ -674,17 +674,27 @@ func TestInt_IcebergTables(t *testing.T) {
 			HasComment("").
 			HasNoNameMapping().
 			HasOwnerRoleType("ROLE").
-			HasCatalogSyncName(""),
+			HasCatalogSyncName("").
+			HasAutoRefreshStatus(""),
 		)
 
 		assertThatObject(t, objectparametersassert.IcebergTableParameters(t, id).
 			HasCatalog(catalogForDeltaLakeId.Name()).
-			HasExternalVolume(externalVolumeId.Name()),
+			HasExternalVolume(externalVolumeId.Name()).
+			HasReplaceInvalidCharacters(false),
 		)
 
 		details, err := client.IcebergTables.Describe(ctx, id)
 		require.NoError(t, err)
 		require.NotEmpty(t, details)
+		for _, col := range details {
+			assertThatObject(t, objectassert.IcebergTableDetailsFromObject(t, &col).
+				HasKind("COLUMN").
+				HasNoPolicyName().
+				HasNoPrivacyDomain().
+				HasNoWriteDefault(),
+			)
+		}
 	})
 
 	t.Run("create from delta lake: all options", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds integration tests for `CreateFromDeltaLake`: basic, all options, and if-not-exists variants
- Fixes `SourceIcebergType` nullability in `IcebergTableDetails`: changed from `string` to `*string` (and `sql.NullString` in the row struct) so `DESCRIBE` does not fail when the column is `NULL` (e.g. for non-Iceberg-catalog tables)
- Adds `HasNoSourceIcebergType` assertion helper and updates `HasSourceIcebergType` to nil-check before dereferencing