### PR TITLE
chore: run go fix any and waitgroup

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - ineffassign
     - makezero
     - misspell
+    - modernize
     - prealloc
     - revive
     - staticcheck
@@ -20,6 +21,44 @@ linters:
     - wastedassign
     - whitespace
   settings:
+    modernize:
+      disable:
+        # Replace []byte(fmt.Sprintf) with fmt.Appendf.
+        - fmtappendf
+        # Remove redundant re-declaration of loop variables.
+        - forvar
+        # Replace explicit loops over maps with calls to maps package.
+        - mapsloop
+        # Replace if/else statements with calls to min or max.
+        - minmax
+        # Simplify code by using go1.26's new(expr).
+        - newexpr
+        # Suggest replacing omitempty with omitzero for struct fields.
+        - omitzero
+        # Remove obsolete //+build comments.
+        - plusbuild
+        # Replace 3-clause for loops with for-range over integers.
+        - rangeint
+        # Replace reflect.TypeOf(x) with TypeFor[T]().
+        - reflecttypefor
+        # Replace loops with slices.Contains or slices.ContainsFunc.
+        - slicescontains
+        # Replace sort.Slice with slices.Sort for basic types.
+        - slicessort
+        # Use iterators instead of Len/At-style APIs.
+        - stditerators
+        # Replace strings.Index etc. with strings.Cut.
+        - stringscut
+        # Replace HasPrefix/TrimPrefix with CutPrefix.
+        - stringscutprefix
+        # Replace ranging over Split/Fields with SplitSeq/FieldsSeq.
+        - stringsseq
+        # Replace += with strings.Builder.
+        - stringsbuilder
+        # Replace context.WithCancel with t.Context in tests.
+        - testingcontext
+        # Replace unsafe pointer arithmetic with function calls.
+        - unsafefuncs
     misspell:
       locale: US
     revive:

--- a/pkg/acceptance/testenvs/testenvs_test.go
+++ b/pkg/acceptance/testenvs/testenvs_test.go
@@ -15,11 +15,9 @@ func Test_GetOrSkipTest(t *testing.T) {
 		t.Helper()
 		var env string
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			env = testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
-		}()
+		})
 		wg.Wait()
 		return env
 	}
@@ -51,11 +49,9 @@ func Test_SkipTestIfSet(t *testing.T) {
 	runSkipTestIfSetInGoroutineAndWaitForCompletion := func(t *testing.T, env testenvs.Env) {
 		t.Helper()
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			testenvs.SkipTestIfSet(t, env, "some good reason")
-		}()
+		})
 		wg.Wait()
 	}
 
@@ -84,11 +80,9 @@ func Test_SkipTestIfSetTo(t *testing.T) {
 	runSkipTestIfSetToInGoroutineAndWaitForCompletion := func(t *testing.T, env testenvs.Env, value string) {
 		t.Helper()
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			testenvs.SkipTestIfSetTo(t, env, value, "some good reason")
-		}()
+		})
 		wg.Wait()
 	}
 
@@ -126,11 +120,9 @@ func Test_SkipTestIfValueIn(t *testing.T) {
 	runSkipTestIfValueInInGoroutineAndWaitForCompletion := func(t *testing.T, env testenvs.Env, values []string) {
 		t.Helper()
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			testenvs.SkipTestIfValueIn(t, env, values, "some good reason")
-		}()
+		})
 		wg.Wait()
 	}
 
@@ -167,11 +159,9 @@ func Test_Assertions(t *testing.T) {
 	// so we need to be wrapped in a Goroutine.
 	runAssertionInGoroutineAndWaitForCompletion := func(assertion func()) {
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			assertion()
-		}()
+		})
 		wg.Wait()
 	}
 

