### PR TITLE
chore: Rename in hierarchies - extract and refactor

### DIFF
--- a/pkg/resources/hierarchy_renames.go
+++ b/pkg/resources/hierarchy_renames.go
@@ -1,8 +1,10 @@
 package resources
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -34,4 +36,55 @@ func handleHierarchyMove[T sdk.ObjectIdentifier](d *schema.ResourceData, encodeI
 	}
 	d.SetId(encodeIdFn())
 	return nil
+}
+
+// handleShallowHierarchyRename handles the complete single-level rename/move detection.
+// P is the parent identifier type, O is the probed object identifier type, M is the moved object type.
+// PR and OR are the return types of the ShowByID functions.
+func handleShallowHierarchyRename[P, O, M sdk.ObjectIdentifier, PR, OR any](
+	d *schema.ResourceData,
+	ctx context.Context,
+	parentShowByIDFn func(context.Context, P) (PR, error),
+	objectShowByIDFn func(context.Context, O) (OR, error),
+	newParentId, oldParentId P,
+	targetObjectId, currentObjectId O,
+	movedObjectId M,
+	renameFn func(string),
+	moveFn func(M, string) diag.Diagnostics,
+	parentLevelName string,
+	childLevelName string,
+	leafLevelName string,
+) diag.Diagnostics {
+	_, errNewParent := parentShowByIDFn(ctx, newParentId)
+	newParentExists := errNewParent == nil
+	_, errOldParent := parentShowByIDFn(ctx, oldParentId)
+	oldParentExists := errOldParent == nil
+	_, errTargetObject := objectShowByIDFn(ctx, targetObjectId)
+	objectAtTargetExists := errTargetObject == nil
+	_, errCurrentObject := objectShowByIDFn(ctx, currentObjectId)
+	objectAtSourceExists := errCurrentObject == nil
+
+	switch {
+	case isRenameOfTheGivenLevelInTheHierarchy(newParentExists, oldParentExists, objectAtTargetExists):
+		renameFn(fmt.Sprintf("%s was renamed for %s", capitalize(parentLevelName), leafLevelName))
+		return nil
+	case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newParentExists, oldParentExists, objectAtSourceExists):
+		return moveFn(movedObjectId, fmt.Sprintf("Moving %s to different %s", leafLevelName, parentLevelName))
+	default:
+		d.Partial(true)
+		return diag.FromErr(fmt.Errorf(
+			"unknown rename use case: old %s %s (exists: %t), new %s %s (exists: %t), old %s %s (exists: %t), new %s %s (exists: %t). See https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/object_renaming_guide",
+			parentLevelName, oldParentId.FullyQualifiedName(), oldParentExists,
+			parentLevelName, newParentId.FullyQualifiedName(), newParentExists,
+			childLevelName, currentObjectId.FullyQualifiedName(), objectAtSourceExists,
+			childLevelName, targetObjectId.FullyQualifiedName(), objectAtTargetExists,
+		))
+	}
+}
+
+func capitalize(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
 }

--- a/pkg/resources/hierarchy_renames.go
+++ b/pkg/resources/hierarchy_renames.go
@@ -26,9 +26,9 @@ func handleHierarchyRenameIdUpdate(d *schema.ResourceData, encodeIdFn func() str
 
 // handleHierarchyMove handles the "move" case: performs the ALTER to move the object
 // to its new location and updates the Terraform state ID.
-func handleHierarchyMove(d *schema.ResourceData, encodeIdFn func() string, currentId, targetId sdk.ObjectIdentifier, alterFn func() error, caseDescription string) diag.Diagnostics {
+func handleHierarchyMove[T sdk.ObjectIdentifier](d *schema.ResourceData, encodeIdFn func() string, currentId, targetId T, renameFn func(T, T) func() error, caseDescription string) diag.Diagnostics {
 	log.Printf("[DEBUG] %s - executing ALTER RENAME TO from %s to %s...", caseDescription, currentId.FullyQualifiedName(), targetId.FullyQualifiedName())
-	if err := alterFn(); err != nil {
+	if err := renameFn(currentId, targetId)(); err != nil {
 		d.Partial(true)
 		return diag.FromErr(fmt.Errorf("failed to move from %s to %s: %w", currentId.FullyQualifiedName(), targetId.FullyQualifiedName(), err))
 	}

--- a/pkg/resources/hierarchy_renames.go
+++ b/pkg/resources/hierarchy_renames.go
@@ -202,35 +202,35 @@ func handleBothParentsChangeRename(
 	oldDatabaseExists := errOldDb == nil
 
 	// Probe schemas (4 combinations)
-	schemaInNewDbOldName := sdk.NewDatabaseObjectIdentifier(newDatabaseName, oldSchemaName)
-	schemaInNewDbNewName := sdk.NewDatabaseObjectIdentifier(newDatabaseName, newSchemaName)
-	schemaInOldDbOldName := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, oldSchemaName)
-	schemaInOldDbNewName := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, newSchemaName)
+	newDbOldSchemaId := sdk.NewDatabaseObjectIdentifier(newDatabaseName, oldSchemaName)
+	newDbNewSchemaId := sdk.NewDatabaseObjectIdentifier(newDatabaseName, newSchemaName)
+	oldDbOldSchemaId := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, oldSchemaName)
+	oldDbNewSchemaId := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, newSchemaName)
 
-	_, errSchemaNewDbOld := client.Schemas.ShowByID(ctx, schemaInNewDbOldName)
-	schemaNewDbOldExists := errSchemaNewDbOld == nil
-	_, errSchemaNewDbNew := client.Schemas.ShowByID(ctx, schemaInNewDbNewName)
-	schemaNewDbNewExists := errSchemaNewDbNew == nil
-	_, errSchemaOldDbOld := client.Schemas.ShowByID(ctx, schemaInOldDbOldName)
-	schemaOldDbOldExists := errSchemaOldDbOld == nil
-	_, errSchemaOldDbNew := client.Schemas.ShowByID(ctx, schemaInOldDbNewName)
-	schemaOldDbNewExists := errSchemaOldDbNew == nil
+	_, errNewDbOldSchema := client.Schemas.ShowByID(ctx, newDbOldSchemaId)
+	newDbOldSchemaExists := errNewDbOldSchema == nil
+	_, errNewDbNewSchema := client.Schemas.ShowByID(ctx, newDbNewSchemaId)
+	newDbNewSchemaExists := errNewDbNewSchema == nil
+	_, errOldDbOldSchemaId := client.Schemas.ShowByID(ctx, oldDbOldSchemaId)
+	oldDbOldSchemaExists := errOldDbOldSchemaId == nil
+	_, errOldDbNewSchemaId := client.Schemas.ShowByID(ctx, oldDbNewSchemaId)
+	oldDbNewSchemaExists := errOldDbNewSchemaId == nil
 
 	switch {
 	// Scenario 1: DB rename + Schema rename → just update ID
-	case !oldDatabaseExists && newDatabaseExists && !schemaNewDbOldExists && schemaNewDbNewExists:
+	case !oldDatabaseExists && newDatabaseExists && !newDbOldSchemaExists && newDbNewSchemaExists:
 		renameFn(fmt.Sprintf("Database and schema were both renamed for %s", leafLevelName))
 		return nil
 	// Scenario 2: DB rename + Schema move → object is at (newDb, oldSchema)
-	case !oldDatabaseExists && newDatabaseExists && schemaNewDbOldExists:
+	case !oldDatabaseExists && newDatabaseExists && newDbOldSchemaExists:
 		currentId := sdk.NewSchemaObjectIdentifier(newDatabaseName, oldSchemaName, objectName)
 		return moveFn(currentId, fmt.Sprintf("Database was renamed, moving %s to different schema", leafLevelName))
 	// Scenario 3: DB move + Schema rename → object is at (oldDb, newSchema)
-	case oldDatabaseExists && newDatabaseExists && !schemaOldDbOldExists && schemaOldDbNewExists:
+	case oldDatabaseExists && newDatabaseExists && !oldDbOldSchemaExists && oldDbNewSchemaExists:
 		currentId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, newSchemaName, objectName)
 		return moveFn(currentId, fmt.Sprintf("Schema was renamed, moving %s to different database", leafLevelName))
 	// Scenario 4: DB move + Schema move → object is at (oldDb, oldSchema)
-	case oldDatabaseExists && newDatabaseExists && schemaOldDbOldExists:
+	case oldDatabaseExists && newDatabaseExists && oldDbOldSchemaExists:
 		currentId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, oldSchemaName, objectName)
 		return moveFn(currentId, fmt.Sprintf("Moving %s to different database and schema", leafLevelName))
 	default:
@@ -239,10 +239,10 @@ func handleBothParentsChangeRename(
 			"unknown rename use case: old database %s (exists: %t), new database %s (exists: %t), schema %s (exists: %t), schema %s (exists: %t), schema %s (exists: %t), schema %s (exists: %t). See https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/object_renaming_guide",
 			oldDatabaseId.FullyQualifiedName(), oldDatabaseExists,
 			newDatabaseId.FullyQualifiedName(), newDatabaseExists,
-			schemaInNewDbOldName.FullyQualifiedName(), schemaNewDbOldExists,
-			schemaInNewDbNewName.FullyQualifiedName(), schemaNewDbNewExists,
-			schemaInOldDbOldName.FullyQualifiedName(), schemaOldDbOldExists,
-			schemaInOldDbNewName.FullyQualifiedName(), schemaOldDbNewExists,
+			newDbOldSchemaId.FullyQualifiedName(), newDbOldSchemaExists,
+			newDbNewSchemaId.FullyQualifiedName(), newDbNewSchemaExists,
+			oldDbOldSchemaId.FullyQualifiedName(), oldDbOldSchemaExists,
+			oldDbNewSchemaId.FullyQualifiedName(), oldDbNewSchemaExists,
 		))
 	}
 }

--- a/pkg/resources/hierarchy_renames.go
+++ b/pkg/resources/hierarchy_renames.go
@@ -151,6 +151,92 @@ func handleDeepHierarchyRename(
 	}
 }
 
