### PR TITLE
chore(hybrid table): restructure assertion models and consolidate acceptance tests

### DIFF
--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/hybrid_table_resource_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/hybrid_table_resource_ext.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 )
 
@@ -16,6 +17,27 @@ func (h *HybridTableResourceAssert) HasColumns(columns []sdk.TableColumnSignatur
 		// canonically equivalent (see buildHybridColumnStateFromDescribe), so
 		// state holds the same form the model writes to HCL — Type.ToSql().
 		h.AddAssertion(assert.ValueSet(fmt.Sprintf("column.%d.type", i), col.Type.ToSql()))
+	}
+	return h
+}
+
+// HasColumnConfigs asserts all per-column fields (name, type, nullable, comment, collate)
+// in one call. Use this when the model was built with WithColumnConfigs. Zero-valued
+// fields in HybridTableColumnConfig are not asserted.
+func (h *HybridTableResourceAssert) HasColumnConfigs(columns []model.HybridTableColumnConfig) *HybridTableResourceAssert {
+	h.AddAssertion(assert.ValueSet("column.#", strconv.Itoa(len(columns))))
+	for i, col := range columns {
+		h.AddAssertion(assert.ValueSet(fmt.Sprintf("column.%d.name", i), col.Name))
+		h.AddAssertion(assert.ValueSet(fmt.Sprintf("column.%d.type", i), col.Type))
+		if col.Nullable != nil {
+			h.AddAssertion(assert.ValueSet(fmt.Sprintf("column.%d.nullable", i), strconv.FormatBool(*col.Nullable)))
+		}
+		if col.Comment != "" {
+			h.AddAssertion(assert.ValueSet(fmt.Sprintf("column.%d.comment", i), col.Comment))
+		}
+		if col.Collate != "" {
+			h.AddAssertion(assert.ValueSet(fmt.Sprintf("column.%d.collate", i), col.Collate))
+		}
 	}
 	return h
 }

--- a/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert/hybrid_table_desc_output_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert/hybrid_table_desc_output_ext.go
@@ -1,0 +1,104 @@
+package resourceshowoutputassert
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
+)
+
+// HybridTableDescribeOutputAssert asserts fields of a single row in the
+// describe_output list. Because hybrid table describe output has one row per
+// column, callers must supply the 0-based row index (= column position in the
+// physical column order returned by DESCRIBE TABLE).
+type HybridTableDescribeOutputAssert struct {
+	*assert.ResourceAssert
+	rowIndex int
+}
+
+func HybridTableDescribeOutput(t *testing.T, name string, rowIndex int) *HybridTableDescribeOutputAssert {
+	t.Helper()
+	return &HybridTableDescribeOutputAssert{
+		ResourceAssert: assert.NewResourceAssert(name, "describe_output"),
+		rowIndex:       rowIndex,
+	}
+}
+
+func (h *HybridTableDescribeOutputAssert) field(name string) string {
+	return fmt.Sprintf("describe_output.%d.%s", h.rowIndex, name)
+}
+
+////////////////////////////
+// Attribute value checks //
+////////////////////////////
+
+func (h *HybridTableDescribeOutputAssert) HasName(expected string) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("name"), expected))
+	return h
+}
+
+func (h *HybridTableDescribeOutputAssert) HasType(expected string) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("type"), expected))
+	return h
+}
+
+func (h *HybridTableDescribeOutputAssert) HasCollation(expected string) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("collation"), expected))
+	return h
+}
+
+func (h *HybridTableDescribeOutputAssert) HasKind(expected string) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("kind"), expected))
+	return h
+}
+
+func (h *HybridTableDescribeOutputAssert) HasIsNullable(expected bool) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("is_nullable"), strconv.FormatBool(expected)))
+	return h
+}
+
+func (h *HybridTableDescribeOutputAssert) HasDefault(expected string) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("default"), expected))
+	return h
+}
+
+func (h *HybridTableDescribeOutputAssert) HasPrimaryKey(expected bool) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("primary_key"), strconv.FormatBool(expected)))
+	return h
+}
+
+func (h *HybridTableDescribeOutputAssert) HasUniqueKey(expected bool) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("unique_key"), strconv.FormatBool(expected)))
+	return h
+}
+
+func (h *HybridTableDescribeOutputAssert) HasCheck(expected string) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("check"), expected))
+	return h
+}
+
+func (h *HybridTableDescribeOutputAssert) HasExpression(expected string) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("expression"), expected))
+	return h
+}
+
+func (h *HybridTableDescribeOutputAssert) HasComment(expected string) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("comment"), expected))
+	return h
+}
+
+func (h *HybridTableDescribeOutputAssert) HasPolicyName(expected string) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("policy_name"), expected))
+	return h
+}
+
+func (h *HybridTableDescribeOutputAssert) HasPrivacyDomain(expected string) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("privacy_domain"), expected))
+	return h
+}
+
+func (h *HybridTableDescribeOutputAssert) HasSchemaEvolutionRecord(expected string) *HybridTableDescribeOutputAssert {
+	h.AddAssertion(assert.ValueSet(h.field("schema_evolution_record"), expected))
+	return h
+}

