### PR TITLE
docs(hybrid table): explain d.Partial(true) usage in Update

### DIFF
--- a/pkg/resources/hybrid_table.go
+++ b/pkg/resources/hybrid_table.go
@@ -743,6 +743,13 @@ func UpdateHybridTable(ctx context.Context, d *schema.ResourceData, meta any) di
 		)
 
 		if err := client.HybridTables.Alter(ctx, sdk.NewAlterHybridTableRequest(id).WithNewName(newId)); err != nil {
+			// d.Partial(true) preserves the resource's previous state on error. Without it, SDKv2 writes
+			// the proposed config into state when Update returns an error — even without any d.Set calls —
+			// replacing known-good state with unverified config values.
+			// See terraform-plugin-sdk/v2 (helper/schema/resource_data.go: Partial).
+			// Computed-only fields (show_output, describe_output) are also preserved by this mechanism:
+			// because they are never sourced from config, their prior values survive any early return
+			// without requiring explicit d.Set calls before the error path.
 			d.Partial(true)
 			return diag.FromErr(fmt.Errorf("error renaming hybrid table from %v to %v: %w", id.FullyQualifiedName(), newId.FullyQualifiedName(), err))
 		}


### PR DESCRIPTION
## Summary

- Adds a comment before the first \`d.Partial(true)\` call in \`UpdateHybridTable\` explaining the SDKv2 partial-state contract and its interaction with \`Computed: true\` fields
- No logic changes

## Context — item 9 from the post-#4689 follow-up plan

**\`d.Partial(true)\`** is called ~10 times in \`UpdateHybridTable\`. In SDKv2, when \`Update\` returns an error the framework writes the *proposed config* into state — even without any \`d.Set\` calls — replacing known-good prior state with unverified values. \`d.Partial(true)\` prevents this by preserving the previous state.

**\`Computed: true\` interaction**: \`show_output\` and \`describe_output\` are only refreshed when \`Update\` succeeds (via the trailing \`ReadHybridTable\` call). On any early-return error path, those fields are safely preserved because (a) they are \`Computed: true\` so Terraform never sources them from config, and (b) \`d.Partial(true)\` preserves all prior state. The comment connects these two concepts in one place.

The comment cites \`terraform-plugin-sdk/v2 (helper/schema/resource_data.go: Partial)\`, consistent with the existing citation style at lines 527 and 1091 of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)