### PR TITLE
chore: Inline EscapeSnowflakeString / UnescapeSnowflakeString in table.go

### DIFF
--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -413,7 +413,7 @@ func getTableColumnRequest(from interface{}) (*sdk.TableColumnRequest, error) {
 		if c, ok := _default[0].(map[string]interface{})["constant"]; ok {
 			if constant, ok := c.(string); ok && len(constant) > 0 {
 				if datatypes.IsTextDataType(dataType) {
-					expression = snowflake.EscapeSnowflakeString(constant)
+					expression = "'" + strings.ReplaceAll(constant, "'", "''") + "'"
 				} else {
 					expression = constant
 				}
@@ -550,7 +550,8 @@ func toColumnDefaultConfig(td sdk.TableColumnDetails) map[string]any {
 	}
 
 	if sdk.IsStringType(string(td.Type)) {
-		def["constant"] = snowflake.UnescapeSnowflakeString(defaultRaw)
+		unquoted := strings.TrimSuffix(strings.TrimPrefix(defaultRaw, "'"), "'")
+		def["constant"] = strings.ReplaceAll(unquoted, "''", "'")
 		return def
 	}
 
@@ -825,7 +826,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				}
 				var expression string
 				if sdk.IsStringType(cA.dataType) {
-					expression = snowflake.EscapeSnowflakeString(*cA._default.constant)
+					expression = "'" + strings.ReplaceAll(*cA._default.constant, "'", "''") + "'"
 				} else {
 					expression = *cA._default.constant
 				}


### PR DESCRIPTION
Inlines the `'`-quoting/unquoting logic in `pkg/resources/table.go`, matching the pattern already used in `pkg/resources/hybrid_table.go` (introduced in commit `af007338`). No behavioral change — the inlined expressions are bit-for-bit equivalent to `pkg/snowflake.EscapeSnowflakeString` / `UnescapeSnowflakeString`.

Three call sites migrated:
- `getTableColumnRequest` (column default for new column)
- `toColumnDefaultConfig` (read-back of string default from Snowflake)
- `UpdateTable` (column default when adding a column via `ALTER TABLE`)

The `pkg/snowflake` import remains — `EscapeString` and `QuoteStringList` are still used elsewhere in the file.

## Test Plan
* [ ] acceptance tests (existing `TestAcc_Table_*` suites cover string defaults end-to-end)
* [x] `go build ./...`
* [x] `go vet ./pkg/resources/...`

## References

* Follow-up to #4689 (hybrid_table preview resource), item 6 of the post-merge follow-up plan
* Mirrors the inline pattern from `hybrid_table.go` (`af007338`)