### PR TITLE
chore: Stabilize replication-related database tests

### DIFF
--- a/pkg/acceptance/helpers/database_client.go
+++ b/pkg/acceptance/helpers/database_client.go
@@ -138,7 +138,7 @@ func (c *DatabaseClient) CreatePrimaryDatabase(t *testing.T, enableReplicationTo
 	t.Helper()
 	ctx := context.Background()
 
-	primaryDatabase, primaryDatabaseCleanup := c.CreateDatabase(t)
+	primaryDatabase, _ := c.CreateDatabase(t)
 
 	err := c.client().AlterReplication(ctx, sdk.NewAlterReplicationDatabaseRequest(primaryDatabase.ID()).WithEnableReplication(
 		*sdk.NewEnableReplicationRequest().WithToAccounts(enableReplicationTo).WithIgnoreEditionCheck(true),
@@ -149,7 +149,45 @@ func (c *DatabaseClient) CreatePrimaryDatabase(t *testing.T, enableReplicationTo
 	require.NoError(t, err)
 
 	externalPrimaryId := sdk.NewExternalObjectIdentifier(sdk.NewAccountIdentifier(sessionDetails.OrganizationName, sessionDetails.AccountName), primaryDatabase.ID())
-	return primaryDatabase, externalPrimaryId, primaryDatabaseCleanup
+
+	// Dropping the primary database can fail until the removal of its secondary database has propagated across
+	// regions, so retry the cleanup until it succeeds.
+	// TODO(SNOW-1562172): Replace this retry-based workaround once there is a deterministic way to detect that the cross-region replication change has propagated.
+	cleanup := func() {
+		require.Eventually(t, func() bool {
+			return c.DropDatabase(t, primaryDatabase.ID()) == nil
+		}, 2*time.Minute, 5*time.Second)
+	}
+
+	return primaryDatabase, externalPrimaryId, cleanup
+}
+
+// WaitForReplicationToTakeEffect waits until replication of the given primary database has taken effect on
+// this account, polling SHOW REPLICATION DATABASES until the primary appears. Enabling replication triggers
+// cross-region operations that take a few seconds to take effect, so the primary database may not be
+// immediately usable for creating a secondary database.
+// TODO(SNOW-1562172): Replace this polling-based workaround once there is a deterministic way to detect that the cross-region replication change has propagated.
+func (c *DatabaseClient) WaitForReplicationToTakeEffect(t *testing.T, primaryDatabaseId sdk.ExternalObjectIdentifier) {
+	t.Helper()
+	ctx := context.Background()
+	t.Logf("Waiting for replication of primary database %s to take effect", primaryDatabaseId.FullyQualifiedName())
+	require.Eventually(t, func() bool {
+		replicationDatabases, err := c.context.client.ReplicationFunctions.ShowReplicationDatabases(ctx, &sdk.ShowReplicationDatabasesOptions{
+			WithPrimary: &primaryDatabaseId,
+		})
+		if err != nil {
+			t.Logf("Error showing replication databases, retrying: %v", err)
+			return false
+		}
+		for _, replicationDatabase := range replicationDatabases {
+			if replicationDatabase.IsPrimary && replicationDatabase.Name == primaryDatabaseId.Name() {
+				t.Logf("Replication of primary database %s has taken effect", primaryDatabaseId.FullyQualifiedName())
+				return true
+			}
+		}
+		t.Logf("Replication of primary database %s has not taken effect yet, retrying", primaryDatabaseId.FullyQualifiedName())
+		return false
+	}, 2*time.Minute, 5*time.Second)
 }
 
 func (c *DatabaseClient) UpdateDataRetentionTime(t *testing.T, id sdk.AccountObjectIdentifier, days int) {

--- a/pkg/sdk/testint/databases_integration_test.go
+++ b/pkg/sdk/testint/databases_integration_test.go
@@ -259,23 +259,10 @@ func TestInt_DatabasesCreateShared(t *testing.T) {
 
 func TestInt_DatabasesCreateSecondary(t *testing.T) {
 	client := testClient(t)
-	secondaryClient := testSecondaryClient(t)
 	ctx := testContext(t)
 
-	sharedDatabase, sharedDatabaseCleanup := secondaryTestClientHelper().Database.CreateDatabase(t)
-	t.Cleanup(sharedDatabaseCleanup)
-
-	databaseId := sharedDatabase.ID()
-
-	err := secondaryClient.Databases.AlterReplication(
-		ctx, sdk.NewAlterReplicationDatabaseRequest(sharedDatabase.ID()).
-			WithEnableReplication(*sdk.NewEnableReplicationRequest().
-				WithToAccounts([]sdk.AccountIdentifier{
-					testClientHelper().Account.GetAccountIdentifier(t),
-				}).
-				WithIgnoreEditionCheck(true)),
-	)
-	require.NoError(t, err)
+	primaryDatabase, externalDatabaseId := createPrimaryDatabase(t)
+	databaseId := primaryDatabase.ID()
 
 	externalVolume, externalVolumeCleanup := testClientHelper().ExternalVolume.Create(t)
 	t.Cleanup(externalVolumeCleanup)
@@ -283,10 +270,8 @@ func TestInt_DatabasesCreateSecondary(t *testing.T) {
 	catalog, catalogCleanup := testClientHelper().CatalogIntegration.Create(t)
 	t.Cleanup(catalogCleanup)
 
-	externalDatabaseId := sdk.NewExternalObjectIdentifier(secondaryTestClientHelper().Account.GetAccountIdentifier(t), sharedDatabase.ID())
-
 	comment := random.Comment()
-	err = client.Databases.CreateSecondary(
+	err := client.Databases.CreateSecondary(
 		ctx, sdk.NewCreateSecondaryDatabaseRequest(databaseId, externalDatabaseId).
 			WithIfNotExists(true).
 			WithDataRetentionTimeInDays(10).
@@ -613,18 +598,7 @@ func TestInt_DatabasesAlterReplication(t *testing.T) {
 		secondaryClient := testSecondaryClient(t)
 		ctx := testContext(t)
 
-		sharedDatabase, sharedDatabaseCleanup := secondaryTestClientHelper().Database.CreateDatabase(t)
-		t.Cleanup(sharedDatabaseCleanup)
-
-		err := secondaryClient.Databases.AlterReplication(
-			ctx, sdk.NewAlterReplicationDatabaseRequest(sharedDatabase.ID()).
-				WithEnableReplication(*sdk.NewEnableReplicationRequest().
-					WithToAccounts([]sdk.AccountIdentifier{
-						testClientHelper().Account.GetAccountIdentifier(t),
-					}).
-					WithIgnoreEditionCheck(true)),
-		)
-		require.NoError(t, err)
+		sharedDatabase, externalDatabaseId := createPrimaryDatabase(t)
 
 		externalVolume, externalVolumeCleanup := testClientHelper().ExternalVolume.Create(t)
 		t.Cleanup(externalVolumeCleanup)
@@ -632,9 +606,8 @@ func TestInt_DatabasesAlterReplication(t *testing.T) {
 		catalog, catalogCleanup := testClientHelper().CatalogIntegration.Create(t)
 		t.Cleanup(catalogCleanup)
 
-		externalDatabaseId := sdk.NewExternalObjectIdentifier(secondaryTestClientHelper().Ids.AccountIdentifierWithLocator(), sharedDatabase.ID())
 		comment := random.Comment()
-		err = client.Databases.CreateSecondary(
+		err := client.Databases.CreateSecondary(
 			ctx, sdk.NewCreateSecondaryDatabaseRequest(sharedDatabase.ID(), externalDatabaseId).
 				WithIfNotExists(true).
 				WithDataRetentionTimeInDays(1).

--- a/pkg/sdk/testint/helpers_test.go
+++ b/pkg/sdk/testint/helpers_test.go
@@ -58,30 +58,32 @@ func createDatabaseFromShare(t *testing.T) (*sdk.Database, func()) {
 func createDatabaseReplica(t *testing.T) (*sdk.Database, func()) {
 	t.Helper()
 	client := testClient(t)
-	secondaryClient := testSecondaryClient(t)
 	ctx := testContext(t)
 
-	sharedDatabase, sharedDatabaseCleanup := secondaryTestClientHelper().Database.CreateDatabase(t)
-	t.Cleanup(sharedDatabaseCleanup)
+	sharedDatabase, externalDatabaseId := createPrimaryDatabase(t)
 
-	err := secondaryClient.Databases.AlterReplication(
-		ctx, sdk.NewAlterReplicationDatabaseRequest(sharedDatabase.ID()).
-			WithEnableReplication(*sdk.NewEnableReplicationRequest().
-				WithToAccounts([]sdk.AccountIdentifier{
-					testClientHelper().Account.GetAccountIdentifier(t),
-				}).
-				WithIgnoreEditionCheck(true)),
-	)
-	require.NoError(t, err)
-
-	externalDatabaseId := sdk.NewExternalObjectIdentifier(secondaryTestClientHelper().Ids.AccountIdentifierWithLocator(), sharedDatabase.ID())
-	err = client.Databases.CreateSecondary(ctx, sdk.NewCreateSecondaryDatabaseRequest(sharedDatabase.ID(), externalDatabaseId))
+	err := client.Databases.CreateSecondary(ctx, sdk.NewCreateSecondaryDatabaseRequest(sharedDatabase.ID(), externalDatabaseId))
 	require.NoError(t, err)
 
 	database, err := client.Databases.ShowByID(ctx, sharedDatabase.ID())
 	require.NoError(t, err)
 
 	return database, testClientHelper().Database.DropDatabaseFunc(t, sharedDatabase.ID())
+}
+
+// createPrimaryDatabase creates a database on the secondary account. It returns the created primary
+// database and its external identifier as seen from the current account.
+func createPrimaryDatabase(t *testing.T) (*sdk.Database, sdk.ExternalObjectIdentifier) {
+	t.Helper()
+
+	primaryDatabase, externalDatabaseId, primaryDatabaseCleanup := secondaryTestClientHelper().Database.CreatePrimaryDatabase(t, []sdk.AccountIdentifier{
+		testClientHelper().Account.GetAccountIdentifier(t),
+	})
+	t.Cleanup(primaryDatabaseCleanup)
+
+	testClientHelper().Database.WaitForReplicationToTakeEffect(t, externalDatabaseId)
+
+	return primaryDatabase, externalDatabaseId
 }
 
 func createApplicationPackage(t *testing.T) (*sdk.ApplicationPackage, func()) {

--- a/pkg/sdk/testint/replication_functions_integration_test.go
+++ b/pkg/sdk/testint/replication_functions_integration_test.go
@@ -24,21 +24,11 @@ func TestInt_ShowReplicationDatabases(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	accountId := testClientHelper().Ids.AccountIdentifierWithLocator()
-	secondaryAccountId := secondaryTestClientHelper().Ids.AccountIdentifierWithLocator()
-
-	db, dbCleanup := testClientHelper().Database.CreateDatabase(t)
-	t.Cleanup(dbCleanup)
-	db2, dbCleanup2 := testClientHelper().Database.CreateDatabase(t)
-	t.Cleanup(dbCleanup2)
-
-	err := client.Databases.AlterReplication(ctx, sdk.NewAlterReplicationDatabaseRequest(db.ID()).WithEnableReplication(*sdk.NewEnableReplicationRequest().WithToAccounts([]sdk.AccountIdentifier{secondaryAccountId})))
-	require.NoError(t, err)
-	err = client.Databases.AlterReplication(ctx, sdk.NewAlterReplicationDatabaseRequest(db2.ID()).WithEnableReplication(*sdk.NewEnableReplicationRequest().WithToAccounts([]sdk.AccountIdentifier{secondaryAccountId})))
-	require.NoError(t, err)
+	db, primaryDatabaseId := createPrimaryDatabase(t)
+	db2, _ := createPrimaryDatabase(t)
 
 	id3 := testClientHelper().Ids.RandomAccountObjectIdentifier()
-	db3, dbCleanup3 := secondaryTestClientHelper().Database.CreateSecondaryDatabaseWithOptions(t, id3, sdk.NewExternalObjectIdentifier(accountId, db.ID()), sdk.NewCreateSecondaryDatabaseRequest(id3, sdk.NewExternalObjectIdentifier(accountId, db.ID())))
+	db3, dbCleanup3 := testClientHelper().Database.CreateSecondaryDatabaseWithOptions(t, id3, primaryDatabaseId, sdk.NewCreateSecondaryDatabaseRequest(id3, primaryDatabaseId))
 	t.Cleanup(dbCleanup3)
 
 	getByName := func(replicationDatabases []sdk.ReplicationDatabase, name sdk.AccountObjectIdentifier) *sdk.ReplicationDatabase {
@@ -105,7 +95,7 @@ func TestInt_ShowReplicationDatabases(t *testing.T) {
 
 	t.Run("with primary", func(t *testing.T) {
 		opts := &sdk.ShowReplicationDatabasesOptions{
-			WithPrimary: sdk.Pointer(sdk.NewExternalObjectIdentifier(accountId, db.ID())),
+			WithPrimary: &primaryDatabaseId,
 		}
 		replicationDatabases, err := client.ReplicationFunctions.ShowReplicationDatabases(ctx, opts)
 		require.NoError(t, err)

--- a/pkg/testacc/resource_secondary_database_acceptance_test.go
+++ b/pkg/testacc/resource_secondary_database_acceptance_test.go
@@ -5,7 +5,6 @@ package testacc
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	accconfig "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
@@ -22,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAcc_SecondaryDatabase_BasicUseCase(t *testing.T) {
@@ -30,19 +28,18 @@ func TestAcc_SecondaryDatabase_BasicUseCase(t *testing.T) {
 	newId := testClient().Ids.RandomAccountObjectIdentifier()
 	comment := random.Comment()
 
-	primaryDatabase, externalPrimaryId, _ := secondaryTestClient().Database.CreatePrimaryDatabase(t, []sdk.AccountIdentifier{
+	_, externalPrimaryId, primaryDatabaseCleanup := secondaryTestClient().Database.CreatePrimaryDatabase(t, []sdk.AccountIdentifier{
 		testClient().Account.GetAccountIdentifier(t),
 	})
-	t.Cleanup(func() {
-		// TODO(SNOW-1562172): Create a better solution for this type of situations
-		require.Eventually(t, func() bool { return secondaryTestClient().Database.DropDatabase(t, primaryDatabase.ID()) == nil }, time.Second*5, time.Second)
-	})
+	t.Cleanup(primaryDatabaseCleanup)
 
 	externalVolumeId, externalVolumeCleanup := testClient().ExternalVolume.Create(t)
 	t.Cleanup(externalVolumeCleanup)
 
 	catalogId, catalogCleanup := testClient().CatalogIntegration.Create(t)
 	t.Cleanup(catalogCleanup)
+
+	testClient().Database.WaitForReplicationToTakeEffect(t, externalPrimaryId)
 
 	basic := model.SecondaryDatabase("test", id.Name(), externalPrimaryId.FullyQualifiedName())
 
@@ -251,19 +248,18 @@ func TestAcc_SecondaryDatabase_CompleteUseCase(t *testing.T) {
 	id := testClient().Ids.RandomAccountObjectIdentifier()
 	comment := random.Comment()
 
-	primaryDatabase, externalPrimaryId, _ := secondaryTestClient().Database.CreatePrimaryDatabase(t, []sdk.AccountIdentifier{
+	_, externalPrimaryId, primaryDatabaseCleanup := secondaryTestClient().Database.CreatePrimaryDatabase(t, []sdk.AccountIdentifier{
 		testClient().Account.GetAccountIdentifier(t),
 	})
-	t.Cleanup(func() {
-		// TODO(SNOW-1562172): Create a better solution for this type of situations
-		require.Eventually(t, func() bool { return secondaryTestClient().Database.DropDatabase(t, primaryDatabase.ID()) == nil }, time.Second*5, time.Second)
-	})
+	t.Cleanup(primaryDatabaseCleanup)
 
 	externalVolumeId, externalVolumeCleanup := testClient().ExternalVolume.Create(t)
 	t.Cleanup(externalVolumeCleanup)
 
 	catalogId, catalogCleanup := testClient().CatalogIntegration.Create(t)
 	t.Cleanup(catalogCleanup)
+
+	testClient().Database.WaitForReplicationToTakeEffect(t, externalPrimaryId)
 
 	completeModel := model.SecondaryDatabase("test", id.Name(), externalPrimaryId.FullyQualifiedName()).
 		WithIsTransient(true).
@@ -362,13 +358,12 @@ func TestAcc_CreateSecondaryDatabase_DataRetentionTimeInDays(t *testing.T) {
 
 	id := testClient().Ids.RandomAccountObjectIdentifier()
 
-	primaryDatabase, externalPrimaryId, _ := secondaryTestClient().Database.CreatePrimaryDatabase(t, []sdk.AccountIdentifier{
+	_, externalPrimaryId, primaryDatabaseCleanup := secondaryTestClient().Database.CreatePrimaryDatabase(t, []sdk.AccountIdentifier{
 		sdk.NewAccountIdentifierFromAccountLocator(testClient().GetAccountLocator()),
 	})
-	t.Cleanup(func() {
-		// TODO(SNOW-1562172): Create a better solution for this type of situations
-		require.Eventually(t, func() bool { return secondaryTestClient().Database.DropDatabase(t, primaryDatabase.ID()) == nil }, time.Second*5, time.Second)
-	})
+	t.Cleanup(primaryDatabaseCleanup)
+
+	testClient().Database.WaitForReplicationToTakeEffect(t, externalPrimaryId)
 
 	accountDataRetentionTimeInDays := testClient().Parameter.ShowAccountParameter(t, sdk.AccountParameterDataRetentionTimeInDays)
 
@@ -465,13 +460,12 @@ func TestAcc_SecondaryDatabase_migrateFromV0941_ensureSmoothUpgradeWithNewResour
 	id := testClient().Ids.RandomAccountObjectIdentifier()
 	providerConfig := providermodel.V097CompatibleProviderConfig(t)
 
-	primaryDatabase, externalPrimaryId, _ := secondaryTestClient().Database.CreatePrimaryDatabase(t, []sdk.AccountIdentifier{
+	_, externalPrimaryId, primaryDatabaseCleanup := secondaryTestClient().Database.CreatePrimaryDatabase(t, []sdk.AccountIdentifier{
 		sdk.NewAccountIdentifierFromAccountLocator(testClient().GetAccountLocator()),
 	})
-	t.Cleanup(func() {
-		// TODO(SNOW-1562172): Create a better solution for this type of situations
-		require.Eventually(t, func() bool { return secondaryTestClient().Database.DropDatabase(t, primaryDatabase.ID()) == nil }, time.Second*5, time.Second)
-	})
+	t.Cleanup(primaryDatabaseCleanup)
+
+	testClient().Database.WaitForReplicationToTakeEffect(t, externalPrimaryId)
 
 	secondaryDatabaseModel := model.SecondaryDatabase("test", id.Name(), externalPrimaryId.FullyQualifiedName())
 
@@ -506,14 +500,13 @@ func TestAcc_SecondaryDatabase_IdentifierQuotingDiffSuppression(t *testing.T) {
 	quotedId := fmt.Sprintf(`"%s"`, id.Name())
 	providerConfig := providermodel.V097CompatibleProviderConfig(t)
 
-	primaryDatabase, externalPrimaryId, _ := secondaryTestClient().Database.CreatePrimaryDatabase(t, []sdk.AccountIdentifier{
+	_, externalPrimaryId, primaryDatabaseCleanup := secondaryTestClient().Database.CreatePrimaryDatabase(t, []sdk.AccountIdentifier{
 		sdk.NewAccountIdentifierFromAccountLocator(testClient().GetAccountLocator()),
 	})
 	unquotedExternalPrimaryId := fmt.Sprintf("%s.%s.%s", externalPrimaryId.AccountIdentifier().OrganizationName(), externalPrimaryId.AccountIdentifier().AccountName(), externalPrimaryId.Name())
-	t.Cleanup(func() {
-		// TODO(SNOW-1562172): Create a better solution for this type of situations
-		require.Eventually(t, func() bool { return secondaryTestClient().Database.DropDatabase(t, primaryDatabase.ID()) == nil }, time.Second*5, time.Second)
-	})
+	t.Cleanup(primaryDatabaseCleanup)
+
+	testClient().Database.WaitForReplicationToTakeEffect(t, externalPrimaryId)
 
 	secondaryDatabaseModel := model.SecondaryDatabase("test", quotedId, unquotedExternalPrimaryId)
 


### PR DESCRIPTION
Wait for cross-region replication to take effect before creating secondary databases, and retry primary database cleanup until the removal of the secondary database has propagated. This reduces flakiness in the secondary/replication database integration and acceptance tests.

Fixes 13 tests in total, leaving 5 that still need to be fixed.