### PR TITLE
chore: Skip failing DECFLOAT and hybrid table integration tests

### DIFF
--- a/pkg/sdk/testint/hybrid_tables_integration_test.go
+++ b/pkg/sdk/testint/hybrid_tables_integration_test.go
@@ -33,7 +33,22 @@ func TestInt_HybridTables(t *testing.T) {
 				HasOwnerRoleType("ROLE"))
 		})
 
+		// TODO(SNOW-3643759): Investigate and unskip:
+		//hybrid_tables_integration_test.go:170:
+		//           Error Trace:    /home/runner/work/terraform-provider-snowflake/terraform-provider-snowflake/pkg/sdk/testint/hybrid_tables_integration_test.go:170
+		//           Error:          Not equal:
+		//                           expected: "VARCHAR(200)"
+		//                           actual  : "VARCHAR(200) COLLATE 'en-ci'"
+		//
+		//                           Diff:
+		//                           --- Expected
+		//                           +++ Actual
+		//                           @@ -1 +1 @@
+		//                           -VARCHAR(200)
+		//                           +VARCHAR(200) COLLATE 'en-ci'
+		//           Test:           TestInt_HybridTables/create_operations/complete_-_all_column_and_constraint_options
 		t.Run("complete - all column and constraint options", func(t *testing.T) {
+			t.Skip("TODO(SNOW-3643759): Investigate and unskip")
 			refId, refCleanup := testClientHelper().HybridTable.CreateWithColumns(t, []sdk.HybridTableColumnRequest{
 				{Name: "REF_ID", DataType: sdk.DataType("NUMBER(38,0)"), InlineConstraint: &sdk.ColumnInlineConstraint{Type: sdk.ColumnConstraintTypePrimaryKey}},
 			})

--- a/pkg/sdk/testint/procedures_integration_test.go
+++ b/pkg/sdk/testint/procedures_integration_test.go
@@ -2868,6 +2868,7 @@ def filter_by_role(session, name, role):
 	// `The DECFLOAT data type isn’t supported in stored procedures or user-defined functions (UDFs) written in a language other than SQL, such as Python or Java.`
 	// is unclear. Confirming that DECFLOAT is not supported even for SQL procedures.
 	t.Run("document that DECFLOAT is not supported even for SQL procedures", func(t *testing.T) {
+		t.Skip("TODO(next prs): fix or remove the test now that DECFLOAT is supported for SQL procedures")
 		argName := "A"
 		dataType, err := datatypes.ParseDataType("DECFLOAT")
 		require.NoError(t, err)


### PR DESCRIPTION
Skip the DECFLOAT SQL procedure test (now that DECFLOAT is supported for SQL procedures) and the hybrid table complete column/constraint options test (VARCHAR COLLATE mismatch), with TODOs to investigate and unskip.