+// handleThreeLevelHierarchyRename handles the full 3-level hierarchy rename/move
+// for a schema-level object (database → schema → object).
+// OR is the return type of objectShowByIDFn.
+func handleThreeLevelHierarchyRename[OR any](
+	d *schema.ResourceData,
+	ctx context.Context,
+	client *sdk.Client,
+	id *sdk.SchemaObjectIdentifier,
+	objectRenameFn func(sdk.SchemaObjectIdentifier, sdk.SchemaObjectIdentifier) func() error,
+	objectShowByIDFn func(context.Context, sdk.SchemaObjectIdentifier) (OR, error),
+	encodeIdFn func(sdk.SchemaObjectIdentifier) string,
+	leafLevelName string,
+) diag.Diagnostics {
+	oldDatabaseNameRaw, newDatabaseNameRaw := d.GetChange("database")
+	oldDatabaseName, newDatabaseName := oldDatabaseNameRaw.(string), newDatabaseNameRaw.(string)
+	oldSchemaNameRaw, newSchemaNameRaw := d.GetChange("schema")
+	oldSchemaName, newSchemaName := oldSchemaNameRaw.(string), newSchemaNameRaw.(string)
+	objectName := id.Name()
+
+	databaseChanged := d.HasChange("database")
+	schemaChanged := d.HasChange("schema")
+
+	oldDatabaseId := sdk.NewAccountObjectIdentifier(oldDatabaseName)
+	newDatabaseId := sdk.NewAccountObjectIdentifier(newDatabaseName)
+	oldSchemaId := sdk.NewDatabaseObjectIdentifierInDatabase(oldDatabaseId, oldSchemaName)
+	newSchemaId := sdk.NewDatabaseObjectIdentifierInDatabase(newDatabaseId, newSchemaName)
+	oldObjectId := sdk.NewSchemaObjectIdentifierInSchema(oldSchemaId, objectName)
+	newObjectId := sdk.NewSchemaObjectIdentifierInSchema(newSchemaId, objectName)
+
+	renameObj := func(description string) {
+		handleHierarchyRenameIdUpdate(d,
+			func() string { return encodeIdFn(newObjectId) },
+			description)
+	}
+
+	moveObj := func(currentId sdk.SchemaObjectIdentifier, description string) diag.Diagnostics {
+		return handleHierarchyMove(d,
+			func() string { return encodeIdFn(newObjectId) },
+			currentId, newObjectId,
+			objectRenameFn,
+			description)
+	}
+
+	switch {
+	case databaseChanged && !schemaChanged:
+		if diags := handleShallowHierarchyRename(d, ctx,
+			client.Databases.ShowByID,
+			client.Schemas.ShowByID,
+			newDatabaseId, oldDatabaseId,
+			newSchemaId, oldSchemaId,
+			*id,
+			renameObj, moveObj,
+			"database", "schema", leafLevelName,
+		); diags != nil {
+			return diags
+		}
+
+	case !databaseChanged && schemaChanged:
+		if diags := handleShallowHierarchyRename(d, ctx,
+			client.Schemas.ShowByID,
+			objectShowByIDFn,
+			newSchemaId, oldSchemaId,
+			newObjectId, oldObjectId,
+			*id,
+			renameObj, moveObj,
+			"schema", leafLevelName, leafLevelName,
+		); diags != nil {
+			return diags
+		}
+
+	default:
+		if diags := handleDeepHierarchyRename(d, ctx, client,
+			newDatabaseId, oldDatabaseId,
+			oldSchemaName, newSchemaName,
+			objectName,
+			renameObj, moveObj,
+			leafLevelName,
+		); diags != nil {
+			return diags
+		}
+	}
+
+	*id = newObjectId
+	return nil
+}
+
 func capitalize(s string) string {
 	if len(s) == 0 {
 		return s

--- a/pkg/resources/hierarchy_renames.go
+++ b/pkg/resources/hierarchy_renames.go
@@ -151,6 +151,58 @@ func handleDeepHierarchyRename(
 	}
 }
 
+// handleTwoLevelHierarchyRename handles the full 2-level hierarchy rename/move
+// for a database-level object (database → object).
+// OR is the return type of objectShowByIDFn.
+func handleTwoLevelHierarchyRename[OR any](
+	d *schema.ResourceData,
+	ctx context.Context,
+	client *sdk.Client,
+	id *sdk.DatabaseObjectIdentifier,
+	objectRenameFn func(sdk.DatabaseObjectIdentifier, sdk.DatabaseObjectIdentifier) func() error,
+	objectShowByIDFn func(context.Context, sdk.DatabaseObjectIdentifier) (OR, error),
+	encodeIdFn func(sdk.DatabaseObjectIdentifier) string,
+	leafLevelName string,
+) diag.Diagnostics {
+	oldDatabaseNameRaw, newDatabaseNameRaw := d.GetChange("database")
+	oldDatabaseName, newDatabaseName := oldDatabaseNameRaw.(string), newDatabaseNameRaw.(string)
+	objectName := id.Name()
+
+	oldDatabaseId := sdk.NewAccountObjectIdentifier(oldDatabaseName)
+	newDatabaseId := sdk.NewAccountObjectIdentifier(newDatabaseName)
+	oldObjectId := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, objectName)
+	newObjectId := sdk.NewDatabaseObjectIdentifier(newDatabaseName, objectName)
+
+	renameObj := func(description string) {
+		handleHierarchyRenameIdUpdate(d,
+			func() string { return encodeIdFn(newObjectId) },
+			description)
+	}
+
+	moveObj := func(currentId sdk.DatabaseObjectIdentifier, description string) diag.Diagnostics {
+		return handleHierarchyMove(d,
+			func() string { return encodeIdFn(newObjectId) },
+			currentId, newObjectId,
+			objectRenameFn,
+			description)
+	}
+
+	if diags := handleShallowHierarchyRename(d, ctx,
+		client.Databases.ShowByID,
+		objectShowByIDFn,
+		newDatabaseId, oldDatabaseId,
+		newObjectId, oldObjectId,
+		*id,
+		renameObj, moveObj,
+		"database", leafLevelName, leafLevelName,
+	); diags != nil {
+		return diags
+	}
+
+	*id = newObjectId
+	return nil
+}
+
 // handleThreeLevelHierarchyRename handles the full 3-level hierarchy rename/move
 // for a schema-level object (database → schema → object).
 // OR is the return type of objectShowByIDFn.

