### PR TITLE
chore: reset global gosnowflake logger level after NewClient tests

### DIFF
--- a/pkg/sdk/testint/client_integration_test.go
+++ b/pkg/sdk/testint/client_integration_test.go
@@ -26,6 +26,15 @@ import (
 // TODO [SNOW-1827310]: use generated config for these tests
 // TODO [SNOW-2054366]: Use dedicated users for these tests.
 func TestInt_Client_NewClient(t *testing.T) {
+	// gosnowflake.GetLogger() is a single global logger for the whole test binary. The driver sets the global logger
+	// level in its init. Every time a connection is opened with a non‑empty Tracing, the driver overwrites that
+	// global level. We reset it with the following cleanup function.
+	defaultLogLevel := gosnowflake.GetLogger().GetLogLevel()
+	t.Cleanup(func() {
+		err := gosnowflake.GetLogger().SetLogLevel(defaultLogLevel)
+		require.NoError(t, err)
+	})
+
 	t.Run("with default config (legacy)", func(t *testing.T) {
 		tmpServiceUser := testClientHelper().SetUpTemporaryServiceUser(t)
 		tmpServiceUserConfig := testClientHelper().StoreTempTomlConfigWithProfile(t, testprofiles.Default, func(profile string) string {


### PR DESCRIPTION
TestInt_Client_NewClient opens connections with configs that hardcode driver_tracing=warn (Full[Legacy]TomlConfigForServiceUser). Because gosnowflake.GetLogger() is a process-global logger, this permanently mutated the level for the rest of the test binary, causing the later "get default gosnowflake driver logging level" assertion to see WARN instead of the driver's init default (FATAL on CI / ERROR locally).

Snapshot the log level at the start of the test and restore it via t.Cleanup so the test no longer leaks state into subsequent tests.
