### PR TITLE
chore(sdk): trim PR-archeology from hybrid_tables def NOTEs

### DIFF
--- a/pkg/sdk/generator/defs/hybrid_tables_def.go
+++ b/pkg/sdk/generator/defs/hybrid_tables_def.go
@@ -22,7 +22,6 @@ var hybridTableOutOfLineConstraint = g.NewQueryStruct("HybridTableOutOfLineConst
 	// NOTE: Constraint modifier flags (Enforced, NotEnforced, Deferrable, NotDeferrable,
 	// InitiallyDeferred, InitiallyImmediate, Enable, Disable, Validate, Novalidate, Rely, Norely)
 	// are not supported on hybrid tables — Snowflake returns "invalid constraint property".
-	// Removed from the SDK per PR #4461 review feedback.
 	PredefinedQueryStructField("ForeignKey", g.KindOfTPointer[sdkcommons.OutOfLineForeignKey](), g.KeywordOptions())
 
 var hybridTableOutOfLineIndex = g.NewQueryStruct("HybridTableOutOfLineIndex").
@@ -61,8 +60,8 @@ var hybridTableConstraintAction = g.NewQueryStruct("HybridTableConstraintAction"
 	).
 	OptionalQueryStructField(
 		"Drop",
-		// NOTE: PRIMARY KEY is not included here — DROP PRIMARY KEY is unsupported on hybrid tables.
-		// Snowflake returns an error at runtime; removed per PR #4461 review feedback.
+		// NOTE: PRIMARY KEY is not included here — DROP PRIMARY KEY is unsupported on hybrid tables
+		// (Snowflake returns an error at runtime).
 		g.NewQueryStruct("HybridTableConstraintActionDrop").
 			SQL("DROP").
 			OptionalAssignmentWithFieldName("CONSTRAINT", "*string", g.ParameterOptions().NoEquals().DoubleQuotes(), "ConstraintName").
@@ -128,11 +127,10 @@ var hybridTableSetProperties = g.NewQueryStruct("HybridTableSetProperties").
 	WithValidation(g.AtLeastOneValueSet, "DataRetentionTimeInDays", "MaxDataExtensionTimeInDays", "Comment")
 
 // NOTE: Multi-property `ALTER TABLE ... UNSET` on hybrid tables requires comma-separated
-// property names (`UNSET A, B, C`) — the bare-keyword form (`UNSET A B C`) emitted by the
-// generator's default `keyword` rendering is rejected by the parser. Applying
-// `g.ListOptions().NoParentheses().SQL("UNSET")` to the parent field on
-// AlterHybridTableOptions causes the SQL builder to comma-join the children.
-// Mirrors NetworkPolicyUnset in pkg/sdk/network_policies_gen.go:74. Verified on preprod6.
+// property names (`UNSET A, B, C`); the generator's default `keyword` rendering emits the
+// bare-keyword form, which the parser rejects. Applying `g.ListOptions().NoParentheses()
+// .SQL("UNSET")` on the parent field causes the SQL builder to comma-join the children —
+// mirrors NetworkPolicyUnset in pkg/sdk/network_policies_gen.go:74.
 var hybridTableUnsetProperties = g.NewQueryStruct("HybridTableUnsetProperties").
 	OptionalSQL("COMMENT").
 	OptionalSQL("DATA_RETENTION_TIME_IN_DAYS").

--- a/pkg/sdk/generator/defs/hybrid_tables_def.go
+++ b/pkg/sdk/generator/defs/hybrid_tables_def.go
@@ -128,9 +128,9 @@ var hybridTableSetProperties = g.NewQueryStruct("HybridTableSetProperties").
 
 // NOTE: Multi-property `ALTER TABLE ... UNSET` on hybrid tables requires comma-separated
 // property names (`UNSET A, B, C`); the generator's default `keyword` rendering emits the
-// bare-keyword form, which the parser rejects. Applying `g.ListOptions().NoParentheses()
-// .SQL("UNSET")` on the parent field causes the SQL builder to comma-join the children —
-// mirrors NetworkPolicyUnset in pkg/sdk/network_policies_gen.go:74.
+// bare-keyword form, which the parser rejects. Applying
+// `g.ListOptions().NoParentheses().SQL("UNSET")` on the parent field causes the SQL builder
+// to comma-join the children — mirrors NetworkPolicyUnset in pkg/sdk/network_policies_gen.go:74.
 var hybridTableUnsetProperties = g.NewQueryStruct("HybridTableUnsetProperties").
 	OptionalSQL("COMMENT").
 	OptionalSQL("DATA_RETENTION_TIME_IN_DAYS").


### PR DESCRIPTION
Follow-up to #4689. Per @sfc-gh-jcieslak: \"verbose comments — proponuję wyczyścić w follow-up\".

Trims the PR-archeology trailers (\`Removed from the SDK per PR #4461 review feedback\`, \`Verified on preprod6\`) from three NOTE blocks in \`pkg/sdk/generator/defs/hybrid_tables_def.go\` while keeping the Snowflake-quirk descriptions, the workaround mechanism, and the cross-reference to \`network_policies_gen.go:74\`.

Operationally-critical NOTEs (post-generation manual fixes for \`Null\` tag and \`Collation\` field; the catalog of unsupported SET properties; the CREATE-time \`DATA_RETENTION_TIME_IN_DAYS\` quirk) are kept verbatim — they document hard requirements for anyone re-running \`make generate-sdk\`.

Comment-only edit; no \`make generate-sdk\` re-run, no SDK or resource behavior change.

## Test Plan
- [x] \`go build ./pkg/sdk/...\` clean
- [x] \`go vet ./pkg/sdk/...\` clean
- [x] \`grep -n 'NOTE:' pkg/sdk/generator/defs/hybrid_tables_def.go\` — count unchanged (9 NOTE markers)

## References
* Follow-up to #4689 (item 7 of the post-merge follow-up plan)