--- a/pkg/resources/hierarchy_renames.go
+++ b/pkg/resources/hierarchy_renames.go
@@ -42,8 +42,8 @@ func handleHierarchyMove[T sdk.ObjectIdentifier](d *schema.ResourceData, encodeI
 // P is the parent identifier type, O is the probed object identifier type, M is the moved object type.
 // PR and OR are the return types of the ShowByID functions.
 func handleShallowHierarchyRename[P, O, M sdk.ObjectIdentifier, PR, OR any](
-	d *schema.ResourceData,
 	ctx context.Context,
+	d *schema.ResourceData,
 	parentShowByIDFn func(context.Context, P) (PR, error),
 	objectShowByIDFn func(context.Context, O) (OR, error),
 	newParentId, oldParentId P,
@@ -86,8 +86,8 @@ func handleShallowHierarchyRename[P, O, M sdk.ObjectIdentifier, PR, OR any](
 // for a schema-level object. It determines whether the database/schema were renamed
 // or moved and acts accordingly.
 func handleDeepHierarchyRename(
-	d *schema.ResourceData,
 	ctx context.Context,
+	d *schema.ResourceData,
 	client *sdk.Client,
 	newDatabaseId, oldDatabaseId sdk.AccountObjectIdentifier,
 	oldSchemaName, newSchemaName string,
@@ -155,8 +155,8 @@ func handleDeepHierarchyRename(
 // for a database-level object (database → object).
 // OR is the return type of objectShowByIDFn.
 func handleTwoLevelHierarchyRename[OR any](
-	d *schema.ResourceData,
 	ctx context.Context,
+	d *schema.ResourceData,
 	client *sdk.Client,
 	id *sdk.DatabaseObjectIdentifier,
 	objectRenameFn func(sdk.DatabaseObjectIdentifier, sdk.DatabaseObjectIdentifier) func() error,
@@ -187,15 +187,7 @@ func handleTwoLevelHierarchyRename[OR any](
 			description)
 	}
 
-	if diags := handleShallowHierarchyRename(d, ctx,
-		client.Databases.ShowByID,
-		objectShowByIDFn,
-		newDatabaseId, oldDatabaseId,
-		newObjectId, oldObjectId,
-		*id,
-		renameObj, moveObj,
-		"database", leafLevelName, leafLevelName,
-	); diags != nil {
+	if diags := handleShallowHierarchyRename(ctx, d, client.Databases.ShowByID, objectShowByIDFn, newDatabaseId, oldDatabaseId, newObjectId, oldObjectId, *id, renameObj, moveObj, "database", leafLevelName, leafLevelName); diags != nil {
 		return diags
 	}
 
@@ -207,8 +199,8 @@ func handleTwoLevelHierarchyRename[OR any](
 // for a schema-level object (database → schema → object).
 // OR is the return type of objectShowByIDFn.
 func handleThreeLevelHierarchyRename[OR any](
-	d *schema.ResourceData,
 	ctx context.Context,
+	d *schema.ResourceData,
 	client *sdk.Client,
 	id *sdk.SchemaObjectIdentifier,
 	objectRenameFn func(sdk.SchemaObjectIdentifier, sdk.SchemaObjectIdentifier) func() error,
@@ -248,39 +240,17 @@ func handleThreeLevelHierarchyRename[OR any](
 
 	switch {
 	case databaseChanged && !schemaChanged:
-		if diags := handleShallowHierarchyRename(d, ctx,
-			client.Databases.ShowByID,
-			client.Schemas.ShowByID,
-			newDatabaseId, oldDatabaseId,
-			newSchemaId, oldSchemaId,
-			*id,
-			renameObj, moveObj,
-			"database", "schema", leafLevelName,
-		); diags != nil {
+		if diags := handleShallowHierarchyRename(ctx, d, client.Databases.ShowByID, client.Schemas.ShowByID, newDatabaseId, oldDatabaseId, newSchemaId, oldSchemaId, *id, renameObj, moveObj, "database", "schema", leafLevelName); diags != nil {
 			return diags
 		}
 
 	case !databaseChanged && schemaChanged:
-		if diags := handleShallowHierarchyRename(d, ctx,
-			client.Schemas.ShowByID,
-			objectShowByIDFn,
-			newSchemaId, oldSchemaId,
-			newObjectId, oldObjectId,
-			*id,
-			renameObj, moveObj,
-			"schema", leafLevelName, leafLevelName,
-		); diags != nil {
+		if diags := handleShallowHierarchyRename(ctx, d, client.Schemas.ShowByID, objectShowByIDFn, newSchemaId, oldSchemaId, newObjectId, oldObjectId, *id, renameObj, moveObj, "schema", leafLevelName, leafLevelName); diags != nil {
 			return diags
 		}
 
 	default:
-		if diags := handleDeepHierarchyRename(d, ctx, client,
-			newDatabaseId, oldDatabaseId,
-			oldSchemaName, newSchemaName,
-			objectName,
-			renameObj, moveObj,
-			leafLevelName,
-		); diags != nil {
+		if diags := handleDeepHierarchyRename(ctx, d, client, newDatabaseId, oldDatabaseId, oldSchemaName, newSchemaName, objectName, renameObj, moveObj, leafLevelName); diags != nil {
 			return diags
 		}
 	}

--- a/pkg/resources/hierarchy_renames.go
+++ b/pkg/resources/hierarchy_renames.go
@@ -1,0 +1,36 @@
+package resources
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func isRenameOfTheGivenLevelInTheHierarchy(newParentExists, oldParentExists, objectAtTargetLocationExists bool) bool {
+	return newParentExists && !oldParentExists && objectAtTargetLocationExists
+}
+
+func isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newParentExists, oldParentExists, objectAtSourceLocationExists bool) bool {
+	return newParentExists && oldParentExists && objectAtSourceLocationExists
+}
+
+// handleHierarchyRenameIdUpdate handles the "rename" case: a parent was renamed,
+// so only the Terraform state ID needs updating (no Snowflake ALTER needed).
+func handleHierarchyRenameIdUpdate(d *schema.ResourceData, encodeIdFn func() string, logMsg string) {
+	log.Printf("[DEBUG] %s", logMsg)
+	d.SetId(encodeIdFn())
+}
+
+// handleHierarchyMove handles the "move" case: performs the ALTER to move the object
+// to its new location and updates the Terraform state ID.
+func handleHierarchyMove(d *schema.ResourceData, encodeIdFn func() string, currentFQN, targetFQN string, alterFn func() error, logMsg string) diag.Diagnostics {
+	log.Printf("[DEBUG] %s", logMsg)
+	if err := alterFn(); err != nil {
+		d.Partial(true)
+		return diag.FromErr(fmt.Errorf("failed to move from %s to %s: %w", currentFQN, targetFQN, err))
+	}
+	d.SetId(encodeIdFn())
+	return nil
+}

--- a/pkg/resources/hierarchy_renames.go
+++ b/pkg/resources/hierarchy_renames.go
@@ -11,37 +11,118 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func isRenameOfTheGivenLevelInTheHierarchy(newParentExists, oldParentExists, objectAtTargetLocationExists bool) bool {
-	return newParentExists && !oldParentExists && objectAtTargetLocationExists
-}
+// handleTwoLevelHierarchyRename handles the full 2-level hierarchy rename/move
+// for a database-level object (database → object).
+// OR is the return type of objectShowByIDFn.
+func handleTwoLevelHierarchyRename[OR any](
+	ctx context.Context,
+	d *schema.ResourceData,
+	client *sdk.Client,
+	id *sdk.DatabaseObjectIdentifier,
+	objectRenameFn func(sdk.DatabaseObjectIdentifier, sdk.DatabaseObjectIdentifier) func() error,
+	objectShowByIDFn func(context.Context, sdk.DatabaseObjectIdentifier) (OR, error),
+	encodeIdFn func(sdk.DatabaseObjectIdentifier) string,
+	leafLevelName string,
+) diag.Diagnostics {
+	oldDatabaseNameRaw, newDatabaseNameRaw := d.GetChange("database")
+	oldDatabaseName, newDatabaseName := oldDatabaseNameRaw.(string), newDatabaseNameRaw.(string)
+	objectName := id.Name()
 
-func isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newParentExists, oldParentExists, objectAtSourceLocationExists bool) bool {
-	return newParentExists && oldParentExists && objectAtSourceLocationExists
-}
+	oldDatabaseId := sdk.NewAccountObjectIdentifier(oldDatabaseName)
+	newDatabaseId := sdk.NewAccountObjectIdentifier(newDatabaseName)
+	oldObjectId := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, objectName)
+	newObjectId := sdk.NewDatabaseObjectIdentifier(newDatabaseName, objectName)
 
-// handleHierarchyRenameIdUpdate handles the "rename" case: a parent was renamed,
-// so only the Terraform state ID needs updating (no Snowflake ALTER needed).
-func handleHierarchyRenameIdUpdate(d *schema.ResourceData, encodeIdFn func() string, caseDescription string) {
-	log.Printf("[DEBUG] %s - no Snowflake modification needed, updating the id...", caseDescription)
-	d.SetId(encodeIdFn())
-}
-
-// handleHierarchyMove handles the "move" case: performs the ALTER to move the object
-// to its new location and updates the Terraform state ID.
-func handleHierarchyMove[T sdk.ObjectIdentifier](d *schema.ResourceData, encodeIdFn func() string, currentId, targetId T, renameFn func(T, T) func() error, caseDescription string) diag.Diagnostics {
-	log.Printf("[DEBUG] %s - executing ALTER RENAME TO from %s to %s...", caseDescription, currentId.FullyQualifiedName(), targetId.FullyQualifiedName())
-	if err := renameFn(currentId, targetId)(); err != nil {
-		d.Partial(true)
-		return diag.FromErr(fmt.Errorf("failed to move from %s to %s: %w", currentId.FullyQualifiedName(), targetId.FullyQualifiedName(), err))
+	renameObj := func(description string) {
+		handleHierarchyRenameIdUpdate(d,
+			func() string { return encodeIdFn(newObjectId) },
+			description)
 	}
-	d.SetId(encodeIdFn())
+
+	moveObj := func(currentId sdk.DatabaseObjectIdentifier, description string) diag.Diagnostics {
+		return handleHierarchyMove(d,
+			func() string { return encodeIdFn(newObjectId) },
+			currentId, newObjectId,
+			objectRenameFn,
+			description)
+	}
+
+	if diags := handleOneParentChangeRename(ctx, d, client.Databases.ShowByID, objectShowByIDFn, newDatabaseId, oldDatabaseId, newObjectId, oldObjectId, *id, renameObj, moveObj, "database", leafLevelName, leafLevelName); diags != nil {
+		return diags
+	}
+
+	*id = newObjectId
 	return nil
 }
 
-// handleShallowHierarchyRename handles the complete single-level rename/move detection.
+// handleThreeLevelHierarchyRename handles the full 3-level hierarchy rename/move
+// for a schema-level object (database → schema → object).
+// OR is the return type of objectShowByIDFn.
+func handleThreeLevelHierarchyRename[OR any](
+	ctx context.Context,
+	d *schema.ResourceData,
+	client *sdk.Client,
+	id *sdk.SchemaObjectIdentifier,
+	objectRenameFn func(sdk.SchemaObjectIdentifier, sdk.SchemaObjectIdentifier) func() error,
+	objectShowByIDFn func(context.Context, sdk.SchemaObjectIdentifier) (OR, error),
+	encodeIdFn func(sdk.SchemaObjectIdentifier) string,
+	leafLevelName string,
+) diag.Diagnostics {
+	oldDatabaseNameRaw, newDatabaseNameRaw := d.GetChange("database")
+	oldDatabaseName, newDatabaseName := oldDatabaseNameRaw.(string), newDatabaseNameRaw.(string)
+	oldSchemaNameRaw, newSchemaNameRaw := d.GetChange("schema")
+	oldSchemaName, newSchemaName := oldSchemaNameRaw.(string), newSchemaNameRaw.(string)
+	objectName := id.Name()
+
+	databaseChanged := d.HasChange("database")
+	schemaChanged := d.HasChange("schema")
+
+	oldDatabaseId := sdk.NewAccountObjectIdentifier(oldDatabaseName)
+	newDatabaseId := sdk.NewAccountObjectIdentifier(newDatabaseName)
+	oldSchemaId := sdk.NewDatabaseObjectIdentifierInDatabase(oldDatabaseId, oldSchemaName)
+	newSchemaId := sdk.NewDatabaseObjectIdentifierInDatabase(newDatabaseId, newSchemaName)
+	oldObjectId := sdk.NewSchemaObjectIdentifierInSchema(oldSchemaId, objectName)
+	newObjectId := sdk.NewSchemaObjectIdentifierInSchema(newSchemaId, objectName)
+
+	renameObj := func(description string) {
+		handleHierarchyRenameIdUpdate(d,
+			func() string { return encodeIdFn(newObjectId) },
+			description)
+	}
+
+	moveObj := func(currentId sdk.SchemaObjectIdentifier, description string) diag.Diagnostics {
+		return handleHierarchyMove(d,
+			func() string { return encodeIdFn(newObjectId) },
+			currentId, newObjectId,
+			objectRenameFn,
+			description)
+	}
+
+	switch {
+	case databaseChanged && !schemaChanged:
+		if diags := handleOneParentChangeRename(ctx, d, client.Databases.ShowByID, client.Schemas.ShowByID, newDatabaseId, oldDatabaseId, newSchemaId, oldSchemaId, *id, renameObj, moveObj, "database", "schema", leafLevelName); diags != nil {
+			return diags
+		}
+
+	case !databaseChanged && schemaChanged:
+		if diags := handleOneParentChangeRename(ctx, d, client.Schemas.ShowByID, objectShowByIDFn, newSchemaId, oldSchemaId, newObjectId, oldObjectId, *id, renameObj, moveObj, "schema", leafLevelName, leafLevelName); diags != nil {
+			return diags
+		}
+
+	default:
+		if diags := handleBothParentsChangeRename(ctx, d, client, newDatabaseId, oldDatabaseId, oldSchemaName, newSchemaName, objectName, renameObj, moveObj, leafLevelName); diags != nil {
+			return diags
+		}
+	}
+
+	*id = newObjectId
+	return nil
+}
+
+// handleOneParentChangeRename handles the complete single-level rename/move detection.
 // P is the parent identifier type, O is the probed object identifier type, M is the moved object type.
 // PR and OR are the return types of the ShowByID functions.
-func handleShallowHierarchyRename[P, O, M sdk.ObjectIdentifier, PR, OR any](
+func handleOneParentChangeRename[P, O, M sdk.ObjectIdentifier, PR, OR any](
 	ctx context.Context,
 	d *schema.ResourceData,
 	parentShowByIDFn func(context.Context, P) (PR, error),
@@ -64,6 +145,21 @@ func handleShallowHierarchyRename[P, O, M sdk.ObjectIdentifier, PR, OR any](
 	_, errCurrentObject := objectShowByIDFn(ctx, currentObjectId)
 	objectAtSourceExists := errCurrentObject == nil
 
+	capitalize := func(s string) string {
+		if len(s) == 0 {
+			return s
+		}
+		return strings.ToUpper(s[:1]) + s[1:]
+	}
+
+	isRenameOfTheGivenLevelInTheHierarchy := func(newParentExists, oldParentExists, objectAtTargetLocationExists bool) bool {
+		return newParentExists && !oldParentExists && objectAtTargetLocationExists
+	}
+
+	isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy := func(newParentExists, oldParentExists, objectAtSourceLocationExists bool) bool {
+		return newParentExists && oldParentExists && objectAtSourceLocationExists
+	}
+
 	switch {
 	case isRenameOfTheGivenLevelInTheHierarchy(newParentExists, oldParentExists, objectAtTargetExists):
 		renameFn(fmt.Sprintf("%s was renamed for %s", capitalize(parentLevelName), leafLevelName))
@@ -82,10 +178,10 @@ func handleShallowHierarchyRename[P, O, M sdk.ObjectIdentifier, PR, OR any](
 	}
 }
 
-// handleDeepHierarchyRename handles the case where both database AND schema change
+// handleBothParentsChangeRename handles the case where both database AND schema change
 // for a schema-level object. It determines whether the database/schema were renamed
 // or moved and acts accordingly.
-func handleDeepHierarchyRename(
+func handleBothParentsChangeRename(
 	ctx context.Context,
 	d *schema.ResourceData,
 	client *sdk.Client,
@@ -151,117 +247,21 @@ func handleDeepHierarchyRename(
 	}
 }
 
-// handleTwoLevelHierarchyRename handles the full 2-level hierarchy rename/move
-// for a database-level object (database → object).
-// OR is the return type of objectShowByIDFn.
-func handleTwoLevelHierarchyRename[OR any](
-	ctx context.Context,
-	d *schema.ResourceData,
-	client *sdk.Client,
-	id *sdk.DatabaseObjectIdentifier,
-	objectRenameFn func(sdk.DatabaseObjectIdentifier, sdk.DatabaseObjectIdentifier) func() error,
-	objectShowByIDFn func(context.Context, sdk.DatabaseObjectIdentifier) (OR, error),
-	encodeIdFn func(sdk.DatabaseObjectIdentifier) string,
-	leafLevelName string,
-) diag.Diagnostics {
-	oldDatabaseNameRaw, newDatabaseNameRaw := d.GetChange("database")
-	oldDatabaseName, newDatabaseName := oldDatabaseNameRaw.(string), newDatabaseNameRaw.(string)
-	objectName := id.Name()
-
-	oldDatabaseId := sdk.NewAccountObjectIdentifier(oldDatabaseName)
-	newDatabaseId := sdk.NewAccountObjectIdentifier(newDatabaseName)
-	oldObjectId := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, objectName)
-	newObjectId := sdk.NewDatabaseObjectIdentifier(newDatabaseName, objectName)
-
-	renameObj := func(description string) {
-		handleHierarchyRenameIdUpdate(d,
-			func() string { return encodeIdFn(newObjectId) },
-			description)
-	}
-
-	moveObj := func(currentId sdk.DatabaseObjectIdentifier, description string) diag.Diagnostics {
-		return handleHierarchyMove(d,
-			func() string { return encodeIdFn(newObjectId) },
-			currentId, newObjectId,
-			objectRenameFn,
-			description)
-	}
-
-	if diags := handleShallowHierarchyRename(ctx, d, client.Databases.ShowByID, objectShowByIDFn, newDatabaseId, oldDatabaseId, newObjectId, oldObjectId, *id, renameObj, moveObj, "database", leafLevelName, leafLevelName); diags != nil {
-		return diags
-	}
-
-	*id = newObjectId
-	return nil
+// handleHierarchyRenameIdUpdate handles the "rename" case: a parent was renamed,
+// so only the Terraform state ID needs updating (no Snowflake ALTER needed).
+func handleHierarchyRenameIdUpdate(d *schema.ResourceData, encodeIdFn func() string, caseDescription string) {
+	log.Printf("[DEBUG] %s - no Snowflake modification needed, updating the id...", caseDescription)
+	d.SetId(encodeIdFn())
 }
 
-// handleThreeLevelHierarchyRename handles the full 3-level hierarchy rename/move
-// for a schema-level object (database → schema → object).
-// OR is the return type of objectShowByIDFn.
-func handleThreeLevelHierarchyRename[OR any](
-	ctx context.Context,
-	d *schema.ResourceData,
-	client *sdk.Client,
-	id *sdk.SchemaObjectIdentifier,
-	objectRenameFn func(sdk.SchemaObjectIdentifier, sdk.SchemaObjectIdentifier) func() error,
-	objectShowByIDFn func(context.Context, sdk.SchemaObjectIdentifier) (OR, error),
-	encodeIdFn func(sdk.SchemaObjectIdentifier) string,
-	leafLevelName string,
-) diag.Diagnostics {
-	oldDatabaseNameRaw, newDatabaseNameRaw := d.GetChange("database")
-	oldDatabaseName, newDatabaseName := oldDatabaseNameRaw.(string), newDatabaseNameRaw.(string)
-	oldSchemaNameRaw, newSchemaNameRaw := d.GetChange("schema")
-	oldSchemaName, newSchemaName := oldSchemaNameRaw.(string), newSchemaNameRaw.(string)
-	objectName := id.Name()
-
-	databaseChanged := d.HasChange("database")
-	schemaChanged := d.HasChange("schema")
-
-	oldDatabaseId := sdk.NewAccountObjectIdentifier(oldDatabaseName)
-	newDatabaseId := sdk.NewAccountObjectIdentifier(newDatabaseName)
-	oldSchemaId := sdk.NewDatabaseObjectIdentifierInDatabase(oldDatabaseId, oldSchemaName)
-	newSchemaId := sdk.NewDatabaseObjectIdentifierInDatabase(newDatabaseId, newSchemaName)
-	oldObjectId := sdk.NewSchemaObjectIdentifierInSchema(oldSchemaId, objectName)
-	newObjectId := sdk.NewSchemaObjectIdentifierInSchema(newSchemaId, objectName)
-
-	renameObj := func(description string) {
-		handleHierarchyRenameIdUpdate(d,
-			func() string { return encodeIdFn(newObjectId) },
-			description)
+// handleHierarchyMove handles the "move" case: performs the ALTER to move the object
+// to its new location and updates the Terraform state ID.
+func handleHierarchyMove[T sdk.ObjectIdentifier](d *schema.ResourceData, encodeIdFn func() string, currentId, targetId T, renameFn func(T, T) func() error, caseDescription string) diag.Diagnostics {
+	log.Printf("[DEBUG] %s - executing ALTER RENAME TO from %s to %s...", caseDescription, currentId.FullyQualifiedName(), targetId.FullyQualifiedName())
+	if err := renameFn(currentId, targetId)(); err != nil {
+		d.Partial(true)
+		return diag.FromErr(fmt.Errorf("failed to move from %s to %s: %w", currentId.FullyQualifiedName(), targetId.FullyQualifiedName(), err))
 	}
-
-	moveObj := func(currentId sdk.SchemaObjectIdentifier, description string) diag.Diagnostics {
-		return handleHierarchyMove(d,
-			func() string { return encodeIdFn(newObjectId) },
-			currentId, newObjectId,
-			objectRenameFn,
-			description)
-	}
-
-	switch {
-	case databaseChanged && !schemaChanged:
-		if diags := handleShallowHierarchyRename(ctx, d, client.Databases.ShowByID, client.Schemas.ShowByID, newDatabaseId, oldDatabaseId, newSchemaId, oldSchemaId, *id, renameObj, moveObj, "database", "schema", leafLevelName); diags != nil {
-			return diags
-		}
-
-	case !databaseChanged && schemaChanged:
-		if diags := handleShallowHierarchyRename(ctx, d, client.Schemas.ShowByID, objectShowByIDFn, newSchemaId, oldSchemaId, newObjectId, oldObjectId, *id, renameObj, moveObj, "schema", leafLevelName, leafLevelName); diags != nil {
-			return diags
-		}
-
-	default:
-		if diags := handleDeepHierarchyRename(ctx, d, client, newDatabaseId, oldDatabaseId, oldSchemaName, newSchemaName, objectName, renameObj, moveObj, leafLevelName); diags != nil {
-			return diags
-		}
-	}
-
-	*id = newObjectId
+	d.SetId(encodeIdFn())
 	return nil
-}
-
-func capitalize(s string) string {
-	if len(s) == 0 {
-		return s
-	}
-	return strings.ToUpper(s[:1]) + s[1:]
 }

--- a/pkg/resources/hierarchy_renames.go
+++ b/pkg/resources/hierarchy_renames.go
@@ -82,6 +82,75 @@ func handleShallowHierarchyRename[P, O, M sdk.ObjectIdentifier, PR, OR any](
 	}
 }
 
+// handleDeepHierarchyRename handles the case where both database AND schema change
+// for a schema-level object. It determines whether the database/schema were renamed
+// or moved and acts accordingly.
+func handleDeepHierarchyRename(
+	d *schema.ResourceData,
+	ctx context.Context,
+	client *sdk.Client,
+	newDatabaseId, oldDatabaseId sdk.AccountObjectIdentifier,
+	oldSchemaName, newSchemaName string,
+	objectName string,
+	renameFn func(string),
+	moveFn func(sdk.SchemaObjectIdentifier, string) diag.Diagnostics,
+	leafLevelName string,
+) diag.Diagnostics {
+	oldDatabaseName := oldDatabaseId.Name()
+	newDatabaseName := newDatabaseId.Name()
+
+	// Probe databases
+	_, errNewDb := client.Databases.ShowByID(ctx, newDatabaseId)
+	newDatabaseExists := errNewDb == nil
+	_, errOldDb := client.Databases.ShowByID(ctx, oldDatabaseId)
+	oldDatabaseExists := errOldDb == nil
+
+	// Probe schemas (4 combinations)
+	schemaInNewDbOldName := sdk.NewDatabaseObjectIdentifier(newDatabaseName, oldSchemaName)
+	schemaInNewDbNewName := sdk.NewDatabaseObjectIdentifier(newDatabaseName, newSchemaName)
+	schemaInOldDbOldName := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, oldSchemaName)
+	schemaInOldDbNewName := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, newSchemaName)
+
+	_, errSchemaNewDbOld := client.Schemas.ShowByID(ctx, schemaInNewDbOldName)
+	schemaNewDbOldExists := errSchemaNewDbOld == nil
+	_, errSchemaNewDbNew := client.Schemas.ShowByID(ctx, schemaInNewDbNewName)
+	schemaNewDbNewExists := errSchemaNewDbNew == nil
+	_, errSchemaOldDbOld := client.Schemas.ShowByID(ctx, schemaInOldDbOldName)
+	schemaOldDbOldExists := errSchemaOldDbOld == nil
+	_, errSchemaOldDbNew := client.Schemas.ShowByID(ctx, schemaInOldDbNewName)
+	schemaOldDbNewExists := errSchemaOldDbNew == nil
+
+	switch {
+	// Scenario 1: DB rename + Schema rename → just update ID
+	case !oldDatabaseExists && newDatabaseExists && !schemaNewDbOldExists && schemaNewDbNewExists:
+		renameFn(fmt.Sprintf("Database and schema were both renamed for %s", leafLevelName))
+		return nil
+	// Scenario 2: DB rename + Schema move → object is at (newDb, oldSchema)
+	case !oldDatabaseExists && newDatabaseExists && schemaNewDbOldExists:
+		currentId := sdk.NewSchemaObjectIdentifier(newDatabaseName, oldSchemaName, objectName)
+		return moveFn(currentId, fmt.Sprintf("Database was renamed, moving %s to different schema", leafLevelName))
+	// Scenario 3: DB move + Schema rename → object is at (oldDb, newSchema)
+	case oldDatabaseExists && newDatabaseExists && !schemaOldDbOldExists && schemaOldDbNewExists:
+		currentId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, newSchemaName, objectName)
+		return moveFn(currentId, fmt.Sprintf("Schema was renamed, moving %s to different database", leafLevelName))
+	// Scenario 4: DB move + Schema move → object is at (oldDb, oldSchema)
+	case oldDatabaseExists && newDatabaseExists && schemaOldDbOldExists:
+		currentId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, oldSchemaName, objectName)
+		return moveFn(currentId, fmt.Sprintf("Moving %s to different database and schema", leafLevelName))
+	default:
+		d.Partial(true)
+		return diag.FromErr(fmt.Errorf(
+			"unknown rename use case: old database %s (exists: %t), new database %s (exists: %t), schema %s (exists: %t), schema %s (exists: %t), schema %s (exists: %t), schema %s (exists: %t). See https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/object_renaming_guide",
+			oldDatabaseId.FullyQualifiedName(), oldDatabaseExists,
+			newDatabaseId.FullyQualifiedName(), newDatabaseExists,
+			schemaInNewDbOldName.FullyQualifiedName(), schemaNewDbOldExists,
+			schemaInNewDbNewName.FullyQualifiedName(), schemaNewDbNewExists,
+			schemaInOldDbOldName.FullyQualifiedName(), schemaOldDbOldExists,
+			schemaInOldDbNewName.FullyQualifiedName(), schemaOldDbNewExists,
+		))
+	}
+}
+
 func capitalize(s string) string {
 	if len(s) == 0 {
 		return s

--- a/pkg/resources/hierarchy_renames.go
+++ b/pkg/resources/hierarchy_renames.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -18,18 +19,18 @@ func isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newParentExists, oldP
 
 // handleHierarchyRenameIdUpdate handles the "rename" case: a parent was renamed,
 // so only the Terraform state ID needs updating (no Snowflake ALTER needed).
-func handleHierarchyRenameIdUpdate(d *schema.ResourceData, encodeIdFn func() string, logMsg string) {
-	log.Printf("[DEBUG] %s", logMsg)
+func handleHierarchyRenameIdUpdate(d *schema.ResourceData, encodeIdFn func() string, caseDescription string) {
+	log.Printf("[DEBUG] %s - no Snowflake modification needed, updating the id...", caseDescription)
 	d.SetId(encodeIdFn())
 }
 
 // handleHierarchyMove handles the "move" case: performs the ALTER to move the object
 // to its new location and updates the Terraform state ID.
-func handleHierarchyMove(d *schema.ResourceData, encodeIdFn func() string, currentFQN, targetFQN string, alterFn func() error, logMsg string) diag.Diagnostics {
-	log.Printf("[DEBUG] %s", logMsg)
+func handleHierarchyMove(d *schema.ResourceData, encodeIdFn func() string, currentId, targetId sdk.ObjectIdentifier, alterFn func() error, caseDescription string) diag.Diagnostics {
+	log.Printf("[DEBUG] %s - executing ALTER RENAME TO from %s to %s...", caseDescription, currentId.FullyQualifiedName(), targetId.FullyQualifiedName())
 	if err := alterFn(); err != nil {
 		d.Partial(true)
-		return diag.FromErr(fmt.Errorf("failed to move from %s to %s: %w", currentFQN, targetFQN, err))
+		return diag.FromErr(fmt.Errorf("failed to move from %s to %s: %w", currentId.FullyQualifiedName(), targetId.FullyQualifiedName(), err))
 	}
 	d.SetId(encodeIdFn())
 	return nil

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -347,31 +347,16 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 				description)
 		}
 
-		_, errNewDb := client.Databases.ShowByID(ctx, newDatabaseId)
-		newDatabaseExists := errNewDb == nil
-		_, errOldDb := client.Databases.ShowByID(ctx, oldDatabaseId)
-		oldDatabaseExists := errOldDb == nil
-		_, errNewSchema := client.Schemas.ShowByID(ctx, newSchemaId)
-		newSchemaExists := errNewSchema == nil
-		_, errOldSchema := client.Schemas.ShowByID(ctx, oldSchemaId)
-		oldSchemaExists := errOldSchema == nil
-
-		switch {
-		case isRenameOfTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, newSchemaExists):
-			renameSchema("Database was renamed for schema")
-		case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, oldSchemaExists):
-			if diags := moveSchema(oldSchemaId, "Moving schema to different database"); diags != nil {
-				return diags
-			}
-		default:
-			d.Partial(true)
-			return diag.FromErr(fmt.Errorf(
-				"unknown rename use case: old database %s (exists: %t), new database %s (exists: %t), old schema %s (exists: %t), new schema %s (exists: %t). See https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/object_renaming_guide",
-				oldDatabaseId.FullyQualifiedName(), oldDatabaseExists,
-				newDatabaseId.FullyQualifiedName(), newDatabaseExists,
-				oldSchemaId.FullyQualifiedName(), oldSchemaExists,
-				newSchemaId.FullyQualifiedName(), newSchemaExists,
-			))
+		if diags := handleShallowHierarchyRename(d, ctx,
+			client.Databases.ShowByID,
+			client.Schemas.ShowByID,
+			newDatabaseId, oldDatabaseId,
+			newSchemaId, oldSchemaId,
+			oldSchemaId,
+			renameSchema, moveSchema,
+			"database", "schema", "schema",
+		); diags != nil {
+			return diags
 		}
 
 		id = newSchemaId

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -340,16 +340,16 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 		case isRenameOfTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, newSchemaExists):
 			handleHierarchyRenameIdUpdate(d,
 				func() string { return helpers.EncodeResourceIdentifier(newSchemaId) },
-				"Database was renamed for schema - no Snowflake modification needed, updating the id...")
+				"Database was renamed for schema")
 			id = newSchemaId
 		case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, oldSchemaExists):
 			if diags := handleHierarchyMove(d,
 				func() string { return helpers.EncodeResourceIdentifier(newSchemaId) },
-				oldSchemaId.FullyQualifiedName(), newSchemaId.FullyQualifiedName(),
+				oldSchemaId, newSchemaId,
 				func() error {
 					return client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(oldSchemaId).WithNewName(newSchemaId))
 				},
-				"Moving schema to different database - executing ALTER RENAME..."); diags != nil {
+				"Moving schema to different database"); diags != nil {
 				return diags
 			}
 			id = newSchemaId

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -324,7 +324,13 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 			}
 		}
 
-		if diags := handleTwoLevelHierarchyRename(ctx, d, client, &id, schemaRenameFn, client.Schemas.ShowByID, func(id sdk.DatabaseObjectIdentifier) string { return helpers.EncodeResourceIdentifier(id) }, "schema"); diags != nil {
+		if diags := handleTwoLevelHierarchyRename(
+			ctx, d, client, &id,
+			schemaRenameFn,
+			client.Schemas.ShowByID,
+			func(id sdk.DatabaseObjectIdentifier) string { return helpers.EncodeResourceIdentifier(id) },
+			"schema",
+		); diags != nil {
 			return diags
 		}
 	}

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -333,6 +333,20 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 			}
 		}
 
+		renameSchema := func(description string) {
+			handleHierarchyRenameIdUpdate(d,
+				func() string { return helpers.EncodeResourceIdentifier(newSchemaId) },
+				description)
+		}
+
+		moveSchema := func(currentId sdk.DatabaseObjectIdentifier, description string) diag.Diagnostics {
+			return handleHierarchyMove(d,
+				func() string { return helpers.EncodeResourceIdentifier(newSchemaId) },
+				currentId, newSchemaId,
+				schemaRenameFn,
+				description)
+		}
+
 		_, errNewDb := client.Databases.ShowByID(ctx, newDatabaseId)
 		newDatabaseExists := errNewDb == nil
 		_, errOldDb := client.Databases.ShowByID(ctx, oldDatabaseId)
@@ -344,19 +358,11 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 
 		switch {
 		case isRenameOfTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, newSchemaExists):
-			handleHierarchyRenameIdUpdate(d,
-				func() string { return helpers.EncodeResourceIdentifier(newSchemaId) },
-				"Database was renamed for schema")
-			id = newSchemaId
+			renameSchema("Database was renamed for schema")
 		case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, oldSchemaExists):
-			if diags := handleHierarchyMove(d,
-				func() string { return helpers.EncodeResourceIdentifier(newSchemaId) },
-				oldSchemaId, newSchemaId,
-				schemaRenameFn,
-				"Moving schema to different database"); diags != nil {
+			if diags := moveSchema(oldSchemaId, "Moving schema to different database"); diags != nil {
 				return diags
 			}
-			id = newSchemaId
 		default:
 			d.Partial(true)
 			return diag.FromErr(fmt.Errorf(
@@ -367,6 +373,8 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 				newSchemaId.FullyQualifiedName(), newSchemaExists,
 			))
 		}
+
+		id = newSchemaId
 	}
 
 	if d.HasChange("name") && !d.GetRawState().IsNull() {

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -336,31 +336,22 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 		_, errOldSchema := client.Schemas.ShowByID(ctx, oldSchemaId)
 		oldSchemaExists := errOldSchema == nil
 
-		// TODO [next PRs]: extract helper methods and generalize them to any non-leaf level; same with switch and error handling
-		isRenameOfTheGivenLevelInTheHierarchy := func() bool {
-			return newDatabaseExists && !oldDatabaseExists && newSchemaExists
-		}
-
-		isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy := func() bool {
-			return newDatabaseExists && oldDatabaseExists && oldSchemaExists
-		}
-
 		switch {
-		// Case 1: "Rename of the given level in the hierarchy"
-		case isRenameOfTheGivenLevelInTheHierarchy():
-			log.Printf("[DEBUG] Database was renamed for schema - no Snowflake modification needed, updating the id...")
-			// Just update the ID — no Snowflake modification needed
-			d.SetId(helpers.EncodeResourceIdentifier(newSchemaId))
+		case isRenameOfTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, newSchemaExists):
+			handleHierarchyRenameIdUpdate(d,
+				func() string { return helpers.EncodeResourceIdentifier(newSchemaId) },
+				"Database was renamed for schema - no Snowflake modification needed, updating the id...")
 			id = newSchemaId
-		// Case 2: "Move to a different object on the given level in the hierarchy"
-		case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy():
-			log.Printf("[DEBUG] Moving schema to different database - executing ALTER RENAME...")
-			// Perform the rename in Snowflake: ALTER SCHEMA A.X RENAME TO B.X
-			if renameErr := client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(oldSchemaId).WithNewName(newSchemaId)); renameErr != nil {
-				d.Partial(true)
-				return diag.FromErr(fmt.Errorf("failed to move schema from %s to %s: %w", oldSchemaId.FullyQualifiedName(), newSchemaId.FullyQualifiedName(), renameErr))
+		case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, oldSchemaExists):
+			if diags := handleHierarchyMove(d,
+				func() string { return helpers.EncodeResourceIdentifier(newSchemaId) },
+				oldSchemaId.FullyQualifiedName(), newSchemaId.FullyQualifiedName(),
+				func() error {
+					return client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(oldSchemaId).WithNewName(newSchemaId))
+				},
+				"Moving schema to different database - executing ALTER RENAME..."); diags != nil {
+				return diags
 			}
-			d.SetId(helpers.EncodeResourceIdentifier(newSchemaId))
 			id = newSchemaId
 		default:
 			d.Partial(true)

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -327,6 +327,12 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 		newSchemaId := sdk.NewDatabaseObjectIdentifier(newDatabaseName, oldSchemaName)
 		oldSchemaId := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, oldSchemaName)
 
+		schemaRenameFn := func(currentId, targetId sdk.DatabaseObjectIdentifier) func() error {
+			return func() error {
+				return client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(oldSchemaId).WithNewName(newSchemaId))
+			}
+		}
+
 		_, errNewDb := client.Databases.ShowByID(ctx, newDatabaseId)
 		newDatabaseExists := errNewDb == nil
 		_, errOldDb := client.Databases.ShowByID(ctx, oldDatabaseId)
@@ -346,9 +352,7 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 			if diags := handleHierarchyMove(d,
 				func() string { return helpers.EncodeResourceIdentifier(newSchemaId) },
 				oldSchemaId, newSchemaId,
-				func() error {
-					return client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(oldSchemaId).WithNewName(newSchemaId))
-				},
+				schemaRenameFn,
 				"Moving schema to different database"); diags != nil {
 				return diags
 			}

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -324,12 +324,7 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 			}
 		}
 
