### PR TITLE
chore: Add SYSTEM$CLUSTERING_INFORMATION SDK support and iceberg cluster-by validation

### DIFF
--- a/pkg/sdk/errors.go
+++ b/pkg/sdk/errors.go
@@ -24,6 +24,7 @@ var (
 	ErrAccountIsEmpty                           = NewError("account is empty")
 	ErrGrantPartiallyExecuted                   = NewError("grant partially executed")
 	ErrPatNotFound                              = NewError("programmatic access token not found")
+	ErrTableNotClustered                        = NewError("table is not clustered")
 
 	// snowflake-sdk errors.
 	ErrInvalidObjectIdentifier = NewError("invalid object identifier")
@@ -113,6 +114,7 @@ func decodeDriverError(err error) error {
 		"does not exist or not authorized":                        ErrObjectNotExistOrAuthorized,
 		"account is empty":                                        ErrAccountIsEmpty,
 		"Grant partially executed":                                ErrGrantPartiallyExecuted,
+		"is not clustered":                                        ErrTableNotClustered,
 	}
 	for k, v := range m {
 		if strings.Contains(err.Error(), k) {

--- a/pkg/sdk/generator/defs/iceberg_tables_def.go
+++ b/pkg/sdk/generator/defs/iceberg_tables_def.go
@@ -189,7 +189,7 @@ var icebergTablesDef = g.NewInterface(
 		QueryStructField("ColumnsAndConstraints", icebergTableColumnsAndConstraints, g.ListOptions().Parentheses().Required()).
 		ListQueryStructField("PartitionBy", icebergTablePartitionExpression, g.KeywordOptions().Parentheses().SQL("PARTITION BY")).
 		OptionalAssignment("PATH_LAYOUT", IcebergTablePathLayoutEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
-		// TODO: report docs discrepancy to Snowflake - the CREATE ICEBERG TABLE docs list both PARTITION BY and
+		// TODO [next PRs]: report docs discrepancy to Snowflake - the CREATE ICEBERG TABLE docs list both PARTITION BY and
 		// CLUSTER BY as available options without noting they are mutually exclusive, but Snowflake rejects setting both with
 		// error 099207 (0A000): "Partition by and Cluster by cannot be specified together for Iceberg tables." This is enforced
 		// by the ConflictingFields validation below.

--- a/pkg/sdk/generator/defs/iceberg_tables_def.go
+++ b/pkg/sdk/generator/defs/iceberg_tables_def.go
@@ -189,6 +189,10 @@ var icebergTablesDef = g.NewInterface(
 		QueryStructField("ColumnsAndConstraints", icebergTableColumnsAndConstraints, g.ListOptions().Parentheses().Required()).
 		ListQueryStructField("PartitionBy", icebergTablePartitionExpression, g.KeywordOptions().Parentheses().SQL("PARTITION BY")).
 		OptionalAssignment("PATH_LAYOUT", IcebergTablePathLayoutEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
+		// TODO: report docs discrepancy to Snowflake - the CREATE ICEBERG TABLE docs list both PARTITION BY and
+		// CLUSTER BY as available options without noting they are mutually exclusive, but Snowflake rejects setting both with
+		// error 099207 (0A000): "Partition by and Cluster by cannot be specified together for Iceberg tables." This is enforced
+		// by the ConflictingFields validation below.
 		PredefinedQueryStructField("ClusterBy", "[]string", g.KeywordOptions().Parentheses().SQL("CLUSTER BY")).
 		OptionalIdentifier("ExternalVolume", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("EXTERNAL_VOLUME").Equals().SingleQuotes()).
 		OptionalAssignment("CATALOG", IcebergTableCatalogEnumDef.KindPtr(), g.ParameterOptions().SingleQuotes()).
@@ -211,6 +215,7 @@ var icebergTablesDef = g.NewInterface(
 		PredefinedQueryStructField("Contact", "[]TableContact", g.KeywordOptions().Parentheses().SQL("WITH CONTACT")).
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists").
+		WithValidation(g.ConflictingFields, "PartitionBy", "ClusterBy").
 		WithAdditionalValidations(),
 ).CustomOperation(
 	"CreateFromIcebergFiles",

--- a/pkg/sdk/iceberg_tables_gen_test.go
+++ b/pkg/sdk/iceberg_tables_gen_test.go
@@ -53,6 +53,15 @@ func TestIcebergTables_Create(t *testing.T) {
 		assertOptsInvalidJoinedErrors(t, opts, errOneOf("CreateIcebergTableOptions", "OrReplace", "IfNotExists"))
 	})
 
+	t.Run("validation: conflicting fields for [opts.PartitionBy opts.ClusterBy]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.PartitionBy = []IcebergTablePartitionExpression{
+			{Identity: new("ID")},
+		}
+		opts.ClusterBy = []string{`"ID"`}
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("CreateIcebergTableOptions", "PartitionBy", "ClusterBy"))
+	})
+
 	t.Run("validation: exactly one field from [opts.PartitionBy.Identity opts.PartitionBy.Bucket opts.PartitionBy.Truncate opts.PartitionBy.Year opts.PartitionBy.Month opts.PartitionBy.Day opts.PartitionBy.Hour] should be present", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.PartitionBy = []IcebergTablePartitionExpression{
@@ -303,6 +312,12 @@ func TestIcebergTables_Create(t *testing.T) {
 		assertOptsValidAndSQLEquals(t, opts, `CREATE ICEBERG TABLE IF NOT EXISTS %s`, id.FullyQualifiedName())
 	})
 
+	t.Run("with cluster by", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.ClusterBy = []string{`"col1"`, `"col2"`}
+		assertOptsValidAndSQLEquals(t, opts, `CREATE ICEBERG TABLE %s CLUSTER BY ("col1", "col2")`, id.FullyQualifiedName())
+	})
+
 	t.Run("all options", func(t *testing.T) {
 		contactId := randomSchemaObjectIdentifier()
 		opts := defaultOpts()
@@ -373,7 +388,6 @@ func TestIcebergTables_Create(t *testing.T) {
 			},
 		}
 		opts.PathLayout = new(IcebergTablePathLayoutHierarchical)
-		opts.ClusterBy = []string{`"col1"`, `"col2"`}
 		opts.ExternalVolume = new(NewAccountObjectIdentifier("vol1"))
 		opts.Catalog = new(IcebergTableCatalogSnowflake)
 		opts.BaseLocation = new("base/loc")
@@ -411,7 +425,6 @@ func TestIcebergTables_Create(t *testing.T) {
 				`"NAME" VARCHAR(16777216) COMMENT 'name column') `+
 				`PARTITION BY ("ID", BUCKET (4, "NAME"), TRUNCATE (10, "C1"), YEAR ("C2"), MONTH ("C3"), DAY ("C4"), HOUR ("C5")) `+
 				`PATH_LAYOUT = HIERARCHICAL `+
-				`CLUSTER BY ("col1", "col2") `+
 				`EXTERNAL_VOLUME = '\"vol1\"' `+
 				`CATALOG = 'SNOWFLAKE' `+
 				`BASE_LOCATION = 'base/loc' `+

--- a/pkg/sdk/iceberg_tables_validations_gen.go
+++ b/pkg/sdk/iceberg_tables_validations_gen.go
@@ -25,6 +25,9 @@ func (opts *CreateIcebergTableOptions) validate() error {
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateIcebergTableOptions", "OrReplace", "IfNotExists"))
 	}
+	if everyValueSet(opts.PartitionBy, opts.ClusterBy) {
+		errs = append(errs, errOneOf("CreateIcebergTableOptions", "PartitionBy", "ClusterBy"))
+	}
 	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.PartitionBy) {
 		for _, partitionBy := range opts.PartitionBy {

--- a/pkg/sdk/policy_references_dto_builders_gen.go
+++ b/pkg/sdk/policy_references_dto_builders_gen.go
@@ -2,8 +2,6 @@
 
 package sdk
 
-import ()
-
 func NewGetForEntityPolicyReferenceRequest(
 	RefEntityName ObjectIdentifier,
 	RefEntityDomain PolicyEntityDomain,

--- a/pkg/sdk/system_functions.go
+++ b/pkg/sdk/system_functions.go
@@ -278,20 +278,37 @@ func (c *systemFunctions) GetClusteringInformation(ctx context.Context, id Schem
 	row := &struct {
 		Info string `db:"CLUSTERING_INFORMATION"`
 	}{}
-	var columnsArg string
-	if len(columns) > 0 {
-		columns = collections.Map(columns, func(col string) string {
-			return DoubleQuotes.Modify(col)
-		})
-		columnsArg = `, ` + SingleQuotes.Modify(fmt.Sprintf("(%s)", strings.Join(columns, ", ")))
+	opts := &getClusteringInformationOptions{
+		arguments: &clusteringInformationArgs{
+			Name: id,
+			Columns: collections.Map(columns, func(col string) clusteringInformationColumn {
+				return clusteringInformationColumn{Name: col}
+			}),
+		},
 	}
-	idEscaped := SingleQuotes.Modify(id.FullyQualifiedNameEscaped())
-	sql := fmt.Sprintf(`SELECT SYSTEM$CLUSTERING_INFORMATION(%s%s) AS "CLUSTERING_INFORMATION"`, idEscaped, columnsArg)
-	err := c.client.queryOne(ctx, row, sql)
+	sql, err := structToSQL(opts)
 	if err != nil {
 		return nil, err
 	}
+	if err := c.client.queryOne(ctx, row, sql); err != nil {
+		return nil, err
+	}
 	return parseClusteringInformation(row.Info)
+}
+
+type getClusteringInformationOptions struct {
+	selectSystemClusteringInformation bool                       `ddl:"static" sql:"SELECT SYSTEM$CLUSTERING_INFORMATION"`
+	arguments                         *clusteringInformationArgs `ddl:"list,parentheses,must_parentheses"`
+	as                                bool                       `ddl:"static" sql:"AS \"CLUSTERING_INFORMATION\""`
+}
+
+type clusteringInformationArgs struct {
+	Name    SchemaObjectIdentifier        `ddl:"identifier,single_quotes"`
+	Columns []clusteringInformationColumn `ddl:"parameter,no_equals,single_quotes,parentheses"`
+}
+
+type clusteringInformationColumn struct {
+	Name string `ddl:"keyword,double_quotes"`
 }
 
 func parseClusteringInformation(raw string) (*ClusteringInformation, error) {

--- a/pkg/sdk/system_functions.go
+++ b/pkg/sdk/system_functions.go
@@ -22,6 +22,10 @@ type SystemFunctions interface {
 	ShowActiveBehaviorChangeBundles(ctx context.Context) ([]BehaviorChangeBundleInfo, error)
 	BehaviorChangeBundleStatus(ctx context.Context, bundle string) (BehaviorChangeBundleStatus, error)
 	GetIcebergTableInformation(ctx context.Context, id SchemaObjectIdentifier) (*IcebergTableInformation, error)
+	// GetClusteringInformation returns clustering information for a table. If columns is empty, the table's defined
+	// clustering key is used; otherwise the given expressions are used as the clustering key for the calculation.
+	// See more in https://docs.snowflake.com/en/sql-reference/functions/system_clustering_information.
+	GetClusteringInformation(ctx context.Context, id SchemaObjectIdentifier, columns ...string) (*ClusteringInformation, error)
 }
 
 var _ SystemFunctions = (*systemFunctions)(nil)
@@ -235,5 +239,75 @@ func (c *systemFunctions) GetIcebergTableInformation(ctx context.Context, id Sch
 
 	return &IcebergTableInformation{
 		MetadataLocation: info.MetadataLocation,
+	}, nil
+}
+
+type clusteringInformationDbStruct struct {
+	ClusterByKeys               string                         `json:"cluster_by_keys"`
+	TotalPartitionCount         int                            `json:"total_partition_count"`
+	TotalConstantPartitionCount int                            `json:"total_constant_partition_count"`
+	AverageOverlaps             float64                        `json:"average_overlaps"`
+	AverageDepth                float64                        `json:"average_depth"`
+	PartitionDepthHistogram     map[string]int                 `json:"partition_depth_histogram"`
+	ClusteringErrors            []clusteringErrorEntryDbStruct `json:"clustering_errors"`
+}
+
+type clusteringErrorEntryDbStruct struct {
+	Timestamp string `json:"timestamp"`
+	Error     string `json:"error"`
+}
+
+type ClusteringInformation struct {
+	ClusterByKeys               string
+	TotalPartitionCount         int
+	TotalConstantPartitionCount int
+	AverageOverlaps             float64
+	AverageDepth                float64
+	PartitionDepthHistogram     map[string]int
+	ClusteringErrors            []ClusteringError
+}
+
+type ClusteringError struct {
+	Timestamp string
+	Error     string
+}
+
+// GetClusteringInformation is an implementation of SYSTEM$CLUSTERING_INFORMATION - see https://docs.snowflake.com/en/sql-reference/functions/system_clustering_information.
+// The clustering key is not returned by SHOW/DESCRIBE for Iceberg tables, so this is the way to verify it.
+func (c *systemFunctions) GetClusteringInformation(ctx context.Context, id SchemaObjectIdentifier, columns ...string) (*ClusteringInformation, error) {
+	row := &struct {
+		Info string `db:"CLUSTERING_INFORMATION"`
+	}{}
+	var columnsArg string
+	if len(columns) > 0 {
+		columnsArg = fmt.Sprintf(`, '(%s)'`, strings.Join(columns, ", "))
+	}
+	sql := fmt.Sprintf(`SELECT SYSTEM$CLUSTERING_INFORMATION('%s'%s) AS "CLUSTERING_INFORMATION"`, id.FullyQualifiedName(), columnsArg)
+	err := c.client.queryOne(ctx, row, sql)
+	if err != nil {
+		return nil, err
+	}
+	return parseClusteringInformation(row.Info)
+}
+
+func parseClusteringInformation(raw string) (*ClusteringInformation, error) {
+	var info clusteringInformationDbStruct
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return nil, err
+	}
+
+	return &ClusteringInformation{
+		ClusterByKeys:               info.ClusterByKeys,
+		TotalPartitionCount:         info.TotalPartitionCount,
+		TotalConstantPartitionCount: info.TotalConstantPartitionCount,
+		AverageOverlaps:             info.AverageOverlaps,
+		AverageDepth:                info.AverageDepth,
+		PartitionDepthHistogram:     info.PartitionDepthHistogram,
+		ClusteringErrors: collections.Map(info.ClusteringErrors, func(entry clusteringErrorEntryDbStruct) ClusteringError {
+			return ClusteringError{
+				Timestamp: entry.Timestamp,
+				Error:     entry.Error,
+			}
+		}),
 	}, nil
 }

--- a/pkg/sdk/system_functions.go
+++ b/pkg/sdk/system_functions.go
@@ -280,9 +280,13 @@ func (c *systemFunctions) GetClusteringInformation(ctx context.Context, id Schem
 	}{}
 	var columnsArg string
 	if len(columns) > 0 {
-		columnsArg = fmt.Sprintf(`, '(%s)'`, strings.Join(columns, ", "))
+		columns = collections.Map(columns, func(col string) string {
+			return DoubleQuotes.Modify(col)
+		})
+		columnsArg = `, ` + SingleQuotes.Modify(fmt.Sprintf("(%s)", strings.Join(columns, ", ")))
 	}
-	sql := fmt.Sprintf(`SELECT SYSTEM$CLUSTERING_INFORMATION('%s'%s) AS "CLUSTERING_INFORMATION"`, id.FullyQualifiedName(), columnsArg)
+	idEscaped := SingleQuotes.Modify(id.FullyQualifiedNameEscaped())
+	sql := fmt.Sprintf(`SELECT SYSTEM$CLUSTERING_INFORMATION(%s%s) AS "CLUSTERING_INFORMATION"`, idEscaped, columnsArg)
 	err := c.client.queryOne(ctx, row, sql)
 	if err != nil {
 		return nil, err

--- a/pkg/sdk/system_functions_test.go
+++ b/pkg/sdk/system_functions_test.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"testing"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,6 +39,49 @@ func Test_ToBehaviorChangeBundleStatus(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+func Test_getClusteringInformationOptions_SQL(t *testing.T) {
+	id := NewSchemaObjectIdentifier("db", "schema", "table")
+
+	buildColumns := func(columns ...string) []clusteringInformationColumn {
+		return collections.Map(columns, func(col string) clusteringInformationColumn {
+			return clusteringInformationColumn{Name: col}
+		})
+	}
+
+	t.Run("without columns", func(t *testing.T) {
+		opts := &getClusteringInformationOptions{
+			arguments: &clusteringInformationArgs{Name: id},
+		}
+		got, err := structToSQL(opts)
+		require.NoError(t, err)
+		require.Equal(t, `SELECT SYSTEM$CLUSTERING_INFORMATION ('\"db\".\"schema\".\"table\"') AS "CLUSTERING_INFORMATION"`, got)
+	})
+
+	t.Run("with columns", func(t *testing.T) {
+		opts := &getClusteringInformationOptions{
+			arguments: &clusteringInformationArgs{
+				Name:    id,
+				Columns: buildColumns("REGION", "id"),
+			},
+		}
+		got, err := structToSQL(opts)
+		require.NoError(t, err)
+		require.Equal(t, `SELECT SYSTEM$CLUSTERING_INFORMATION ('\"db\".\"schema\".\"table\"', '(\"REGION\", \"id\")') AS "CLUSTERING_INFORMATION"`, got)
+	})
+
+	t.Run("column with double quote is escaped", func(t *testing.T) {
+		opts := &getClusteringInformationOptions{
+			arguments: &clusteringInformationArgs{
+				Name:    id,
+				Columns: buildColumns(`we"ird`),
+			},
+		}
+		got, err := structToSQL(opts)
+		require.NoError(t, err)
+		require.Equal(t, `SELECT SYSTEM$CLUSTERING_INFORMATION ('\"db\".\"schema\".\"table\"', '(\"we\"\"ird\")') AS "CLUSTERING_INFORMATION"`, got)
+	})
 }
 
 func Test_parseClusteringInformation(t *testing.T) {

--- a/pkg/sdk/system_functions_test.go
+++ b/pkg/sdk/system_functions_test.go
@@ -39,3 +39,40 @@ func Test_ToBehaviorChangeBundleStatus(t *testing.T) {
 		})
 	}
 }
+
+func Test_parseClusteringInformation(t *testing.T) {
+	t.Run("valid output", func(t *testing.T) {
+		// Output captured from SYSTEM$CLUSTERING_INFORMATION on a clustered table.
+		raw := `{
+  "cluster_by_keys" : "LINEAR(REGION)",
+  "total_partition_count" : 1,
+  "total_constant_partition_count" : 0,
+  "average_overlaps" : 0.0,
+  "average_depth" : 1.0,
+  "partition_depth_histogram" : {
+    "00000" : 0,
+    "00001" : 1,
+    "00002" : 0,
+    "00016" : 0
+  },
+  "clustering_errors" : [ { "timestamp" : "2024-01-01 00:00:00", "error" : "some error" } ]
+}`
+		info, err := parseClusteringInformation(raw)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		require.Equal(t, "LINEAR(REGION)", info.ClusterByKeys)
+		require.Equal(t, 1, info.TotalPartitionCount)
+		require.Equal(t, 0, info.TotalConstantPartitionCount)
+		require.InDelta(t, 0.0, info.AverageOverlaps, 0.0001)
+		require.InDelta(t, 1.0, info.AverageDepth, 0.0001)
+		require.Equal(t, 1, info.PartitionDepthHistogram["00001"])
+		require.Len(t, info.ClusteringErrors, 1)
+		require.Equal(t, "2024-01-01 00:00:00", info.ClusteringErrors[0].Timestamp)
+		require.Equal(t, "some error", info.ClusteringErrors[0].Error)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		_, err := parseClusteringInformation("not json")
+		require.Error(t, err)
+	})
+}

--- a/pkg/sdk/testint/iceberg_tables_integration_test.go
+++ b/pkg/sdk/testint/iceberg_tables_integration_test.go
@@ -509,6 +509,26 @@ func TestInt_IcebergTables(t *testing.T) {
 		)
 	})
 
+	t.Run("create Snowflake managed: cluster by", func(t *testing.T) {
+		// PARTITION BY and CLUSTER BY are mutually exclusive for Iceberg tables (err 099207), so clustering is
+		// tested in a separate table from the partitioned "all options" one above.
+		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
+
+		err := client.IcebergTables.Create(ctx, sdk.NewCreateIcebergTableRequest(id, sdk.IcebergTableColumnsAndConstraintsRequest{
+			Columns: []sdk.IcebergTableColumnRequest{
+				{Name: "ID", ColumnType: testdatatypes.DataTypeNumber},
+				{Name: "REGION", ColumnType: testdatatypes.DataTypeVarcharIceberg},
+			},
+		}).WithClusterBy([]string{"ID", "REGION"}))
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().IcebergTable.DropFunc(t, id))
+
+		// The clustering key is not returned from SHOW/DESCRIBE, so verify it with SYSTEM$CLUSTERING_INFORMATION.
+		clusteringInfo, err := client.SystemFunctions.GetClusteringInformation(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, "LINEAR(ID, REGION)", clusteringInfo.ClusterByKeys)
+	})
+
 	t.Run("create Snowflake managed: copy grants", func(t *testing.T) {
 		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
 		err := client.IcebergTables.Create(ctx, sdk.NewCreateIcebergTableRequest(id, sdk.IcebergTableColumnsAndConstraintsRequest{
@@ -1107,11 +1127,18 @@ func TestInt_IcebergTables(t *testing.T) {
 			WithClusteringAction(*sdk.NewIcebergTableClusteringActionRequest().WithClusterBy([]string{"REGION"})))
 		require.NoError(t, err)
 
+		// The clustering key is not returned from SHOW/DESCRIBE, so verify it with SYSTEM$CLUSTERING_INFORMATION.
+		info, err := client.SystemFunctions.GetClusteringInformation(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, "LINEAR(REGION)", info.ClusterByKeys)
+
 		err = client.IcebergTables.Alter(ctx, sdk.NewAlterIcebergTableRequest(id).
 			WithClusteringAction(*sdk.NewIcebergTableClusteringActionRequest().WithDropClusteringKey(true)))
 		require.NoError(t, err)
 
-		// TODO (next PR): verify the clustering key with SYSTEM$CLUSTERING_INFORMATION, as it is not returned from SHOW/DESCRIBE.
+		// After dropping the clustering key, the table is no longer clustered.
+		_, err = client.SystemFunctions.GetClusteringInformation(ctx, id)
+		require.ErrorIs(t, err, sdk.ErrTableNotClustered)
 	})
 
 	t.Run("alter: set and unset properties", func(t *testing.T) {

--- a/pkg/sdk/testint/system_functions_integration_test.go
+++ b/pkg/sdk/testint/system_functions_integration_test.go
@@ -215,16 +215,16 @@ func TestInt_GetClusteringInformation(t *testing.T) {
 		err := client.IcebergTables.Create(ctx, sdk.NewCreateIcebergTableRequest(id, sdk.IcebergTableColumnsAndConstraintsRequest{
 			Columns: []sdk.IcebergTableColumnRequest{
 				{Name: "ID", ColumnType: testdatatypes.DataTypeNumber},
-				{Name: "REGION", ColumnType: testdatatypes.DataTypeVarcharIceberg},
+				{Name: "region", ColumnType: testdatatypes.DataTypeVarcharIceberg},
 			},
 		}))
 		require.NoError(t, err)
 		t.Cleanup(testClientHelper().IcebergTable.DropFunc(t, id))
 
-		info, err := client.SystemFunctions.GetClusteringInformation(ctx, id, "REGION")
+		info, err := client.SystemFunctions.GetClusteringInformation(ctx, id, "region")
 		require.NoError(t, err)
 		require.NotNil(t, info)
-		assert.Equal(t, "LINEAR(REGION)", info.ClusterByKeys)
+		assert.Equal(t, `LINEAR("region")`, info.ClusterByKeys)
 	})
 
 	t.Run("unclustered table - without columns returns an error", func(t *testing.T) {

--- a/pkg/sdk/testint/system_functions_integration_test.go
+++ b/pkg/sdk/testint/system_functions_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testdatatypes"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -183,6 +184,62 @@ func TestInt_GetIcebergTableInformation(t *testing.T) {
 	t.Run("get iceberg table information fails when the table does not exist", func(t *testing.T) {
 		_, err := client.SystemFunctions.GetIcebergTableInformation(ctx, testClientHelper().Ids.RandomSchemaObjectIdentifier())
 		require.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
+	})
+}
+
+func TestInt_GetClusteringInformation(t *testing.T) {
+	client := testClient(t)
+	ctx := testContext(t)
+
+	t.Run("clustered table - using the defined clustering key", func(t *testing.T) {
+		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
+		err := client.IcebergTables.Create(ctx, sdk.NewCreateIcebergTableRequest(id, sdk.IcebergTableColumnsAndConstraintsRequest{
+			Columns: []sdk.IcebergTableColumnRequest{
+				{Name: "ID", ColumnType: testdatatypes.DataTypeNumber},
+				{Name: "REGION", ColumnType: testdatatypes.DataTypeVarcharIceberg},
+			},
+		}).WithClusterBy([]string{"REGION"}))
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().IcebergTable.DropFunc(t, id))
+
+		info, err := client.SystemFunctions.GetClusteringInformation(ctx, id)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "LINEAR(REGION)", info.ClusterByKeys)
+		assert.NotNil(t, info.PartitionDepthHistogram)
+		assert.Empty(t, info.ClusteringErrors)
+	})
+
+	t.Run("unclustered table - using explicit columns", func(t *testing.T) {
+		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
+		err := client.IcebergTables.Create(ctx, sdk.NewCreateIcebergTableRequest(id, sdk.IcebergTableColumnsAndConstraintsRequest{
+			Columns: []sdk.IcebergTableColumnRequest{
+				{Name: "ID", ColumnType: testdatatypes.DataTypeNumber},
+				{Name: "REGION", ColumnType: testdatatypes.DataTypeVarcharIceberg},
+			},
+		}))
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().IcebergTable.DropFunc(t, id))
+
+		info, err := client.SystemFunctions.GetClusteringInformation(ctx, id, "REGION")
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "LINEAR(REGION)", info.ClusterByKeys)
+	})
+
+	t.Run("unclustered table - without columns returns an error", func(t *testing.T) {
+		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
+		err := client.IcebergTables.Create(ctx, sdk.NewCreateIcebergTableRequest(id, sdk.IcebergTableColumnsAndConstraintsRequest{
+			Columns: []sdk.IcebergTableColumnRequest{
+				{Name: "ID", ColumnType: testdatatypes.DataTypeNumber},
+				{Name: "REGION", ColumnType: testdatatypes.DataTypeVarcharIceberg},
+			},
+		}))
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().IcebergTable.DropFunc(t, id))
+
+		_, err = client.SystemFunctions.GetClusteringInformation(ctx, id)
+		require.ErrorIs(t, err, sdk.ErrTableNotClustered)
 	})
 }
 


### PR DESCRIPTION
## Changes

- **`SystemFunctions.GetClusteringInformation`** — new SDK method wrapping `SYSTEM$CLUSTERING_INFORMATION`. The clustering key is not returned by `SHOW`/`DESCRIBE` for Iceberg tables, so this is the way to read/verify it. Accepts optional explicit columns (variadic) to compute clustering information against an arbitrary key. Parses the JSON payload into a typed `ClusteringInformation` struct (with unit test coverage for parsing).

- **`PARTITION BY` / `CLUSTER BY` mutual-exclusion validation** — Snowflake rejects setting both on `CREATE ICEBERG TABLE` with error `099207 (0A000): "Partition by and Cluster by cannot be specified together for Iceberg tables."`, even though the [docs](https://docs.snowflake.com/en/sql-reference/sql/create-iceberg-table-snowflake) list both options without that caveat. Added a `ConflictingFields` validation between `PartitionBy` and `ClusterBy` (regenerated via the SDK generator) and a TODO in the def file to report the docs discrepancy to Snowflake.

- **Integration tests** — split the clustering coverage out of the partitioned "all options" case into a dedicated cluster-by test (since the two are mutually exclusive), and assert the clustering key via `GetClusteringInformation`. Added `TestInt_GetClusteringInformation` covering the defined-key, explicit-columns, and unclustered (error) paths.

- **Unit tests** — added a conflicting-fields validation test and a valid `CLUSTER BY` SQL test for `CREATE ICEBERG TABLE`.

## Notes

- The SDK was regenerated with the object filter (`--filter-object-names=IcebergTables`); only the iceberg validations were affected.
- Live integration tests require a Snowflake account and were not run in this environment; unit tests pass and the `testint` package compiles.