### PR TITLE
chore: Introduce interface for generation part names

### DIFF
--- a/pkg/acceptance/bettertestspoc/assert/objectparametersassert/user_parameters_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectparametersassert/user_parameters_snowflake_gen.go
@@ -70,7 +70,7 @@ func (u *UserParametersAssert) HasDefaultParameterValueOnLevel(parameterName sdk
 func (u *UserParametersAssert) HasAllDefaults() *UserParametersAssert {
 	return u.
 		HasDefaultParameterValueOnLevel(sdk.UserParameterEnableUnredactedQuerySyntaxError, sdk.ParameterTypeSnowflakeDefault).
-		// TOOD(SNOW-2048330): HasDefaultParameterValueOnLevel(sdk.UserParameterNetworkPolicy, sdk.ParameterTypeAccount).
+		// TODO(SNOW-2048330): HasDefaultParameterValueOnLevel(sdk.UserParameterNetworkPolicy, sdk.ParameterTypeAccount).
 		HasDefaultParameterValueOnLevel(sdk.UserParameterPreventUnloadToInternalStages, sdk.ParameterTypeSnowflakeDefault).
 		HasDefaultParameterValueOnLevel(sdk.UserParameterAbortDetachedQuery, sdk.ParameterTypeSnowflakeDefault).
 		HasDefaultParameterValueOnLevel(sdk.UserParameterAutocommit, sdk.ParameterTypeSnowflakeDefault).

--- a/pkg/internal/genhelpers/generator.go
+++ b/pkg/internal/genhelpers/generator.go
@@ -94,30 +94,30 @@ func NewGenerator[T ObjectNameProvider, M HasPreambleModel](preamble *PreambleMo
 }
 
 // TODO [SNOW-2324252]: Probably remove later when we have vararg support in the NewGenerator constructor
-func (g *Generator[T, M]) WithGenerationPart(partName string, filenameProvider func(T, M) string, templates []*template.Template) *Generator[T, M] {
-	g.generationParts = append(g.generationParts, NewGenerationPart(partName, filenameProvider, templates))
+func (g *Generator[T, M]) WithGenerationPart(partName GenerationPartNamer, filenameProvider func(T, M) string, templates []*template.Template) *Generator[T, M] {
+	g.generationParts = append(g.generationParts, NewGenerationPart(partName.GenerationPartName(), filenameProvider, templates))
 	return g
 }
 
 // WithConditionalGenerationPart registers a generation part that is only executed for an object when condition returns true.
-func (g *Generator[T, M]) WithConditionalGenerationPart(partName string, filenameProvider func(T, M) string, templates []*template.Template, condition func(T) bool) *Generator[T, M] {
-	part := NewGenerationPart(partName, filenameProvider, templates)
+func (g *Generator[T, M]) WithConditionalGenerationPart(partName GenerationPartNamer, filenameProvider func(T, M) string, templates []*template.Template, condition func(T) bool) *Generator[T, M] {
+	part := NewGenerationPart(partName.GenerationPartName(), filenameProvider, templates)
 	part.condition = condition
 	g.generationParts = append(g.generationParts, part)
 	return g
 }
 
 // WithOptionalGenerationPart registers a generation part that is disabled by default and must be explicitly enabled per object.
-func (g *Generator[T, M]) WithOptionalGenerationPart(partName string, filenameProvider func(T, M) string, templates []*template.Template) *Generator[T, M] {
-	part := NewGenerationPart(partName, filenameProvider, templates)
+func (g *Generator[T, M]) WithOptionalGenerationPart(partName GenerationPartNamer, filenameProvider func(T, M) string, templates []*template.Template) *Generator[T, M] {
+	part := NewGenerationPart(partName.GenerationPartName(), filenameProvider, templates)
 	part.enabledByDefault = false
 	g.generationParts = append(g.generationParts, part)
 	return g
 }
 
 // WithOptionalConditionalGenerationPart registers a generation part that is disabled by default and has an additional runtime condition.
-func (g *Generator[T, M]) WithOptionalConditionalGenerationPart(partName string, filenameProvider func(T, M) string, templates []*template.Template, condition func(T) bool) *Generator[T, M] {
-	part := NewGenerationPart(partName, filenameProvider, templates)
+func (g *Generator[T, M]) WithOptionalConditionalGenerationPart(partName GenerationPartNamer, filenameProvider func(T, M) string, templates []*template.Template, condition func(T) bool) *Generator[T, M] {
+	part := NewGenerationPart(partName.GenerationPartName(), filenameProvider, templates)
 	part.enabledByDefault = false
 	part.condition = condition
 	g.generationParts = append(g.generationParts, part)

--- a/pkg/internal/genhelpers/generator.go
+++ b/pkg/internal/genhelpers/generator.go
@@ -56,9 +56,9 @@ func (g *GenerationPart[_, _]) IsEnabledByDefault() bool {
 	return g.enabledByDefault
 }
 
-func NewGenerationPart[T ObjectNameProvider, M HasPreambleModel](name string, filenameProvider func(T, M) string, templates []*template.Template) GenerationPart[T, M] {
+func NewGenerationPart[T ObjectNameProvider, M HasPreambleModel](name GenerationPartNamer, filenameProvider func(T, M) string, templates []*template.Template) GenerationPart[T, M] {
 	return GenerationPart[T, M]{
-		name:             name,
+		name:             name.GenerationPartName(),
 		filenameProvider: filenameProvider,
 		templates:        templates,
 		enabledByDefault: true,
@@ -69,7 +69,7 @@ func NewGenerator[T ObjectNameProvider, M HasPreambleModel](preamble *PreambleMo
 	// TODO [SNOW-2324252]: handle vararg input
 	parts := []GenerationPart[T, M]{
 		// TODO [SNOW-2324252]: change default to name when changing to vararg
-		NewGenerationPart("default", filenameProvider, templates),
+		NewGenerationPart(DefaultGenerationPart, filenameProvider, templates),
 	}
 	// TODO [SNOW-2324252]: Probably remove later; it should be a part of the constructor
 	defaultDescription := "Generator's description missing."
@@ -95,13 +95,13 @@ func NewGenerator[T ObjectNameProvider, M HasPreambleModel](preamble *PreambleMo
 
 // TODO [SNOW-2324252]: Probably remove later when we have vararg support in the NewGenerator constructor
 func (g *Generator[T, M]) WithGenerationPart(partName GenerationPartNamer, filenameProvider func(T, M) string, templates []*template.Template) *Generator[T, M] {
-	g.generationParts = append(g.generationParts, NewGenerationPart(partName.GenerationPartName(), filenameProvider, templates))
+	g.generationParts = append(g.generationParts, NewGenerationPart(partName, filenameProvider, templates))
 	return g
 }
 
 // WithConditionalGenerationPart registers a generation part that is only executed for an object when condition returns true.
 func (g *Generator[T, M]) WithConditionalGenerationPart(partName GenerationPartNamer, filenameProvider func(T, M) string, templates []*template.Template, condition func(T) bool) *Generator[T, M] {
-	part := NewGenerationPart(partName.GenerationPartName(), filenameProvider, templates)
+	part := NewGenerationPart(partName, filenameProvider, templates)
 	part.condition = condition
 	g.generationParts = append(g.generationParts, part)
 	return g
@@ -109,7 +109,7 @@ func (g *Generator[T, M]) WithConditionalGenerationPart(partName GenerationPartN
 
 // WithOptionalGenerationPart registers a generation part that is disabled by default and must be explicitly enabled per object.
 func (g *Generator[T, M]) WithOptionalGenerationPart(partName GenerationPartNamer, filenameProvider func(T, M) string, templates []*template.Template) *Generator[T, M] {
-	part := NewGenerationPart(partName.GenerationPartName(), filenameProvider, templates)
+	part := NewGenerationPart(partName, filenameProvider, templates)
 	part.enabledByDefault = false
 	g.generationParts = append(g.generationParts, part)
 	return g
@@ -117,7 +117,7 @@ func (g *Generator[T, M]) WithOptionalGenerationPart(partName GenerationPartName
 
 // WithOptionalConditionalGenerationPart registers a generation part that is disabled by default and has an additional runtime condition.
 func (g *Generator[T, M]) WithOptionalConditionalGenerationPart(partName GenerationPartNamer, filenameProvider func(T, M) string, templates []*template.Template, condition func(T) bool) *Generator[T, M] {
-	part := NewGenerationPart(partName.GenerationPartName(), filenameProvider, templates)
+	part := NewGenerationPart(partName, filenameProvider, templates)
 	part.enabledByDefault = false
 	part.condition = condition
 	g.generationParts = append(g.generationParts, part)
@@ -162,7 +162,7 @@ func (g *Generator[T, M]) effectivePartsForObject(object T, globalParts []Genera
 		if s := settings.getObjectGenerationSettings(); s != nil && len(s.AllowedGenerationParts) > 0 {
 			filtered := make([]GenerationPart[T, M], 0)
 			for _, p := range parts {
-				if slices.Contains(s.AllowedGenerationParts, p.name) {
+				if slices.ContainsFunc(s.AllowedGenerationParts, func(n GenerationPartNamer) bool { return n.GenerationPartName() == p.name }) {
 					filtered = append(filtered, p)
 				}
 			}
@@ -171,7 +171,7 @@ func (g *Generator[T, M]) effectivePartsForObject(object T, globalParts []Genera
 	}
 
 	// Filter out optional parts not explicitly enabled for this object or via CLI
-	var enabledParts []string
+	var enabledParts []GenerationPartNamer
 	if settings, ok := any(object).(HasObjectGenerationSettings); ok {
 		if s := settings.getObjectGenerationSettings(); s != nil {
 			enabledParts = s.EnabledGenerationParts
@@ -181,7 +181,7 @@ func (g *Generator[T, M]) effectivePartsForObject(object T, globalParts []Genera
 	for _, p := range parts {
 		if p.enabledByDefault {
 			result = append(result, p)
-		} else if slices.Contains(enabledParts, p.name) || slices.Contains(g.cliEnabledParts, p.name) {
+		} else if slices.ContainsFunc(enabledParts, func(n GenerationPartNamer) bool { return n.GenerationPartName() == p.name }) || slices.Contains(g.cliEnabledParts, p.name) {
 			result = append(result, p)
 		}
 	}
@@ -301,17 +301,17 @@ usage: make [clean-%[2]s] generate-%[2]s SF_TF_GENERATOR_ARGS='<args>'
 		if settings, ok := any(o).(HasObjectGenerationSettings); ok {
 			if s := settings.getObjectGenerationSettings(); s != nil {
 				for _, name := range s.AllowedGenerationParts {
-					if !slices.ContainsFunc(parts, func(p GenerationPart[T, M]) bool { return p.name == name }) {
-						return fmt.Errorf("object %s: allowed generation part %q does not exist", o.ObjectName(), name)
+					if !slices.ContainsFunc(parts, func(p GenerationPart[T, M]) bool { return p.name == name.GenerationPartName() }) {
+						return fmt.Errorf("object %s: allowed generation part %q does not exist", o.ObjectName(), name.GenerationPartName())
 					}
 				}
 				for _, name := range s.EnabledGenerationParts {
-					idx := slices.IndexFunc(parts, func(p GenerationPart[T, M]) bool { return p.name == name })
+					idx := slices.IndexFunc(parts, func(p GenerationPart[T, M]) bool { return p.name == name.GenerationPartName() })
 					if idx == -1 {
-						return fmt.Errorf("object %s: enabled generation part %q does not exist", o.ObjectName(), name)
+						return fmt.Errorf("object %s: enabled generation part %q does not exist", o.ObjectName(), name.GenerationPartName())
 					}
 					if parts[idx].enabledByDefault {
-						return fmt.Errorf("object %s: enabled generation part %q is already enabled by default", o.ObjectName(), name)
+						return fmt.Errorf("object %s: enabled generation part %q is already enabled by default", o.ObjectName(), name.GenerationPartName())
 					}
 				}
 			}

--- a/pkg/internal/genhelpers/models.go
+++ b/pkg/internal/genhelpers/models.go
@@ -64,3 +64,10 @@ type HasObjectGenerationSettings interface {
 }
 
 func (i *ObjectGenerationSettings) getObjectGenerationSettings() *ObjectGenerationSettings { return i }
+
+// GenerationPartNamer is implemented by typed generation part name constants.
+// Each generator package defines its own private type satisfying this interface,
+// ensuring that only predefined constants can be passed to generation part registration methods.
+type GenerationPartNamer interface {
+	GenerationPartName() string
+}

--- a/pkg/internal/genhelpers/models.go
+++ b/pkg/internal/genhelpers/models.go
@@ -54,9 +54,9 @@ type HasPreambleModel interface {
 type ObjectGenerationSettings struct {
 	// AllowedGenerationParts lists which generation parts apply to this object.
 	// nil/empty means "use the generator's default" (all globally-filtered parts).
-	AllowedGenerationParts []string
+	AllowedGenerationParts []GenerationPartNamer
 	// EnabledGenerationParts lists optional (disabled-by-default) generation parts that should be enabled for this object.
-	EnabledGenerationParts []string
+	EnabledGenerationParts []GenerationPartNamer
 }
 
 type HasObjectGenerationSettings interface {
@@ -71,3 +71,9 @@ func (i *ObjectGenerationSettings) getObjectGenerationSettings() *ObjectGenerati
 type GenerationPartNamer interface {
 	GenerationPartName() string
 }
+
+type defaultGenerationPartName string
+
+func (d defaultGenerationPartName) GenerationPartName() string { return string(d) }
+
+const DefaultGenerationPart defaultGenerationPartName = "default"

--- a/pkg/sdk/cortex_agents_gen_test.go
+++ b/pkg/sdk/cortex_agents_gen_test.go
@@ -9,8 +9,7 @@ import (
 
 func TestCortexAgents_Create(t *testing.T) {
 	id := randomSchemaObjectIdentifier()
-	spec :=
-		`models:
+	spec := `models:
 	orchestration: claude-4-sonnet`
 	// Minimal valid CreateCortexAgentOptions
 	defaultOpts := func() *CreateCortexAgentOptions {
@@ -119,8 +118,7 @@ func TestCortexAgents_Alter(t *testing.T) {
 
 	t.Run("alter modify live version set", func(t *testing.T) {
 		opts := defaultOpts()
-		spec :=
-			`models:
+		spec := `models:
 	orchestration: claude-4-sonnet`
 		opts.ModifyLiveVersionSet = &CortexAgentModifyLiveVersionSet{
 			Specification: spec,

--- a/pkg/sdk/cortex_search_services_gen_test.go
+++ b/pkg/sdk/cortex_search_services_gen_test.go
@@ -228,7 +228,6 @@ func TestCortexSearchServices_Describe(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		opts := defaultOpts()
 		assertOptsValidAndSQLEquals(t, opts, `DESCRIBE CORTEX SEARCH SERVICE %s`, id.FullyQualifiedName())
-
 	})
 
 	// all options test removed

--- a/pkg/sdk/dto-builder-generator/example/pipes_dto_generated.go
+++ b/pkg/sdk/dto-builder-generator/example/pipes_dto_generated.go
@@ -4,6 +4,7 @@ package example
 
 import (
 	"bytes"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 )
 

--- a/pkg/sdk/generator/example/defs/custom_interface_method_example_def.go
+++ b/pkg/sdk/generator/example/defs/custom_interface_method_example_def.go
@@ -11,7 +11,7 @@ var CustomInterfaceMethodExamplesDef = g.NewInterface(
 	"CustomInterfaceMethodExample",
 	g.KindOfT[sdkcommons.AccountObjectIdentifier](),
 ).
-	WithAllowedGenerationParts("default", "dto", "impl", "validations").
+	WithAllowedGenerationParts(g.PartDefault, g.PartDto, g.PartImpl, g.PartValidations).
 	CreateOperation(
 		"https://docs.snowflake.com/en/sql-reference/sql/create-database-role",
 		g.NewQueryStruct("CreateCustomInterfaceMethodExample").

--- a/pkg/sdk/generator/example/defs/drop_safely_example_def.go
+++ b/pkg/sdk/generator/example/defs/drop_safely_example_def.go
@@ -11,7 +11,7 @@ var DropSafelyHookExampleDef = g.NewInterface(
 	"DropSafelyHookExamples",
 	"DropSafelyHookExample",
 	g.KindOfT[sdkcommons.AccountObjectIdentifier](),
-).WithAllowedGenerationParts("default", "impl", "dto", "dto_builders", "validations").
+).WithAllowedGenerationParts(g.PartDefault, g.PartImpl, g.PartDto, g.PartDtoBuilders, g.PartValidations).
 	DropOperation(
 		"https://example.com",
 		g.NewQueryStruct("DropDropSafelyHookExample").
@@ -29,7 +29,7 @@ var DropSafelyForceExampleDef = g.NewInterface(
 	"DropSafelyForceExamples",
 	"DropSafelyForceExample",
 	g.KindOfT[sdkcommons.AccountObjectIdentifier](),
-).WithAllowedGenerationParts("default", "impl", "dto", "dto_builders", "validations").
+).WithAllowedGenerationParts(g.PartDefault, g.PartImpl, g.PartDto, g.PartDtoBuilders, g.PartValidations).
 	DropOperation(
 		"https://example.com",
 		g.NewQueryStruct("DropDropSafelyForceExample").

--- a/pkg/sdk/generator/example/defs/enum_examples_def.go
+++ b/pkg/sdk/generator/example/defs/enum_examples_def.go
@@ -26,5 +26,5 @@ var EnumExamplesDef = g.NewInterface(
 	"EnumExamples",
 	"EnumExample",
 	g.KindOfT[sdkcommons.AccountObjectIdentifier](),
-).WithAllowedGenerationParts("enums", "unit_tests").
+).WithAllowedGenerationParts(g.PartEnums, g.PartUnitTests).
 	WithEnums(ExampleStatusDef, ExampleSizeDef)

--- a/pkg/sdk/generator/example/defs/paired_struct_def.go
+++ b/pkg/sdk/generator/example/defs/paired_struct_def.go
@@ -78,7 +78,7 @@ var PairedStructExample = g.NewInterface(
 	"PairedStructExample",
 	g.KindOfT[sdkcommons.AccountObjectIdentifier](),
 ).
-	WithAllowedGenerationParts("default", "dto", "dto_builders", "impl", "validations").
+	WithAllowedGenerationParts(g.PartDefault, g.PartDto, g.PartDtoBuilders, g.PartImpl, g.PartValidations).
 	ShowOperationWithPairedStructs(
 		"https://example.com",
 		pairedStructExampleAllOptions("pairedStructExampleRow", "PairedStructExample"),

--- a/pkg/sdk/generator/example/defs/partial_generation_example_def.go
+++ b/pkg/sdk/generator/example/defs/partial_generation_example_def.go
@@ -11,7 +11,7 @@ var PartialGenerationExample = g.NewInterface(
 	"PartialGenerationExample",
 	g.KindOfT[sdkcommons.DatabaseObjectIdentifier](),
 ).
-	WithAllowedGenerationParts("default", "dto", "impl", "validations").
+	WithAllowedGenerationParts(g.PartDefault, g.PartDto, g.PartImpl, g.PartValidations).
 	CreateOperation("https://example.com",
 		g.NewQueryStruct("Alter").
 			Alter().

--- a/pkg/sdk/generator/gen/generation_part_names.go
+++ b/pkg/sdk/generator/gen/generation_part_names.go
@@ -1,0 +1,25 @@
+package gen
+
+import "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/genhelpers"
+
+type generationPartName string
+
+// GenerationPartName restricts which values can be passed to SDK generator part APIs.
+// Only constants defined in this package satisfy this interface.
+type GenerationPartName interface {
+	genhelpers.GenerationPartNamer
+	xxxProtected()
+}
+
+func (g generationPartName) GenerationPartName() string { return string(g) }
+func (g generationPartName) xxxProtected()              {}
+
+const (
+	PartDefault     generationPartName = "default"
+	PartDto         generationPartName = "dto"
+	PartDtoBuilders generationPartName = "dto_builders"
+	PartImpl        generationPartName = "impl"
+	PartUnitTests   generationPartName = "unit_tests"
+	PartValidations generationPartName = "validations"
+	PartEnums       generationPartName = "enums"
+)

--- a/pkg/sdk/generator/gen/interface.go
+++ b/pkg/sdk/generator/gen/interface.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"fmt"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/genhelpers"
 )
 
@@ -77,21 +78,25 @@ type Interface struct {
 
 // WithAllowedGenerationParts restricts this object to only the specified generation parts.
 // Parts not listed here will be skipped during generation, even if enabled globally.
-func (i *Interface) WithAllowedGenerationParts(parts ...string) *Interface {
+func (i *Interface) WithAllowedGenerationParts(parts ...GenerationPartName) *Interface {
 	if i.ObjectGenerationSettings == nil {
 		i.ObjectGenerationSettings = &genhelpers.ObjectGenerationSettings{}
 	}
-	i.ObjectGenerationSettings.AllowedGenerationParts = parts
+	i.ObjectGenerationSettings.AllowedGenerationParts = generationPartNamesToStrings(parts)
 	return i
 }
 
 // WithEnabledGenerationParts enables optional (disabled-by-default) generation parts for this object.
-func (i *Interface) WithEnabledGenerationParts(parts ...string) *Interface {
+func (i *Interface) WithEnabledGenerationParts(parts ...GenerationPartName) *Interface {
 	if i.ObjectGenerationSettings == nil {
 		i.ObjectGenerationSettings = &genhelpers.ObjectGenerationSettings{}
 	}
-	i.ObjectGenerationSettings.EnabledGenerationParts = parts
+	i.ObjectGenerationSettings.EnabledGenerationParts = generationPartNamesToStrings(parts)
 	return i
+}
+
+func generationPartNamesToStrings(parts []GenerationPartName) []string {
+	return collections.Map(parts, func(p GenerationPartName) string { return p.GenerationPartName() })
 }
 
 func (i *Interface) ObjectName() string {

--- a/pkg/sdk/generator/gen/interface.go
+++ b/pkg/sdk/generator/gen/interface.go
@@ -82,7 +82,7 @@ func (i *Interface) WithAllowedGenerationParts(parts ...GenerationPartName) *Int
 	if i.ObjectGenerationSettings == nil {
 		i.ObjectGenerationSettings = &genhelpers.ObjectGenerationSettings{}
 	}
-	i.ObjectGenerationSettings.AllowedGenerationParts = generationPartNamesToStrings(parts)
+	i.ObjectGenerationSettings.AllowedGenerationParts = generationPartNamesToNamers(parts)
 	return i
 }
 
@@ -91,12 +91,12 @@ func (i *Interface) WithEnabledGenerationParts(parts ...GenerationPartName) *Int
 	if i.ObjectGenerationSettings == nil {
 		i.ObjectGenerationSettings = &genhelpers.ObjectGenerationSettings{}
 	}
-	i.ObjectGenerationSettings.EnabledGenerationParts = generationPartNamesToStrings(parts)
+	i.ObjectGenerationSettings.EnabledGenerationParts = generationPartNamesToNamers(parts)
 	return i
 }
 
-func generationPartNamesToStrings(parts []GenerationPartName) []string {
-	return collections.Map(parts, func(p GenerationPartName) string { return p.GenerationPartName() })
+func generationPartNamesToNamers(parts []GenerationPartName) []genhelpers.GenerationPartNamer {
+	return collections.Map(parts, func(p GenerationPartName) genhelpers.GenerationPartNamer { return p })
 }
 
 func (i *Interface) ObjectName() string {

--- a/pkg/sdk/generator/gen/main/main.go
+++ b/pkg/sdk/generator/gen/main/main.go
@@ -25,12 +25,12 @@ func main() {
 		filenameForPart(""),
 		[]*template.Template{genhelpers.PreambleTemplate, gen.InterfaceTemplate, gen.OperationStructIterateTemplate},
 	).
-		WithGenerationPart("dto", filenameForPart("dto"), []*template.Template{genhelpers.PreambleTemplate, gen.DtoTemplate}).
-		WithGenerationPart("dto_builders", filenameForPart("dto_builders"), []*template.Template{genhelpers.PreambleTemplate, gen.DtoBuildersTemplate}).
-		WithGenerationPart("impl", filenameForPart("impl"), []*template.Template{genhelpers.PreambleTemplate, gen.ImplementationTemplate}).
-		WithGenerationPart("unit_tests", testFilenameForPart(""), []*template.Template{genhelpers.PreambleTemplate, gen.UnitTestsTemplate}).
-		WithGenerationPart("validations", filenameForPart("validations"), []*template.Template{genhelpers.PreambleTemplate, gen.ValidationsTemplate}).
-		WithConditionalGenerationPart("enums", filenameForPart("enums"), []*template.Template{genhelpers.PreambleTemplate, gen.EnumTemplate}, func(i *gen.Interface) bool {
+		WithGenerationPart(gen.PartDto, filenameForPart("dto"), []*template.Template{genhelpers.PreambleTemplate, gen.DtoTemplate}).
+		WithGenerationPart(gen.PartDtoBuilders, filenameForPart("dto_builders"), []*template.Template{genhelpers.PreambleTemplate, gen.DtoBuildersTemplate}).
+		WithGenerationPart(gen.PartImpl, filenameForPart("impl"), []*template.Template{genhelpers.PreambleTemplate, gen.ImplementationTemplate}).
+		WithGenerationPart(gen.PartUnitTests, testFilenameForPart(""), []*template.Template{genhelpers.PreambleTemplate, gen.UnitTestsTemplate}).
+		WithGenerationPart(gen.PartValidations, filenameForPart("validations"), []*template.Template{genhelpers.PreambleTemplate, gen.ValidationsTemplate}).
+		WithConditionalGenerationPart(gen.PartEnums, filenameForPart("enums"), []*template.Template{genhelpers.PreambleTemplate, gen.EnumTemplate}, func(i *gen.Interface) bool {
 			return len(i.Enums) > 0
 		}).
 		WithDescription("Generate SDK objects based on the SQL definitions provided.").

--- a/pkg/sdk/storage_integrations_gen_test.go
+++ b/pkg/sdk/storage_integrations_gen_test.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// imports adjusted manualy
+// imports adjusted manually
 import (
 	"fmt"
 	"testing"

--- a/pkg/sdk/tasks_gen_test.go
+++ b/pkg/sdk/tasks_gen_test.go
@@ -700,7 +700,7 @@ func TestParseTaskSchedule(t *testing.T) {
 				assert.Nil(t, taskSchedule)
 				assert.ErrorContains(t, err, tc.Error)
 			} else {
-				assert.EqualValues(t, tc.ExpectedTaskSchedule, taskSchedule)
+				assert.Equal(t, tc.ExpectedTaskSchedule, taskSchedule)
 				assert.NoError(t, err)
 			}
 		})

--- a/pkg/sdk/views_gen_test.go
+++ b/pkg/sdk/views_gen_test.go
@@ -525,7 +525,6 @@ func TestViews_Show(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		opts := defaultOpts()
 		assertOptsValidAndSQLEquals(t, opts, "SHOW VIEWS")
-
 	})
 
 	// variants added manually


### PR DESCRIPTION
- Require fixed generation part names
  - Required on the generators setup level
  - Enforced on the generator implementation side, that no other parts are accepted
- Apply in the SDK generator (the only one with generation parts)
- Fix a few typos and whitespace