### PR TITLE
chore: Add SDK support for SYSTEM$GET_ICEBERG_TABLE_INFORMATION system function

### DIFF
--- a/pkg/acceptance/helpers/iceberg_table_client.go
+++ b/pkg/acceptance/helpers/iceberg_table_client.go
@@ -59,3 +59,12 @@ func (c *IcebergTableClient) Describe(t *testing.T, id sdk.SchemaObjectIdentifie
 	ctx := context.Background()
 	return c.context.client.IcebergTables.Describe(ctx, id)
 }
+
+func (c *IcebergTableClient) GetIcebergTableInformation(t *testing.T, id sdk.SchemaObjectIdentifier) sdk.IcebergTableInformation {
+	t.Helper()
+	ctx := context.Background()
+	info, err := c.context.client.SystemFunctions.GetIcebergTableInformation(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	return *info
+}

--- a/pkg/sdk/system_functions.go
+++ b/pkg/sdk/system_functions.go
@@ -21,6 +21,7 @@ type SystemFunctions interface {
 	DisableBehaviorChangeBundle(ctx context.Context, bundle string) error
 	ShowActiveBehaviorChangeBundles(ctx context.Context) ([]BehaviorChangeBundleInfo, error)
 	BehaviorChangeBundleStatus(ctx context.Context, bundle string) (BehaviorChangeBundleStatus, error)
+	GetIcebergTableInformation(ctx context.Context, id SchemaObjectIdentifier) (*IcebergTableInformation, error)
 }
 
 var _ SystemFunctions = (*systemFunctions)(nil)
@@ -197,4 +198,36 @@ func (c *systemFunctions) BehaviorChangeBundleStatus(ctx context.Context, bundle
 		return "", err
 	}
 	return ToBehaviorChangeBundleStatus(row.StatusRaw)
+}
+
+type icebergTableInformationDbStruct struct {
+	MetadataLocation string `json:"metadataLocation"`
+	Status           string `json:"status"`
+}
+
+type IcebergTableInformation struct {
+	MetadataLocation string
+}
+
+// Implementation of SYSTEM$GET_ICEBERG_TABLE_INFORMATION - see https://docs.snowflake.com/en/sql-reference/functions/system_get_iceberg_table_information.
+func (c *systemFunctions) GetIcebergTableInformation(ctx context.Context, id SchemaObjectIdentifier) (*IcebergTableInformation, error) {
+	row := &struct {
+		Info string `db:"ICEBERG_TABLE_INFORMATION"`
+	}{}
+	sql := fmt.Sprintf(`SELECT SYSTEM$GET_ICEBERG_TABLE_INFORMATION('%s') AS "ICEBERG_TABLE_INFORMATION"`, id.FullyQualifiedName())
+	err := c.client.queryOne(ctx, row, sql)
+	if err != nil {
+		return nil, err
+	}
+	var info icebergTableInformationDbStruct
+	if err = json.Unmarshal([]byte(row.Info), &info); err != nil {
+		return nil, err
+	}
+	if !strings.EqualFold(info.Status, "success") {
+		return nil, fmt.Errorf("getting iceberg table information failed: %s", info.Status)
+	}
+
+	return &IcebergTableInformation{
+		MetadataLocation: info.MetadataLocation,
+	}, nil
 }