-		if diags := handleTwoLevelHierarchyRename(d, ctx, client, &id,
-			schemaRenameFn,
-			client.Schemas.ShowByID,
-			func(id sdk.DatabaseObjectIdentifier) string { return helpers.EncodeResourceIdentifier(id) },
-			"schema",
-		); diags != nil {
+		if diags := handleTwoLevelHierarchyRename(ctx, d, client, &id, schemaRenameFn, client.Schemas.ShowByID, func(id sdk.DatabaseObjectIdentifier) string { return helpers.EncodeResourceIdentifier(id) }, "schema"); diags != nil {
 			return diags
 		}
 	}

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -320,7 +320,7 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 	if experimentalfeatures.IsExperimentEnabled(experimentalfeatures.HierarchyRenames, providerCtx.EnabledExperiments) && d.HasChange("database") {
 		schemaRenameFn := func(currentId, targetId sdk.DatabaseObjectIdentifier) func() error {
 			return func() error {
-				return client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(oldSchemaId).WithNewName(newSchemaId))
+				return client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(currentId).WithNewName(targetId))
 			}
 		}
 

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -318,48 +318,20 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	if experimentalfeatures.IsExperimentEnabled(experimentalfeatures.HierarchyRenames, providerCtx.EnabledExperiments) && d.HasChange("database") {
-		oldDatabaseNameRaw, newDatabaseNameRaw := d.GetChange("database")
-		oldDatabaseName, newDatabaseName := oldDatabaseNameRaw.(string), newDatabaseNameRaw.(string)
-		oldSchemaName := id.Name()
-
-		oldDatabaseId := sdk.NewAccountObjectIdentifier(oldDatabaseName)
-		newDatabaseId := sdk.NewAccountObjectIdentifier(newDatabaseName)
-		newSchemaId := sdk.NewDatabaseObjectIdentifier(newDatabaseName, oldSchemaName)
-		oldSchemaId := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, oldSchemaName)
-
 		schemaRenameFn := func(currentId, targetId sdk.DatabaseObjectIdentifier) func() error {
 			return func() error {
 				return client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(oldSchemaId).WithNewName(newSchemaId))
 			}
 		}
 