--- a/pkg/acceptance/helpers/sequence_client.go
+++ b/pkg/acceptance/helpers/sequence_client.go
@@ -33,3 +33,16 @@ func (c *SequenceClient) DropFunc(t *testing.T, id sdk.SchemaObjectIdentifier) f
 		require.NoError(t, err)
 	}
 }
+
+func (c *SequenceClient) Create(t *testing.T) (sdk.SchemaObjectIdentifier, func()) {
+	t.Helper()
+	return c.CreateWithId(t, c.ids.RandomSchemaObjectIdentifier())
+}
+
+func (c *SequenceClient) CreateWithId(t *testing.T, id sdk.SchemaObjectIdentifier) (sdk.SchemaObjectIdentifier, func()) {
+	t.Helper()
+	ctx := context.Background()
+	err := c.client().Create(ctx, sdk.NewCreateSequenceRequest(id))
+	require.NoError(t, err)
+	return id, c.DropFunc(t, id)
+}

--- a/pkg/testacc/resource_hybrid_table_acceptance_test.go
+++ b/pkg/testacc/resource_hybrid_table_acceptance_test.go
@@ -36,6 +36,18 @@ func TestAcc_HybridTable_BasicUseCase(t *testing.T) {
 
 	modelBasic := model.HybridTableFromId("test", id, columns, pk)
 
+	// The single ID column is identical across every step of this test (PK, NOT NULL,
+	// no default/comment), so its describe_output row-0 assertion is shared.
+	assertIDColumnDescribeOutput := func(ref string) assert.TestCheckFuncProvider {
+		return resourceshowoutputassert.HybridTableDescribeOutput(t, ref, 0).
+			HasName("ID").
+			HasIsNullable(false).
+			HasPrimaryKey(true).
+			HasUniqueKey(false).
+			HasDefault("").
+			HasComment("")
+	}
+
 	assertBasic := []assert.TestCheckFuncProvider{
 		resourceassert.HybridTableResource(t, modelBasic.ResourceReference()).
 			HasNameString(id.Name()).
@@ -44,6 +56,7 @@ func TestAcc_HybridTable_BasicUseCase(t *testing.T) {
 			HasCommentString("").
 			HasFullyQualifiedNameString(id.FullyQualifiedName()).
 			HasColumns(columns).
+			HasColumnNullable(0, false).
 			HasPrimaryKeyKeys("ID"),
 		objectparametersassert.HybridTableParameters(t, id).
 			HasDataRetentionTimeInDaysLevel(sdk.ParameterTypeDatabase).
@@ -65,14 +78,7 @@ func TestAcc_HybridTable_BasicUseCase(t *testing.T) {
 			HasComment("").
 			HasRowsNil().
 			HasBytesNil(),
-		// DESC-level assertions (is_nullable/default/primary_key/unique_key/check/
-		// expression/comment/policy_name/privacy_domain/schema_evolution_record) are
-		// not yet exposed as typed helpers on resourceassert.HybridTableResource (the
-		// generator does not emit HasDescribeOutput* methods for nested-list fields).
-		// HasColumns + HasPrimaryKeyKeys above cover the column-list shape; raw
-		// TestCheckResourceAttr on describe_output.N.* would be fragile against the
-		// DESC column ordering. Typed DESC helpers are a follow-up for the assert
-		// generator, tracked under review thread 3188821668.
+		assertIDColumnDescribeOutput(modelBasic.ResourceReference()),
 	}
 
 	modelComplete := model.HybridTableFromId("test", id, columns, pk).
@@ -113,6 +119,7 @@ func TestAcc_HybridTable_BasicUseCase(t *testing.T) {
 			HasComment(comment).
 			HasRowsNil().
 			HasBytesNil(),
+		assertIDColumnDescribeOutput(modelComplete.ResourceReference()),
 	}
 
 	assertAfterUnset := []assert.TestCheckFuncProvider{
@@ -123,6 +130,7 @@ func TestAcc_HybridTable_BasicUseCase(t *testing.T) {
 			HasCommentString("").
 			HasFullyQualifiedNameString(id.FullyQualifiedName()).
 			HasColumns(columns).
+			HasColumnNullable(0, false).
 			HasPrimaryKeyKeys("ID"),
 		objectparametersassert.HybridTableParameters(t, id).
 			HasDataRetentionTimeInDaysLevel(sdk.ParameterTypeDatabase).
@@ -144,6 +152,7 @@ func TestAcc_HybridTable_BasicUseCase(t *testing.T) {
 			HasComment("").
 			HasRowsNil().
 			HasBytesNil(),
+		assertIDColumnDescribeOutput(modelBasic.ResourceReference()),
 	}
 
 	importStateVerifyIgnore := []string{
@@ -153,6 +162,38 @@ func TestAcc_HybridTable_BasicUseCase(t *testing.T) {
 		// Constraint name may differ between config (empty) and what DESCRIBE returns.
 		"primary_key",
 	}
+
+	// Column-mutation models for the add/drop lifecycle steps absorbed from the
+	// standalone TestAcc_HybridTable_ColumnAdd / ColumnDrop tests.
+	colsWith2 := []sdk.TableColumnSignature{
+		{Name: "ID", Type: testdatatypes.DataTypeInteger},
+		{Name: "NAME", Type: testdatatypes.DataTypeVarchar},
+	}
+	colsWith4 := []sdk.TableColumnSignature{
+		{Name: "ID", Type: testdatatypes.DataTypeInteger},
+		{Name: "NAME", Type: testdatatypes.DataTypeVarchar},
+		{Name: "EMAIL", Type: testdatatypes.DataTypeVarchar},
+		{Name: "AGE", Type: testdatatypes.DataTypeInteger},
+	}
+	// colsWith5MidInsert inserts MIDDLE_COL between NAME and EMAIL (not at the end).
+	// Snowflake ADD COLUMN appends physically, so post-apply column order differs
+	// from config order and the next plan is non-empty.
+	colsWith5MidInsert := []sdk.TableColumnSignature{
+		{Name: "ID", Type: testdatatypes.DataTypeInteger},
+		{Name: "NAME", Type: testdatatypes.DataTypeVarchar},
+		{Name: "MIDDLE_COL", Type: testdatatypes.DataTypeInteger},
+		{Name: "EMAIL", Type: testdatatypes.DataTypeVarchar},
+		{Name: "AGE", Type: testdatatypes.DataTypeInteger},
+	}
+	colsWith3 := []sdk.TableColumnSignature{
+		{Name: "ID", Type: testdatatypes.DataTypeInteger},
+		{Name: "NAME", Type: testdatatypes.DataTypeVarchar},
+		{Name: "EMAIL", Type: testdatatypes.DataTypeVarchar},
+	}
+	modelWith2Cols := model.HybridTableFromId("test", id, colsWith2, pk)
+	modelWith4Cols := model.HybridTableFromId("test", id, colsWith4, pk)
+	modelWith5ColsMidInsert := model.HybridTableFromId("test", id, colsWith5MidInsert, pk)
+	modelWith3Cols := model.HybridTableFromId("test", id, colsWith3, pk)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
@@ -246,6 +287,73 @@ func TestAcc_HybridTable_BasicUseCase(t *testing.T) {
 				Config: accconfig.FromModels(t, modelComplete),
 				Check:  assertThat(t, assertComplete...),
 			},
+			// Column-add lifecycle (absorbed from TestAcc_HybridTable_ColumnAdd)
+			// Add one column
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(modelWith2Cols.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: accconfig.FromModels(t, modelWith2Cols),
+				Check: assertThat(t,
+					resourceassert.HybridTableResource(t, modelWith2Cols.ResourceReference()).
+						HasColumns(colsWith2).
+						HasPrimaryKeyKeys("ID"),
+				),
+			},
+			// Add two more columns in one apply
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(modelWith4Cols.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: accconfig.FromModels(t, modelWith4Cols),
+				Check: assertThat(t,
+					resourceassert.HybridTableResource(t, modelWith4Cols.ResourceReference()).
+						HasColumns(colsWith4).
+						HasPrimaryKeyKeys("ID"),
+				),
+			},
+			// Insert a column NOT at the end. Snowflake's ALTER TABLE ADD COLUMN appends
+			// physically, so the resulting on-disk order (ID, NAME, EMAIL, AGE, MIDDLE_COL)
+			// differs from the config order (ID, NAME, MIDDLE_COL, EMAIL, AGE). The apply
+			// succeeds but the post-apply plan is non-empty (index drift on the TypeList).
+			{
+				Config:             accconfig.FromModels(t, modelWith5ColsMidInsert),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(modelWith5ColsMidInsert.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			// Column-drop lifecycle (absorbed from TestAcc_HybridTable_ColumnDrop)
+			// Drop back to 3 columns (drops AGE and MIDDLE_COL)
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(modelWith3Cols.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: accconfig.FromModels(t, modelWith3Cols),
+				Check: assertThat(t,
+					resourceassert.HybridTableResource(t, modelWith3Cols.ResourceReference()).
+						HasColumns(colsWith3).
+						HasPrimaryKeyKeys("ID"),
+				),
+			},
+			// Drop back to single column — assertBasic confirms full state consistency
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(modelBasic.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: accconfig.FromModels(t, modelBasic),
+				Check:  assertThat(t, assertBasic...),
+			},
 		},
 	})
 }
@@ -254,21 +362,34 @@ func TestAcc_HybridTable_CompleteUseCase(t *testing.T) {
 	id := testClient().Ids.RandomSchemaObjectIdentifier()
 	comment, changedComment := random.Comment(), random.Comment()
 
-	columns := []sdk.TableColumnSignature{
+	columnConfigs := []model.HybridTableColumnConfig{
+		{Name: "ID", Type: testdatatypes.DataTypeInteger.ToSql()},
+		{Name: "NAME", Type: testdatatypes.DataTypeVarchar.ToSql(), Comment: "name column"},
+		{Name: "EMAIL", Type: testdatatypes.DataTypeVarchar.ToSql(), Nullable: sdk.Bool(false)},
+	}
+	columnConfigsChanged := []model.HybridTableColumnConfig{
+		{Name: "ID", Type: testdatatypes.DataTypeInteger.ToSql()},
+		{Name: "NAME", Type: testdatatypes.DataTypeVarchar.ToSql(), Comment: "updated name column"},
+		{Name: "EMAIL", Type: testdatatypes.DataTypeVarchar.ToSql(), Nullable: sdk.Bool(false)},
+	}
+	// colSigs extracts the name+type pairs needed for HybridTableFromId constructor.
+	colSigs := []sdk.TableColumnSignature{
 		{Name: "ID", Type: testdatatypes.DataTypeInteger},
 		{Name: "NAME", Type: testdatatypes.DataTypeVarchar},
 		{Name: "EMAIL", Type: testdatatypes.DataTypeVarchar},
 	}
-	pk := []sdk.TableColumnSignature{
-		{Name: "ID"},
-	}
+	pk := []sdk.TableColumnSignature{{Name: "ID"}}
 
-	modelComplete := model.HybridTableFromId("test", id, columns, pk).
+	modelComplete := model.HybridTableFromId("test", id, colSigs, pk).
+		WithColumnConfigs(columnConfigs).
+		WithUniqueConstraint([]string{"NAME"}).
 		WithComment(comment).
 		WithDataRetentionTimeInDays(5).
 		WithMaxDataExtensionTimeInDays(10)
 
-	modelChanged := model.HybridTableFromId("test", id, columns, pk).
+	modelChanged := model.HybridTableFromId("test", id, colSigs, pk).
+		WithColumnConfigs(columnConfigsChanged).
+		WithUniqueConstraint([]string{"NAME"}).
 		WithComment(changedComment).
 		WithDataRetentionTimeInDays(10).
 		WithMaxDataExtensionTimeInDays(20)
@@ -279,6 +400,28 @@ func TestAcc_HybridTable_CompleteUseCase(t *testing.T) {
 		"column",
 		// Constraint name may differ between config (empty) and what DESCRIBE returns.
 		"primary_key",
+		"unique_constraint",
+	}
+
+	// The ID (row 0) and EMAIL (row 2) describe_output rows are unchanged across the
+	// create and update steps — only the NAME row's comment differs — so they are shared.
+	assertIDColumnDescribeOutput := func(ref string) assert.TestCheckFuncProvider {
+		return resourceshowoutputassert.HybridTableDescribeOutput(t, ref, 0).
+			HasName("ID").
+			HasIsNullable(false).
+			HasPrimaryKey(true).
+			HasUniqueKey(false).
+			HasDefault("").
+			HasComment("")
+	}
+	assertEmailColumnDescribeOutput := func(ref string) assert.TestCheckFuncProvider {
+		return resourceshowoutputassert.HybridTableDescribeOutput(t, ref, 2).
+			HasName("EMAIL").
+			HasIsNullable(false).
+			HasPrimaryKey(false).
+			HasUniqueKey(false).
+			HasDefault("").
+			HasComment("")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -300,8 +443,9 @@ func TestAcc_HybridTable_CompleteUseCase(t *testing.T) {
 						HasDataRetentionTimeInDaysString("5").
 						HasMaxDataExtensionTimeInDaysString("10").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()).
-						HasColumns(columns).
-						HasPrimaryKeyKeys("ID"),
+						HasColumnConfigs(columnConfigs).
+						HasPrimaryKeyKeys("ID").
+						HasUniqueConstraintCount(1),
 					objectparametersassert.HybridTableParameters(t, id).
 						HasDataRetentionTimeInDays(5).
 						HasDataRetentionTimeInDaysLevel(sdk.ParameterTypeTable).
@@ -324,6 +468,15 @@ func TestAcc_HybridTable_CompleteUseCase(t *testing.T) {
 						HasComment(comment).
 						HasRowsNil().
 						HasBytesNil(),
+					assertIDColumnDescribeOutput(modelComplete.ResourceReference()),
+					resourceshowoutputassert.HybridTableDescribeOutput(t, modelComplete.ResourceReference(), 1).
+						HasName("NAME").
+						HasIsNullable(true).
+						HasPrimaryKey(false).
+						HasUniqueKey(true).
+						HasDefault("").
+						HasComment("name column"),
+					assertEmailColumnDescribeOutput(modelComplete.ResourceReference()),
 				),
 			},
 			// Import
@@ -351,8 +504,9 @@ func TestAcc_HybridTable_CompleteUseCase(t *testing.T) {
 						HasDataRetentionTimeInDaysString("10").
 						HasMaxDataExtensionTimeInDaysString("20").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()).
-						HasColumns(columns).
-						HasPrimaryKeyKeys("ID"),
+						HasColumnConfigs(columnConfigsChanged).
+						HasPrimaryKeyKeys("ID").
+						HasUniqueConstraintCount(1),
 					objectparametersassert.HybridTableParameters(t, id).
 						HasDataRetentionTimeInDays(10).
 						HasDataRetentionTimeInDaysLevel(sdk.ParameterTypeTable).
@@ -375,6 +529,15 @@ func TestAcc_HybridTable_CompleteUseCase(t *testing.T) {
 						HasComment(changedComment).
 						HasRowsNil().
 						HasBytesNil(),
+					assertIDColumnDescribeOutput(modelChanged.ResourceReference()),
+					resourceshowoutputassert.HybridTableDescribeOutput(t, modelChanged.ResourceReference(), 1).
+						HasName("NAME").
+						HasIsNullable(true).
+						HasPrimaryKey(false).
+						HasUniqueKey(true).
+						HasDefault("").
+						HasComment("updated name column"),
+					assertEmailColumnDescribeOutput(modelChanged.ResourceReference()),
 				),
 			},
 		},
@@ -654,15 +817,37 @@ func TestAcc_HybridTable_ColumnDefaultVariants(t *testing.T) {
 	})
 
 	t.Run("sequence", func(t *testing.T) {
-		// Deferred: a sequence default needs a fixture (CREATE SEQUENCE + cleanup)
-		// and a fully-qualified sequence identifier threaded into the model. The
-		// existing helpers.SequenceClient exposes only DropFunc; a Create helper
-		// would need to be added, which is out of scope for the F2 split.
-		// Tracking: the sequence variant is covered at the SDK/integration-test
-		// level (see pkg/sdk/testint/hybrid_tables_integration_test.go) — this
-		// acceptance-level coverage is a follow-up once helpers.SequenceClient
-		// grows a Create helper.
-		t.Skip("sequence default variant deferred: needs helpers.SequenceClient.Create (see test comment)")
+		id := testClient().Ids.RandomSchemaObjectIdentifier()
+		pk := []sdk.TableColumnSignature{{Name: "ID"}}
+		cols := []sdk.TableColumnSignature{
+			{Name: "ID", Type: testdatatypes.DataTypeInteger},
+			{Name: "SCORE", Type: testdatatypes.DataTypeInteger},
+		}
+		seqId, cleanup := testClient().Sequence.Create(t)
+		t.Cleanup(cleanup)
+		seqFQN := seqId.FullyQualifiedName()
+		m := model.HybridTableFromId("test", id, cols, pk).
+			WithColumnConfigs([]model.HybridTableColumnConfig{
+				{Name: "ID", Type: testdatatypes.DataTypeInteger.ToSql()},
+				{Name: "SCORE", Type: testdatatypes.DataTypeInteger.ToSql(), Default: &model.HybridTableColumnDefaultConfig{Sequence: &seqFQN}},
+			})
+
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.RequireAbove(tfversion.Version1_5_0),
+			},
+			CheckDestroy: CheckDestroy(t, resources.HybridTable),
+			Steps: []resource.TestStep{
+				{
+					Config: accconfig.FromModels(t, m),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(m.ResourceReference(), "column.1.default.#", "1"),
+						resource.TestCheckResourceAttr(m.ResourceReference(), "column.1.default.0.sequence", seqFQN),
+					),
+				},
+			},
+		})
 	})
 
 	// Negative test: setting more than one of {constant, expression, sequence}