--- a/pkg/sdk/testint/iceberg_tables_integration_test.go
+++ b/pkg/sdk/testint/iceberg_tables_integration_test.go
@@ -304,6 +304,9 @@ func TestInt_IcebergTables(t *testing.T) {
 		t.Cleanup(testClientHelper().IcebergTable.DropFunc(t, id))
 
 		basicAssertions(t, id)
+
+		info := testClientHelper().IcebergTable.GetIcebergTableInformation(t, id)
+		assert.NotEmpty(t, info.MetadataLocation)
 	})
 
 	t.Run("create Snowflake managed: all options", func(t *testing.T) {
@@ -440,6 +443,9 @@ func TestInt_IcebergTables(t *testing.T) {
 
 		completeAssertions(t, id, maskingPolicy.ID())
 
+		info := testClientHelper().IcebergTable.GetIcebergTableInformation(t, id)
+		assert.NotEmpty(t, info.MetadataLocation)
+
 		references, err := testClientHelper().PolicyReferences.GetPolicyReferences(t, id, sdk.PolicyEntityDomainTable)
 		require.NoError(t, err)
 		require.Len(t, references, 4)
@@ -492,6 +498,9 @@ func TestInt_IcebergTables(t *testing.T) {
 
 		_, err = client.IcebergTables.ShowByID(ctx, id)
 		require.NoError(t, err)
+
+		info := testClientHelper().IcebergTable.GetIcebergTableInformation(t, id)
+		assert.NotEmpty(t, info.MetadataLocation)
 	})
 	t.Run("create from iceberg files: basic", func(t *testing.T) {
 		id := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(schemaIdForIcebergFiles)
@@ -557,6 +566,9 @@ func TestInt_IcebergTables(t *testing.T) {
 		references, err := testClientHelper().PolicyReferences.GetPolicyReferences(t, id, sdk.PolicyEntityDomainTable)
 		require.NoError(t, err)
 		require.Empty(t, references)
+
+		info := testClientHelper().IcebergTable.GetIcebergTableInformation(t, id)
+		assert.Equal(t, s3CompatBaseUrl+metadataFilePath, info.MetadataLocation)
 	})
 
 	t.Run("create from iceberg files: all options", func(t *testing.T) {
@@ -623,6 +635,9 @@ func TestInt_IcebergTables(t *testing.T) {
 				HasNoWriteDefault(),
 			)
 		}
+
+		info := testClientHelper().IcebergTable.GetIcebergTableInformation(t, id)
+		assert.Equal(t, s3CompatBaseUrl+metadataFilePath, info.MetadataLocation)
 	})
 
 	t.Run("create from iceberg files: if not exists", func(t *testing.T) {

--- a/pkg/sdk/testint/system_functions_integration_test.go
+++ b/pkg/sdk/testint/system_functions_integration_test.go
@@ -180,6 +180,28 @@ func TestInt_PipeForceResume(t *testing.T) {
 	require.Equal(t, sdk.RunningPipeExecutionState, pipeExecutionState)
 }
 
+func TestInt_GetIcebergTableInformation(t *testing.T) {
+	client := testClient(t)
+	ctx := testContext(t)
+
+	// We test only one variant of the iceberg tables here. See more tests in the iceberg table integration tests.
+	icebergTable, icebergTableCleanup := testClientHelper().IcebergTable.Create(t)
+	t.Cleanup(icebergTableCleanup)
+
+	t.Run("get iceberg table information", func(t *testing.T) {
+		info, err := client.SystemFunctions.GetIcebergTableInformation(ctx, icebergTable.ID())
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		// Assert not empty because Snowflake returns a temporary location like
+		// s3://sfc-prod2-xyz/iceberg/path/to/file/file.metadata.json
+		assert.NotEmpty(t, info.MetadataLocation)
+	})
+	t.Run("get iceberg table information fails when the table does not exist", func(t *testing.T) {
+		_, err := client.SystemFunctions.GetIcebergTableInformation(ctx, testClientHelper().Ids.RandomSchemaObjectIdentifier())
+		require.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
+	})
+}
+
 func TestInt_BcrBundles(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)


### PR DESCRIPTION
## Changes

Adds `GetIcebergTableInformation` to the `SystemFunctions` SDK interface, implementing the [`SYSTEM$GET_ICEBERG_TABLE_INFORMATION`](https://docs.snowflake.com/en/sql-reference/functions/system_get_iceberg_table_information) syscall.

- New `GetIcebergTableInformation(ctx, SchemaObjectIdentifier) (*IcebergTableInformation, error)` method on `SystemFunctions`
- Parses the JSON response and returns `IcebergTableInformation{MetadataLocation string}`
- Returns an error when the response status is not `"success"` or the table does not exist (`ErrObjectNotExistOrAuthorized`)
- Helper method `IcebergTableClient.GetIcebergTableInformation` for use in acceptance tests
- Integration tests in `TestInt_GetIcebergTableInformation` (dedicated) and piggy-backed assertions in existing iceberg table create tests