-		renameSchema := func(description string) {
-			handleHierarchyRenameIdUpdate(d,
-				func() string { return helpers.EncodeResourceIdentifier(newSchemaId) },
-				description)
-		}
-
-		moveSchema := func(currentId sdk.DatabaseObjectIdentifier, description string) diag.Diagnostics {
-			return handleHierarchyMove(d,
-				func() string { return helpers.EncodeResourceIdentifier(newSchemaId) },
-				currentId, newSchemaId,
-				schemaRenameFn,
-				description)
-		}
-
-		if diags := handleShallowHierarchyRename(d, ctx,
-			client.Databases.ShowByID,
+		if diags := handleTwoLevelHierarchyRename(d, ctx, client, &id,
+			schemaRenameFn,
 			client.Schemas.ShowByID,
-			newDatabaseId, oldDatabaseId,
-			newSchemaId, oldSchemaId,
-			oldSchemaId,
-			renameSchema, moveSchema,
-			"database", "schema", "schema",
+			func(id sdk.DatabaseObjectIdentifier) string { return helpers.EncodeResourceIdentifier(id) },
+			"schema",
 		); diags != nil {
 			return diags
 		}
-
-		id = newSchemaId
 	}
 
 	if d.HasChange("name") && !d.GetRawState().IsNull() {

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -763,14 +763,14 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			case isRenameOfTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, newSchemaExists):
 				handleHierarchyRenameIdUpdate(d,
 					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					"Database was renamed for table - no Snowflake modification needed, updating the id...")
