### PR TITLE
chore: Add new provider factory

### DIFF
--- a/pkg/testacc/1_setup_provider_test.go
+++ b/pkg/testacc/1_setup_provider_test.go
@@ -60,6 +60,7 @@ var (
 	grantAccountRoleSafePublicRoleProviderFactory    = providerFactoryUsingCache("GrantAccountRoleSafePublicRole")
 	importBooleanDefaultProviderFactory              = providerFactoryUsingCache("ImportBooleanDefault")
 	experimentalHierarchyRenamesProviderFactory      = providerFactoryUsingCache("ExperimentalHierarchyRenames")
+	activeWarehouseSetOnUserProviderFactory          = providerFactoryUsingCache("ActiveWarehouseSetOnUser")
 )
 
 // TODO [SNOW-2661409]: secondary account can have also a different configuration, so for now we need to be careful; let's add some hash check for the config or something else to mitigate

--- a/pkg/testacc/data_source_schemas_acceptance_test.go
+++ b/pkg/testacc/data_source_schemas_acceptance_test.go
@@ -135,7 +135,7 @@ func TestAcc_Schemas_CompleteUseCase(t *testing.T) {
 		WithDependsOn(schemaModel.ResourceReference(), viewModel.ResourceReference())
 
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: activeWarehouseSetOnUserProviderFactory,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},

--- a/pkg/testacc/data_source_tags_acceptance_test.go
+++ b/pkg/testacc/data_source_tags_acceptance_test.go
@@ -63,7 +63,7 @@ func TestAcc_Tags_BasicUseCase_DifferentFiltering(t *testing.T) {
 		WithDependsOn(tagModel1.ResourceReference(), tagModel2.ResourceReference(), tagModel3.ResourceReference())
 
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: activeWarehouseSetOnUserProviderFactory,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
@@ -123,7 +123,7 @@ func TestAcc_Tags_CompleteUseCase(t *testing.T) {
 		WithDependsOn(tagModel.ResourceReference())
 
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: activeWarehouseSetOnUserProviderFactory,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},

--- a/pkg/testacc/resource_tag_acceptance_test.go
+++ b/pkg/testacc/resource_tag_acceptance_test.go
@@ -109,7 +109,7 @@ func TestAcc_Tag_BasicUseCase(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: tagsProviderFactory,
+		ProtoV6ProviderFactories: activeWarehouseSetOnUserProviderFactory,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
@@ -199,7 +199,7 @@ func TestAcc_Tag_CompleteUseCase_AllowedValuesOrdering(t *testing.T) {
 	basicWithDifferentValues := model.TagBase("test", id).WithAllowedValues("", "bar", "foo")
 
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: tagsProviderFactory,
+		ProtoV6ProviderFactories: activeWarehouseSetOnUserProviderFactory,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
@@ -289,7 +289,7 @@ func TestAcc_Tag_CompleteUseCase_OnConflictAllowedValuesSequence_Bcr2291(t *test
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: activeWarehouseSetOnUserProviderFactory,
 		Steps: []resource.TestStep{
 			// Step 1: create a tag with allowed_values + allowed_values_sequence on_conflict.
 			{

--- a/pkg/testacc/resource_user_session_policy_attachment_acceptance_test.go
+++ b/pkg/testacc/resource_user_session_policy_attachment_acceptance_test.go
@@ -59,7 +59,7 @@ func TestAcc_UserSessionPolicyAttachment_BasicUseCase(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: sessionPoliciesProviderFactory,
+		ProtoV6ProviderFactories: activeWarehouseSetOnUserProviderFactory,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
 		},


### PR DESCRIPTION
## Changes
- To fix `No active warehouse selected in the current session.  Select an active warehouse with the 'use warehouse' command.` errors, used a newly created provider factory in failing tests. The fix was confirmed by a successful test run on the failing Snowflake environment.