### PR TITLE
chore: Isolate /ok-to-test concurrency group per PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ permissions:
 
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.pull_request.number) || (github.event_name == 'pull_request' && github.event.pull_request.number) }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
/ok-to-test runs the Tests workflow via a repository_dispatch event, where github.ref always resolves to the default branch. The concurrency group therefore collapsed to the same value for every PR, so cancel-in-progress caused an /ok-to-test on one PR to cancel in-progress runs on other PRs.

Key the concurrency group on the PR number (from the matching event payload) so each PR is isolated while same-PR reruns still cancel.