+					"Database was renamed for table")
 				id = newTableId
 			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, oldSchemaExists):
 				if diags := handleHierarchyMove(d,
 					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					id.FullyQualifiedName(), newTableId.FullyQualifiedName(),
+					id, newTableId,
 					func() error { return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)) },
-					"Moving table to different database - executing ALTER TABLE RENAME TO..."); diags != nil {
+					"Moving table to different database"); diags != nil {
 					return diags
 				}
 				id = newTableId
@@ -800,14 +800,14 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			case isRenameOfTheGivenLevelInTheHierarchy(newSchemaExists, oldSchemaExists, newTableExists):
 				handleHierarchyRenameIdUpdate(d,
 					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					"Schema was renamed for table - no Snowflake modification needed, updating the id...")
+					"Schema was renamed for table")
 				id = newTableId
 			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newSchemaExists, oldSchemaExists, oldTableExists):
 				if diags := handleHierarchyMove(d,
 					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					id.FullyQualifiedName(), newTableId.FullyQualifiedName(),
+					id, newTableId,
 					func() error { return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)) },
-					"Moving table to different schema - executing ALTER TABLE RENAME TO..."); diags != nil {
+					"Moving table to different schema"); diags != nil {
 					return diags
 				}
 				id = newTableId
@@ -863,17 +863,17 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			case isDbRenameSchemaRename():
 				handleHierarchyRenameIdUpdate(d,
 					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					"Database and schema were both renamed for table - no Snowflake modification needed, updating the id...")
+					"Database and schema were both renamed for table")
 				id = newTableId
 			case isDbRenameSchemaMove():
 				currentTableId := sdk.NewSchemaObjectIdentifier(newDatabaseName, oldSchemaName, tableName)
 				if diags := handleHierarchyMove(d,
 					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					currentTableId.FullyQualifiedName(), newTableId.FullyQualifiedName(),
+					currentTableId, newTableId,
 					func() error {
 						return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(currentTableId).WithNewName(&newTableId))
 					},
-					"Database was renamed, moving table to different schema - executing ALTER TABLE RENAME TO..."); diags != nil {
+					"Database was renamed, moving table to different schema"); diags != nil {
 					return diags
 				}
 				id = newTableId
@@ -881,20 +881,20 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				currentTableId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, newSchemaName, tableName)
 				if diags := handleHierarchyMove(d,
 					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					currentTableId.FullyQualifiedName(), newTableId.FullyQualifiedName(),
+					currentTableId, newTableId,
 					func() error {
 						return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(currentTableId).WithNewName(&newTableId))
 					},
-					"Schema was renamed, moving table to different database - executing ALTER TABLE RENAME TO..."); diags != nil {
+					"Schema was renamed, moving table to different database"); diags != nil {
 					return diags
 				}
 				id = newTableId
 			case isDbMoveSchemaMove():
 				if diags := handleHierarchyMove(d,
 					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					id.FullyQualifiedName(), newTableId.FullyQualifiedName(),
+					id, newTableId,
 					func() error { return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)) },
-					"Moving table to different database and schema - executing ALTER TABLE RENAME TO..."); diags != nil {
+					"Moving table to different database and schema"); diags != nil {
 					return diags
 				}
 				id = newTableId

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -737,12 +737,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			}
 		}
 
-		if diags := handleThreeLevelHierarchyRename(d, ctx, client, &id,
-			tableRenameFn,
-			client.Tables.ShowByID,
-			func(id sdk.SchemaObjectIdentifier) string { return helpers.EncodeSnowflakeID(id) },
-			"table",
-		); diags != nil {
+		if diags := handleThreeLevelHierarchyRename(ctx, d, client, &id, tableRenameFn, client.Tables.ShowByID, func(id sdk.SchemaObjectIdentifier) string { return helpers.EncodeSnowflakeID(id) }, "table"); diags != nil {
 			return diags
 		}
 	}

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -747,6 +747,12 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 		oldTableId := sdk.NewSchemaObjectIdentifierInSchema(oldSchemaId, tableName)
 		newTableId := sdk.NewSchemaObjectIdentifierInSchema(newSchemaId, tableName)
 
+		tableRenameFn := func(currentId, targetId sdk.SchemaObjectIdentifier) func() error {
+			return func() error {
+				return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(currentId).WithNewName(&targetId))
+			}
+		}
+
 		switch {
 		// Case A: Only database changes (same as schema resource's 2-level logic)
 		case databaseChanged && !schemaChanged:
@@ -769,7 +775,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				if diags := handleHierarchyMove(d,
 					func() string { return helpers.EncodeSnowflakeID(newTableId) },
 					id, newTableId,
-					func() error { return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)) },
+					tableRenameFn,
 					"Moving table to different database"); diags != nil {
 					return diags
 				}
@@ -806,7 +812,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				if diags := handleHierarchyMove(d,
 					func() string { return helpers.EncodeSnowflakeID(newTableId) },
 					id, newTableId,
-					func() error { return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)) },
+					tableRenameFn,
 					"Moving table to different schema"); diags != nil {
 					return diags
 				}
@@ -870,9 +876,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				if diags := handleHierarchyMove(d,
 					func() string { return helpers.EncodeSnowflakeID(newTableId) },
 					currentTableId, newTableId,
-					func() error {
-						return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(currentTableId).WithNewName(&newTableId))
-					},
+					tableRenameFn,
 					"Database was renamed, moving table to different schema"); diags != nil {
 					return diags
 				}
@@ -882,18 +886,17 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				if diags := handleHierarchyMove(d,
 					func() string { return helpers.EncodeSnowflakeID(newTableId) },
 					currentTableId, newTableId,
-					func() error {
-						return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(currentTableId).WithNewName(&newTableId))
-					},
+					tableRenameFn,
 					"Schema was renamed, moving table to different database"); diags != nil {
 					return diags
 				}
 				id = newTableId
 			case isDbMoveSchemaMove():
+				currentTableId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, oldSchemaName, tableName)
 				if diags := handleHierarchyMove(d,
 					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					id, newTableId,
-					func() error { return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)) },
+					currentTableId, newTableId,
+					tableRenameFn,
 					"Moving table to different database and schema"); diags != nil {
 					return diags
 				}

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -759,27 +759,20 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			_, errOldSchema := client.Schemas.ShowByID(ctx, oldSchemaId)
 			oldSchemaExists := errOldSchema == nil
 
-			isRenameOfTheGivenLevelInTheHierarchy := func() bool {
-				return newDatabaseExists && !oldDatabaseExists && newSchemaExists
-			}
-			isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy := func() bool {
-				return newDatabaseExists && oldDatabaseExists && oldSchemaExists
-			}
-
 			switch {
-			// Case 1: "Rename of the given level in the hierarchy"
-			case isRenameOfTheGivenLevelInTheHierarchy():
-				log.Printf("[DEBUG] Database was renamed for table - no Snowflake modification needed, updating the id...")
-				// Just update the ID — no Snowflake modification needed
-				d.SetId(helpers.EncodeSnowflakeID(newTableId))
+			case isRenameOfTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, newSchemaExists):
+				handleHierarchyRenameIdUpdate(d,
+					func() string { return helpers.EncodeSnowflakeID(newTableId) },
+					"Database was renamed for table - no Snowflake modification needed, updating the id...")
 				id = newTableId
-			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy():
-				log.Printf("[DEBUG] Moving table to different database - executing ALTER TABLE RENAME TO...")
-				if renameErr := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)); renameErr != nil {
-					d.Partial(true)
-					return diag.FromErr(fmt.Errorf("failed to move table from %s to %s: %w", id.FullyQualifiedName(), newTableId.FullyQualifiedName(), renameErr))
+			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, oldSchemaExists):
+				if diags := handleHierarchyMove(d,
+					func() string { return helpers.EncodeSnowflakeID(newTableId) },
+					id.FullyQualifiedName(), newTableId.FullyQualifiedName(),
+					func() error { return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)) },
+					"Moving table to different database - executing ALTER TABLE RENAME TO..."); diags != nil {
+					return diags
 				}
-				d.SetId(helpers.EncodeSnowflakeID(newTableId))
 				id = newTableId
 			default:
 				d.Partial(true)
@@ -803,28 +796,20 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			_, errOldTable := client.Tables.ShowByID(ctx, oldTableId)
 			oldTableExists := errOldTable == nil
 
-			isRenameOfTheGivenLevelInTheHierarchy := func() bool {
-				return newSchemaExists && !oldSchemaExists && newTableExists
-			}
-			isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy := func() bool {
-				return newSchemaExists && oldSchemaExists && oldTableExists
-			}
-
 			switch {
-			// Case 1: "Rename of the given level in the hierarchy"
-			case isRenameOfTheGivenLevelInTheHierarchy():
-				log.Printf("[DEBUG] Schema was renamed for table - no Snowflake modification needed, updating the id...")
-				// Just update the ID — no Snowflake modification needed
-				d.SetId(helpers.EncodeSnowflakeID(newTableId))
+			case isRenameOfTheGivenLevelInTheHierarchy(newSchemaExists, oldSchemaExists, newTableExists):
+				handleHierarchyRenameIdUpdate(d,
+					func() string { return helpers.EncodeSnowflakeID(newTableId) },
+					"Schema was renamed for table - no Snowflake modification needed, updating the id...")
 				id = newTableId
-			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy():
-				log.Printf("[DEBUG] Moving table to different schema - executing ALTER TABLE RENAME TO...")
-				// Perform the rename in Snowflake: ALTER TABLE A.X RENAME TO B.X
-				if renameErr := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)); renameErr != nil {
-					d.Partial(true)
-					return diag.FromErr(fmt.Errorf("failed to move table from %s to %s: %w", id.FullyQualifiedName(), newTableId.FullyQualifiedName(), renameErr))
+			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newSchemaExists, oldSchemaExists, oldTableExists):
+				if diags := handleHierarchyMove(d,
+					func() string { return helpers.EncodeSnowflakeID(newTableId) },
+					id.FullyQualifiedName(), newTableId.FullyQualifiedName(),
+					func() error { return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)) },
+					"Moving table to different schema - executing ALTER TABLE RENAME TO..."); diags != nil {
+					return diags
 				}
-				d.SetId(helpers.EncodeSnowflakeID(newTableId))
 				id = newTableId
 			default:
 				d.Partial(true)
@@ -876,34 +861,42 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 
 			switch {
 			case isDbRenameSchemaRename():
-				log.Printf("[DEBUG] Database and schema were both renamed for table - no Snowflake modification needed, updating the id...")
-				d.SetId(helpers.EncodeSnowflakeID(newTableId))
+				handleHierarchyRenameIdUpdate(d,
+					func() string { return helpers.EncodeSnowflakeID(newTableId) },
+					"Database and schema were both renamed for table - no Snowflake modification needed, updating the id...")
 				id = newTableId
 			case isDbRenameSchemaMove():
-				log.Printf("[DEBUG] Database was renamed, moving table to different schema - executing ALTER TABLE RENAME TO...")
 				currentTableId := sdk.NewSchemaObjectIdentifier(newDatabaseName, oldSchemaName, tableName)
-				if renameErr := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(currentTableId).WithNewName(&newTableId)); renameErr != nil {
-					d.Partial(true)
-					return diag.FromErr(fmt.Errorf("failed to move table from %s to %s: %w", currentTableId.FullyQualifiedName(), newTableId.FullyQualifiedName(), renameErr))
+				if diags := handleHierarchyMove(d,
+					func() string { return helpers.EncodeSnowflakeID(newTableId) },
+					currentTableId.FullyQualifiedName(), newTableId.FullyQualifiedName(),
+					func() error {
+						return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(currentTableId).WithNewName(&newTableId))
+					},
+					"Database was renamed, moving table to different schema - executing ALTER TABLE RENAME TO..."); diags != nil {
+					return diags
 				}