@@ -749,174 +934,6 @@ func TestAcc_HybridTable_PrimaryKeyForceNew(t *testing.T) {
 					resourceassert.HybridTableResource(t, model2.ResourceReference()).
 						HasColumns(cols).
 						HasPrimaryKeyKeys("ID", "NAME"),
-				),
-			},
-		},
-	})
-}
-
-func TestAcc_HybridTable_ColumnAdd(t *testing.T) {
-	id := testClient().Ids.RandomSchemaObjectIdentifier()
-	pk := []sdk.TableColumnSignature{{Name: "ID"}}
-
-	cols1 := []sdk.TableColumnSignature{
-		{Name: "ID", Type: testdatatypes.DataTypeInteger},
-	}
-	cols2 := []sdk.TableColumnSignature{
-		{Name: "ID", Type: testdatatypes.DataTypeInteger},
-		{Name: "NAME", Type: testdatatypes.DataTypeVarchar},
-	}
-	cols3 := []sdk.TableColumnSignature{
-		{Name: "ID", Type: testdatatypes.DataTypeInteger},
-		{Name: "NAME", Type: testdatatypes.DataTypeVarchar},
-		{Name: "EMAIL", Type: testdatatypes.DataTypeVarchar},
-		{Name: "AGE", Type: testdatatypes.DataTypeInteger},
-	}
-	// cols4 inserts MIDDLE_COL between NAME and EMAIL (not at the end of cols3).
-	// Snowflake ADD COLUMN appends physically, so the post-apply state column order
-	// differs from the config order, and the next plan must be non-empty.
-	cols4 := []sdk.TableColumnSignature{
-		{Name: "ID", Type: testdatatypes.DataTypeInteger},
-		{Name: "NAME", Type: testdatatypes.DataTypeVarchar},
-		{Name: "MIDDLE_COL", Type: testdatatypes.DataTypeInteger},
-		{Name: "EMAIL", Type: testdatatypes.DataTypeVarchar},
-		{Name: "AGE", Type: testdatatypes.DataTypeInteger},
-	}
-
-	model1 := model.HybridTableFromId("test", id, cols1, pk)
-	model2 := model.HybridTableFromId("test", id, cols2, pk)
-	model3 := model.HybridTableFromId("test", id, cols3, pk)
-	model4 := model.HybridTableFromId("test", id, cols4, pk)
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.RequireAbove(tfversion.Version1_5_0),
-		},
-		CheckDestroy: CheckDestroy(t, resources.HybridTable),
-		Steps: []resource.TestStep{
-			// Create with single column
-			{
-				Config: accconfig.FromModels(t, model1),
-				Check: assertThat(t,
-					resourceassert.HybridTableResource(t, model1.ResourceReference()).
-						HasColumns(cols1).
-						HasPrimaryKeyKeys("ID"),
-				),
-			},
-			// Add one column
-			{
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(model2.ResourceReference(), plancheck.ResourceActionUpdate),
-					},
-				},
-				Config: accconfig.FromModels(t, model2),
-				Check: assertThat(t,
-					resourceassert.HybridTableResource(t, model2.ResourceReference()).
-						HasColumns(cols2).
-						HasPrimaryKeyKeys("ID"),
-				),
-			},
-			// Add two more columns in one apply
-			{
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(model3.ResourceReference(), plancheck.ResourceActionUpdate),
-					},
-				},
-				Config: accconfig.FromModels(t, model3),
-				Check: assertThat(t,
-					resourceassert.HybridTableResource(t, model3.ResourceReference()).
-						HasColumns(cols3).
-						HasPrimaryKeyKeys("ID"),
-				),
-			},
-			// Insert a column NOT at the end. Snowflake's ALTER TABLE ADD COLUMN
-			// appends physically, so the resulting on-disk order
-			// (ID, NAME, EMAIL, AGE, MIDDLE_COL) differs from the config order
-			// (ID, NAME, MIDDLE_COL, EMAIL, AGE). The apply succeeds (the column
-			// is added), but the post-apply plan is non-empty: subsequent indices
-			// in the TypeList show drift. Achieving a true mid-list insertion
-			// would require recreation, which the resource does not currently do.
-			{
-				Config:             accconfig.FromModels(t, model4),
-				ExpectNonEmptyPlan: true,
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(model4.ResourceReference(), plancheck.ResourceActionUpdate),
-					},
-				},
-			},
-		},
-	})
-}
-
-func TestAcc_HybridTable_ColumnDrop(t *testing.T) {
-	id := testClient().Ids.RandomSchemaObjectIdentifier()
-	pk := []sdk.TableColumnSignature{{Name: "ID"}}
-
-	cols1 := []sdk.TableColumnSignature{
-		{Name: "ID", Type: testdatatypes.DataTypeInteger},
-		{Name: "NAME", Type: testdatatypes.DataTypeVarchar},
-		{Name: "EMAIL", Type: testdatatypes.DataTypeVarchar},
-		{Name: "AGE", Type: testdatatypes.DataTypeInteger},
-	}
-	cols2 := []sdk.TableColumnSignature{
-		{Name: "ID", Type: testdatatypes.DataTypeInteger},
-		{Name: "NAME", Type: testdatatypes.DataTypeVarchar},
-		{Name: "EMAIL", Type: testdatatypes.DataTypeVarchar},
-	}
-	cols3 := []sdk.TableColumnSignature{
-		{Name: "ID", Type: testdatatypes.DataTypeInteger},
-	}
-
-	model1 := model.HybridTableFromId("test", id, cols1, pk)
-	model2 := model.HybridTableFromId("test", id, cols2, pk)
-	model3 := model.HybridTableFromId("test", id, cols3, pk)
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.RequireAbove(tfversion.Version1_5_0),
-		},
-		CheckDestroy: CheckDestroy(t, resources.HybridTable),
-		Steps: []resource.TestStep{
-			// Create with four columns
-			{
-				Config: accconfig.FromModels(t, model1),
-				Check: assertThat(t,
-					resourceassert.HybridTableResource(t, model1.ResourceReference()).
-						HasColumns(cols1).
-						HasPrimaryKeyKeys("ID"),
-				),
-			},
-			// Drop one column
-			{
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(model2.ResourceReference(), plancheck.ResourceActionUpdate),
-					},
-				},
-				Config: accconfig.FromModels(t, model2),
-				Check: assertThat(t,
-					resourceassert.HybridTableResource(t, model2.ResourceReference()).
-						HasColumns(cols2).
-						HasPrimaryKeyKeys("ID"),
-				),
-			},
-			// Drop two more columns in one apply
-			{
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(model3.ResourceReference(), plancheck.ResourceActionUpdate),
-					},
-				},
-				Config: accconfig.FromModels(t, model3),
-				Check: assertThat(t,
-					resourceassert.HybridTableResource(t, model3.ResourceReference()).
-						HasColumns(cols3).
-						HasPrimaryKeyKeys("ID"),
 				),
 			},
 		},


