### PR TITLE
feat: Support tagging iceberg table columns in tag_association

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -110,6 +110,22 @@ With the experiment enabled, renaming `snowflake_database.example` from `my_data
 
 For more details, see the [Object Renaming Guide](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/object_renaming_guide).
 
+### *(new feature)* Tagging support for iceberg table columns
+
+Tagging support for iceberg table columns is now supported. We added a new `ICEBERG TABLE COLUMN` value to the allowed `object_type` values of the `snowflake_tag_association` resource. Use it to tag a column of an Iceberg table:
+
+```terraform
+resource "snowflake_tag_association" "example" {
+  # For now, column fully qualified names have to be constructed manually.
+  object_identifiers = [format("%s.\"column1\"", snowflake_iceberg_table.example.fully_qualified_name)]
+  object_type        = "ICEBERG TABLE COLUMN"
+  tag_id             = snowflake_tag.example.fully_qualified_name
+  tag_value          = "example"
+}
+```
+
+Do not use the `COLUMN` object type, as it is reserved for table columns.
+
 ## v2.16.0 ➞ v2.17.0
 
 ### *(bug fix)* `snowflake_catalog_integration_iceberg_rest` and `snowflake_catalog_integration_open_catalog`: import fix for ForceNew fields

--- a/docs/resources/tag_association.md
+++ b/docs/resources/tag_association.md
@@ -11,6 +11,8 @@ description: |-
 
 -> **Note** If you want to change tag value to a value that is already present in another `tag_association` resource, first remove the relevant `object_identifiers` from the resource with the old value, run `terraform apply`, then add the relevant `object_identifiers` in the resource with new value, and run `terraform apply` once again. Removing and adding object identifier from one `snowflake_tag_association` resource to another may not work due to Terraform executing changes for non-dependent resources simultaneously. The same applies to an object being specified in multiple `snowflake_tag_association` resources for the same `tag_id`, but different `tag_value`s.
 
+-> **Note** Use `ICEBERG TABLE COLUMN` object type to tag iceberg table columns. The `COLUMN` object type cannot be used to tag iceberg table columns.
+
 -> **Note** Default timeout is set to 70 minutes for Terraform Create operation.
 
 # snowflake_tag_association (Resource)
@@ -91,7 +93,7 @@ resource "snowflake_tag_association" "account_association" {
 ### Required
 
 - `object_identifiers` (Set of String) Specifies the object identifiers for the tag association.
-- `object_type` (String) Specifies the type of object to add a tag. Allowed object types: `ACCOUNT` | `APPLICATION` | `APPLICATION PACKAGE` | `COMPUTE POOL` | `DATABASE` | `FAILOVER GROUP` | `INTEGRATION` | `NETWORK POLICY` | `REPLICATION GROUP` | `ROLE` | `SHARE` | `USER` | `WAREHOUSE` | `DATABASE ROLE` | `SCHEMA` | `ALERT` | `SNOWFLAKE.CORE.BUDGET` | `SNOWFLAKE.ML.CLASSIFICATION` | `EXTERNAL FUNCTION` | `EXTERNAL TABLE` | `FUNCTION` | `IMAGE REPOSITORY` | `GIT REPOSITORY` | `ICEBERG TABLE` | `MATERIALIZED VIEW` | `PIPE` | `MASKING POLICY` | `PASSWORD POLICY` | `ROW ACCESS POLICY` | `SESSION POLICY` | `STORAGE LIFECYCLE POLICY` | `PRIVACY POLICY` | `PROCEDURE` | `SERVICE` | `STAGE` | `STREAM` | `TABLE` | `TASK` | `VIEW` | `COLUMN` | `EVENT TABLE`.
+- `object_type` (String) Specifies the type of object to add a tag. Allowed object types: `ACCOUNT` | `APPLICATION` | `APPLICATION PACKAGE` | `COMPUTE POOL` | `DATABASE` | `FAILOVER GROUP` | `INTEGRATION` | `NETWORK POLICY` | `REPLICATION GROUP` | `ROLE` | `SHARE` | `USER` | `WAREHOUSE` | `DATABASE ROLE` | `SCHEMA` | `ALERT` | `SNOWFLAKE.CORE.BUDGET` | `SNOWFLAKE.ML.CLASSIFICATION` | `EXTERNAL FUNCTION` | `EXTERNAL TABLE` | `FUNCTION` | `IMAGE REPOSITORY` | `GIT REPOSITORY` | `ICEBERG TABLE` | `MATERIALIZED VIEW` | `PIPE` | `MASKING POLICY` | `PASSWORD POLICY` | `ROW ACCESS POLICY` | `SESSION POLICY` | `STORAGE LIFECYCLE POLICY` | `PRIVACY POLICY` | `PROCEDURE` | `SERVICE` | `STAGE` | `STREAM` | `TABLE` | `TASK` | `VIEW` | `COLUMN` | `EVENT TABLE` | `ICEBERG TABLE COLUMN`.
 - `tag_id` (String) Specifies the identifier for the tag.
 - `tag_value` (String) Specifies the value of the tag, (e.g. 'finance' or 'engineering')
 

--- a/pkg/resources/grant_ownership.go
+++ b/pkg/resources/grant_ownership.go
@@ -494,7 +494,8 @@ func GetOnObjectIdentifier(objectType sdk.ObjectType, objectName string) (sdk.Ob
 		sdk.ObjectTypeFunction,
 		sdk.ObjectTypeProcedure:
 		return sdk.ParseSchemaObjectIdentifierWithArguments(objectName)
-	case sdk.ObjectTypeColumn:
+	case sdk.ObjectTypeColumn,
+		sdk.ObjectTypeIcebergTableColumn:
 		return sdk.ParseTableColumnIdentifier(objectName)
 
 	default:

--- a/pkg/sdk/object_types.go
+++ b/pkg/sdk/object_types.go
@@ -115,6 +115,9 @@ const (
 	// For actual Snowflake operations where object type is needed, ObjectTypeIntegration should be used.
 	ObjectTypeApiIntegration     ObjectType = "API INTEGRATION"
 	ObjectTypeCatalogIntegration ObjectType = "CATALOG INTEGRATION"
+	// ObjectTypeIcebergTableColumn is a pseudo-object, only used in in handling iceberg table column tags - in generic SET and UNSET,
+	// and as a helper in GET TAG.
+	ObjectTypeIcebergTableColumn ObjectType = "ICEBERG TABLE COLUMN"
 )
 
 func (o ObjectType) String() string {
@@ -182,6 +185,7 @@ var allObjectTypes = []ObjectType{
 	ObjectTypeOnlineFeatureTable,
 	ObjectTypeColumn,
 	ObjectTypeIcebergTable,
+	ObjectTypeIcebergTableColumn,
 	ObjectTypeJoinPolicy,
 	ObjectTypeExternalVolume,
 	ObjectTypeNetworkRule,

--- a/pkg/sdk/object_types_test.go
+++ b/pkg/sdk/object_types_test.go
@@ -67,6 +67,7 @@ func Test_ToObjectType(t *testing.T) {
 		{input: "STREAMLIT", want: ObjectTypeStreamlit},
 		{input: "COLUMN", want: ObjectTypeColumn},
 		{input: "ICEBERG TABLE", want: ObjectTypeIcebergTable},
+		{input: "ICEBERG TABLE COLUMN", want: ObjectTypeIcebergTableColumn},
 		{input: "EXTERNAL VOLUME", want: ObjectTypeExternalVolume},
 		{input: "NETWORK RULE", want: ObjectTypeNetworkRule},
 		{input: "NOTEBOOK", want: ObjectTypeNotebook},

--- a/pkg/sdk/system_functions.go
+++ b/pkg/sdk/system_functions.go
@@ -35,6 +35,11 @@ func (c *systemFunctions) GetTag(ctx context.Context, tagID ObjectIdentifier, ob
 	if err != nil {
 		return nil, err
 	}
+	// ObjectTypeIcebergTableColumn is a dedicated type for handling iceberg table column tags.
+	// However, Snowflake expects just the column type.
+	if objectType == ObjectTypeIcebergTableColumn {
+		objectType = ObjectTypeColumn
+	}
 
 	s := &struct {
 		Tag sql.NullString `db:"TAG"`
@@ -64,6 +69,7 @@ func normalizeGetTagObjectType(objectType ObjectType) (ObjectType, error) {
 	if slices.Contains([]ObjectType{ObjectTypeExternalFunction}, objectType) {
 		return ObjectTypeFunction, nil
 	}
+
 	return objectType, nil
 }
 

--- a/pkg/sdk/tag_association_validations.go
+++ b/pkg/sdk/tag_association_validations.go
@@ -55,24 +55,7 @@ var (
 		// table or column level
 		ObjectTypeColumn,
 		ObjectTypeEventTable,
-	}
-	// TODO(SNOW-1229218): Object types should be able tell their id structure and tagAssociationAllowedObjectTypes should be used to filter correct object types.
-	TagAssociationTagObjectTypeIsSchemaObjectType = []ObjectType{
-		ObjectTypeAlert,
-		ObjectTypeExternalFunction,
-		ObjectTypeExternalTable,
-		ObjectTypeGitRepository,
-		ObjectTypeIcebergTable,
-		ObjectTypeMaterializedView,
-		ObjectTypeColumn, // As a workaround for object_name can be specified as `table_name.column_name`
-		ObjectTypePipe,
-		ObjectTypeProcedure,
-		ObjectTypeStage,
-		ObjectTypeStream,
-		ObjectTypeTable,
-		ObjectTypeTask,
-		ObjectTypeView,
-		ObjectTypeEventTable,
+		ObjectTypeIcebergTableColumn,
 	}
 	TagAssociationAllowedObjectTypesString = make([]string, len(TagAssociationAllowedObjectTypes))
 )

--- a/pkg/sdk/tags_impl.go
+++ b/pkg/sdk/tags_impl.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"slices"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
@@ -196,12 +197,16 @@ func (s *SetTagRequest) toOpts() *setTagOptions {
 		SetTags:    s.SetTags,
 	}
 	// TODO [SNOW-1022645]: discuss how we handle situation like this in the SDK
-	if o.objectType == ObjectTypeColumn {
+	if slices.Contains([]ObjectType{ObjectTypeColumn, ObjectTypeIcebergTableColumn}, o.objectType) {
 		id, ok := o.objectName.(TableColumnIdentifier)
 		if ok {
-			o.objectType = ObjectTypeTable
+			if o.objectType == ObjectTypeColumn {
+				o.objectType = ObjectTypeTable
+			} else {
+				o.objectType = ObjectTypeIcebergTable
+			}
 			o.objectName = id.SchemaObjectId()
-			o.column = String(id.Name())
+			o.column = new(id.Name())
 		}
 	}
 	// TODO(SNOW-1818976): Remove this workaround. Currently ALTER "ORGNAME"."ACCOUNTNAME" SET TAG does not work, but ALTER "ACCOUNTNAME" does.
@@ -223,12 +228,16 @@ func (s *UnsetTagRequest) toOpts() *unsetTagOptions {
 		UnsetTags:  s.UnsetTags,
 	}
 	// TODO [SNOW-1022645]: discuss how we handle situation like this in the SDK
-	if o.objectType == ObjectTypeColumn {
+	if slices.Contains([]ObjectType{ObjectTypeColumn, ObjectTypeIcebergTableColumn}, o.objectType) {
 		id, ok := o.objectName.(TableColumnIdentifier)
 		if ok {
-			o.objectType = ObjectTypeTable
+			if o.objectType == ObjectTypeColumn {
+				o.objectType = ObjectTypeTable
+			} else {
+				o.objectType = ObjectTypeIcebergTable
+			}
 			o.objectName = id.SchemaObjectId()
-			o.column = String(id.Name())
+			o.column = new(id.Name())
 		}
 	}
 

--- a/pkg/sdk/testint/tags_integration_test.go
+++ b/pkg/sdk/testint/tags_integration_test.go
@@ -1118,20 +1118,6 @@ func TestInt_TagsAssociations(t *testing.T) {
 		unsetTags   func(sdk.TableColumnIdentifier, []sdk.ObjectIdentifier) error
 	}{
 		{
-			name: "IcebergTable",
-			setupObject: func() (sdk.TableColumnIdentifier, func()) {
-				object, objectCleanup := testClientHelper().IcebergTable.Create(t)
-				columnId := sdk.NewTableColumnIdentifier(object.ID().DatabaseName(), object.ID().SchemaName(), object.ID().Name(), "ID")
-				return columnId, objectCleanup
-			},
-			setTags: func(id sdk.TableColumnIdentifier, tags []sdk.TagAssociation) error {
-				return client.IcebergTables.Alter(ctx, sdk.NewAlterIcebergTableRequest(id.SchemaObjectId()).WithSetTagsOnColumn(*sdk.NewTableSetColumnTagsRequest(id.Name(), tags)))
-			},
-			unsetTags: func(id sdk.TableColumnIdentifier, tags []sdk.ObjectIdentifier) error {
-				return client.IcebergTables.Alter(ctx, sdk.NewAlterIcebergTableRequest(id.SchemaObjectId()).WithUnsetTagsOnColumn(*sdk.NewTableUnsetColumnTagsRequest(id.Name(), tags)))
-			},
-		},
-		{
 			name: "Table",
 			setupObject: func() (sdk.TableColumnIdentifier, func()) {
 				object, objectCleanup := testClientHelper().Table.Create(t)
@@ -1187,6 +1173,24 @@ func TestInt_TagsAssociations(t *testing.T) {
 		})
 	}
 
+	t.Run("iceberg table column", func(t *testing.T) {
+		// Iceberg table columns are handled separately because they use a dedicated object type.
+		object, objectCleanup := testClientHelper().IcebergTable.Create(t)
+		id := sdk.NewTableColumnIdentifier(object.ID().DatabaseName(), object.ID().SchemaName(), object.ID().Name(), "ID")
+		t.Cleanup(objectCleanup)
+		err := client.IcebergTables.Alter(ctx, sdk.NewAlterIcebergTableRequest(id.SchemaObjectId()).WithSetTagsOnColumn(*sdk.NewTableSetColumnTagsRequest(id.Name(), tags)))
+		require.NoError(t, err)
+
+		assertTagSet(id, sdk.ObjectTypeColumn)
+
+		err = client.IcebergTables.Alter(ctx, sdk.NewAlterIcebergTableRequest(id.SchemaObjectId()).WithUnsetTagsOnColumn(*sdk.NewTableUnsetColumnTagsRequest(id.Name(), unsetTags)))
+		require.NoError(t, err)
+
+		assertTagUnset(id, sdk.ObjectTypeColumn)
+
+		// test object methods
+		testTagSet(id, sdk.ObjectTypeIcebergTableColumn)
+	})
 	schemaObjectWithArgumentsTestCases := []struct {
 		name        string
 		objectType  sdk.ObjectType

--- a/pkg/testacc/resource_tag_association_acceptance_test.go
+++ b/pkg/testacc/resource_tag_association_acceptance_test.go
@@ -397,8 +397,11 @@ func TestAcc_TagAssociationIcebergTableColumn(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(tagAssociationModel.ResourceReference(), "object_identifiers.*", columnId.FullyQualifiedName()),
 					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "tag_id", tagId.FullyQualifiedName()),
 					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "tag_value", tagValue),
-					testAccCheckTableColumnTagAssociation(tagId, columnId, tagValue),
 				),
+			},
+			{
+				Config:  accconfig.FromModels(t, tagAssociationModel),
+				Destroy: true,
 			},
 		},
 	})

--- a/pkg/testacc/resource_tag_association_acceptance_test.go
+++ b/pkg/testacc/resource_tag_association_acceptance_test.go
@@ -367,6 +367,43 @@ func TestAcc_TagAssociationColumn(t *testing.T) {
 	})
 }
 
+func TestAcc_TagAssociationIcebergTableColumn(t *testing.T) {
+	tag, tagCleanup := testClient().Tag.CreateTag(t)
+	t.Cleanup(tagCleanup)
+
+	icebergTable, icebergTableCleanup := testClient().IcebergTable.Create(t)
+	t.Cleanup(icebergTableCleanup)
+
+	tagId := tag.ID()
+	icebergTableId := icebergTable.ID()
+	columnId := sdk.NewTableColumnIdentifier(icebergTableId.DatabaseName(), icebergTableId.SchemaName(), icebergTableId.Name(), "ID")
+	tagValue := "TAG_VALUE"
+
+	tagAssociationModel := model.TagAssociation("test", []sdk.ObjectIdentifier{columnId}, string(sdk.ObjectTypeIcebergTableColumn), tag.ID().FullyQualifiedName(), tagValue)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: tagsProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: accconfig.FromModels(t, tagAssociationModel),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "id", helpers.EncodeSnowflakeID(tagId.FullyQualifiedName(), tagValue, string(sdk.ObjectTypeIcebergTableColumn))),
+					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "object_type", string(sdk.ObjectTypeIcebergTableColumn)),
+					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "object_identifiers.#", "1"),
+					resource.TestCheckTypeSetElemAttr(tagAssociationModel.ResourceReference(), "object_identifiers.*", columnId.FullyQualifiedName()),
+					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "tag_id", tagId.FullyQualifiedName()),
+					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "tag_value", tagValue),
+					testAccCheckTableColumnTagAssociation(tagId, columnId, tagValue),
+				),
+			},
+		},
+	})
+}
+
 func TestAcc_TagAssociationIssue1202(t *testing.T) {
 	tag, tagCleanup := testClient().Tag.CreateTag(t)
 	t.Cleanup(tagCleanup)

--- a/templates/resources/tag_association.md.tmpl
+++ b/templates/resources/tag_association.md.tmpl
@@ -15,6 +15,8 @@ description: |-
 
 -> **Note** If you want to change tag value to a value that is already present in another `tag_association` resource, first remove the relevant `object_identifiers` from the resource with the old value, run `terraform apply`, then add the relevant `object_identifiers` in the resource with new value, and run `terraform apply` once again. Removing and adding object identifier from one `snowflake_tag_association` resource to another may not work due to Terraform executing changes for non-dependent resources simultaneously. The same applies to an object being specified in multiple `snowflake_tag_association` resources for the same `tag_id`, but different `tag_value`s.
 
+-> **Note** Use `ICEBERG TABLE COLUMN` object type to tag iceberg table columns. The `COLUMN` object type cannot be used to tag iceberg table columns.
+
 -> **Note** Default timeout is set to 70 minutes for Terraform Create operation.
 
 # {{.Name}} ({{.Type}})


### PR DESCRIPTION
## Summary

Tagging a column of an Iceberg table through `snowflake_tag_association` previously failed. Using `object_type = "COLUMN"` generated an `ALTER TABLE … ALTER COLUMN … SET TAG` statement, which is not valid for Iceberg tables — they require `ALTER ICEBERG TABLE …`.

This PR introduces a dedicated `ICEBERG TABLE COLUMN` object type:

- New `sdk.ObjectTypeIcebergTableColumn` ("ICEBERG TABLE COLUMN"), registered in `allObjectTypes` (so `ToObjectType` accepts it) and in `TagAssociationAllowedObjectTypes` (so the `snowflake_tag_association` resource allows it).
- `SetTag`/`UnsetTag` route this type to `ALTER ICEBERG TABLE … SET/UNSET TAG` on the column.
- `GetTag` maps it back to `COLUMN`, since Snowflake's `GET_TAG` expects the column type.
- Removed the now-unused `TagAssociationTagObjectTypeIsSchemaObjectType` variable.

Docs (template + generated) and the migration guide are updated, and integration + acceptance tests cover the new path.