-				d.SetId(helpers.EncodeSnowflakeID(newTableId))
 				id = newTableId
 			case isDbMoveSchemaRename():
-				log.Printf("[DEBUG] Schema was renamed, moving table to different database - executing ALTER TABLE RENAME TO...")
 				currentTableId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, newSchemaName, tableName)
-				if renameErr := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(currentTableId).WithNewName(&newTableId)); renameErr != nil {
-					d.Partial(true)
-					return diag.FromErr(fmt.Errorf("failed to move table from %s to %s: %w", currentTableId.FullyQualifiedName(), newTableId.FullyQualifiedName(), renameErr))
+				if diags := handleHierarchyMove(d,
+					func() string { return helpers.EncodeSnowflakeID(newTableId) },
+					currentTableId.FullyQualifiedName(), newTableId.FullyQualifiedName(),
+					func() error {
+						return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(currentTableId).WithNewName(&newTableId))
+					},
+					"Schema was renamed, moving table to different database - executing ALTER TABLE RENAME TO..."); diags != nil {
+					return diags
 				}
-				d.SetId(helpers.EncodeSnowflakeID(newTableId))
 				id = newTableId
 			case isDbMoveSchemaMove():
-				log.Printf("[DEBUG] Moving table to different database and schema - executing ALTER TABLE RENAME TO...")
-				if renameErr := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)); renameErr != nil {
-					d.Partial(true)
-					return diag.FromErr(fmt.Errorf("failed to move table from %s to %s: %w", id.FullyQualifiedName(), newTableId.FullyQualifiedName(), renameErr))
+				if diags := handleHierarchyMove(d,
+					func() string { return helpers.EncodeSnowflakeID(newTableId) },
+					id.FullyQualifiedName(), newTableId.FullyQualifiedName(),
+					func() error { return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newTableId)) },
+					"Moving table to different database and schema - executing ALTER TABLE RENAME TO..."); diags != nil {
+					return diags
 				}
-				d.SetId(helpers.EncodeSnowflakeID(newTableId))
 				id = newTableId
 			default:
 				d.Partial(true)

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -731,84 +731,20 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 	id := helpers.DecodeSnowflakeIDLegacy(d.Id()).(sdk.SchemaObjectIdentifier)
 
 	if experimentalfeatures.IsExperimentEnabled(experimentalfeatures.HierarchyRenames, providerCtx.EnabledExperiments) && (d.HasChange("database") || d.HasChange("schema")) {
-		oldDatabaseNameRaw, newDatabaseNameRaw := d.GetChange("database")
-		oldDatabaseName, newDatabaseName := oldDatabaseNameRaw.(string), newDatabaseNameRaw.(string)
-		oldSchemaNameRaw, newSchemaNameRaw := d.GetChange("schema")
-		oldSchemaName, newSchemaName := oldSchemaNameRaw.(string), newSchemaNameRaw.(string)
-		tableName := id.Name()
-
-		databaseChanged := d.HasChange("database")
-		schemaChanged := d.HasChange("schema")
-
-		oldDatabaseId := sdk.NewAccountObjectIdentifier(oldDatabaseName)
-		newDatabaseId := sdk.NewAccountObjectIdentifier(newDatabaseName)
-		oldSchemaId := sdk.NewDatabaseObjectIdentifierInDatabase(oldDatabaseId, oldSchemaName)
-		newSchemaId := sdk.NewDatabaseObjectIdentifierInDatabase(newDatabaseId, newSchemaName)
-		oldTableId := sdk.NewSchemaObjectIdentifierInSchema(oldSchemaId, tableName)
-		newTableId := sdk.NewSchemaObjectIdentifierInSchema(newSchemaId, tableName)
-
 		tableRenameFn := func(currentId, targetId sdk.SchemaObjectIdentifier) func() error {
 			return func() error {
 				return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(currentId).WithNewName(&targetId))
 			}
 		}
 
-		parentRename := func(description string) {
-			handleHierarchyRenameIdUpdate(d, func() string { return helpers.EncodeSnowflakeID(newTableId) }, description)
+		if diags := handleThreeLevelHierarchyRename(d, ctx, client, &id,
+			tableRenameFn,
+			client.Tables.ShowByID,
+			func(id sdk.SchemaObjectIdentifier) string { return helpers.EncodeSnowflakeID(id) },
+			"table",
+		); diags != nil {
+			return diags
 		}
-
-		parentMove := func(currentId sdk.SchemaObjectIdentifier, description string) diag.Diagnostics {
-			return handleHierarchyMove(d,
-				func() string { return helpers.EncodeSnowflakeID(newTableId) },
-				currentId, newTableId,
-				tableRenameFn,
-				description,
-			)
-		}
-
-		switch {
-		// Case A: Only database changes (same as schema resource's 2-level logic)
-		case databaseChanged && !schemaChanged:
-			if diags := handleShallowHierarchyRename(d, ctx,
-				client.Databases.ShowByID,
-				client.Schemas.ShowByID,
-				newDatabaseId, oldDatabaseId,
-				newSchemaId, oldSchemaId,
-				id,
-				parentRename, parentMove,
-				"database", "schema", "table",
-			); diags != nil {
-				return diags
-			}
-
-		// Case B: Only schema changes (similar to schema resource's 2-level logic, but schema-table instead of database-schema)
-		case !databaseChanged && schemaChanged:
-			if diags := handleShallowHierarchyRename(d, ctx,
-				client.Schemas.ShowByID,
-				client.Tables.ShowByID,
-				newSchemaId, oldSchemaId,
-				newTableId, oldTableId,
-				id,
-				parentRename, parentMove,
-				"schema", "table", "table",
-			); diags != nil {
-				return diags
-			}
-
-		// Case C: Both database AND schema change (full 4-scenario algorithm)
-		default:
-			if diags := handleDeepHierarchyRename(d, ctx, client,
-				newDatabaseId, oldDatabaseId,
-				oldSchemaName, newSchemaName,
-				tableName,
-				parentRename, parentMove,
-				"table",
-			); diags != nil {
-				return diags
-			}
-		}
-
-		id = newTableId
 	}
 
 	if d.HasChange("name") {

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -737,7 +737,13 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			}
 		}
 
-		if diags := handleThreeLevelHierarchyRename(ctx, d, client, &id, tableRenameFn, client.Tables.ShowByID, func(id sdk.SchemaObjectIdentifier) string { return helpers.EncodeSnowflakeID(id) }, "table"); diags != nil {
+		if diags := handleThreeLevelHierarchyRename(
+			ctx, d, client, &id,
+			tableRenameFn,
+			client.Tables.ShowByID,
+			func(id sdk.SchemaObjectIdentifier) string { return helpers.EncodeSnowflakeID(id) },
+			"table",
+		); diags != nil {
 			return diags
 		}
 	}

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -753,18 +753,17 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			}
 		}
 
-		renameTable := func(description string) {
-			handleHierarchyRenameIdUpdate(d,
-				func() string { return helpers.EncodeSnowflakeID(newTableId) },
-				description)
+		parentRename := func(description string) {
+			handleHierarchyRenameIdUpdate(d, func() string { return helpers.EncodeSnowflakeID(newTableId) }, description)
 		}
 
-		moveTable := func(currentId sdk.SchemaObjectIdentifier, description string) diag.Diagnostics {
+		parentMove := func(currentId sdk.SchemaObjectIdentifier, description string) diag.Diagnostics {
 			return handleHierarchyMove(d,
 				func() string { return helpers.EncodeSnowflakeID(newTableId) },
 				currentId, newTableId,
 				tableRenameFn,
-				description)
+				description,
+			)
 		}
 
 		switch {
@@ -776,7 +775,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				newDatabaseId, oldDatabaseId,
 				newSchemaId, oldSchemaId,
 				id,
-				renameTable, moveTable,
+				parentRename, parentMove,
 				"database", "schema", "table",
 			); diags != nil {
 				return diags
@@ -790,7 +789,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				newSchemaId, oldSchemaId,
 				newTableId, oldTableId,
 				id,
-				renameTable, moveTable,
+				parentRename, parentMove,
 				"schema", "table", "table",
 			); diags != nil {
 				return diags
@@ -802,7 +801,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				newDatabaseId, oldDatabaseId,
 				oldSchemaName, newSchemaName,
 				tableName,
-				renameTable, moveTable,
+				parentRename, parentMove,
 				"table",
 			); diags != nil {
 				return diags

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -770,58 +770,30 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 		switch {
 		// Case A: Only database changes (same as schema resource's 2-level logic)
 		case databaseChanged && !schemaChanged:
-			_, errNewDb := client.Databases.ShowByID(ctx, newDatabaseId)
-			newDatabaseExists := errNewDb == nil
-			_, errOldDb := client.Databases.ShowByID(ctx, oldDatabaseId)
-			oldDatabaseExists := errOldDb == nil
-			_, errNewSchema := client.Schemas.ShowByID(ctx, newSchemaId)
-			newSchemaExists := errNewSchema == nil
-			_, errOldSchema := client.Schemas.ShowByID(ctx, oldSchemaId)
-			oldSchemaExists := errOldSchema == nil
-
-			switch {
-			case isRenameOfTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, newSchemaExists):
-				renameTable("Database was renamed for table")
-			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, oldSchemaExists):
-				if diags := moveTable(id, "Moving table to different database"); diags != nil {
-					return diags
-				}
-			default:
-				d.Partial(true)
-				return diag.FromErr(fmt.Errorf(
-					"unknown rename use case: old database %s (exists: %t), new database %s (exists: %t), old schema %s (exists: %t), new schema %s (exists: %t). See https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/object_renaming_guide",
-					oldDatabaseId.FullyQualifiedName(), oldDatabaseExists,
-					newDatabaseId.FullyQualifiedName(), newDatabaseExists,
-					oldSchemaId.FullyQualifiedName(), oldSchemaExists,
-					newSchemaId.FullyQualifiedName(), newSchemaExists,
-				))
+			if diags := handleShallowHierarchyRename(d, ctx,
+				client.Databases.ShowByID,
+				client.Schemas.ShowByID,
+				newDatabaseId, oldDatabaseId,
+				newSchemaId, oldSchemaId,
+				id,
+				renameTable, moveTable,
+				"database", "schema", "table",
+			); diags != nil {
+				return diags
 			}
 
 		// Case B: Only schema changes (similar to schema resource's 2-level logic, but schema-table instead of database-schema)
 		case !databaseChanged && schemaChanged:
-			_, errNewSchema := client.Schemas.ShowByID(ctx, newSchemaId)
-			newSchemaExists := errNewSchema == nil
-			_, errOldSchema := client.Schemas.ShowByID(ctx, oldSchemaId)
-			oldSchemaExists := errOldSchema == nil
-			_, errNewTable := client.Tables.ShowByID(ctx, newTableId)
-			newTableExists := errNewTable == nil
-			_, errOldTable := client.Tables.ShowByID(ctx, oldTableId)
-			oldTableExists := errOldTable == nil
-
-			switch {
-			case isRenameOfTheGivenLevelInTheHierarchy(newSchemaExists, oldSchemaExists, newTableExists):
-				renameTable("Schema was renamed for table")
-			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newSchemaExists, oldSchemaExists, oldTableExists):
-				if diags := moveTable(id, "Moving table to different schema"); diags != nil {
-					return diags
-				}
-			default:
-				d.Partial(true)
-				return diag.FromErr(fmt.Errorf(
-					"unknown rename use case: old schema %s (exists: %t), new schema %s (exists: %t). See https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/object_renaming_guide",
-					oldSchemaId.FullyQualifiedName(), oldSchemaExists,
-					newSchemaId.FullyQualifiedName(), newSchemaExists,
-				))
+			if diags := handleShallowHierarchyRename(d, ctx,
+				client.Schemas.ShowByID,
+				client.Tables.ShowByID,
+				newSchemaId, oldSchemaId,
+				newTableId, oldTableId,
+				id,
+				renameTable, moveTable,
+				"schema", "table", "table",
+			); diags != nil {
+				return diags
 			}
 
 		// Case C: Both database AND schema change (full 4-scenario algorithm)

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -782,12 +782,10 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			switch {
 			case isRenameOfTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, newSchemaExists):
 				renameTable("Database was renamed for table")
-				id = newTableId
 			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, oldSchemaExists):
 				if diags := moveTable(id, "Moving table to different database"); diags != nil {
 					return diags
 				}
-				id = newTableId
 			default:
 				d.Partial(true)
 				return diag.FromErr(fmt.Errorf(
@@ -813,12 +811,10 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			switch {
 			case isRenameOfTheGivenLevelInTheHierarchy(newSchemaExists, oldSchemaExists, newTableExists):
 				renameTable("Schema was renamed for table")
-				id = newTableId
 			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newSchemaExists, oldSchemaExists, oldTableExists):
 				if diags := moveTable(id, "Moving table to different schema"); diags != nil {
 					return diags
 				}
-				id = newTableId
 			default:
 				d.Partial(true)
 				return diag.FromErr(fmt.Errorf(
@@ -870,25 +866,21 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			switch {
 			case isDbRenameSchemaRename():
 				renameTable("Database and schema were both renamed for table")
-				id = newTableId
 			case isDbRenameSchemaMove():
 				currentTableId := sdk.NewSchemaObjectIdentifier(newDatabaseName, oldSchemaName, tableName)
 				if diags := moveTable(currentTableId, "Database was renamed, moving table to different schema"); diags != nil {
 					return diags
 				}
-				id = newTableId
 			case isDbMoveSchemaRename():
 				currentTableId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, newSchemaName, tableName)
 				if diags := moveTable(currentTableId, "Schema was renamed, moving table to different database"); diags != nil {
 					return diags
 				}
-				id = newTableId
 			case isDbMoveSchemaMove():
 				currentTableId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, oldSchemaName, tableName)
 				if diags := moveTable(currentTableId, "Moving table to different database and schema"); diags != nil {
 					return diags
 				}
-				id = newTableId
 			default:
 				d.Partial(true)
 				return diag.FromErr(fmt.Errorf(
@@ -902,6 +894,8 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				))
 			}
 		}
+
+		id = newTableId
 	}
 
 	if d.HasChange("name") {

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -753,6 +753,20 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			}
 		}
 