--- a/pkg/datasources/cortex_search_services.go
+++ b/pkg/datasources/cortex_search_services.go
@@ -129,7 +129,7 @@ func ReadCortexSearchServices(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if v, ok := d.GetOk("in"); ok {
-		in := v.([]interface{})[0].(map[string]interface{})
+		in := v.([]any)[0].(map[string]any)
 		if v, ok := in["account"]; ok {
 			account := v.(bool)
 			if account {
@@ -154,7 +154,7 @@ func ReadCortexSearchServices(ctx context.Context, d *schema.ResourceData, meta 
 		request.WithStartsWith(startsWith)
 	}
 	if v, ok := d.GetOk("limit"); ok {
-		l := v.([]interface{})[0].(map[string]interface{})
+		l := v.([]any)[0].(map[string]any)
 		limit := sdk.LimitFrom{}
 		if v, ok := l["rows"]; ok {
 			rows := v.(int)

--- a/pkg/datasources/dynamic_tables.go
+++ b/pkg/datasources/dynamic_tables.go
@@ -208,13 +208,13 @@ func ReadDynamicTables(ctx context.Context, d *schema.ResourceData, meta any) di
 	client := meta.(*provider.Context).Client
 	request := sdk.NewShowDynamicTableRequest()
 	if v, ok := d.GetOk("like"); ok {
-		like := v.([]interface{})[0].(map[string]interface{})
+		like := v.([]any)[0].(map[string]any)
 		pattern := like["pattern"].(string)
 		request.WithLike(&sdk.Like{Pattern: sdk.String(pattern)})
 	}
 
 	if v, ok := d.GetOk("in"); ok {
-		in := v.([]interface{})[0].(map[string]interface{})
+		in := v.([]any)[0].(map[string]any)
 		if v, ok := in["account"]; ok {
 			account := v.(bool)
 			if account {
@@ -239,7 +239,7 @@ func ReadDynamicTables(ctx context.Context, d *schema.ResourceData, meta any) di
 		request.WithStartsWith(sdk.String(startsWith))
 	}
 	if v, ok := d.GetOk("limit"); ok {
-		l := v.([]interface{})[0].(map[string]interface{})
+		l := v.([]any)[0].(map[string]any)
 		limit := sdk.LimitFrom{}
 		if v, ok := l["rows"]; ok {
 			rows := v.(int)

--- a/pkg/datasources/external_functions.go
+++ b/pkg/datasources/external_functions.go
@@ -67,7 +67,7 @@ func ExternalFunctions() *schema.Resource {
 	}
 }
 
-func ReadContextExternalFunctions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ReadContextExternalFunctions(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	databaseName := d.Get("database").(string)
 	schemaName := d.Get("schema").(string)
@@ -79,9 +79,9 @@ func ReadContextExternalFunctions(ctx context.Context, d *schema.ResourceData, m
 		return nil
 	}
 
-	externalFunctionsList := []map[string]interface{}{}
+	externalFunctionsList := []map[string]any{}
 	for _, externalFunction := range externalFunctions {
-		externalFunctionMap := map[string]interface{}{}
+		externalFunctionMap := map[string]any{}
 		externalFunctionMap["name"] = externalFunction.Name
 
 		// do we filter by database?

--- a/pkg/datasources/failover_groups.go
+++ b/pkg/datasources/failover_groups.go
@@ -140,9 +140,9 @@ func ReadFailoverGroups(ctx context.Context, d *schema.ResourceData, meta any) d
 		return diag.FromErr(err)
 	}
 	d.SetId("failover_groups")
-	failoverGroupsFlatten := []map[string]interface{}{}
+	failoverGroupsFlatten := []map[string]any{}
 	for _, failoverGroup := range failoverGroups {
-		m := map[string]interface{}{}
+		m := map[string]any{}
 		m["region_group"] = failoverGroup.RegionGroup
 		m["snowflake_region"] = failoverGroup.SnowflakeRegion
 		m["created_on"] = failoverGroup.CreatedOn.String()

--- a/pkg/datasources/file_formats.go
+++ b/pkg/datasources/file_formats.go
@@ -81,10 +81,10 @@ func ReadFileFormats(ctx context.Context, d *schema.ResourceData, meta any) diag
 		return diag.FromErr(err)
 	}
 
-	fileFormats := []map[string]interface{}{}
+	fileFormats := []map[string]any{}
 
 	for _, fileFormat := range result {
-		fileFormatMap := map[string]interface{}{}
+		fileFormatMap := map[string]any{}
 
 		fileFormatMap["name"] = fileFormat.Name.Name()
 		fileFormatMap["database"] = fileFormat.Name.DatabaseName()

--- a/pkg/datasources/functions.go
+++ b/pkg/datasources/functions.go
@@ -71,7 +71,7 @@ func Functions() *schema.Resource {
 	}
 }
 
-func ReadContextFunctions(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ReadContextFunctions(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	databaseName := d.Get("database").(string)
 	schemaName := d.Get("schema").(string)
@@ -92,9 +92,9 @@ func ReadContextFunctions(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
-	entities := []map[string]interface{}{}
+	entities := []map[string]any{}
 	for _, item := range functions {
-		m := map[string]interface{}{}
+		m := map[string]any{}
 		m["name"] = item.Name
 		m["database"] = databaseName
 		m["schema"] = schemaName

--- a/pkg/datasources/parameters.go
+++ b/pkg/datasources/parameters.go
@@ -142,9 +142,9 @@ func ReadParameters(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	d.SetId("parameters")
 
-	params := []map[string]interface{}{}
+	params := []map[string]any{}
 	for _, param := range parameters {
-		paramMap := map[string]interface{}{}
+		paramMap := map[string]any{}
 
 		paramMap["key"] = param.Key
 		paramMap["value"] = param.Value

--- a/pkg/datasources/procedures.go
+++ b/pkg/datasources/procedures.go
@@ -70,7 +70,7 @@ func Procedures() *schema.Resource {
 	}
 }
 
-func ReadContextProcedures(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ReadContextProcedures(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	databaseName := d.Get("database").(string)
 	schemaName := d.Get("schema").(string)
@@ -95,10 +95,10 @@ func ReadContextProcedures(ctx context.Context, d *schema.ResourceData, meta int
 			},
 		}
 	}
-	proceduresList := []map[string]interface{}{}
+	proceduresList := []map[string]any{}
 
 	for _, procedure := range procedures {
-		procedureMap := map[string]interface{}{}
+		procedureMap := map[string]any{}
 		procedureMap["name"] = procedure.Name
 		procedureMap["database"] = procedure.CatalogName
 		procedureMap["schema"] = procedure.SchemaName

--- a/pkg/datasources/sequences.go
+++ b/pkg/datasources/sequences.go
@@ -72,9 +72,9 @@ func ReadSequences(ctx context.Context, d *schema.ResourceData, meta any) diag.D
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	sequences := []map[string]interface{}{}
+	sequences := []map[string]any{}
 	for _, seq := range seqs {
-		sequenceMap := map[string]interface{}{}
+		sequenceMap := map[string]any{}
 		sequenceMap["name"] = seq.Name
 		sequenceMap["database"] = seq.DatabaseName
 		sequenceMap["schema"] = seq.SchemaName

--- a/pkg/datasources/shares.go
+++ b/pkg/datasources/shares.go
@@ -80,9 +80,9 @@ func ReadShares(ctx context.Context, d *schema.ResourceData, meta any) diag.Diag
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	sharesFlatten := []map[string]interface{}{}
+	sharesFlatten := []map[string]any{}
 	for _, share := range shares {
-		m := map[string]interface{}{}
+		m := map[string]any{}
 		m["name"] = share.Name.Name()
 		m["comment"] = share.Comment
 		m["owner"] = share.Owner

--- a/pkg/datasources/streamlits.go
+++ b/pkg/datasources/streamlits.go
@@ -118,7 +118,7 @@ func ReadStreamlits(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		})
 	}
 	if v, ok := d.GetOk("in"); ok {
-		in := v.([]interface{})[0].(map[string]interface{})
+		in := v.([]any)[0].(map[string]any)
 		if v, ok := in["account"]; ok {
 			account := v.(bool)
 			if account {
@@ -139,7 +139,7 @@ func ReadStreamlits(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		}
 	}
 	if v, ok := d.GetOk("limit"); ok {
-		l := v.([]interface{})[0].(map[string]interface{})
+		l := v.([]any)[0].(map[string]any)
 		limit := sdk.LimitFrom{}
 		if v, ok := l["rows"]; ok {
 			rows := v.(int)

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -29,7 +29,7 @@ func StringToBool(s string) bool {
 }
 
 // EncodeSnowflakeID generates a unique ID for a resource.
-func EncodeSnowflakeID(attributes ...interface{}) string {
+func EncodeSnowflakeID(attributes ...any) string {
 	// is attribute already an object identifier?
 	if len(attributes) == 1 {
 		if id, ok := attributes[0].(sdk.ObjectIdentifier); ok {

--- a/pkg/internal/provider/cache_test.go
+++ b/pkg/internal/provider/cache_test.go
@@ -96,13 +96,11 @@ func TestCache_ConcurrentReadsAreSafe(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 100 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			result, err := cache.GetOrLoad("ROLE_A", func() ([]sdk.Grant, error) { return grants, nil })
 			assert.NoError(t, err)
 			assert.Equal(t, grants, result)
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/pkg/internal/provider/validators/validators.go
+++ b/pkg/internal/provider/validators/validators.go
@@ -14,7 +14,7 @@ import (
 )
 
 func NormalizeValidation[T any](normalize func(string) (T, error)) schema.SchemaValidateDiagFunc {
-	return func(val interface{}, _ cty.Path) diag.Diagnostics {
+	return func(val any, _ cty.Path) diag.Diagnostics {
 		_, err := normalize(val.(string))
 		if err != nil {
 			return diag.FromErr(err)
@@ -114,7 +114,7 @@ func getExpectedIdentifierForm(id any) string {
 
 // StringInSlice has the same implementation as validation.StringInSlice, but adapted to schema.SchemaValidateDiagFunc
 func StringInSlice(valid []string, ignoreCase bool) schema.SchemaValidateDiagFunc {
-	return func(i interface{}, path cty.Path) diag.Diagnostics {
+	return func(i any, path cty.Path) diag.Diagnostics {
 		v, ok := i.(string)
 		if !ok {
 			return diag.Errorf("expected type of %v to be string", path)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -870,7 +870,7 @@ func fixBooleanConfigFields(s *schema.ResourceData, config *gosnowflake.Config) 
 }
 
 // TODO: reuse with the function from resources package
-func expandStringList(configured []interface{}) []string {
+func expandStringList(configured []any) []string {
 	vs := make([]string, 0, len(configured))
 	for _, v := range configured {
 		val, ok := v.(string)
@@ -1018,9 +1018,9 @@ func getDriverConfigFromTerraform(s *schema.ResourceData) (*gosnowflake.Config, 
 		config.Account = strings.Join([]string{organizationName, accountName}, "-")
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	if v, ok := s.GetOk("params"); ok {
-		m = v.(map[string]interface{})
+		m = v.(map[string]any)
 	}
 
 	params := make(map[string]*string)

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -22,7 +22,7 @@ func TestProvider(t *testing.T) {
 }
 
 func TestGetDriverConfigFromTerraform_EmptyConfiguration(t *testing.T) {
-	d := schema.TestResourceDataRaw(t, GetProviderSchema(), map[string]interface{}{})
+	d := schema.TestResourceDataRaw(t, GetProviderSchema(), map[string]any{})
 
 	config, err := getDriverConfigFromTerraform(d)
 
@@ -85,7 +85,7 @@ func TestGetDriverConfigFromTerraform_EmptyConfiguration(t *testing.T) {
 }
 
 func TestGetDriverConfigFromTerraform_AllFields(t *testing.T) {
-	d := schema.TestResourceDataRaw(t, GetProviderSchema(), map[string]interface{}{ //nolint:gosec // test credentials
+	d := schema.TestResourceDataRaw(t, GetProviderSchema(), map[string]any{ //nolint:gosec // test credentials
 		"account_name":                      "test_account",
 		"organization_name":                 "test_org",
 		"user":                              "test_user",
@@ -118,7 +118,7 @@ func TestGetDriverConfigFromTerraform_AllFields(t *testing.T) {
 		"driver_tracing":                    "INFO",
 		"tmp_directory_path":                "/tmp/snowflake",
 		"disable_console_login":             "false",
-		"params": map[string]interface{}{
+		"params": map[string]any{
 			"QUERY_TAG": "test_tag",
 			"TIMEZONE":  "UTC",
 		},

--- a/pkg/resources/account_authentication_policy_attachment.go
+++ b/pkg/resources/account_authentication_policy_attachment.go
@@ -42,7 +42,7 @@ func AccountAuthenticationPolicyAttachment() *schema.Resource {
 }
 
 // CreateAccountAuthenticationPolicyAttachment implements schema.CreateFunc.
-func CreateAccountAuthenticationPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateAccountAuthenticationPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
 	authenticationPolicy, ok := sdk.NewObjectIdentifierFromFullyQualifiedName(d.Get("authentication_policy").(string)).(sdk.SchemaObjectIdentifier)
@@ -64,7 +64,7 @@ func CreateAccountAuthenticationPolicyAttachment(ctx context.Context, d *schema.
 	return ReadAccountAuthenticationPolicyAttachment(ctx, d, meta)
 }
 
-func ReadAccountAuthenticationPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ReadAccountAuthenticationPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	authenticationPolicy := helpers.DecodeSnowflakeIDLegacy(d.Id())
 	if err := d.Set("authentication_policy", authenticationPolicy.FullyQualifiedName()); err != nil {
 		return diag.FromErr(err)
@@ -74,7 +74,7 @@ func ReadAccountAuthenticationPolicyAttachment(ctx context.Context, d *schema.Re
 }
 
 // DeleteAccountAuthenticationPolicyAttachment implements schema.DeleteFunc.
-func DeleteAccountAuthenticationPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func DeleteAccountAuthenticationPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
 	err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{

--- a/pkg/resources/account_password_policy_attachment.go
+++ b/pkg/resources/account_password_policy_attachment.go
@@ -42,7 +42,7 @@ func AccountPasswordPolicyAttachment() *schema.Resource {
 }
 
 // CreateAccountPasswordPolicyAttachment implements schema.CreateFunc.
-func CreateAccountPasswordPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateAccountPasswordPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
 	passwordPolicy, ok := sdk.NewObjectIdentifierFromFullyQualifiedName(d.Get("password_policy").(string)).(sdk.SchemaObjectIdentifier)
@@ -64,7 +64,7 @@ func CreateAccountPasswordPolicyAttachment(ctx context.Context, d *schema.Resour
 	return ReadAccountPasswordPolicyAttachment(ctx, d, meta)
 }
 
-func ReadAccountPasswordPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ReadAccountPasswordPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	passwordPolicy := helpers.DecodeSnowflakeIDLegacy(d.Id())
 	if err := d.Set("password_policy", passwordPolicy.FullyQualifiedName()); err != nil {
 		return diag.FromErr(err)
@@ -74,7 +74,7 @@ func ReadAccountPasswordPolicyAttachment(ctx context.Context, d *schema.Resource
 }
 
 // DeleteAccountPasswordPolicyAttachment implements schema.DeleteFunc.
-func DeleteAccountPasswordPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func DeleteAccountPasswordPolicyAttachment(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
 	err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{

--- a/pkg/resources/alert.go
+++ b/pkg/resources/alert.go
@@ -132,7 +132,7 @@ func Alert() *schema.Resource {
 }
 
 // ReadAlert implements schema.ReadContextFunc.
-func ReadAlert(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ReadAlert(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	id := helpers.DecodeSnowflakeIDLegacy(d.Id()).(sdk.SchemaObjectIdentifier)
 
@@ -174,8 +174,8 @@ func ReadAlert(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 			if err != nil {
 				return diag.FromErr(err)
 			}
-			err = d.Set("alert_schedule", []interface{}{
-				map[string]interface{}{
+			err = d.Set("alert_schedule", []any{
+				map[string]any{
 					"interval": interval,
 				},
 			})
@@ -186,10 +186,10 @@ func ReadAlert(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 			repScheduleParts := strings.Split(alertSchedule, " ")
 			timeZone := repScheduleParts[len(repScheduleParts)-1]
 			expression := strings.TrimSuffix(strings.TrimPrefix(alertSchedule, "USING CRON "), " "+timeZone)
-			err = d.Set("alert_schedule", []interface{}{
-				map[string]interface{}{
-					"cron": []interface{}{
-						map[string]interface{}{
+			err = d.Set("alert_schedule", []any{
+				map[string]any{
+					"cron": []any{
+						map[string]any{
 							"expression": expression,
 							"time_zone":  timeZone,
 						},
@@ -225,7 +225,7 @@ func ReadAlert(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 }
 
 // CreateAlert implements schema.CreateContextFunc.
-func CreateAlert(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateAlert(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
 	databaseName := d.Get("database").(string)
@@ -271,13 +271,13 @@ func CreateAlert(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	return append(diags, ReadAlert(ctx, d, meta)...)
 }
 
-func getAlertSchedule(v interface{}) string {
+func getAlertSchedule(v any) string {
 	var alertSchedule string
-	schedule := v.([]interface{})[0].(map[string]interface{})
+	schedule := v.([]any)[0].(map[string]any)
 	if v, ok := schedule["cron"]; ok {
-		c := v.([]interface{})
+		c := v.([]any)
 		if len(c) > 0 {
-			cron := c[0].(map[string]interface{})
+			cron := c[0].(map[string]any)
 			cronExpression := cron["expression"].(string)
 			timeZone := cron["time_zone"].(string)
 			alertSchedule = fmt.Sprintf("USING CRON %s %s", cronExpression, timeZone)
@@ -293,7 +293,7 @@ func getAlertSchedule(v interface{}) string {
 }
 
 // UpdateAlert implements schema.UpdateContextFunc.
-func UpdateAlert(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func UpdateAlert(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	objectIdentifier := helpers.DecodeSnowflakeIDLegacy(d.Id()).(sdk.SchemaObjectIdentifier)
 

--- a/pkg/resources/api_authentication_integration_with_authorization_code_grant.go
+++ b/pkg/resources/api_authentication_integration_with_authorization_code_grant.go
@@ -96,7 +96,7 @@ func ImportApiAuthenticationWithAuthorizationCodeGrant(ctx context.Context, d *s
 	return []*schema.ResourceData{d}, nil
 }
 
-func CreateContextApiAuthenticationIntegrationWithAuthorizationCodeGrant(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateContextApiAuthenticationIntegrationWithAuthorizationCodeGrant(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	commonCreate, err := handleApiAuthCreate(d)
 	if err != nil {
@@ -138,7 +138,7 @@ func CreateContextApiAuthenticationIntegrationWithAuthorizationCodeGrant(ctx con
 }
 
 func ReadContextApiAuthenticationIntegrationWithAuthorizationCodeGrant(withExternalChangesMarking bool) schema.ReadContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 		client := meta.(*provider.Context).Client
 		id, err := sdk.ParseAccountObjectIdentifier(d.Id())
 		if err != nil {
@@ -197,7 +197,7 @@ func ReadContextApiAuthenticationIntegrationWithAuthorizationCodeGrant(withExter
 	}
 }
 
-func UpdateContextApiAuthenticationIntegrationWithAuthorizationCodeGrant(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func UpdateContextApiAuthenticationIntegrationWithAuthorizationCodeGrant(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	id, err := sdk.ParseAccountObjectIdentifier(d.Id())
 	if err != nil {

--- a/pkg/resources/api_authentication_integration_with_client_credentials.go
+++ b/pkg/resources/api_authentication_integration_with_client_credentials.go
@@ -81,7 +81,7 @@ func ImportApiAuthenticationWithClientCredentials(ctx context.Context, d *schema
 	return []*schema.ResourceData{d}, nil
 }
 
-func CreateContextApiAuthenticationIntegrationWithClientCredentials(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateContextApiAuthenticationIntegrationWithClientCredentials(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	commonCreate, err := handleApiAuthCreate(d)
 	if err != nil {
@@ -119,7 +119,7 @@ func CreateContextApiAuthenticationIntegrationWithClientCredentials(ctx context.
 }
 
 func ReadContextApiAuthenticationIntegrationWithClientCredentials(withExternalChangesMarking bool) schema.ReadContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 		client := meta.(*provider.Context).Client
 		id, err := sdk.ParseAccountObjectIdentifier(d.Id())
 		if err != nil {
@@ -168,7 +168,7 @@ func ReadContextApiAuthenticationIntegrationWithClientCredentials(withExternalCh
 	}
 }
 
-func UpdateContextApiAuthenticationIntegrationWithClientCredentials(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func UpdateContextApiAuthenticationIntegrationWithClientCredentials(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	id, err := sdk.ParseAccountObjectIdentifier(d.Id())
 	if err != nil {

--- a/pkg/resources/api_authentication_integration_with_jwt_bearer.go
+++ b/pkg/resources/api_authentication_integration_with_jwt_bearer.go
@@ -94,7 +94,7 @@ func ImportApiAuthenticationWithJwtBearer(ctx context.Context, d *schema.Resourc
 	return []*schema.ResourceData{d}, nil
 }
 
-func CreateContextApiAuthenticationIntegrationWithJwtBearer(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateContextApiAuthenticationIntegrationWithJwtBearer(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	commonCreate, err := handleApiAuthCreate(d)
 	if err != nil {
@@ -127,7 +127,7 @@ func CreateContextApiAuthenticationIntegrationWithJwtBearer(ctx context.Context,
 }
 
 func ReadContextApiAuthenticationIntegrationWithJwtBearer(withExternalChangesMarking bool) schema.ReadContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 		client := meta.(*provider.Context).Client
 		id, err := sdk.ParseAccountObjectIdentifier(d.Id())
 		if err != nil {
@@ -183,7 +183,7 @@ func ReadContextApiAuthenticationIntegrationWithJwtBearer(withExternalChangesMar
 	}
 }
 
-func UpdateContextApiAuthenticationIntegrationWithJwtBearer(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func UpdateContextApiAuthenticationIntegrationWithJwtBearer(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	id, err := sdk.ParseAccountObjectIdentifier(d.Id())
 	if err != nil {

--- a/pkg/resources/api_integration.go
+++ b/pkg/resources/api_integration.go
@@ -155,20 +155,20 @@ func toApiIntegrationEndpointPrefix(paths []string) []sdk.ApiIntegrationEndpoint
 }
 
 // CreateAPIIntegration implements schema.CreateFunc.
-func CreateAPIIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateAPIIntegration(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
 	name := d.Get("name").(string)
 	id := sdk.NewAccountObjectIdentifier(name)
 	enabled := d.Get("enabled").(bool)
 
-	allowedPrefixesRaw := expandStringList(d.Get("api_allowed_prefixes").([]interface{}))
+	allowedPrefixesRaw := expandStringList(d.Get("api_allowed_prefixes").([]any))
 	allowedPrefixes := toApiIntegrationEndpointPrefix(allowedPrefixesRaw)
 
 	createRequest := sdk.NewCreateApiIntegrationRequest(id, allowedPrefixes, enabled)
 
 	if _, ok := d.GetOk("api_blocked_prefixes"); ok {
-		blockedPrefixesRaw := expandStringList(d.Get("api_blocked_prefixes").([]interface{}))
+		blockedPrefixesRaw := expandStringList(d.Get("api_blocked_prefixes").([]any))
 		createRequest.WithApiBlockedPrefixes(toApiIntegrationEndpointPrefix(blockedPrefixesRaw))
 	}
 
@@ -224,7 +224,7 @@ func CreateAPIIntegration(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 // ReadAPIIntegration implements schema.ReadFunc.
-func ReadAPIIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ReadAPIIntegration(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	id := helpers.DecodeSnowflakeIDLegacy(d.Id()).(sdk.AccountObjectIdentifier)
 
@@ -339,7 +339,7 @@ func ReadAPIIntegration(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 // UpdateAPIIntegration implements schema.UpdateFunc.
-func UpdateAPIIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func UpdateAPIIntegration(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	id := helpers.DecodeSnowflakeIDLegacy(d.Id()).(sdk.AccountObjectIdentifier)
 
@@ -352,7 +352,7 @@ func UpdateAPIIntegration(ctx context.Context, d *schema.ResourceData, meta inte
 
 	if d.HasChange("api_allowed_prefixes") {
 		runSetStatement = true
-		setRequest.WithApiAllowedPrefixes(toApiIntegrationEndpointPrefix(expandStringList(d.Get("api_allowed_prefixes").([]interface{}))))
+		setRequest.WithApiAllowedPrefixes(toApiIntegrationEndpointPrefix(expandStringList(d.Get("api_allowed_prefixes").([]any))))
 	}
 
 	if d.HasChange("comment") {
@@ -362,7 +362,7 @@ func UpdateAPIIntegration(ctx context.Context, d *schema.ResourceData, meta inte
 
 	// We need to UNSET this if we remove all api blocked prefixes.
 	if d.HasChange("api_blocked_prefixes") {
-		v := d.Get("api_blocked_prefixes").([]interface{})
+		v := d.Get("api_blocked_prefixes").([]any)
 		if len(v) == 0 {
 			err := client.ApiIntegrations.Alter(ctx, sdk.NewAlterApiIntegrationRequest(id).WithUnset(*sdk.NewApiIntegrationUnsetRequest().WithApiBlockedPrefixes(true)))
 			if err != nil {

--- a/pkg/resources/custom_diffs.go
+++ b/pkg/resources/custom_diffs.go
@@ -132,7 +132,7 @@ func ForceNewIfNotDefault(key string) schema.CustomizeDiffFunc {
 // If the field is not found in the given schema, it continues without error. Only top level schema fields should be used.
 // If the field is a nested field, it may cause diffs eagerly. This happens because diff.HasChange returns true, even if a nested field diff is suppressed.
 func ComputedIfAnyAttributeChanged(resourceSchema map[string]*schema.Schema, key string, changedAttributeKeys ...string) schema.CustomizeDiffFunc {
-	return customdiff.ComputedIf(key, func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+	return customdiff.ComputedIf(key, func(ctx context.Context, diff *schema.ResourceDiff, meta any) bool {
 		var result bool
 		for _, changedKey := range changedAttributeKeys {
 			if diff.HasChange(changedKey) || !diff.NewValueKnown(changedKey) {
@@ -252,7 +252,7 @@ func TemporaryWorkaroundIdentifierForceNewIfHierarchyRenamesExperimentNotEnabled
 }
 
 func RecreateWhenUserTypeChangedExternally(userType sdk.UserType) schema.CustomizeDiffFunc {
-	return func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 		if n := diff.Get("user_type"); n != nil {
 			log.Printf("[DEBUG] new external value for user type: %s", n.(string))
 			if acceptableUserTypes, ok := sdk.AcceptableUserTypes[userType]; ok && !slices.Contains(acceptableUserTypes, strings.ToUpper(n.(string))) {
@@ -267,7 +267,7 @@ func RecreateWhenUserTypeChangedExternally(userType sdk.UserType) schema.Customi
 }
 
 func RecreateWhenStageTypeChangedExternally(stageType sdk.StageType) schema.CustomizeDiffFunc {
-	return func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 		if n := diff.Get("stage_type"); n != nil {
 			log.Printf("[DEBUG] new external value for stage type: %s", n.(string))
 
@@ -281,7 +281,7 @@ func RecreateWhenStageTypeChangedExternally(stageType sdk.StageType) schema.Cust
 }
 
 func RecreateWhenSecretTypeChangedExternally(secretType sdk.SecretType) schema.CustomizeDiffFunc {
-	return func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 		if n := diff.Get("secret_type"); n != nil {
 			log.Printf("[DEBUG] new external value for secret type: %s", n.(string))
 
@@ -336,7 +336,7 @@ func RecreateWhenStageCloudChangedExternally(stageCloud sdk.StageCloud) schema.C
 // HandleWarehouseExternalTypeChange detects when the warehouse type has been changed externally
 // and plans an update to restore it to warehouseType (without forcing recreation).
 func HandleWarehouseExternalTypeChange(warehouseType sdk.WarehouseType) schema.CustomizeDiffFunc {
-	return func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 		if n := diff.Get("warehouse_type"); n != nil {
 			gotTypeRaw := n.(string)
 			if gotTypeRaw == "" {
@@ -356,7 +356,7 @@ func HandleWarehouseExternalTypeChange(warehouseType sdk.WarehouseType) schema.C
 
 // RecreateWhenResourceTypeChangedExternally recreates a resource when argument wantType is different than the value in typeField.
 func RecreateWhenResourceTypeChangedExternally[T ~string](typeField string, wantType T, toType func(string) (T, error)) schema.CustomizeDiffFunc {
-	return func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 		if n := diff.Get(typeField); n != nil {
 			log.Printf("[DEBUG] new external value for %s", typeField)
 
@@ -384,7 +384,7 @@ func RecreateWhenResourceTypeChangedExternally[T ~string](typeField string, want
 // RecreateWhenStreamIsStale detects when the stream is stale, and sets a `false` value for `stale` field.
 // This means that the provider can detect that change in `stale` from `true` to `false`, where `false` is our desired state.
 func RecreateWhenStreamIsStale() schema.CustomizeDiffFunc {
-	return func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 		if old, _ := diff.GetChange("stale"); old.(bool) {
 			return diff.SetNew("stale", false)
 		}
@@ -399,7 +399,7 @@ func RecreateWhenStreamIsStale() schema.CustomizeDiffFunc {
 // - From storage_integration to credentials: ForceNew on credentials
 // - From credentials to storage_integration: ForceNew on storage_integration
 func RecreateWhenCredentialsAndStorageIntegrationChangedOnExternalStage() schema.CustomizeDiffFunc {
-	return func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 		credentialsOld, credentialsNew := diff.GetChange("credentials")
 		storageIntegrationOld, storageIntegrationNew := diff.GetChange("storage_integration")
 		// Change from storage_integration to credentials requires recreation
@@ -417,7 +417,7 @@ func RecreateWhenCredentialsAndStorageIntegrationChangedOnExternalStage() schema
 
 // RecreateWhenResourceBoolFieldChangedExternally recreates a resource when wantValue is different than value in boolField.
 func RecreateWhenResourceBoolFieldChangedExternally(boolField string, wantValue bool) schema.CustomizeDiffFunc {
-	return func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 		if n := diff.Get(boolField); n != nil {
 			log.Printf("[DEBUG] new external value for %v", boolField)
 			if n.(bool) != wantValue {

--- a/pkg/resources/dynamic_table.go
+++ b/pkg/resources/dynamic_table.go
@@ -223,15 +223,15 @@ func ReadDynamicTable(ctx context.Context, d *schema.ResourceData, meta any) dia
 	if err := d.Set("comment", dynamicTable.Comment); err != nil {
 		return diag.FromErr(err)
 	}
-	tl := map[string]interface{}{}
+	tl := map[string]any{}
 	if dynamicTable.TargetLag == "DOWNSTREAM" {
 		tl["downstream"] = true
-		if err := d.Set("target_lag", []interface{}{tl}); err != nil {
+		if err := d.Set("target_lag", []any{tl}); err != nil {
 			return diag.FromErr(err)
 		}
 	} else {
 		tl["maximum_duration"] = dynamicTable.TargetLag
-		if err := d.Set("target_lag", []interface{}{tl}); err != nil {
+		if err := d.Set("target_lag", []any{tl}); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -334,9 +334,9 @@ func ReadDynamicTable(ctx context.Context, d *schema.ResourceData, meta any) dia
 	return nil
 }
 
-func parseTargetLag(v interface{}) sdk.TargetLag {
+func parseTargetLag(v any) sdk.TargetLag {
 	var result sdk.TargetLag
-	tl := v.([]interface{})[0].(map[string]interface{})
+	tl := v.([]any)[0].(map[string]any)
 	if v, ok := tl["maximum_duration"]; ok {
 		result.MaximumDuration = sdk.String(v.(string))
 	}

--- a/pkg/resources/external_function.go
+++ b/pkg/resources/external_function.go
@@ -229,16 +229,16 @@ func ExternalFunction() *schema.Resource {
 	}
 }
 
-func CreateContextExternalFunction(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateContextExternalFunction(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	database := d.Get("database").(string)
 	schemaName := d.Get("schema").(string)
 	name := d.Get("name").(string)
 	args := make([]sdk.ExternalFunctionArgumentRequest, 0)
 	if v, ok := d.GetOk("arg"); ok {
-		for _, arg := range v.([]interface{}) {
-			argName := arg.(map[string]interface{})["name"].(string)
-			argType := arg.(map[string]interface{})["type"].(string)
+		for _, arg := range v.([]any) {
+			argName := arg.(map[string]any)["name"].(string)
+			argType := arg.(map[string]any)["type"].(string)
 			argDataType, err := datatypes.ParseDataType(argType)
 			if err != nil {
 				return diag.FromErr(err)
@@ -300,7 +300,7 @@ func CreateContextExternalFunction(ctx context.Context, d *schema.ResourceData, 
 	if _, ok := d.GetOk("header"); ok {
 		headers := make([]sdk.ExternalFunctionHeaderRequest, 0)
 		for _, header := range d.Get("header").(*schema.Set).List() {
-			m := header.(map[string]interface{})
+			m := header.(map[string]any)
 			headerName := m["name"].(string)
 			headerValue := m["value"].(string)
 			headers = append(headers, sdk.ExternalFunctionHeaderRequest{
@@ -312,7 +312,7 @@ func CreateContextExternalFunction(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if v, ok := d.GetOk("context_headers"); ok {
-		contextHeadersList := expandStringList(v.([]interface{}))
+		contextHeadersList := expandStringList(v.([]any))
 		contextHeaders := make([]sdk.ExternalFunctionContextHeaderRequest, 0)
 		for _, header := range contextHeadersList {
 			contextHeaders = append(contextHeaders, sdk.ExternalFunctionContextHeaderRequest{
@@ -347,7 +347,7 @@ func CreateContextExternalFunction(ctx context.Context, d *schema.ResourceData, 
 	return ReadContextExternalFunction(ctx, d, meta)
 }
 
-func ReadContextExternalFunction(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ReadContextExternalFunction(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
 	id, err := sdk.ParseSchemaObjectIdentifierWithArguments(d.Id())
@@ -409,12 +409,12 @@ func ReadContextExternalFunction(ctx context.Context, d *schema.ResourceData, me
 
 			if args != "" { // Do nothing for functions without arguments
 				argPairs := strings.Split(args, ", ")
-				args := []interface{}{}
+				args := []any{}
 
 				for _, argPair := range argPairs {
 					argItem := strings.Split(argPair, " ")
 
-					arg := map[string]interface{}{}
+					arg := map[string]any{}
 					arg["name"] = argItem[0]
 					arg["type"] = argItem[1]
 					args = append(args, arg)
@@ -512,7 +512,7 @@ func ReadContextExternalFunction(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func UpdateContextExternalFunction(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func UpdateContextExternalFunction(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
 	id, err := sdk.ParseSchemaObjectIdentifierWithArguments(d.Id())

--- a/pkg/resources/external_function_state_upgraders.go
+++ b/pkg/resources/external_function_state_upgraders.go
@@ -39,7 +39,7 @@ func parseV085ExternalFunctionId(stringID string) (*v085ExternalFunctionId, erro
 	}, nil
 }
 
-func v085ExternalFunctionStateUpgrader(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func v085ExternalFunctionStateUpgrader(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
 	if rawState == nil {
 		return rawState, nil
 	}

--- a/pkg/resources/external_oauth_integration.go
+++ b/pkg/resources/external_oauth_integration.go
@@ -306,7 +306,7 @@ func ImportExternalOauthIntegration(ctx context.Context, d *schema.ResourceData,
 	return []*schema.ResourceData{d}, nil
 }
 
-func CreateContextExternalOauthIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateContextExternalOauthIntegration(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	enabled := d.Get("enabled").(bool)
 	externalOauthIssuer := d.Get("external_oauth_issuer").(string)
@@ -407,7 +407,7 @@ func CreateContextExternalOauthIntegration(ctx context.Context, d *schema.Resour
 }
 
 func ReadContextExternalOauthIntegration(withExternalChangesMarking bool) schema.ReadContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 		providerCtx := meta.(*provider.Context)
 		client := providerCtx.Client
 		id, err := sdk.ParseAccountObjectIdentifier(d.Id())
@@ -570,7 +570,7 @@ func ReadContextExternalOauthIntegration(withExternalChangesMarking bool) schema
 	}
 }
 
-func UpdateContextExternalOauthIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func UpdateContextExternalOauthIntegration(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	id, err := sdk.ParseAccountObjectIdentifier(d.Id())
 	if err != nil {

--- a/pkg/resources/failover_group.go
+++ b/pkg/resources/failover_group.go
@@ -174,7 +174,7 @@ func CreateFailoverGroup(ctx context.Context, d *schema.ResourceData, meta any) 
 
 	// if from_replica is set, then we are creating a failover group from an existing replica
 	if v, ok := d.GetOk("from_replica"); ok {
-		fromReplica := v.([]interface{})[0].(map[string]interface{})
+		fromReplica := v.([]any)[0].(map[string]any)
 		organizationName := fromReplica["organization_name"].(string)
 		sourceAccountName := fromReplica["source_account_name"].(string)
 		sourceFailoverGroupName := fromReplica["name"].(string)
@@ -252,11 +252,11 @@ func CreateFailoverGroup(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	if v, ok := d.GetOk("replication_schedule"); ok {
-		replicationSchedule := v.([]interface{})[0].(map[string]interface{})
+		replicationSchedule := v.([]any)[0].(map[string]any)
 		if v, ok := replicationSchedule["cron"]; ok {
-			c := v.([]interface{})
+			c := v.([]any)
 			if len(c) > 0 {
-				cron := c[0].(map[string]interface{})
+				cron := c[0].(map[string]any)
 				cronExpression := cron["expression"].(string)
 				if v, ok := cron["time_zone"]; ok {
 					timeZone := v.(string)
@@ -320,8 +320,8 @@ func ReadFailoverGroup(ctx context.Context, d *schema.ResourceData, meta any) di
 			if err != nil {
 				return diag.FromErr(err)
 			}
-			err = d.Set("replication_schedule", []interface{}{
-				map[string]interface{}{
+			err = d.Set("replication_schedule", []any{
+				map[string]any{
 					"interval": interval,
 				},
 			})
@@ -332,10 +332,10 @@ func ReadFailoverGroup(ctx context.Context, d *schema.ResourceData, meta any) di
 			repScheduleParts := strings.Split(replicationSchedule, " ")
 			timeZone := repScheduleParts[len(repScheduleParts)-1]
 			expression := strings.TrimSuffix(strings.TrimPrefix(replicationSchedule, "USING CRON "), " "+timeZone)
-			err = d.Set("replication_schedule", []interface{}{
-				map[string]interface{}{
-					"cron": []interface{}{
-						map[string]interface{}{
+			err = d.Set("replication_schedule", []any{
+				map[string]any{
+					"cron": []any{
+						map[string]any{
 							"expression": expression,
 							"time_zone":  timeZone,
 						},
@@ -348,7 +348,7 @@ func ReadFailoverGroup(ctx context.Context, d *schema.ResourceData, meta any) di
 		}
 	}
 	// object types
-	objectTypes := make([]interface{}, len(failoverGroup.ObjectTypes))
+	objectTypes := make([]any, len(failoverGroup.ObjectTypes))
 	for i, v := range failoverGroup.ObjectTypes {
 		objectTypes[i] = string(v)
 	}
@@ -358,7 +358,7 @@ func ReadFailoverGroup(ctx context.Context, d *schema.ResourceData, meta any) di
 	}
 
 	// integration types
-	allowedIntegrationTypes := make([]interface{}, len(failoverGroup.AllowedIntegrationTypes))
+	allowedIntegrationTypes := make([]any, len(failoverGroup.AllowedIntegrationTypes))
 	for i, v := range failoverGroup.AllowedIntegrationTypes {
 		allowedIntegrationTypes[i] = string(v)
 	}
@@ -369,7 +369,7 @@ func ReadFailoverGroup(ctx context.Context, d *schema.ResourceData, meta any) di
 	}
 
 	// allowed accounts
-	allowedAccounts := make([]interface{}, len(failoverGroup.AllowedAccounts))
+	allowedAccounts := make([]any, len(failoverGroup.AllowedAccounts))
 	for i, v := range failoverGroup.AllowedAccounts {
 		allowedAccounts[i] = v.Name()
 	}
@@ -383,7 +383,7 @@ func ReadFailoverGroup(ctx context.Context, d *schema.ResourceData, meta any) di
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	allowedDatabases := make([]interface{}, len(databases))
+	allowedDatabases := make([]any, len(databases))
 	for i, database := range databases {
 		allowedDatabases[i] = database.Name()
 	}
@@ -403,7 +403,7 @@ func ReadFailoverGroup(ctx context.Context, d *schema.ResourceData, meta any) di
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	allowedShares := make([]interface{}, len(shares))
+	allowedShares := make([]any, len(shares))
 	for i, share := range shares {
 		allowedShares[i] = share.Name()
 	}

--- a/pkg/resources/file_format.go
+++ b/pkg/resources/file_format.go
@@ -901,7 +901,7 @@ func UpdateFileFormat(ctx context.Context, d *schema.ResourceData, meta any) dia
 		}
 		if d.HasChange("null_if") {
 			nullIf := []sdk.NullString{}
-			for _, s := range d.Get("null_if").([]interface{}) {
+			for _, s := range d.Get("null_if").([]any) {
 				if s == nil {
 					s = ""
 				} else {
@@ -970,7 +970,7 @@ func UpdateFileFormat(ctx context.Context, d *schema.ResourceData, meta any) dia
 		}
 		if d.HasChange("null_if") {
 			nullIf := []sdk.NullString{}
-			for _, s := range d.Get("null_if").([]interface{}) {
+			for _, s := range d.Get("null_if").([]any) {
 				if s == nil {
 					s = ""
 				} else {
@@ -1034,7 +1034,7 @@ func UpdateFileFormat(ctx context.Context, d *schema.ResourceData, meta any) dia
 		}
 		if d.HasChange("null_if") {
 			nullIf := []sdk.NullString{}
-			for _, s := range d.Get("null_if").([]interface{}) {
+			for _, s := range d.Get("null_if").([]any) {
 				if s == nil {
 					s = ""
 				} else {
@@ -1053,7 +1053,7 @@ func UpdateFileFormat(ctx context.Context, d *schema.ResourceData, meta any) dia
 		}
 		if d.HasChange("null_if") {
 			nullIf := []sdk.NullString{}
-			for _, s := range d.Get("null_if").([]interface{}) {
+			for _, s := range d.Get("null_if").([]any) {
 				if s == nil {
 					s = ""
 				} else {
@@ -1082,7 +1082,7 @@ func UpdateFileFormat(ctx context.Context, d *schema.ResourceData, meta any) dia
 		}
 		if d.HasChange("null_if") {
 			nullIf := []sdk.NullString{}
-			for _, s := range d.Get("null_if").([]interface{}) {
+			for _, s := range d.Get("null_if").([]any) {
 				if s == nil {
 					s = ""
 				} else {
@@ -1169,7 +1169,7 @@ func fileFormatIDFromString(stringID string) (*fileFormatID, error) {
 	}, nil
 }
 
-func getFormatTypeOption(d *schema.ResourceData, formatType, formatTypeOption string) (interface{}, bool, error) {
+func getFormatTypeOption(d *schema.ResourceData, formatType, formatTypeOption string) (any, bool, error) {
 	validFormatTypeOptions := formatTypeOptions[formatType]
 	if v, ok := d.GetOk(formatTypeOption); ok {
 		if err := validateFormatTypeOptions(formatType, formatTypeOption, validFormatTypeOptions); err != nil {

--- a/pkg/resources/grant_account_role.go
+++ b/pkg/resources/grant_account_role.go
@@ -58,7 +58,7 @@ func GrantAccountRole() *schema.Resource {
 		DeleteContext: TrackingDeleteWrapper(resources.GrantAccountRole, DeleteGrantAccountRole),
 		Schema:        grantAccountRoleSchema,
 		Importer: &schema.ResourceImporter{
-			StateContext: TrackingImportWrapper(resources.GrantAccountRole, func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+			StateContext: TrackingImportWrapper(resources.GrantAccountRole, func(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
 				parts := strings.Split(d.Id(), helpers.IDDelimiter)
 				if len(parts) != 3 {
 					return nil, fmt.Errorf("invalid ID specified: %v, expected <role_name>|<grantee_object_type>|<grantee_identifier>", d.Id())
@@ -87,7 +87,7 @@ func GrantAccountRole() *schema.Resource {
 }
 
 // CreateGrantAccountRole implements schema.CreateFunc.
-func CreateGrantAccountRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateGrantAccountRole(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	providerCtx := meta.(*provider.Context)
 	client := providerCtx.Client
 	roleName := d.Get("role_name").(string)
@@ -136,7 +136,7 @@ func CreateGrantAccountRole(ctx context.Context, d *schema.ResourceData, meta in
 	return ReadGrantAccountRole(ctx, d, meta)
 }
 
-func ReadGrantAccountRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ReadGrantAccountRole(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	providerCtx := meta.(*provider.Context)
 	client := providerCtx.Client
 	parts := strings.Split(d.Id(), helpers.IDDelimiter)
@@ -195,7 +195,7 @@ func ReadGrantAccountRole(ctx context.Context, d *schema.ResourceData, meta inte
 	return nil
 }
 
-func DeleteGrantAccountRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func DeleteGrantAccountRole(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	providerCtx := meta.(*provider.Context)
 	client := providerCtx.Client
 	parts := strings.Split(d.Id(), helpers.IDDelimiter)

--- a/pkg/resources/grant_application_role.go
+++ b/pkg/resources/grant_application_role.go
@@ -59,7 +59,7 @@ func GrantApplicationRole() *schema.Resource {
 		DeleteContext: TrackingDeleteWrapper(resources.GrantApplicationRole, DeleteContextGrantApplicationRole),
 		Schema:        grantApplicationRoleSchema,
 		Importer: &schema.ResourceImporter{
-			StateContext: TrackingImportWrapper(resources.GrantApplicationRole, func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+			StateContext: TrackingImportWrapper(resources.GrantApplicationRole, func(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
 				parts := helpers.ParseResourceIdentifier(d.Id())
 				if len(parts) != 3 {
 					return nil, fmt.Errorf("invalid ID specified: %v, expected <application_role_name>|<object_type>|<target_identifier>", d.Id())
@@ -95,7 +95,7 @@ func GrantApplicationRole() *schema.Resource {
 	}
 }
 
-func CreateContextGrantApplicationRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateContextGrantApplicationRole(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	name := d.Get("application_role_name").(string)
 	applicationRoleIdentifier, err := sdk.ParseDatabaseObjectIdentifier(name)
@@ -129,7 +129,7 @@ func CreateContextGrantApplicationRole(ctx context.Context, d *schema.ResourceDa
 	return ReadContextGrantApplicationRole(ctx, d, meta)
 }
 
-func ReadContextGrantApplicationRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ReadContextGrantApplicationRole(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	parts := strings.Split(d.Id(), helpers.IDDelimiter)
 	applicationRoleName := parts[0]
@@ -259,7 +259,7 @@ func ReadContextGrantApplicationRole(ctx context.Context, d *schema.ResourceData
 	return nil
 }
 
-func DeleteContextGrantApplicationRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func DeleteContextGrantApplicationRole(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	providerCtx := meta.(*provider.Context)
 	client := providerCtx.Client
 

--- a/pkg/resources/grant_database_role.go
+++ b/pkg/resources/grant_database_role.go
@@ -74,7 +74,7 @@ func GrantDatabaseRole() *schema.Resource {
 		DeleteContext: TrackingDeleteWrapper(resources.GrantDatabaseRole, DeleteGrantDatabaseRole),
 		Schema:        grantDatabaseRoleSchema,
 		Importer: &schema.ResourceImporter{
-			StateContext: TrackingImportWrapper(resources.GrantDatabaseRole, func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+			StateContext: TrackingImportWrapper(resources.GrantDatabaseRole, func(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
 				parts := helpers.ParseResourceIdentifier(d.Id())
 				if len(parts) != 3 {
 					return nil, fmt.Errorf("invalid ID specified: %v, expected <database_role_name>|<object_type>|<target_identifier>", d.Id())
@@ -125,7 +125,7 @@ func GrantDatabaseRole() *schema.Resource {
 }
 
 // CreateGrantDatabaseRole implements schema.CreateFunc.
-func CreateGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	databaseRoleName := d.Get("database_role_name").(string)
 	databaseRoleIdentifier, err := sdk.ParseDatabaseObjectIdentifier(databaseRoleName)
@@ -170,7 +170,7 @@ func CreateGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 // ReadGrantDatabaseRole implements schema.ReadFunc.
-func ReadGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ReadGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	parts := helpers.ParseResourceIdentifier(d.Id())
 	databaseRoleName := parts[0]
@@ -211,7 +211,7 @@ func ReadGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 // DeleteGrantDatabaseRole implements schema.DeleteFunc.
-func DeleteGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func DeleteGrantDatabaseRole(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	providerCtx := meta.(*provider.Context)
 	client := providerCtx.Client
 

--- a/pkg/resources/grant_privileges_to_share.go
+++ b/pkg/resources/grant_privileges_to_share.go
@@ -126,8 +126,8 @@ func GrantPrivilegesToShare() *schema.Resource {
 	}
 }
 
-func ImportGrantPrivilegesToShare() func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	return func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func ImportGrantPrivilegesToShare() func(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
+	return func(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
 		id, err := ParseGrantPrivilegesToShareId(d.Id())
 		if err != nil {
 			return nil, err

--- a/pkg/resources/helper_expansion.go
+++ b/pkg/resources/helper_expansion.go
@@ -9,7 +9,7 @@ import (
 
 // borrowed from https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/structure.go#L924:6
 
-func expandIntList(configured []interface{}) []int {
+func expandIntList(configured []any) []int {
 	vs := make([]int, 0, len(configured))
 	for _, v := range configured {
 		if val, ok := v.(int); ok {
@@ -19,7 +19,7 @@ func expandIntList(configured []interface{}) []int {
 	return vs
 }
 
-func expandStringList(configured []interface{}) []string {
+func expandStringList(configured []any) []string {
 	vs := make([]string, 0, len(configured))
 	for _, v := range configured {
 		val, ok := v.(string)
@@ -53,7 +53,7 @@ func ExpandObjectIdentifierSet(configured []any, objectType sdk.ObjectType) ([]s
 	return ids, nil
 }
 
-func expandStringListAllowEmpty(configured []interface{}) []string {
+func expandStringListAllowEmpty(configured []any) []string {
 	// Allow empty values during expansion
 	vs := make([]string, 0, len(configured))
 	for _, v := range configured {
@@ -67,8 +67,8 @@ func expandStringListAllowEmpty(configured []interface{}) []string {
 	return vs
 }
 
-func expandObjectIdentifier(objectIdentifier interface{}) (string, string, string) {
-	objectIdentifierMap := objectIdentifier.([]interface{})[0].(map[string]interface{})
+func expandObjectIdentifier(objectIdentifier any) (string, string, string) {
+	objectIdentifierMap := objectIdentifier.([]any)[0].(map[string]any)
 	objectName := objectIdentifierMap["name"].(string)
 	var objectSchema string
 	if v := objectIdentifierMap["schema"]; v != nil {
@@ -82,7 +82,7 @@ func expandObjectIdentifier(objectIdentifier interface{}) (string, string, strin
 }
 
 // ADiffB takes all the elements of A that are not also present in B, A-B in set notation
-func ADiffB(setA []interface{}, setB []interface{}) []string {
+func ADiffB(setA []any, setB []any) []string {
 	res := make([]string, 0)
 	sliceA := expandStringList(setA)
 	sliceB := expandStringList(setB)

--- a/pkg/resources/helper_expansion_internal_test.go
+++ b/pkg/resources/helper_expansion_internal_test.go
@@ -9,7 +9,7 @@ import (
 func TestExpandStringList(t *testing.T) {
 	r := require.New(t)
 
-	in := []interface{}{"this", "is", "just", "a", "test"}
+	in := []any{"this", "is", "just", "a", "test"}
 	out := expandStringList(in)
 
 	r.Equal("this", out[0])
@@ -21,7 +21,7 @@ func TestExpandStringList(t *testing.T) {
 
 func TestExpandBlankStringList(t *testing.T) {
 	r := require.New(t)
-	in := []interface{}{}
+	in := []any{}
 	out := expandStringList(in)
 
 	r.Empty(out)

--- a/pkg/resources/helpers.go
+++ b/pkg/resources/helpers.go
@@ -223,11 +223,11 @@ type tag struct {
 	schema   string
 }
 
-func getTags(from interface{}) (to tags) {
-	tags := from.([]interface{})
+func getTags(from any) (to tags) {
+	tags := from.([]any)
 	to = make([]tag, len(tags))
 	for i, t := range tags {
-		v := t.(map[string]interface{})
+		v := t.(map[string]any)
 		to[i] = tag{
 			name:     v["name"].(string),
 			value:    v["value"].(string),

--- a/pkg/resources/helpers_test.go
+++ b/pkg/resources/helpers_test.go
@@ -50,7 +50,7 @@ func Test_GetPropertyAsPointer(t *testing.T) {
 			Type:     schema.TypeBool,
 			Optional: true,
 		},
-	}, map[string]interface{}{
+	}, map[string]any{
 		"integer":        123,
 		"second_integer": 0,
 		"string":         "some string",
@@ -117,7 +117,7 @@ func Test_GetConfigPropertyAsPointerAllowingZeroValue(t *testing.T) {
 			Type:     schema.TypeBool,
 			Optional: true,
 		},
-	}, map[string]interface{}{
+	}, map[string]any{
 		"integer":        123,
 		"second_integer": 0,
 		"string":         "some string",

--- a/pkg/resources/network_policy.go
+++ b/pkg/resources/network_policy.go
@@ -134,7 +134,7 @@ func NetworkPolicy() *schema.Resource {
 	}
 }
 
-func CreateContextNetworkPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateContextNetworkPolicy(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	id, err := sdk.ParseAccountObjectIdentifier(d.Get("name").(string))
 	if err != nil {
 		return diag.FromErr(err)
@@ -290,7 +290,7 @@ func ReadContextNetworkPolicy(ctx context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
-func UpdateContextNetworkPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func UpdateContextNetworkPolicy(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	id, err := sdk.ParseAccountObjectIdentifier(d.Id())
 	if err != nil {
@@ -378,7 +378,7 @@ func UpdateContextNetworkPolicy(ctx context.Context, d *schema.ResourceData, met
 }
 
 // parseIPList is a helper function to parse a given ip list from ResourceData.
-func parseIPList(v interface{}) []sdk.IPRequest {
+func parseIPList(v any) []sdk.IPRequest {
 	ipList := expandStringList(v.(*schema.Set).List())
 	ipRequests := make([]sdk.IPRequest, len(ipList))
 	for i, v := range ipList {

--- a/pkg/resources/network_policy_attachment.go
+++ b/pkg/resources/network_policy_attachment.go
@@ -230,7 +230,7 @@ func unsetOnAccount(ctx context.Context, d *schema.ResourceData, meta any) error
 }
 
 // setOnUsers sets the network policy for list of users.
-func setOnUsers(ctx context.Context, users []string, data *schema.ResourceData, meta interface{}) error {
+func setOnUsers(ctx context.Context, users []string, data *schema.ResourceData, meta any) error {
 	policyName := data.Get("network_policy_name").(string)
 	for _, user := range users {
 		if err := setOnUser(ctx, user, data, meta); err != nil {
@@ -242,7 +242,7 @@ func setOnUsers(ctx context.Context, users []string, data *schema.ResourceData, 
 }
 
 // setOnUser sets the network policy for a given user.
-func setOnUser(ctx context.Context, user string, data *schema.ResourceData, meta interface{}) error {
+func setOnUser(ctx context.Context, user string, data *schema.ResourceData, meta any) error {
 	client := meta.(*provider.Context).Client
 
 	policyName := data.Get("network_policy_name").(string)
@@ -256,7 +256,7 @@ func setOnUser(ctx context.Context, user string, data *schema.ResourceData, meta
 }
 
 // unsetOnUsers unsets the network policy for list of users.
-func unsetOnUsers(ctx context.Context, users []string, data *schema.ResourceData, meta interface{}) error {
+func unsetOnUsers(ctx context.Context, users []string, data *schema.ResourceData, meta any) error {
 	policyName := data.Get("network_policy_name").(string)
 	for _, user := range users {
 		if err := unsetOnUser(ctx, user, data, meta); err != nil {
@@ -268,7 +268,7 @@ func unsetOnUsers(ctx context.Context, users []string, data *schema.ResourceData
 }
 
 // unsetOnUser sets the network policy for a given user.
-func unsetOnUser(ctx context.Context, user string, data *schema.ResourceData, meta interface{}) error {
+func unsetOnUser(ctx context.Context, user string, data *schema.ResourceData, meta any) error {
 	client := meta.(*provider.Context).Client
 
 	policyName := data.Get("network_policy_name").(string)
@@ -282,7 +282,7 @@ func unsetOnUser(ctx context.Context, user string, data *schema.ResourceData, me
 }
 
 // ensureUserAlterPrivileges ensures the executing Snowflake user can alter each user in the set of users.
-func ensureUserAlterPrivileges(ctx context.Context, users []string, meta interface{}) error {
+func ensureUserAlterPrivileges(ctx context.Context, users []string, meta any) error {
 	client := meta.(*provider.Context).Client
 
 	for _, user := range users {

--- a/pkg/resources/network_rule.go
+++ b/pkg/resources/network_rule.go
@@ -121,7 +121,7 @@ func NetworkRule() *schema.Resource {
 	}
 }
 
-func CreateContextNetworkRule(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateContextNetworkRule(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	name := d.Get("name").(string)
 	databaseName := d.Get("database").(string)
 	schemaName := d.Get("schema").(string)
@@ -163,7 +163,7 @@ func CreateContextNetworkRule(ctx context.Context, d *schema.ResourceData, meta 
 	return ReadContextNetworkRule(ctx, d, meta)
 }
 
-func ReadContextNetworkRule(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func ReadContextNetworkRule(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 	client := meta.(*provider.Context).Client
 	id, err := sdk.ParseSchemaObjectIdentifier(d.Id())
@@ -215,7 +215,7 @@ func ReadContextNetworkRule(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func UpdateContextNetworkRule(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func UpdateContextNetworkRule(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	id, err := sdk.ParseSchemaObjectIdentifier(d.Id())
 	if err != nil {

--- a/pkg/resources/oauth_integration_for_partner_applications.go
+++ b/pkg/resources/oauth_integration_for_partner_applications.go
@@ -234,7 +234,7 @@ func ImportOauthForPartnerApplicationIntegration(ctx context.Context, d *schema.
 	return []*schema.ResourceData{d}, nil
 }
 
-func CreateContextOauthIntegrationForPartnerApplications(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateContextOauthIntegrationForPartnerApplications(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	id, err := sdk.ParseAccountObjectIdentifier(d.Get("name").(string))
 	if err != nil {
@@ -302,7 +302,7 @@ func CreateContextOauthIntegrationForPartnerApplications(ctx context.Context, d 
 }
 
 func ReadContextOauthIntegrationForPartnerApplications(withExternalChangesMarking bool) schema.ReadContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 		providerCtx := meta.(*provider.Context)
 		client := providerCtx.Client
 		id, err := sdk.ParseAccountObjectIdentifier(d.Id())
@@ -438,7 +438,7 @@ func ReadContextOauthIntegrationForPartnerApplications(withExternalChangesMarkin
 	}
 }
 
-func UpdateContextOauthIntegrationForPartnerApplications(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func UpdateContextOauthIntegrationForPartnerApplications(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	id, err := sdk.ParseAccountObjectIdentifier(d.Id())
 	if err != nil {

--- a/pkg/resources/object_parameter.go
+++ b/pkg/resources/object_parameter.go
@@ -99,7 +99,7 @@ func CreateObjectParameter(ctx context.Context, d *schema.ResourceData, meta any
 
 	o := sdk.Object{}
 	if v, ok := d.GetOk("object_identifier"); ok {
-		objectDatabase, objectSchema, objectName := expandObjectIdentifier(v.([]interface{}))
+		objectDatabase, objectSchema, objectName := expandObjectIdentifier(v.([]any))
 		fullyQualifierObjectIdentifier := FormatFullyQualifiedObjectID(objectDatabase, objectSchema, objectName)
 		fullyQualifierObjectIdentifier = strings.Trim(fullyQualifierObjectIdentifier, "\"")
 		o.Name = sdk.NewObjectIdentifierFromFullyQualifiedName(fullyQualifierObjectIdentifier)
@@ -211,7 +211,7 @@ func DeleteObjectParameter(ctx context.Context, d *schema.ResourceData, meta any
 		}
 	} else {
 		v := d.Get("object_identifier")
-		objectDatabase, objectSchema, objectName := expandObjectIdentifier(v.([]interface{}))
+		objectDatabase, objectSchema, objectName := expandObjectIdentifier(v.([]any))
 		fullyQualifierObjectIdentifier := FormatFullyQualifiedObjectID(objectDatabase, objectSchema, objectName)
 		fullyQualifierObjectIdentifier = strings.Trim(fullyQualifierObjectIdentifier, "\"")
 		objectType, err := sdk.ToObjectType(d.Get("object_type").(string))

--- a/pkg/resources/scim_integration.go
+++ b/pkg/resources/scim_integration.go
@@ -184,7 +184,7 @@ func ImportScimIntegration(ctx context.Context, d *schema.ResourceData, meta any
 	return []*schema.ResourceData{d}, nil
 }
 
-func CreateContextSCIMIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func CreateContextSCIMIntegration(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 
 	id, err := sdk.ParseAccountObjectIdentifier(d.Get("name").(string))
@@ -362,7 +362,7 @@ func ReadContextSCIMIntegration(withExternalChangesMarking bool) schema.ReadCont
 	}
 }
 
-func UpdateContextSCIMIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func UpdateContextSCIMIntegration(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*provider.Context).Client
 	id, err := sdk.ParseAccountObjectIdentifier(d.Id())
 	if err != nil {

--- a/pkg/resources/share.go
+++ b/pkg/resources/share.go
@@ -84,7 +84,7 @@ func CreateShare(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 	}
 	d.SetId(name)
 
-	accounts := expandStringList(d.Get("accounts").([]interface{}))
+	accounts := expandStringList(d.Get("accounts").([]any))
 	if len(accounts) > 0 {
 		shareID := sdk.NewAccountObjectIdentifier(name)
 		accountIdentifiers := make([]sdk.AccountIdentifier, len(accounts))
@@ -186,7 +186,7 @@ func ReadShare(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagn
 
 	currentAccount := d.Get("accounts")
 	if currentAccount != nil {
-		currentAccounts := expandStringList(currentAccount.([]interface{}))
+		currentAccounts := expandStringList(currentAccount.([]any))
 		// reorder the accounts so they match the order in the config
 		// this is to avoid unnecessary diffs
 		accounts = reorderStringList(currentAccounts, accounts)
@@ -216,8 +216,8 @@ func UpdateShare(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 
 	if d.HasChange("accounts") {
 		o, n := d.GetChange("accounts")
-		oldAccounts := expandStringList(o.([]interface{}))
-		newAccounts := expandStringList(n.([]interface{}))
+		oldAccounts := expandStringList(o.([]any))
+		newAccounts := expandStringList(n.([]any))
 		if len(newAccounts) == 0 {
 			accountIdentifiers := accountIdentifiersFromSlice(oldAccounts)
 			err := client.Shares.Alter(ctx, id, &sdk.AlterShareOptions{

--- a/pkg/resources/storage_integration.go
+++ b/pkg/resources/storage_integration.go
@@ -396,7 +396,7 @@ func UpdateStorageIntegration(ctx context.Context, d *schema.ResourceData, meta 
 	// We need to UNSET this if we remove all storage blocked locations, because Snowflake won't accept an empty list
 	if d.HasChange("storage_blocked_locations") {
 		storageBlockedLocations := d.Get("storage_blocked_locations")
-		if len(storageBlockedLocations.([]interface{})) > 0 {
+		if len(storageBlockedLocations.([]any)) > 0 {
 			stringStorageBlockedLocations := expandStringList(storageBlockedLocations.([]any))
 			storageBlockedLocations := make([]sdk.StorageLocation, len(stringStorageBlockedLocations))
 			for i, loc := range stringStorageBlockedLocations {

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -325,7 +325,7 @@ func (c columns) diffs(new columns) (removed columns, added columns, changed cha
 	return c.getNewIn(new), new.getNewIn(c), c.getChangedColumnProperties(new)
 }
 
-func getColumnDefault(def map[string]interface{}) *columnDefault {
+func getColumnDefault(def map[string]any) *columnDefault {
 	if c, ok := def["constant"]; ok {
 		if constant, ok := c.(string); ok && len(constant) > 0 {
 			return &columnDefault{
@@ -353,7 +353,7 @@ func getColumnDefault(def map[string]interface{}) *columnDefault {
 	return nil
 }
 
-func getColumnIdentity(identity map[string]interface{}) *columnIdentity {
+func getColumnIdentity(identity map[string]any) *columnIdentity {
 	if len(identity) > 0 {
 		startNum := identity["start_num"].(int)
 		stepNum := identity["step_num"].(int)
@@ -363,19 +363,19 @@ func getColumnIdentity(identity map[string]interface{}) *columnIdentity {
 	return nil
 }
 
-func getColumn(from interface{}) (to column) {
-	c := from.(map[string]interface{})
+func getColumn(from any) (to column) {
+	c := from.(map[string]any)
 	var cd *columnDefault
 	var id *columnIdentity
 
-	_default := c["default"].([]interface{})
-	identity := c["identity"].([]interface{})
+	_default := c["default"].([]any)
+	identity := c["identity"].([]any)
 
 	if len(_default) == 1 {
-		cd = getColumnDefault(_default[0].(map[string]interface{}))
+		cd = getColumnDefault(_default[0].(map[string]any))
 	}
 	if len(identity) == 1 {
-		id = getColumnIdentity(identity[0].(map[string]interface{}))
+		id = getColumnIdentity(identity[0].(map[string]any))
 	}
 
 	return column{
@@ -390,8 +390,8 @@ func getColumn(from interface{}) (to column) {
 	}
 }
 
-func getColumns(from interface{}) (to columns) {
-	cols := from.([]interface{})
+func getColumns(from any) (to columns) {
+	cols := from.([]any)
 	to = make(columns, len(cols))
 	for i, c := range cols {
 		to[i] = getColumn(c)
@@ -399,8 +399,8 @@ func getColumns(from interface{}) (to columns) {
 	return to
 }
 
-func getTableColumnRequest(from interface{}) (*sdk.TableColumnRequest, error) {
-	c := from.(map[string]interface{})
+func getTableColumnRequest(from any) (*sdk.TableColumnRequest, error) {
+	c := from.(map[string]any)
 	_type := c["type"].(string)
 	dataType, err := datatypes.ParseDataType(_type)
 	if err != nil {
@@ -410,10 +410,10 @@ func getTableColumnRequest(from interface{}) (*sdk.TableColumnRequest, error) {
 	nameInQuotes := fmt.Sprintf(`"%v"`, snowflake.EscapeString(c["name"].(string)))
 	request := sdk.NewTableColumnRequest(nameInQuotes, sdk.DataType(_type))
 
-	_default := c["default"].([]interface{})
+	_default := c["default"].([]any)
 	var expression string
 	if len(_default) == 1 {
-		if c, ok := _default[0].(map[string]interface{})["constant"]; ok {
+		if c, ok := _default[0].(map[string]any)["constant"]; ok {
 			if constant, ok := c.(string); ok && len(constant) > 0 {
 				if datatypes.IsTextDataType(dataType) {
 					expression = snowflake.EscapeSnowflakeString(constant)
@@ -423,13 +423,13 @@ func getTableColumnRequest(from interface{}) (*sdk.TableColumnRequest, error) {
 			}
 		}
 
-		if e, ok := _default[0].(map[string]interface{})["expression"]; ok {
+		if e, ok := _default[0].(map[string]any)["expression"]; ok {
 			if expr, ok := e.(string); ok && len(expr) > 0 {
 				expression = expr
 			}
 		}
 
-		if s, ok := _default[0].(map[string]interface{})["sequence"]; ok {
+		if s, ok := _default[0].(map[string]any)["sequence"]; ok {
 			if seq, ok2 := s.(string); ok2 && len(seq) > 0 {
 				expression = fmt.Sprintf(`%v.NEXTVAL`, seq)
 			}
@@ -437,9 +437,9 @@ func getTableColumnRequest(from interface{}) (*sdk.TableColumnRequest, error) {
 		request.WithDefaultValue(sdk.NewColumnDefaultValueRequest().WithExpression(sdk.String(expression)))
 	}
 
-	identity := c["identity"].([]interface{})
+	identity := c["identity"].([]any)
 	if len(identity) == 1 {
-		identityProp := identity[0].(map[string]interface{})
+		identityProp := identity[0].(map[string]any)
 		startNum := identityProp["start_num"].(int)
 		stepNum := identityProp["step_num"].(int)
 		request.WithDefaultValue(sdk.NewColumnDefaultValueRequest().WithIdentity(sdk.NewColumnIdentityRequest(startNum, stepNum)))
@@ -459,8 +459,8 @@ func getTableColumnRequest(from interface{}) (*sdk.TableColumnRequest, error) {
 		WithComment(sdk.String(c["comment"].(string))), nil
 }
 
-func getTableColumnRequests(from interface{}) ([]sdk.TableColumnRequest, error) {
-	cols := from.([]interface{})
+func getTableColumnRequests(from any) ([]sdk.TableColumnRequest, error) {
+	cols := from.([]any)
 	to := make([]sdk.TableColumnRequest, len(cols))
 	for i, c := range cols {
 		cReq, err := getTableColumnRequest(c)
@@ -477,13 +477,13 @@ type primarykey struct {
 	keys []string
 }
 
-func getPrimaryKey(from interface{}) (to primarykey) {
-	pk := from.([]interface{})
+func getPrimaryKey(from any) (to primarykey) {
+	pk := from.([]any)
 	to = primarykey{}
 	if len(pk) > 0 {
-		pkDetails := pk[0].(map[string]interface{})
+		pkDetails := pk[0].(map[string]any)
 		to.name = pkDetails["name"].(string)
-		to.keys = expandStringList(pkDetails["keys"].([]interface{}))
+		to.keys = expandStringList(pkDetails["keys"].([]any))
 		return to
 	}
 	return to
@@ -596,7 +596,7 @@ func CreateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 	name := d.Get("name").(string)
 	id := sdk.NewSchemaObjectIdentifier(databaseName, schemaName, name)
 
-	tableColumnRequests, err := getTableColumnRequests(d.Get("column").([]interface{}))
+	tableColumnRequests, err := getTableColumnRequests(d.Get("column").([]any))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -608,13 +608,13 @@ func CreateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 	}
 
 	if v, ok := d.GetOk("cluster_by"); ok {
-		createRequest.WithClusterBy(expandStringList(v.([]interface{})))
+		createRequest.WithClusterBy(expandStringList(v.([]any)))
 	}
 
 	if v, ok := d.GetOk("primary_key"); ok {
 		keysList := v.([]any)
 		if len(keysList) > 0 {
-			keys := expandStringList(keysList[0].(map[string]any)["keys"].([]interface{}))
+			keys := expandStringList(keysList[0].(map[string]any)["keys"].([]any))
 			constraintRequest := sdk.NewOutOfLineConstraintRequest(sdk.ColumnConstraintTypePrimaryKey).WithColumns(snowflake.QuoteStringList(keys))
 
 			keyName, isPresent := keysList[0].(map[string]any)["name"]
@@ -701,7 +701,7 @@ func ReadTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagn
 	}
 
 	// Set the relevant data in the state
-	toSet := map[string]interface{}{
+	toSet := map[string]any{
 		"name":            table.Name,
 		"owner":           table.Owner,
 		"database":        table.DatabaseName,
@@ -807,7 +807,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 	}
 
 	if d.HasChange("cluster_by") {
-		cb := expandStringList(d.Get("cluster_by").([]interface{}))
+		cb := expandStringList(d.Get("cluster_by").([]any))
 
 		if len(cb) != 0 {
 			err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithClusteringAction(sdk.NewTableClusteringActionRequest().WithClusterBy(cb)))

--- a/pkg/resources/table_constraint.go
+++ b/pkg/resources/table_constraint.go
@@ -252,7 +252,7 @@ func CreateTableConstraint(ctx context.Context, d *schema.ResourceData, meta any
 	}
 	constraintRequest := sdk.NewOutOfLineConstraintRequest(constraintType).WithName(&name)
 
-	cc := d.Get("columns").([]interface{})
+	cc := d.Get("columns").([]any)
 	columns := make([]string, 0, len(cc))
 	for _, c := range cc {
 		columns = append(columns, c.(string))
@@ -289,8 +289,8 @@ func CreateTableConstraint(ctx context.Context, d *schema.ResourceData, meta any
 
 	// set foreign key specific settings
 	if v, ok := d.GetOk("foreign_key_properties"); ok {
-		foreignKeyProperties := v.([]interface{})[0].(map[string]interface{})
-		references := foreignKeyProperties["references"].([]interface{})[0].(map[string]interface{})
+		foreignKeyProperties := v.([]any)[0].(map[string]any)
+		references := foreignKeyProperties["references"].([]any)[0].(map[string]any)
 		fkTableID := references["table_id"].(string)
 		fkId, err := helpers.DecodeSnowflakeParameterID(fkTableID)
 		if err != nil {
@@ -301,7 +301,7 @@ func CreateTableConstraint(ctx context.Context, d *schema.ResourceData, meta any
 			return diag.FromErr(fmt.Errorf("table id is incorrect: %s", fkId))
 		}
 
-		cols := references["columns"].([]interface{})
+		cols := references["columns"].([]any)
 		var fkColumns []string
 		for _, c := range cols {
 			fkColumns = append(fkColumns, c.(string))
@@ -347,7 +347,7 @@ func CreateTableConstraint(ctx context.Context, d *schema.ResourceData, meta any
 }
 
 // ReadTableConstraint implements schema.ReadFunc.
-func ReadTableConstraint(ctx context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func ReadTableConstraint(ctx context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
 	// TODO(issue-2683): Implement read operation
 	// commenting this out since it requires an active warehouse to be set which may not be intuitive.
 	// also it takes a while for the database to reflect changes. Would likely need to add a validation

--- a/pkg/resources/tag_association.go
+++ b/pkg/resources/tag_association.go
@@ -310,7 +310,7 @@ func UpdateContextTagAssociation(ctx context.Context, d *schema.ResourceData, me
 	return ReadContextTagAssociation(ctx, d, meta)
 }
 
-func DeleteContextTagAssociation(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func DeleteContextTagAssociation(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	providerCtx := meta.(*provider.Context)
 	client := providerCtx.Client
 	tagId, ids, objectType, err := TagIdentifierAndObjectIdentifier(d)

--- a/pkg/resources/user_public_keys.go
+++ b/pkg/resources/user_public_keys.go
@@ -23,7 +23,7 @@ var userPublicKeyProperties = []string{
 }
 
 // sanitize input to suppress diffs, etc.
-func publicKeyStateFunc(v interface{}) string {
+func publicKeyStateFunc(v any) string {
 	value := v.(string)
 	value = strings.TrimSuffix(value, "\n")
 	return value

--- a/pkg/resources/validators.go
+++ b/pkg/resources/validators.go
@@ -63,7 +63,7 @@ func StringInSlice(valid []string, ignoreCase bool) schema.SchemaValidateDiagFun
 
 // IntInSlice has the same implementation as validation.StringInSlice, but adapted to schema.SchemaValidateDiagFunc
 func IntInSlice(valid []int) schema.SchemaValidateDiagFunc {
-	return func(i interface{}, path cty.Path) diag.Diagnostics {
+	return func(i any, path cty.Path) diag.Diagnostics {
 		v, ok := i.(int)
 		if !ok {
 			return diag.Errorf("expected type of %v to be integer", path)

--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -267,14 +267,14 @@ func (c *Client) exec(ctx context.Context, sql string) (sql.Result, error) {
 }
 
 // query runs a query and returns the rows. dest is expected to be a slice of structs.
-func (c *Client) query(ctx context.Context, dest interface{}, sql string) error {
+func (c *Client) query(ctx context.Context, dest any, sql string) error {
 	ctx = context.WithValue(ctx, snowflakeAccountLocatorContextKey, c.accountLocator)
 	sql = appendQueryMetadata(ctx, sql)
 	return decodeDriverError(c.db.SelectContext(ctx, dest, sql))
 }
 
 // queryOne runs a query and returns one row. dest is expected to be a pointer to a struct.
-func (c *Client) queryOne(ctx context.Context, dest interface{}, sql string) error {
+func (c *Client) queryOne(ctx context.Context, dest any, sql string) error {
 	ctx = context.WithValue(ctx, snowflakeAccountLocatorContextKey, c.accountLocator)
 	sql = appendQueryMetadata(ctx, sql)
 	return decodeDriverError(c.db.GetContext(ctx, dest, sql))

--- a/pkg/sdk/generator/gen/sdkcommons/interfaces.go
+++ b/pkg/sdk/generator/gen/sdkcommons/interfaces.go
@@ -1,3 +1,3 @@
 package sdkcommons
 
-type Location interface{}
+type Location any

--- a/pkg/sdk/integration_test_imports.go
+++ b/pkg/sdk/integration_test_imports.go
@@ -20,13 +20,13 @@ func (c *Client) ExecForTests(ctx context.Context, sql string) (sql.Result, erro
 
 // QueryOneForTests is forwarding function for Client.queryOne (that is unexported), that some integration tests/helpers were using
 // TODO: remove after introducing all resources using this
-func (c *Client) QueryOneForTests(ctx context.Context, dest interface{}, sql string) error {
+func (c *Client) QueryOneForTests(ctx context.Context, dest any, sql string) error {
 	return c.queryOne(ctx, dest, sql)
 }
 
 // QueryForTests is forwarding function for Client.query (that is unexported), that some integration tests/helpers were using
 // TODO: remove after introducing all resources using this
-func (c *Client) QueryForTests(ctx context.Context, dest interface{}, sql string) error {
+func (c *Client) QueryForTests(ctx context.Context, dest any, sql string) error {
 	return c.query(ctx, dest, sql)
 }
 

--- a/pkg/sdk/sql_builder.go
+++ b/pkg/sdk/sql_builder.go
@@ -195,7 +195,7 @@ func (b *sqlBuilder) getModifier(tag reflect.StructTag, tagName string, modType 
 	return defaultMod
 }
 
-func structToSQL(v interface{}) (string, error) {
+func structToSQL(v any) (string, error) {
 	clauses, err := builder.parseStruct(v)
 	if err != nil {
 		return "", err
@@ -237,7 +237,7 @@ func (b sqlBuilder) sql(clauses ...sqlClause) (string, error) {
 	return strings.Trim(strings.Join(sList, " "), " "), nil
 }
 
-func (b sqlBuilder) parseInterface(v interface{}, tag reflect.StructTag) (sqlClause, error) {
+func (b sqlBuilder) parseInterface(v any, tag reflect.StructTag) (sqlClause, error) {
 	ddlTag := tag.Get("ddl")
 	sqlTag := tag.Get("sql")
 	if ddlTag == "" {
@@ -270,7 +270,7 @@ func (b sqlBuilder) parseInterface(v interface{}, tag reflect.StructTag) (sqlCla
 }
 
 // parseStruct parses a struct and returns a slice of sqlClauses.
-func (b sqlBuilder) parseStruct(s interface{}) ([]sqlClause, error) {
+func (b sqlBuilder) parseStruct(s any) ([]sqlClause, error) {
 	clauses := make([]sqlClause, 0)
 	v := reflect.ValueOf(s)
 	if v.Kind() == reflect.Pointer {
@@ -613,7 +613,7 @@ func (b sqlBuilder) parseField(field reflect.StructField, value reflect.Value) (
 	return b.renderStaticClause(clause)
 }
 
-func (b sqlBuilder) getInterface(field reflect.Value) interface{} {
+func (b sqlBuilder) getInterface(field reflect.Value) any {
 	// if the field is exported, then do this safely
 	if field.CanInterface() {
 		return field.Interface()
@@ -656,7 +656,7 @@ func (v sqlStaticClause) String() (string, error) {
 }
 
 type sqlKeywordClause struct {
-	key interface{}
+	key any
 	qm  quoteModifier
 }
 
@@ -689,7 +689,7 @@ func (v sqlIdentifierClause) String() (string, error) {
 
 type sqlParameterClause struct {
 	key   string
-	value interface{}
+	value any
 
 	// modifiers
 	qm quoteModifier

--- a/pkg/sdk/validations.go
+++ b/pkg/sdk/validations.go
@@ -25,7 +25,7 @@ func ValidObjectIdentifier(objectIdentifier ObjectIdentifier) bool {
 	return ValidObjectName(objectIdentifier.Name())
 }
 
-func anyValueSet(values ...interface{}) bool {
+func anyValueSet(values ...any) bool {
 	for _, v := range values {
 		if valueSet(v) {
 			return true
@@ -34,7 +34,7 @@ func anyValueSet(values ...interface{}) bool {
 	return false
 }
 
-func exactlyOneValueSet(values ...interface{}) bool {
+func exactlyOneValueSet(values ...any) bool {
 	var count int
 	for _, v := range values {
 		if valueSet(v) {
@@ -44,7 +44,7 @@ func exactlyOneValueSet(values ...interface{}) bool {
 	return count == 1
 }
 
-func moreThanOneValueSet(values ...interface{}) bool {
+func moreThanOneValueSet(values ...any) bool {
 	var count int
 	for _, v := range values {
 		if valueSet(v) {
@@ -54,7 +54,7 @@ func moreThanOneValueSet(values ...interface{}) bool {
 	return count > 1
 }
 
-func everyValueSet(values ...interface{}) bool {
+func everyValueSet(values ...any) bool {
 	for _, v := range values {
 		if !valueSet(v) {
 			return false
@@ -63,7 +63,7 @@ func everyValueSet(values ...interface{}) bool {
 	return true
 }
 
-func everyValueNil(values ...interface{}) bool {
+func everyValueNil(values ...any) bool {
 	for _, v := range values {
 		if valueSet(v) {
 			return false
@@ -72,7 +72,7 @@ func everyValueNil(values ...interface{}) bool {
 	return true
 }
 
-func valueSet(value interface{}) bool {
+func valueSet(value any) bool {
 	if value == nil {
 		return false
 	}


### PR DESCRIPTION
## Changes
Run
```shell
make lint-fix
```
 to only apply `any` and `waitgroup` rules to the codebase that replaces `interface{}` with `any` and adjusts waitgroup logic. The rules were added to the golangci-lint config as `modernize` that under the hood uses standard `go fix` tool.