### PR TITLE
chore: Rename in hierarchies experiment - 3-level hierarchy in snowflake_table

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1009,8 +1009,8 @@ With this experiment, Create, Read, and Delete all treat PUBLIC role grants as p
 #### HIERARCHY_RENAMES
 When enabled, allows in-place handling of hierarchy renames and moves for supported resources.
 
-Currently supported by: `snowflake_schema`.
+Currently supported by: `snowflake_schema`, `snowflake_table`.
 
-Without this experiment, changing the `database` field on `snowflake_schema` forces resource recreation. With this experiment, the provider detects whether the parent database was renamed or the schema should be moved to a different database, and handles it without recreation.
+Without this experiment, changing the `database` field on `snowflake_schema` or the `database`/`schema` fields on `snowflake_table` forces resource recreation. With this experiment, the provider detects whether the parent was renamed or the object should be moved, and handles it without recreation.
 
 For more information, see the [object renaming guide](./guides/object_renaming_guide).

--- a/examples/additional/experimental_features.MD
+++ b/examples/additional/experimental_features.MD
@@ -86,9 +86,9 @@ With this experiment, Create, Read, and Delete all treat PUBLIC role grants as p
 #### HIERARCHY_RENAMES
 When enabled, allows in-place handling of hierarchy renames and moves for supported resources.
 
-Currently supported by: `snowflake_schema`.
+Currently supported by: `snowflake_schema`, `snowflake_table`.
 
-Without this experiment, changing the `database` field on `snowflake_schema` forces resource recreation. With this experiment, the provider detects whether the parent database was renamed or the schema should be moved to a different database, and handles it without recreation.
+Without this experiment, changing the `database` field on `snowflake_schema` or the `database`/`schema` fields on `snowflake_table` forces resource recreation. With this experiment, the provider detects whether the parent was renamed or the object should be moved, and handles it without recreation.
 
 For more information, see the [object renaming guide](./guides/object_renaming_guide).
 

--- a/pkg/acceptance/bettertestspoc/config/model/table_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/table_model_ext.go
@@ -1,8 +1,11 @@
 package model
 
 import (
+	"fmt"
+
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 )
 
