### PR TITLE
fix: Do not normalize Iceberg table object type in GET_TAG

### DIFF
--- a/pkg/sdk/system_functions.go
+++ b/pkg/sdk/system_functions.go
@@ -57,7 +57,7 @@ func normalizeGetTagObjectType(objectType ObjectType) (ObjectType, error) {
 	if !canBeAssociatedWithTag(objectType) {
 		return "", fmt.Errorf("tagging for object type %s is not supported", objectType)
 	}
-	if slices.Contains([]ObjectType{ObjectTypeView, ObjectTypeMaterializedView, ObjectTypeExternalTable, ObjectTypeEventTable, ObjectTypeIcebergTable}, objectType) {
+	if slices.Contains([]ObjectType{ObjectTypeView, ObjectTypeMaterializedView, ObjectTypeExternalTable, ObjectTypeEventTable}, objectType) {
 		return ObjectTypeTable, nil
 	}
 


### PR DESCRIPTION
## Summary

`normalizeGetTagObjectType` was normalizing `ICEBERG TABLE` to `TABLE` when building the `SYSTEM$GET_TAG` query. Iceberg tables are now passed with their own `ICEBERG TABLE` object type, matching how Snowflake expects the argument and fixing the related integration tests.

## Changes

- Removed `ObjectTypeIcebergTable` from the set of object types normalized to `ObjectTypeTable` in `normalizeGetTagObjectType` (`pkg/sdk/system_functions.go`).