+		renameTable := func(description string) {
+			handleHierarchyRenameIdUpdate(d,
+				func() string { return helpers.EncodeSnowflakeID(newTableId) },
+				description)
+		}
+
+		moveTable := func(currentId sdk.SchemaObjectIdentifier, description string) diag.Diagnostics {
+			return handleHierarchyMove(d,
+				func() string { return helpers.EncodeSnowflakeID(newTableId) },
+				currentId, newTableId,
+				tableRenameFn,
+				description)
+		}
+
 		switch {
 		// Case A: Only database changes (same as schema resource's 2-level logic)
 		case databaseChanged && !schemaChanged:
@@ -767,16 +781,10 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 
 			switch {
 			case isRenameOfTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, newSchemaExists):
-				handleHierarchyRenameIdUpdate(d,
-					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					"Database was renamed for table")
+				renameTable("Database was renamed for table")
 				id = newTableId
 			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newDatabaseExists, oldDatabaseExists, oldSchemaExists):
-				if diags := handleHierarchyMove(d,
-					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					id, newTableId,
-					tableRenameFn,
-					"Moving table to different database"); diags != nil {
+				if diags := moveTable(id, "Moving table to different database"); diags != nil {
 					return diags
 				}
 				id = newTableId
@@ -804,16 +812,10 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 
 			switch {
 			case isRenameOfTheGivenLevelInTheHierarchy(newSchemaExists, oldSchemaExists, newTableExists):
-				handleHierarchyRenameIdUpdate(d,
-					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					"Schema was renamed for table")
+				renameTable("Schema was renamed for table")
 				id = newTableId
 			case isMoveToADifferentObjectOnTheGivenLevelInTheHierarchy(newSchemaExists, oldSchemaExists, oldTableExists):
-				if diags := handleHierarchyMove(d,
-					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					id, newTableId,
-					tableRenameFn,
-					"Moving table to different schema"); diags != nil {
+				if diags := moveTable(id, "Moving table to different schema"); diags != nil {
 					return diags
 				}
 				id = newTableId
@@ -867,37 +869,23 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 
 			switch {
 			case isDbRenameSchemaRename():
-				handleHierarchyRenameIdUpdate(d,
-					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					"Database and schema were both renamed for table")
+				renameTable("Database and schema were both renamed for table")
 				id = newTableId
 			case isDbRenameSchemaMove():
 				currentTableId := sdk.NewSchemaObjectIdentifier(newDatabaseName, oldSchemaName, tableName)
-				if diags := handleHierarchyMove(d,
-					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					currentTableId, newTableId,
-					tableRenameFn,
-					"Database was renamed, moving table to different schema"); diags != nil {
+				if diags := moveTable(currentTableId, "Database was renamed, moving table to different schema"); diags != nil {
 					return diags
 				}
 				id = newTableId
 			case isDbMoveSchemaRename():
 				currentTableId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, newSchemaName, tableName)
-				if diags := handleHierarchyMove(d,
-					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					currentTableId, newTableId,
-					tableRenameFn,
-					"Schema was renamed, moving table to different database"); diags != nil {
+				if diags := moveTable(currentTableId, "Schema was renamed, moving table to different database"); diags != nil {
 					return diags
 				}
 				id = newTableId
 			case isDbMoveSchemaMove():
 				currentTableId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, oldSchemaName, tableName)
-				if diags := handleHierarchyMove(d,
-					func() string { return helpers.EncodeSnowflakeID(newTableId) },
-					currentTableId, newTableId,
-					tableRenameFn,
-					"Moving table to different database and schema"); diags != nil {
+				if diags := moveTable(currentTableId, "Moving table to different database and schema"); diags != nil {
 					return diags
 				}
 				id = newTableId

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -798,72 +798,14 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 
 		// Case C: Both database AND schema change (full 4-scenario algorithm)
 		default:
-			_, errNewDb := client.Databases.ShowByID(ctx, newDatabaseId)
-			newDatabaseExists := errNewDb == nil
-			_, errOldDb := client.Databases.ShowByID(ctx, oldDatabaseId)
-			oldDatabaseExists := errOldDb == nil
-
-			// Probe schemas
-			schemaInNewDbOldName := sdk.NewDatabaseObjectIdentifier(newDatabaseName, oldSchemaName)
-			schemaInNewDbNewName := sdk.NewDatabaseObjectIdentifier(newDatabaseName, newSchemaName)
-			schemaInOldDbOldName := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, oldSchemaName)
-			schemaInOldDbNewName := sdk.NewDatabaseObjectIdentifier(oldDatabaseName, newSchemaName)
-
-			_, errSchemaNewDbOld := client.Schemas.ShowByID(ctx, schemaInNewDbOldName)
-			schemaNewDbOldExists := errSchemaNewDbOld == nil
-			_, errSchemaNewDbNew := client.Schemas.ShowByID(ctx, schemaInNewDbNewName)
-			schemaNewDbNewExists := errSchemaNewDbNew == nil
-			_, errSchemaOldDbOld := client.Schemas.ShowByID(ctx, schemaInOldDbOldName)
-			schemaOldDbOldExists := errSchemaOldDbOld == nil
-			_, errSchemaOldDbNew := client.Schemas.ShowByID(ctx, schemaInOldDbNewName)
-			schemaOldDbNewExists := errSchemaOldDbNew == nil
-
-			// Scenario 1: DB rename + Schema rename
-			isDbRenameSchemaRename := func() bool {
-				return !oldDatabaseExists && newDatabaseExists && !schemaNewDbOldExists && schemaNewDbNewExists
-			}
-			// Scenario 2: DB rename + Schema move
-			isDbRenameSchemaMove := func() bool {
-				return !oldDatabaseExists && newDatabaseExists && schemaNewDbOldExists
-			}
-			// Scenario 3: DB move + Schema rename
-			isDbMoveSchemaRename := func() bool {
-				return oldDatabaseExists && newDatabaseExists && !schemaOldDbOldExists && schemaOldDbNewExists
-			}
-			// Scenario 4: DB move + Schema move
-			isDbMoveSchemaMove := func() bool {
-				return oldDatabaseExists && newDatabaseExists && schemaOldDbOldExists
-			}
-
-			switch {
-			case isDbRenameSchemaRename():
-				renameTable("Database and schema were both renamed for table")
-			case isDbRenameSchemaMove():
-				currentTableId := sdk.NewSchemaObjectIdentifier(newDatabaseName, oldSchemaName, tableName)
-				if diags := moveTable(currentTableId, "Database was renamed, moving table to different schema"); diags != nil {
-					return diags
-				}
-			case isDbMoveSchemaRename():
-				currentTableId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, newSchemaName, tableName)
-				if diags := moveTable(currentTableId, "Schema was renamed, moving table to different database"); diags != nil {
-					return diags
-				}
-			case isDbMoveSchemaMove():
-				currentTableId := sdk.NewSchemaObjectIdentifier(oldDatabaseName, oldSchemaName, tableName)
-				if diags := moveTable(currentTableId, "Moving table to different database and schema"); diags != nil {
-					return diags
-				}
-			default:
-				d.Partial(true)
-				return diag.FromErr(fmt.Errorf(
-					"unknown rename use case: old database %s (exists: %t), new database %s (exists: %t), schema %s (exists: %t), schema %s (exists: %t), schema %s (exists: %t), schema %s (exists: %t). See https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/object_renaming_guide",
-					oldDatabaseId.FullyQualifiedName(), oldDatabaseExists,
-					newDatabaseId.FullyQualifiedName(), newDatabaseExists,
-					schemaInNewDbOldName.FullyQualifiedName(), schemaNewDbOldExists,
-					schemaInNewDbNewName.FullyQualifiedName(), schemaNewDbNewExists,
-					schemaInOldDbOldName.FullyQualifiedName(), schemaOldDbOldExists,
-					schemaInOldDbNewName.FullyQualifiedName(), schemaOldDbNewExists,
-				))
+			if diags := handleDeepHierarchyRename(d, ctx, client,
+				newDatabaseId, oldDatabaseId,
+				oldSchemaName, newSchemaName,
+				tableName,
+				renameTable, moveTable,
+				"table",
+			); diags != nil {
+				return diags
 			}
 		}
 


### PR DESCRIPTION
Continuation to https://github.com/snowflakedb/terraform-provider-snowflake/pull/4885

- The logic is cleaned up and extracted, so that we can much more easily add it to other resources later on.
- There are 2 methods: 1 for shallow hierarchy (2 levels), 1 for deeper hierarchy (3 levels, assuming database and schema to be the top ones).
- Table and schema resources adjusted.
- Naming cleaned up after review comment from #4885