### PR TITLE
chore: Add object and parts exclusion filters to the generator commons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ generate-sdk: ## Generate all SDK objects
 	go generate ./pkg/sdk/generate.go
 
 generate-sdk-no-tests: ## Generated all SDK files (except tests)
-	make generate-sdk SF_TF_GENERATOR_ARGS='--filter-generation-part-names=default,dto,dto_builders,impl,validations'
+	make generate-sdk SF_TF_GENERATOR_ARGS='--exclude-generation-part-names=unit_tests'
 
 generate-sdk-no-tests-check: generate-sdk-no-tests ## Check that all generated SDK files (except tests) are up-to-date
 	$(call GIT_DIFF_CHECK,pkg/sdk/*_gen.go pkg/sdk/*_dto_gen.go pkg/sdk/*_dto_builders_gen.go pkg/sdk/*_impl_gen.go pkg/sdk/*_validations_gen.go)

--- a/pkg/internal/genhelpers/README.md
+++ b/pkg/internal/genhelpers/README.md
@@ -68,6 +68,8 @@ To create a new generator:
    - `-h` or `--help` printing the usage for the given generator
    - `--filter-generation-part-names <name1>,<name2>,...` allowing to generate only for the given generation part names; defaults to empty list meaning all generation parts are used
    - `--filter-object-names <name1>,<name2>,...` allowing to generate only for the given object names; defaults to empty list meaning all objects are used
+   - `--exclude-object-names <name1>,<name2>,...` allowing to exclude the given object names from generation; composes with inclusion filters (AND logic)
+   - `--exclude-generation-part-names <name1>,<name2>,...` allowing to exclude the given generation part names from generation; composes with inclusion filters (AND logic)
    - `--verbose` allowing to see the all the additional debug logs
 
 ### Next steps

--- a/pkg/internal/genhelpers/flags.go
+++ b/pkg/internal/genhelpers/flags.go
@@ -8,30 +8,45 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
 
-type filtersFlag struct {
+type namesListFlag struct {
 	name             string
+	prefix           string
 	filters          []string
 	availableOptions []string
 }
 
-func newFiltersFlag(name string, availableOptions []string) *filtersFlag {
+func newInclusionFlag(name string, availableOptions []string) *namesListFlag {
 	slices.Sort(availableOptions)
-	return &filtersFlag{
+	return &namesListFlag{
 		name:             name,
+		prefix:           "filter",
 		filters:          make([]string, 0),
 		availableOptions: availableOptions,
 	}
 }
 
-func (f *filtersFlag) hasValues() bool {
+func newExclusionFlag(name string, availableOptions []string) *namesListFlag {
+	slices.Sort(availableOptions)
+	return &namesListFlag{
+		name:             name,
+		prefix:           "exclude",
+		filters:          make([]string, 0),
+		availableOptions: availableOptions,
+	}
+}
+
+func (f *namesListFlag) hasValues() bool {
 	return len(f.filters) > 0
 }
 
-func (f *filtersFlag) flagName() string {
-	return fmt.Sprintf("filter-%s", strings.ToLower(strings.ReplaceAll(f.name, " ", "-")))
+func (f *namesListFlag) flagName() string {
+	return fmt.Sprintf("%s-%s", f.prefix, strings.ToLower(strings.ReplaceAll(f.name, " ", "-")))
 }
 
-func (f *filtersFlag) usage() string {
+func (f *namesListFlag) usage() string {
+	if f.prefix == "exclude" {
+		return fmt.Sprintf("exclude the given %[1]s from generation like `<name1>,<name2>,...`; available %[1]s:\n%s", f.name, formatAvailableOptions(f.availableOptions))
+	}
 	return fmt.Sprintf("generate only for the given %[1]s like `<name1>,<name2>,...`; available %[1]s:\n%s", f.name, formatAvailableOptions(f.availableOptions))
 }
 
@@ -39,21 +54,21 @@ func formatAvailableOptions(options []string) string {
 	return strings.Join(collections.Map(options, func(s string) string { return " - " + s }), "\n") + "\n"
 }
 
-func (f *filtersFlag) String() string {
+func (f *namesListFlag) String() string {
 	if len(f.filters) == 0 {
 		// this is considered a default value; the default usage prints: (default ...)
 		return fmt.Sprintf("is an empty list: all %s are used", f.name)
 	}
-	return fmt.Sprintf("%s filter with values %s (len: %d)", f.name, f.filters, len(f.filters))
+	return fmt.Sprintf("%s %s with values %s (len: %d)", f.name, f.prefix, f.filters, len(f.filters))
 }
 
-func (f *filtersFlag) Set(value string) error {
+func (f *namesListFlag) Set(value string) error {
 	if len(f.filters) > 0 {
-		return fmt.Errorf("%s filters has been already initiated; use single attribute with comma-separated list", f.name)
+		return fmt.Errorf("%s %s has been already initiated; use single attribute with comma-separated list", f.name, f.prefix)
 	}
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return fmt.Errorf("%s filters cannot be initiated with an empty value; use single attribute with comma-separated list", f.name)
+		return fmt.Errorf("%s %s cannot be initiated with an empty value; use single attribute with comma-separated list", f.name, f.prefix)
 	}
 	for _, fil := range strings.Split(value, ",") {
 		f.filters = append(f.filters, fil)

--- a/pkg/internal/genhelpers/generation_part_filters.go
+++ b/pkg/internal/genhelpers/generation_part_filters.go
@@ -12,3 +12,12 @@ func filterGenerationPartByNameProvider[T ObjectNameProvider, M HasPreambleModel
 		return slices.Contains(allowedGenerationParts, part.GetName())
 	}
 }
+
+func excludeGenerationPartByNameProvider[T ObjectNameProvider, M HasPreambleModel](excludedGenerationParts []string) func(part GenerationPart[T, M]) bool {
+	return func(part GenerationPart[T, M]) bool {
+		if len(excludedGenerationParts) == 0 {
+			return true
+		}
+		return !slices.Contains(excludedGenerationParts, part.GetName())
+	}
+}

--- a/pkg/internal/genhelpers/generator.go
+++ b/pkg/internal/genhelpers/generator.go
@@ -153,13 +153,17 @@ func (g *Generator[T, M]) Run() error {
 	objects := g.objectsProvider()
 	parts := g.generationParts
 
-	filterObjects := newFiltersFlag("object names", collections.Map(objects, func(o T) string { return o.ObjectName() }))
-	filterParts := newFiltersFlag("generation part names", collections.Map(parts, func(p GenerationPart[T, M]) string { return p.GetName() }))
+	filterObjects := newInclusionFlag("object names", collections.Map(objects, func(o T) string { return o.ObjectName() }))
+	filterParts := newInclusionFlag("generation part names", collections.Map(parts, func(p GenerationPart[T, M]) string { return p.GetName() }))
+	excludeObjects := newExclusionFlag("object names", collections.Map(objects, func(o T) string { return o.ObjectName() }))
+	excludeParts := newExclusionFlag("generation part names", collections.Map(parts, func(p GenerationPart[T, M]) string { return p.GetName() }))
 
 	additionalLogs := flag.Bool("verbose", false, "print additional object debug logs")
 	dryRun := flag.Bool("dry-run", false, "generate to std out instead of saving")
 	flag.Var(filterObjects, filterObjects.flagName(), filterObjects.usage())
 	flag.Var(filterParts, filterParts.flagName(), filterParts.usage())
+	flag.Var(excludeObjects, excludeObjects.flagName(), excludeObjects.usage())
+	flag.Var(excludeParts, excludeParts.flagName(), excludeParts.usage())
 
 	flag.Usage = func() {
 		usage := fmt.Sprintf(`%[1]s
@@ -180,6 +184,14 @@ usage: make [clean-%[2]s] generate-%[2]s SF_TF_GENERATOR_ARGS='<args>'
 		fmt.Printf("Generation part filters present: %s\n", filterParts)
 		g.generationPartFilters = append(g.generationPartFilters, filterGenerationPartByNameProvider[T, M](filterParts.filters))
 	}
+	if excludeObjects.hasValues() {
+		fmt.Printf("Object exclusions present: %s\n", excludeObjects)
+		g.objectFilters = append(g.objectFilters, excludeObjectByNameProvider[T](excludeObjects.filters))
+	}
+	if excludeParts.hasValues() {
+		fmt.Printf("Generation part exclusions present: %s\n", excludeParts)
+		g.generationPartFilters = append(g.generationPartFilters, excludeGenerationPartByNameProvider[T, M](excludeParts.filters))
+	}
 
 	if len(g.objectFilters) > 0 {
 		filteredObjects := make([]T, 0)
@@ -193,7 +205,7 @@ usage: make [clean-%[2]s] generate-%[2]s SF_TF_GENERATOR_ARGS='<args>'
 			}
 		}
 		if len(filteredObjects) == 0 {
-			return fmt.Errorf("no objects found for the given filters: %s", filterObjects)
+			return fmt.Errorf("no objects found for the given filters: %s; exclusions: %s", filterObjects, excludeObjects)
 		}
 		objects = filteredObjects
 	}
@@ -208,6 +220,9 @@ usage: make [clean-%[2]s] generate-%[2]s SF_TF_GENERATOR_ARGS='<args>'
 			if matches {
 				filteredGenerationParts = append(filteredGenerationParts, p)
 			}
+		}
+		if len(filteredGenerationParts) == 0 {
+			return fmt.Errorf("no generation parts found for the given filters: %s; exclusions: %s", filterParts, excludeParts)
 		}
 		parts = filteredGenerationParts
 	}

--- a/pkg/internal/genhelpers/object_filters.go
+++ b/pkg/internal/genhelpers/object_filters.go
@@ -12,3 +12,12 @@ func filterObjectByNameProvider[T ObjectNameProvider](allowedObjectNames []strin
 		return slices.Contains(allowedObjectNames, object.ObjectName())
 	}
 }
+
+func excludeObjectByNameProvider[T ObjectNameProvider](excludedObjectNames []string) func(object T) bool {
+	return func(object T) bool {
+		if len(excludedObjectNames) == 0 {
+			return true
+		}
+		return !slices.Contains(excludedObjectNames, object.ObjectName())
+	}
+}

--- a/pkg/sdk/generator/README.md
+++ b/pkg/sdk/generator/README.md
@@ -53,6 +53,18 @@ make generate-sdk SF_TF_GENERATOR_ARGS='--filter-object-names=Sequences'
 # generate chosen objects and chosen files only
 make generate-sdk SF_TF_GENERATOR_ARGS='--filter-generation-part-names=default,impl --filter-object-names=Sequences'
 ```
+```shell
+# generate all objects except the given ones
+make generate-sdk SF_TF_GENERATOR_ARGS='--exclude-object-names=Sequences'
+```
+```shell
+# generate all files except the given generation parts
+make generate-sdk SF_TF_GENERATOR_ARGS='--exclude-generation-part-names=unit_tests'
+```
+```shell
+# combine inclusion and exclusion filters
+make generate-sdk SF_TF_GENERATOR_ARGS='--filter-object-names=Sequences,DatabaseRoles --exclude-object-names=Sequences'
+```
 
 ##### Examples
 
@@ -93,6 +105,14 @@ make generate-sdk-examples SF_TF_GENERATOR_ARGS='--filter-object-names=Sequences
 ```shell
 # generate chosen example objects and chosen files only
 make generate-sdk-examples SF_TF_GENERATOR_ARGS='--filter-generation-part-names=default,impl --filter-object-names=Sequences'
+```
+```shell
+# generate all example objects except the given ones
+make generate-sdk-examples SF_TF_GENERATOR_ARGS='--exclude-object-names=Sequences'
+```
+```shell
+# generate all example files except the given generation parts
+make generate-sdk-examples SF_TF_GENERATOR_ARGS='--exclude-generation-part-names=unit_tests'
 ```
 ```shell
 # show usage


### PR DESCRIPTION
Add object and parts exclusion filters to the generator commons
- To be able to run generator commands more easily, where only a small number of objects/parts need to be excluded.
- This change automatically adds this behavior to every generator in the project.
- Adjusted Makefile.