### PR DESCRIPTION
## Summary

Test-only follow-up to PR #4689, addressing reviewer requests on hybrid_table test coverage.

- **Richer column assertions:** add `HasColumnConfigs([]model.HybridTableColumnConfig)` to check name/type/nullable/comment/collate in one call (per jmichalak's "assert all column fields in one place" request). Existing granular helpers retained.
- **Enriched CompleteUseCase:** columns now carry comments and explicit nullability, and a `unique_constraint` is exercised end-to-end; assertions switched to `HasColumnConfigs` + `HasUniqueConstraintCount`.
- **BasicUseCase:** added `nullable` coverage for the PK column.
- **Row-indexed describe_output helper:** new `HybridTableDescribeOutput(t, ref, rowIndex)` in `resourceshowoutputassert` so the multi-row DESCRIBE output (one row per column) can be asserted per column position — the existing shared helper hardcodes row 0.
- **Unskip sequence default sub-test:** added `SequenceClient.Create`/`CreateWithId` (the helper it was waiting on) and wired the real fixture.
- **Consolidation:** folded the standalone `ColumnAdd`/`ColumnDrop` tests into `BasicUseCase` as lifecycle steps (fewer full create/destroy cycles), preserving the mid-list-insert drift coverage.

## Notes for reviewers

- `foreign_key` deliberately left to its dedicated `TestAcc_HybridTable_ForeignKey` test rather than added to CompleteUseCase (avoids an inline parent-table fixture; mirrors other resources).
- The describe-output helper is a per-resource `_ext.go` (matching `o_auth_rest_authentication_desc_output.go`); generalizing the shared describe-output infra is tracked under SNOW-1501905.

## Test Plan

- [x] `go build ./...`, `go vet -tags non_account_level_tests ./pkg/testacc/`
- [x] gofumpt (v0.9.2) + golangci-lint (v2.12.2): no new findings in changed files
- [ ] `make test-acceptance` (live Snowflake) — validates describe_output values on CI