@@ -12,6 +15,18 @@ func TableWithId(
 	column []sdk.TableColumnSignature,
 ) *TableModel {
 	return Table(resourceName, tableId.DatabaseName(), tableId.SchemaName(), tableId.Name(), column)
+}
+
+func TableWithImplicitDependencies(
+	resourceName string,
+	tableName string,
+	column []sdk.TableColumnSignature,
+	schemaModel *SchemaModel,
+	databaseModel *DatabaseModel,
+) *TableModel {
+	return Table(resourceName, "", "", tableName, column).
+		WithDatabaseValue(config.UnquotedWrapperVariable(fmt.Sprintf("%s.name", databaseModel.ResourceReference()))).
+		WithSchemaValue(config.UnquotedWrapperVariable(fmt.Sprintf("%s.name", schemaModel.ResourceReference())))
 }
 
 func (t *TableModel) WithColumn(column []sdk.TableColumnSignature) *TableModel {

--- a/pkg/provider/experimentalfeatures/experimental_features.go
+++ b/pkg/provider/experimentalfeatures/experimental_features.go
@@ -154,8 +154,8 @@ var allExperiments = []Experiment{
 		ExperimentalFeatureStateActive,
 		joinWithDoubleNewline(
 			"When enabled, allows in-place handling of hierarchy renames and moves for supported resources.",
-			"Currently supported by: `snowflake_schema`.",
-			"Without this experiment, changing the `database` field on `snowflake_schema` forces resource recreation. With this experiment, the provider detects whether the parent database was renamed or the schema should be moved to a different database, and handles it without recreation.",
+			"Currently supported by: `snowflake_schema`, `snowflake_table`.",
+			"Without this experiment, changing the `database` field on `snowflake_schema` or the `database`/`schema` fields on `snowflake_table` forces resource recreation. With this experiment, the provider detects whether the parent was renamed or the object should be moved, and handles it without recreation.",
 			"For more information, see the [object renaming guide](./guides/object_renaming_guide).",
 		),
 	},

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/previewfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
@@ -32,16 +33,16 @@ var tableSchema = map[string]*schema.Schema{
 		DiffSuppressFunc: suppressIdentifierQuoting,
 	},
 	"schema": {
-		Type:        schema.TypeString,
-		Required:    true,
-		ForceNew:    true,
-		Description: "The schema in which to create the table.",
+		Type:             schema.TypeString,
+		Required:         true,
+		Description:      "The schema in which to create the table.",
+		DiffSuppressFunc: suppressIdentifierQuoting,
 	},
 	"database": {
-		Type:        schema.TypeString,
-		Required:    true,
-		ForceNew:    true,
-		Description: "The database in which to create the table.",
+		Type:             schema.TypeString,
+		Required:         true,
+		Description:      "The database in which to create the table.",
+		DiffSuppressFunc: suppressIdentifierQuoting,
 	},
 	"cluster_by": {
 		Type:        schema.TypeList,
@@ -222,7 +223,9 @@ func Table() *schema.Resource {
 		DeleteContext: PreviewFeatureDeleteContextWrapper(string(previewfeatures.TableResource), TrackingDeleteWrapper(resources.Table, deleteFunc)),
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.Table, customdiff.All(
-			ComputedIfAnyAttributeChanged(tableSchema, FullyQualifiedNameAttributeName, "name"),
+			TemporaryWorkaroundIdentifierForceNewIfHierarchyRenamesExperimentNotEnabled("database"),
+			TemporaryWorkaroundIdentifierForceNewIfHierarchyRenamesExperimentNotEnabled("schema"),
+			ComputedIfAnyAttributeChanged(tableSchema, FullyQualifiedNameAttributeName, "name", "database", "schema"),
 		)),
 
 		Schema: tableSchema,
@@ -722,9 +725,200 @@ func ReadTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagn
 
 // UpdateTable implements schema.UpdateFunc.
 func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*provider.Context).Client
+	providerCtx := meta.(*provider.Context)
+	client := providerCtx.Client
 
 	id := helpers.DecodeSnowflakeIDLegacy(d.Id()).(sdk.SchemaObjectIdentifier)
+
+	if experimentalfeatures.IsExperimentEnabled(experimentalfeatures.HierarchyRenames, providerCtx.EnabledExperiments) && (d.HasChange("database") || d.HasChange("schema")) {
+		oldDatabaseNameRaw, newDatabaseNameRaw := d.GetChange("database")
+		oldDatabaseName, newDatabaseName := oldDatabaseNameRaw.(string), newDatabaseNameRaw.(string)
+		oldSchemaNameRaw, newSchemaNameRaw := d.GetChange("schema")
+		oldSchemaName, newSchemaName := oldSchemaNameRaw.(string), newSchemaNameRaw.(string)
+		tableName := id.Name()
+
+		databaseChanged := d.HasChange("database")
+		schemaChanged := d.HasChange("schema")
+
+		oldDatabaseId := sdk.NewAccountObjectIdentifier(oldDatabaseName)
+		newDatabaseId := sdk.NewAccountObjectIdentifier(newDatabaseName)
+		oldSchemaId := sdk.NewDatabaseObjectIdentifierInDatabase(oldDatabaseId, oldSchemaName)
+		newSchemaId := sdk.NewDatabaseObjectIdentifierInDatabase(newDatabaseId, newSchemaName)
+		oldTableId := sdk.NewSchemaObjectIdentifierInSchema(oldSchemaId, tableName)
+		newTableId := sdk.NewSchemaObjectIdentifierInSchema(newSchemaId, tableName)
+
+		switch {
+		// Case A: Only database changes (same as schema resource's 2-level logic)
+		case databaseChanged && !schemaChanged:
+			_, errNewDb := client.Databases.ShowByID(ctx, newDatabaseId)
+			newDatabaseExists := errNewDb == nil
+			_, errOldDb := client.Databases.ShowByID(ctx, oldDatabaseId)
+			oldDatabaseExists := errOldDb == nil
+			_, errNewSchema := client.Schemas.ShowByID(ctx, newSchemaId)
+			newSchemaExists := errNewSchema == nil
+			_, errOldSchema := client.Schemas.ShowByID(ctx, oldSchemaId)
+			oldSchemaExists := errOldSchema == nil
+
+			isRenameOfTheGivenLevelInTheHierarchy := func() bool {
+				return newDatabaseExists && !oldDatabaseExists && newSchemaExists
+			}
+			isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy := func() bool {
+				return newDatabaseExists && oldDatabaseExists && oldSchemaExists
+			}
+
+			switch {
+			// Case 1: "Rename of the given level in the hierarchy"
+			case isRenameOfTheGivenLevelInTheHierarchy():
+				log.Printf("[DEBUG] Database was renamed for table - no Snowflake modification needed, updating the id...")
+				// Just update the ID — no Snowflake modification needed
+				d.SetId(helpers.EncodeSnowflakeID(newTableId))
+				id = newTableId
+			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy():
+				log.Printf("[DEBUG] Moving table to different database - executing ALTER TABLE RENAME TO...")
+				if renameErr := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)); renameErr != nil {
+					d.Partial(true)
+					return diag.FromErr(fmt.Errorf("failed to move table from %s to %s: %w", id.FullyQualifiedName(), newTableId.FullyQualifiedName(), renameErr))
+				}
+				d.SetId(helpers.EncodeSnowflakeID(newTableId))
+				id = newTableId
+			default:
+				d.Partial(true)
+				return diag.FromErr(fmt.Errorf(
+					"unknown rename use case: old database %s (exists: %t), new database %s (exists: %t), old schema %s (exists: %t), new schema %s (exists: %t). See https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/object_renaming_guide",
+					oldDatabaseId.FullyQualifiedName(), oldDatabaseExists,
+					newDatabaseId.FullyQualifiedName(), newDatabaseExists,
+					oldSchemaId.FullyQualifiedName(), oldSchemaExists,
+					newSchemaId.FullyQualifiedName(), newSchemaExists,
+				))
+			}
+
+		// Case B: Only schema changes (similar to schema resource's 2-level logic, but schema-table instead of database-schema)
+		case !databaseChanged && schemaChanged:
+			_, errNewSchema := client.Schemas.ShowByID(ctx, newSchemaId)
+			newSchemaExists := errNewSchema == nil
+			_, errOldSchema := client.Schemas.ShowByID(ctx, oldSchemaId)
+			oldSchemaExists := errOldSchema == nil
+			_, errNewTable := client.Tables.ShowByID(ctx, newTableId)
+			newTableExists := errNewTable == nil
+			_, errOldTable := client.Tables.ShowByID(ctx, oldTableId)
+			oldTableExists := errOldTable == nil
+
+			isRenameOfTheGivenLevelInTheHierarchy := func() bool {
+				return newSchemaExists && !oldSchemaExists && newTableExists
+			}
+			isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy := func() bool {
+				return newSchemaExists && oldSchemaExists && oldTableExists
+			}
+
+			switch {
+			// Case 1: "Rename of the given level in the hierarchy"
+			case isRenameOfTheGivenLevelInTheHierarchy():
+				log.Printf("[DEBUG] Schema was renamed for table - no Snowflake modification needed, updating the id...")
+				// Just update the ID — no Snowflake modification needed
+				d.SetId(helpers.EncodeSnowflakeID(newTableId))
+				id = newTableId
+			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy():
+				log.Printf("[DEBUG] Moving table to different schema - executing ALTER TABLE RENAME TO...")
+				// Perform the rename in Snowflake: ALTER TABLE A.X RENAME TO B.X
+				if renameErr := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)); renameErr != nil {
+					d.Partial(true)
+					return diag.FromErr(fmt.Errorf("failed to move table from %s to %s: %w", id.FullyQualifiedName(), newTableId.FullyQualifiedName(), renameErr))
+				}
+				d.SetId(helpers.EncodeSnowflakeID(newTableId))
+				id = newTableId
+			default:
+				d.Partial(true)
+				return diag.FromErr(fmt.Errorf(
+					"unknown rename use case: old schema %s (exists: %t), new schema %s (exists: %t). See https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/object_renaming_guide",
+					oldSchemaId.FullyQualifiedName(), oldSchemaExists,
+					newSchemaId.FullyQualifiedName(), newSchemaExists,
+				))
+			}
+
+		// Case C: Both database AND schema change (full 4-scenario algorithm)
+		default:
+			_, errNewDb := client.Databases.ShowByID(ctx, newDatabaseId)
+			newDatabaseExists := errNewDb == nil
+			_, errOldDb := client.Databases.ShowByID(ctx, oldDatabaseId)
+			oldDatabaseExists := errOldDb == nil
+
+			// Probe schemas
+			schemaInNewDbOldName := sdk.NewDatabaseObjectIdentifier(newDatabaseName, oldSchemaName)
+			schemaInNewDbNewName := sdk.NewDatabaseObjectIdentifier(newDatabaseName, newSchemaName)
+			schemaInOldDbOldName := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, oldSchemaName)
+			schemaInOldDbNewName := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, newSchemaName)
+
+			_, errSchemaNewDbOld := client.Schemas.ShowByID(ctx, schemaInNewDbOldName)
+			schemaNewDbOldExists := errSchemaNewDbOld == nil
+			_, errSchemaNewDbNew := client.Schemas.ShowByID(ctx, schemaInNewDbNewName)
+			schemaNewDbNewExists := errSchemaNewDbNew == nil
+			_, errSchemaOldDbOld := client.Schemas.ShowByID(ctx, schemaInOldDbOldName)
+			schemaOldDbOldExists := errSchemaOldDbOld == nil
+			_, errSchemaOldDbNew := client.Schemas.ShowByID(ctx, schemaInOldDbNewName)
+			schemaOldDbNewExists := errSchemaOldDbNew == nil
+
+			// Scenario 1: DB rename + Schema rename
+			isDbRenameSchemaRename := func() bool {
+				return !oldDatabaseExists && newDatabaseExists && !schemaNewDbOldExists && schemaNewDbNewExists
+			}
+			// Scenario 2: DB rename + Schema move
+			isDbRenameSchemaMove := func() bool {
+				return !oldDatabaseExists && newDatabaseExists && schemaNewDbOldExists
+			}
+			// Scenario 3: DB move + Schema rename
+			isDbMoveSchemaRename := func() bool {
+				return oldDatabaseExists && newDatabaseExists && !schemaOldDbOldExists && schemaOldDbNewExists
+			}
+			// Scenario 4: DB move + Schema move
+			isDbMoveSchemaMove := func() bool {
+				return oldDatabaseExists && newDatabaseExists && schemaOldDbOldExists
+			}
+
+			switch {
+			case isDbRenameSchemaRename():
+				log.Printf("[DEBUG] Database and schema were both renamed for table - no Snowflake modification needed, updating the id...")
+				d.SetId(helpers.EncodeSnowflakeID(newTableId))
+				id = newTableId
+			case isDbRenameSchemaMove():
+				log.Printf("[DEBUG] Database was renamed, moving table to different schema - executing ALTER TABLE RENAME TO...")
+				currentTableId := sdk.NewSchemaObjectIdentifier(newDatabaseName, oldSchemaName, tableName)
+				if renameErr := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(currentTableId).WithNewName(&newTableId)); renameErr != nil {
+					d.Partial(true)
+					return diag.FromErr(fmt.Errorf("failed to move table from %s to %s: %w", currentTableId.FullyQualifiedName(), newTableId.FullyQualifiedName(), renameErr))
+				}
+				d.SetId(helpers.EncodeSnowflakeID(newTableId))
+				id = newTableId
+			case isDbMoveSchemaRename():
+				log.Printf("[DEBUG] Schema was renamed, moving table to different database - executing ALTER TABLE RENAME TO...")
+				currentTableId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, newSchemaName, tableName)
+				if renameErr := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(currentTableId).WithNewName(&newTableId)); renameErr != nil {
+					d.Partial(true)
+					return diag.FromErr(fmt.Errorf("failed to move table from %s to %s: %w", currentTableId.FullyQualifiedName(), newTableId.FullyQualifiedName(), renameErr))
+				}
+				d.SetId(helpers.EncodeSnowflakeID(newTableId))
+				id = newTableId
+			case isDbMoveSchemaMove():
+				log.Printf("[DEBUG] Moving table to different database and schema - executing ALTER TABLE RENAME TO...")
+				if renameErr := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)); renameErr != nil {
+					d.Partial(true)
+					return diag.FromErr(fmt.Errorf("failed to move table from %s to %s: %w", id.FullyQualifiedName(), newTableId.FullyQualifiedName(), renameErr))
+				}
+				d.SetId(helpers.EncodeSnowflakeID(newTableId))
+				id = newTableId
+			default:
+				d.Partial(true)
+				return diag.FromErr(fmt.Errorf(
+					"unknown rename use case: old database %s (exists: %t), new database %s (exists: %t), schema %s (exists: %t), schema %s (exists: %t), schema %s (exists: %t), schema %s (exists: %t). See https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/object_renaming_guide",
+					oldDatabaseId.FullyQualifiedName(), oldDatabaseExists,
+					newDatabaseId.FullyQualifiedName(), newDatabaseExists,
+					schemaInNewDbOldName.FullyQualifiedName(), schemaNewDbOldExists,
+					schemaInNewDbNewName.FullyQualifiedName(), schemaNewDbNewExists,
+					schemaInOldDbOldName.FullyQualifiedName(), schemaOldDbOldExists,
+					schemaInOldDbNewName.FullyQualifiedName(), schemaOldDbNewExists,
+				))
+			}
+		}
+	}
 
 	if d.HasChange("name") {
 		newId := sdk.NewSchemaObjectIdentifierInSchema(id.SchemaId(), d.Get("name").(string))

--- a/pkg/testacc/resource_table_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_table_experimental_features_acceptance_test.go
@@ -1,0 +1,668 @@
+//go:build non_account_level_tests
+
+package testacc
+
+import (
+	"regexp"
+	"testing"
+
+	accconfig "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert/resourceassert"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/planchecks"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testdatatypes"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+var tableColumns = []sdk.TableColumnSignature{{Name: "ID", Type: testdatatypes.DataTypeNumber}}
+
+// Database A is renamed to B in config. The table resource detects the rename
+// and updates its ID without performing any Snowflake modification.
+func TestAcc_Experimental_Table_HierarchyRenames_DatabaseRenamed(t *testing.T) {
+	databaseId := testClient().Ids.RandomAccountObjectIdentifier()
+	newDatabaseId := testClient().Ids.RandomAccountObjectIdentifier()
+	schemaName := testClient().Ids.Alpha()
+	tableName := testClient().Ids.Alpha()
+
+	providerModel := providermodel.SnowflakeProvider().WithExperimentalFeaturesEnabled(experimentalfeatures.HierarchyRenames)
+	databaseModel := model.DatabaseWithParametersSet("db", databaseId.Name())
+	databaseModelRenamed := model.DatabaseWithParametersSet("db", newDatabaseId.Name())
+
+	schemaModel := model.SchemaWithImplicitDatabaseDependency("schema", schemaName, databaseModel)
+	schemaModelAfterDbRename := model.SchemaWithImplicitDatabaseDependency("schema", schemaName, databaseModelRenamed)
+
+	tableModel := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModel, databaseModel)
+	tableModelAfter := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelAfterDbRename, databaseModelRenamed)
+
+	expectedNewTableId := sdk.NewSchemaObjectIdentifier(newDatabaseId.Name(), schemaName, tableName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: experimentalHierarchyRenamesProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Table),
+		Steps: []resource.TestStep{
+			// Create database, schema, and table
+			{
+				Config: accconfig.FromModels(t, providerModel, databaseModel, schemaModel, tableModel),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModel.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseId.Name()).
+						HasSchemaString(schemaName),
+				),
+			},
+			// Rename database in config — table detects rename (Case A) and updates ID
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(databaseModelRenamed.ResourceReference(), plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(tableModelAfter.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: accconfig.FromModels(t, providerModel, databaseModelRenamed, schemaModelAfterDbRename, tableModelAfter),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelAfter.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(newDatabaseId.Name()).
+						HasSchemaString(schemaName).
+						HasFullyQualifiedNameString(expectedNewTableId.FullyQualifiedName()),
+				),
+			},
+		},
+	})
+}
+
+// Both databases exist in config. The table is moved from database A to database B via ALTER TABLE RENAME TO.
+func TestAcc_Experimental_Table_HierarchyRenames_TableMoveToAnotherDatabase(t *testing.T) {
+	databaseAId := testClient().Ids.RandomAccountObjectIdentifier()
+	databaseBId := testClient().Ids.RandomAccountObjectIdentifier()
+	schemaName := testClient().Ids.Alpha()
+	tableName := testClient().Ids.Alpha()
+
+	providerModel := providermodel.SnowflakeProvider().WithExperimentalFeaturesEnabled(experimentalfeatures.HierarchyRenames)
+	databaseModelA := model.DatabaseWithParametersSet("dbA", databaseAId.Name())
+	databaseModelB := model.DatabaseWithParametersSet("dbB", databaseBId.Name())
+
+	schemaModelA := model.SchemaWithImplicitDatabaseDependency("schemaA", schemaName, databaseModelA)
+	schemaModelB := model.SchemaWithImplicitDatabaseDependency("schemaB", schemaName, databaseModelB)
+
+	tableModelBefore := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelA, databaseModelA)
+	tableModelAfter := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelB, databaseModelB)
+
+	expectedNewTableId := sdk.NewSchemaObjectIdentifier(databaseBId.Name(), schemaName, tableName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: experimentalHierarchyRenamesProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Table),
+		Steps: []resource.TestStep{
+			// Create both databases, schemas, and table in database A
+			{
+				Config: accconfig.FromModels(t, providerModel, databaseModelA, databaseModelB, schemaModelA, schemaModelB, tableModelBefore),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelBefore.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseAId.Name()).
+						HasSchemaString(schemaName),
+				),
+			},
+			// Move table to database B
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(tableModelAfter.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: accconfig.FromModels(t, providerModel, databaseModelA, databaseModelB, schemaModelA, schemaModelB, tableModelAfter),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelAfter.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseBId.Name()).
+						HasSchemaString(schemaName).
+						HasFullyQualifiedNameString(expectedNewTableId.FullyQualifiedName()),
+				),
+			},
+		},
+	})
+}
+
+// Schema X is renamed to Y in config. The table resource detects the rename
+// and updates its ID without performing any Snowflake modification.
+func TestAcc_Experimental_Table_HierarchyRenames_SchemaRenamed(t *testing.T) {
+	databaseId := testClient().Ids.RandomAccountObjectIdentifier()
+	schemaName := testClient().Ids.Alpha()
+	newSchemaName := testClient().Ids.Alpha()
+	tableName := testClient().Ids.Alpha()
+
+	providerModel := providermodel.SnowflakeProvider().WithExperimentalFeaturesEnabled(experimentalfeatures.HierarchyRenames)
+	databaseModel := model.DatabaseWithParametersSet("db", databaseId.Name())
+
+	schemaModel := model.SchemaWithImplicitDatabaseDependency("schema", schemaName, databaseModel)
+	schemaModelRenamed := model.SchemaWithImplicitDatabaseDependency("schema", newSchemaName, databaseModel)
+
+	tableModel := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModel, databaseModel)
+	tableModelAfter := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelRenamed, databaseModel)
+
+	expectedNewTableId := sdk.NewSchemaObjectIdentifier(databaseId.Name(), newSchemaName, tableName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: experimentalHierarchyRenamesProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Table),
+		Steps: []resource.TestStep{
+			// Create database, schema, and table
+			{
+				Config: accconfig.FromModels(t, providerModel, databaseModel, schemaModel, tableModel),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModel.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseId.Name()).
+						HasSchemaString(schemaName),
+				),
+			},
+			// Rename schema in config — table detects rename (Case B) and updates ID
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(schemaModelRenamed.ResourceReference(), plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(tableModelAfter.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: accconfig.FromModels(t, providerModel, databaseModel, schemaModelRenamed, tableModelAfter),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelAfter.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseId.Name()).
+						HasSchemaString(newSchemaName).
+						HasFullyQualifiedNameString(expectedNewTableId.FullyQualifiedName()),
+				),
+			},
+		},
+	})
+}
+
+// Both schemas exist in config. The table is moved from schema X to schema Y via ALTER TABLE RENAME TO.
+func TestAcc_Experimental_Table_HierarchyRenames_TableMoveToAnotherSchema(t *testing.T) {
+	databaseId := testClient().Ids.RandomAccountObjectIdentifier()
+	schemaXName := testClient().Ids.Alpha()
+	schemaYName := testClient().Ids.Alpha()
+	tableName := testClient().Ids.Alpha()
+
+	providerModel := providermodel.SnowflakeProvider().WithExperimentalFeaturesEnabled(experimentalfeatures.HierarchyRenames)
+	databaseModel := model.DatabaseWithParametersSet("db", databaseId.Name())
+
+	schemaModelX := model.SchemaWithImplicitDatabaseDependency("schemaX", schemaXName, databaseModel)
+	schemaModelY := model.SchemaWithImplicitDatabaseDependency("schemaY", schemaYName, databaseModel)
+
+	tableModelBefore := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelX, databaseModel)
+	tableModelAfter := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelY, databaseModel)
+
+	expectedNewTableId := sdk.NewSchemaObjectIdentifier(databaseId.Name(), schemaYName, tableName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: experimentalHierarchyRenamesProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Table),
+		Steps: []resource.TestStep{
+			// Create database, both schemas, and table in schema X
+			{
+				Config: accconfig.FromModels(t, providerModel, databaseModel, schemaModelX, schemaModelY, tableModelBefore),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelBefore.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseId.Name()).
+						HasSchemaString(schemaXName),
+				),
+			},
+			// Move table to schema Y
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(tableModelAfter.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: accconfig.FromModels(t, providerModel, databaseModel, schemaModelX, schemaModelY, tableModelAfter),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelAfter.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseId.Name()).
+						HasSchemaString(schemaYName).
+						HasFullyQualifiedNameString(expectedNewTableId.FullyQualifiedName()),
+				),
+			},
+		},
+	})
+}
+
+// Database A is renamed to B AND schema X is renamed to Y simultaneously.
+// Table detects both renames and updates ID only.
+func TestAcc_Experimental_Table_HierarchyRenames_DatabaseRenamed_SchemaRenamed(t *testing.T) {
+	databaseId := testClient().Ids.RandomAccountObjectIdentifier()
+	newDatabaseId := testClient().Ids.RandomAccountObjectIdentifier()
+	schemaName := testClient().Ids.Alpha()
+	newSchemaName := testClient().Ids.Alpha()
+	tableName := testClient().Ids.Alpha()
+
+	providerModel := providermodel.SnowflakeProvider().WithExperimentalFeaturesEnabled(experimentalfeatures.HierarchyRenames)
+	databaseModel := model.DatabaseWithParametersSet("db", databaseId.Name())
+	databaseModelRenamed := model.DatabaseWithParametersSet("db", newDatabaseId.Name())
+
+	schemaModel := model.SchemaWithImplicitDatabaseDependency("schema", schemaName, databaseModel)
+	schemaModelRenamed := model.SchemaWithImplicitDatabaseDependency("schema", newSchemaName, databaseModelRenamed)
+
+	tableModel := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModel, databaseModel)
+	tableModelAfter := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelRenamed, databaseModelRenamed)
+
+	expectedNewTableId := sdk.NewSchemaObjectIdentifier(newDatabaseId.Name(), newSchemaName, tableName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: experimentalHierarchyRenamesProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Table),
+		Steps: []resource.TestStep{
+			// Create database, schema, and table
+			{
+				Config: accconfig.FromModels(t, providerModel, databaseModel, schemaModel, tableModel),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModel.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseId.Name()).
+						HasSchemaString(schemaName),
+				),
+			},
+			// Rename both database and schema — table detects both renames (Case C Scenario 1)
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(databaseModelRenamed.ResourceReference(), plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(schemaModelRenamed.ResourceReference(), plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(tableModelAfter.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: accconfig.FromModels(t, providerModel, databaseModelRenamed, schemaModelRenamed, tableModelAfter),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelAfter.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(newDatabaseId.Name()).
+						HasSchemaString(newSchemaName).
+						HasFullyQualifiedNameString(expectedNewTableId.FullyQualifiedName()),
+				),
+			},
+		},
+	})
+}
+
+// Database A is renamed to B. Table is moved from schema X to schema Y within renamed database.
+func TestAcc_Experimental_Table_HierarchyRenames_DatabaseRenamed_SchemaMove(t *testing.T) {
+	databaseId := testClient().Ids.RandomAccountObjectIdentifier()
+	newDatabaseId := testClient().Ids.RandomAccountObjectIdentifier()
+	schemaXName := testClient().Ids.Alpha()
+	schemaYName := testClient().Ids.Alpha()
+	tableName := testClient().Ids.Alpha()
+
+	providerModel := providermodel.SnowflakeProvider().WithExperimentalFeaturesEnabled(experimentalfeatures.HierarchyRenames)
+	databaseModel := model.DatabaseWithParametersSet("db", databaseId.Name())
+	databaseModelRenamed := model.DatabaseWithParametersSet("db", newDatabaseId.Name())
+
+	schemaModelX := model.SchemaWithImplicitDatabaseDependency("schemaX", schemaXName, databaseModel)
+	schemaModelY := model.SchemaWithImplicitDatabaseDependency("schemaY", schemaYName, databaseModel)
+	schemaModelXAfter := model.SchemaWithImplicitDatabaseDependency("schemaX", schemaXName, databaseModelRenamed)
+	schemaModelYAfter := model.SchemaWithImplicitDatabaseDependency("schemaY", schemaYName, databaseModelRenamed)
+
+	tableModelBefore := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelX, databaseModel)
+	tableModelAfter := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelYAfter, databaseModelRenamed)
+
+	expectedNewTableId := sdk.NewSchemaObjectIdentifier(newDatabaseId.Name(), schemaYName, tableName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: experimentalHierarchyRenamesProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Table),
+		Steps: []resource.TestStep{
+			// Create database, both schemas, and table in schema X
+			{
+				Config: accconfig.FromModels(t, providerModel, databaseModel, schemaModelX, schemaModelY, tableModelBefore),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelBefore.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseId.Name()).
+						HasSchemaString(schemaXName),
+				),
+			},
+			// Rename database AND move table to different schema (Case C Scenario 2)
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(databaseModelRenamed.ResourceReference(), plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(tableModelAfter.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: accconfig.FromModels(t, providerModel, databaseModelRenamed, schemaModelXAfter, schemaModelYAfter, tableModelAfter),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelAfter.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(newDatabaseId.Name()).
+						HasSchemaString(schemaYName).
+						HasFullyQualifiedNameString(expectedNewTableId.FullyQualifiedName()),
+				),
+			},
+		},
+	})
+}
+
+// Both databases exist. Schema X is renamed to Y in old database. Table is moved to new database.
+func TestAcc_Experimental_Table_HierarchyRenames_DatabaseMove_SchemaRenamed(t *testing.T) {
+	databaseAId := testClient().Ids.RandomAccountObjectIdentifier()
+	databaseBId := testClient().Ids.RandomAccountObjectIdentifier()
+	schemaName := testClient().Ids.Alpha()
+	newSchemaName := testClient().Ids.Alpha()
+	tableName := testClient().Ids.Alpha()
+
+	providerModel := providermodel.SnowflakeProvider().WithExperimentalFeaturesEnabled(experimentalfeatures.HierarchyRenames)
+	databaseModelA := model.DatabaseWithParametersSet("dbA", databaseAId.Name())
+	databaseModelB := model.DatabaseWithParametersSet("dbB", databaseBId.Name())
+
+	schemaModelBefore := model.SchemaWithImplicitDatabaseDependency("schema", schemaName, databaseModelA)
+	schemaModelRenamed := model.SchemaWithImplicitDatabaseDependency("schema", newSchemaName, databaseModelA)
+	schemaModelTarget := model.SchemaWithImplicitDatabaseDependency("schemaTarget", newSchemaName, databaseModelB)
+
+	tableModelBefore := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelBefore, databaseModelA)
+	tableModelAfter := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelTarget, databaseModelB)
+
+	expectedNewTableId := sdk.NewSchemaObjectIdentifier(databaseBId.Name(), newSchemaName, tableName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: experimentalHierarchyRenamesProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Table),
+		Steps: []resource.TestStep{
+			// Create both databases, schema in A, target schema in B, and table in A.schema
+			{
+				Config: accconfig.FromModels(t, providerModel, databaseModelA, databaseModelB, schemaModelBefore, schemaModelTarget, tableModelBefore),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelBefore.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseAId.Name()).
+						HasSchemaString(schemaName),
+				),
+			},
+			// Rename schema in A AND move table to B (Case C Scenario 3)
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(schemaModelRenamed.ResourceReference(), plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(tableModelAfter.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: accconfig.FromModels(t, providerModel, databaseModelA, databaseModelB, schemaModelRenamed, schemaModelTarget, tableModelAfter),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelAfter.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseBId.Name()).
+						HasSchemaString(newSchemaName).
+						HasFullyQualifiedNameString(expectedNewTableId.FullyQualifiedName()),
+				),
+			},
+		},
+	})
+}
+
+// Both databases exist. Both schemas exist. Table moved from A.X to B.Y.
+func TestAcc_Experimental_Table_HierarchyRenames_DatabaseMove_SchemaMove(t *testing.T) {
+	databaseAId := testClient().Ids.RandomAccountObjectIdentifier()
+	databaseBId := testClient().Ids.RandomAccountObjectIdentifier()
+	schemaXName := testClient().Ids.Alpha()
+	schemaYName := testClient().Ids.Alpha()
+	tableName := testClient().Ids.Alpha()
+
+	providerModel := providermodel.SnowflakeProvider().WithExperimentalFeaturesEnabled(experimentalfeatures.HierarchyRenames)
+	databaseModelA := model.DatabaseWithParametersSet("dbA", databaseAId.Name())
+	databaseModelB := model.DatabaseWithParametersSet("dbB", databaseBId.Name())
+
+	schemaModelAX := model.SchemaWithImplicitDatabaseDependency("schemaAX", schemaXName, databaseModelA)
+	schemaModelBY := model.SchemaWithImplicitDatabaseDependency("schemaBY", schemaYName, databaseModelB)
+
+	tableModelBefore := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelAX, databaseModelA)
+	tableModelAfter := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelBY, databaseModelB)
+
+	expectedNewTableId := sdk.NewSchemaObjectIdentifier(databaseBId.Name(), schemaYName, tableName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: experimentalHierarchyRenamesProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Table),
+		Steps: []resource.TestStep{
+			// Create both databases, both schemas, and table in A.X
+			{
+				Config: accconfig.FromModels(t, providerModel, databaseModelA, databaseModelB, schemaModelAX, schemaModelBY, tableModelBefore),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelBefore.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseAId.Name()).
+						HasSchemaString(schemaXName),
+				),
+			},
+			// Move table from A.X to B.Y (Case C Scenario 4)
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(tableModelAfter.ResourceReference(), plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: accconfig.FromModels(t, providerModel, databaseModelA, databaseModelB, schemaModelAX, schemaModelBY, tableModelAfter),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelAfter.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseBId.Name()).
+						HasSchemaString(schemaYName).
+						HasFullyQualifiedNameString(expectedNewTableId.FullyQualifiedName()),
+				),
+			},
+		},
+	})
+}
+
+// Error case: target database does not exist.
+func TestAcc_Experimental_Table_HierarchyRenames_Error_NewDatabaseDoesNotExist(t *testing.T) {
+	dbA, cleanupDbA := testClient().Database.CreateDatabase(t)
+	t.Cleanup(cleanupDbA)
+
+	schema, cleanupSchema := testClient().Schema.CreateSchemaInDatabase(t, dbA.ID())
+	t.Cleanup(cleanupSchema)
+
+	tableName := testClient().Ids.Alpha()
+	nonExistentDbName := testClient().Ids.RandomAccountObjectIdentifier().Name()
+
+	providerModel := providermodel.SnowflakeProvider().WithExperimentalFeaturesEnabled(experimentalfeatures.HierarchyRenames)
+	tableModelBefore := model.Table("test", dbA.ID().Name(), schema.ID().Name(), tableName, tableColumns)
+	tableModelAfter := model.Table("test", nonExistentDbName, schema.ID().Name(), tableName, tableColumns)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: experimentalHierarchyRenamesProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Table),
+		Steps: []resource.TestStep{
+			// Create table
+			{
+				Config: accconfig.FromModels(t, providerModel, tableModelBefore),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelBefore.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(dbA.ID().Name()),
+				),
+			},
+			// Try to move to non-existent database
+			{
+				Config:      accconfig.FromModels(t, providerModel, tableModelAfter),
+				ExpectError: regexp.MustCompile(`unknown rename use case.*object_renaming_guide`),
+			},
+		},
+	})
+}
+
+// Error case: target schema does not exist.
+func TestAcc_Experimental_Table_HierarchyRenames_Error_NewSchemaDoesNotExist(t *testing.T) {
+	dbA, cleanupDbA := testClient().Database.CreateDatabase(t)
+	t.Cleanup(cleanupDbA)
+
+	schema, cleanupSchema := testClient().Schema.CreateSchemaInDatabase(t, dbA.ID())
+	t.Cleanup(cleanupSchema)
+
+	tableName := testClient().Ids.Alpha()
+	nonExistentSchemaName := testClient().Ids.Alpha()
+
+	providerModel := providermodel.SnowflakeProvider().WithExperimentalFeaturesEnabled(experimentalfeatures.HierarchyRenames)
+	tableModelBefore := model.Table("test", dbA.ID().Name(), schema.ID().Name(), tableName, tableColumns)
+	tableModelAfter := model.Table("test", dbA.ID().Name(), nonExistentSchemaName, tableName, tableColumns)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: experimentalHierarchyRenamesProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Table),
+		Steps: []resource.TestStep{
+			// Create table
+			{
+				Config: accconfig.FromModels(t, providerModel, tableModelBefore),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelBefore.ResourceReference()).
+						HasNameString(tableName).
+						HasSchemaString(schema.ID().Name()),
+				),
+			},
+			// Try to move to non-existent schema
+			{
+				Config:      accconfig.FromModels(t, providerModel, tableModelAfter),
+				ExpectError: regexp.MustCompile(`unknown rename use case.*object_renaming_guide`),
+			},
+		},
+	})
+}
+
+// When the experiment is NOT enabled, changing the database or schema field still forces recreation (existing behavior preserved).
+func TestAcc_Experimental_Table_HierarchyRenames_Disabled_ForceRecreation(t *testing.T) {
+	databaseAId := testClient().Ids.RandomAccountObjectIdentifier()
+	databaseBId := testClient().Ids.RandomAccountObjectIdentifier()
+	schemaName := testClient().Ids.Alpha()
+	tableName := testClient().Ids.Alpha()
+
+	databaseModelA := model.DatabaseWithParametersSet("dbA", databaseAId.Name())
+	databaseModelB := model.DatabaseWithParametersSet("dbB", databaseBId.Name())
+
+	schemaModelA := model.SchemaWithImplicitDatabaseDependency("schemaA", schemaName, databaseModelA)
+	schemaModelB := model.SchemaWithImplicitDatabaseDependency("schemaB", schemaName, databaseModelB)
+
+	// No experiment enabled — use default provider
+	tableModelBefore := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelA, databaseModelA)
+	tableModelAfter := model.TableWithImplicitDependencies("test", tableName, tableColumns, schemaModelB, databaseModelB)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Table),
+		Steps: []resource.TestStep{
+			// Create both databases, schemas, and table in database A
+			{
+				Config: accconfig.FromModels(t, databaseModelA, databaseModelB, schemaModelA, schemaModelB, tableModelBefore),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelBefore.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseAId.Name()),
+				),
+			},
+			// Change database — should force recreation
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(tableModelAfter.ResourceReference(), plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Config: accconfig.FromModels(t, databaseModelA, databaseModelB, schemaModelA, schemaModelB, tableModelAfter),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelAfter.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(databaseBId.Name()),
+				),
+			},
+		},
+	})
+}
+
+// Externally dropped schema: table move fails with unknown rename use case.
+func TestAcc_Experimental_Table_HierarchyRenames_Error_SchemaDroppedExternally(t *testing.T) {
+	dbA, cleanupDbA := testClient().Database.CreateDatabase(t)
+	t.Cleanup(cleanupDbA)
+
+	dbB, cleanupDbB := testClient().Database.CreateDatabase(t)
+	t.Cleanup(cleanupDbB)
+
+	schema, cleanupSchema := testClient().Schema.CreateSchemaInDatabase(t, dbA.ID())
+	t.Cleanup(cleanupSchema)
+
+	tableName := testClient().Ids.Alpha()
+
+	providerModel := providermodel.SnowflakeProvider().WithExperimentalFeaturesEnabled(experimentalfeatures.HierarchyRenames)
+	tableModelBefore := model.Table("test", dbA.ID().Name(), schema.ID().Name(), tableName, tableColumns)
+	tableModelAfter := model.Table("test", dbB.ID().Name(), schema.ID().Name(), tableName, tableColumns)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: experimentalHierarchyRenamesProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Table),
+		Steps: []resource.TestStep{
+			// Create table in database A
+			{
+				Config: accconfig.FromModels(t, providerModel, tableModelBefore),
+				Check: assertThat(t,
+					resourceassert.TableResource(t, tableModelBefore.ResourceReference()).
+						HasNameString(tableName).
+						HasDatabaseString(dbA.ID().Name()),
+				),
+			},
+			// Drop schema externally, then try to move
+			{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.Execute(func() {
+							testClient().Schema.Alter(t, schema.ID(), &sdk.AlterSchemaOptions{
+								NewName: sdk.Pointer(sdk.NewDatabaseObjectIdentifier(dbA.ID().Name(), testClient().Ids.Alpha())),
+							})
+						}),
+					},
+				},
+				Config:      accconfig.FromModels(t, providerModel, tableModelAfter),
+				ExpectError: regexp.MustCompile(`unknown rename use case.*object_renaming_guide`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Continuation to https://github.com/snowflakedb/terraform-provider-snowflake/pull/4825

- Logic extended to 3-level hierarchy
  - case A: database name changes, schema name unchanged - the logic is the same as for database-schema
  - case B: schema name changes, database name unchanged - the logic is the same as for database-schema
  - case C: both database and schema names change - there are 4 cases:
    - move + move
    - move + rename
    - rename + move
    - rename + rename
- The logic is currently directly inside the table resource - it will be extracted and simplified to be able to reuse it later in other resources - it will be done in the next PR