### PR TITLE
feat: add SDK support for CREATE ICEBERG TABLE from REST catalog

### DIFF
--- a/pkg/sdk/generator/defs/iceberg_tables_def.go
+++ b/pkg/sdk/generator/defs/iceberg_tables_def.go
@@ -35,6 +35,10 @@ var (
 		"StorageSerializationPolicy", "StorageSerializationPolicies",
 		"COMPATIBLE", "OPTIMIZED",
 	)
+	IcebergTableIcebergMergeOnReadBehaviorEnumDef = g.NewEnum(
+		"IcebergTableIcebergMergeOnReadBehavior", "IcebergTableIcebergMergeOnReadBehaviors",
+		"AUTO", "ENABLED", "DISABLED",
+	)
 )
 
 var icebergTableColumn = g.NewQueryStruct("IcebergTableColumn").
@@ -245,6 +249,31 @@ var icebergTablesDef = g.NewInterface(
 		PredefinedQueryStructField("Contact", "[]TableContact", g.KeywordOptions().Parentheses().SQL("WITH CONTACT")).
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists"),
+).CustomOperation(
+	"CreateFromIcebergRest",
+	"https://docs.snowflake.com/en/sql-reference/sql/create-iceberg-table-rest",
+	g.NewQueryStruct("CreateFromIcebergRest").
+		Create().
+		OrReplace().
+		SQL("ICEBERG TABLE").
+		IfNotExists().
+		Name().
+		OptionalIdentifier("ExternalVolume", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("EXTERNAL_VOLUME").Equals().SingleQuotes()).
+		OptionalIdentifier("Catalog", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("CATALOG").Equals().SingleQuotes()).
+		TextAssignment("CATALOG_TABLE_NAME", g.ParameterOptions().SingleQuotes().Required()).
+		OptionalTextAssignment("CATALOG_NAMESPACE", g.ParameterOptions().SingleQuotes()).
+		OptionalAssignment("PATH_LAYOUT", IcebergTablePathLayoutEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
+		OptionalAssignment("TARGET_FILE_SIZE", IcebergTableTargetFileSizeEnumDef.KindPtr(), g.ParameterOptions().SingleQuotes()).
+		OptionalBooleanAssignment("REPLACE_INVALID_CHARACTERS", g.ParameterOptions()).
+		OptionalBooleanAssignment("AUTO_REFRESH", g.ParameterOptions()).
+		OptionalComment().
+		OptionalAssignment("STORAGE_SERIALIZATION_POLICY", StorageSerializationPolicyEnumDef.KindPtr(), g.ParameterOptions().NoQuotes()).
+		OptionalAssignment("ICEBERG_MERGE_ON_READ_BEHAVIOR", IcebergTableIcebergMergeOnReadBehaviorEnumDef.KindPtr(), g.ParameterOptions().SingleQuotes()).
+		OptionalBooleanAssignment("ENABLE_ICEBERG_MERGE_ON_READ", g.ParameterOptions()).
+		OptionalTags().
+		PredefinedQueryStructField("Contact", "[]TableContact", g.KeywordOptions().Parentheses().SQL("WITH CONTACT")).
+		WithValidation(g.ValidIdentifier, "name").
+		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists"),
 ).AlterOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/alter-iceberg-table",
 	g.NewQueryStruct("AlterIcebergTable").
@@ -416,4 +445,5 @@ var icebergTablesDef = g.NewInterface(
 	IcebergTableTypeEnumDef,
 	IcebergTableCatalogEnumDef,
 	StorageSerializationPolicyEnumDef,
+	IcebergTableIcebergMergeOnReadBehaviorEnumDef,
 )

--- a/pkg/sdk/iceberg_tables_dto_builders_gen.go
+++ b/pkg/sdk/iceberg_tables_dto_builders_gen.go
@@ -918,6 +918,91 @@ func (s *CreateFromDeltaLakeIcebergTableRequest) WithContact(contact []TableCont
 	return s
 }
 
+func NewCreateFromIcebergRestIcebergTableRequest(
+	name SchemaObjectIdentifier,
+	catalogTableName string,
+) *CreateFromIcebergRestIcebergTableRequest {
+	s := CreateFromIcebergRestIcebergTableRequest{}
+	s.name = name
+	s.CatalogTableName = catalogTableName
+	return &s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithOrReplace(orReplace bool) *CreateFromIcebergRestIcebergTableRequest {
+	s.OrReplace = &orReplace
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithIfNotExists(ifNotExists bool) *CreateFromIcebergRestIcebergTableRequest {
+	s.IfNotExists = &ifNotExists
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithExternalVolume(externalVolume AccountObjectIdentifier) *CreateFromIcebergRestIcebergTableRequest {
+	s.ExternalVolume = &externalVolume
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithCatalog(catalog AccountObjectIdentifier) *CreateFromIcebergRestIcebergTableRequest {
+	s.Catalog = &catalog
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithCatalogNamespace(catalogNamespace string) *CreateFromIcebergRestIcebergTableRequest {
+	s.CatalogNamespace = &catalogNamespace
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithPathLayout(pathLayout IcebergTablePathLayout) *CreateFromIcebergRestIcebergTableRequest {
+	s.PathLayout = &pathLayout
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithTargetFileSize(targetFileSize IcebergTableTargetFileSize) *CreateFromIcebergRestIcebergTableRequest {
+	s.TargetFileSize = &targetFileSize
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithReplaceInvalidCharacters(replaceInvalidCharacters bool) *CreateFromIcebergRestIcebergTableRequest {
+	s.ReplaceInvalidCharacters = &replaceInvalidCharacters
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithAutoRefresh(autoRefresh bool) *CreateFromIcebergRestIcebergTableRequest {
+	s.AutoRefresh = &autoRefresh
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithComment(comment string) *CreateFromIcebergRestIcebergTableRequest {
+	s.Comment = &comment
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithStorageSerializationPolicy(storageSerializationPolicy StorageSerializationPolicy) *CreateFromIcebergRestIcebergTableRequest {
+	s.StorageSerializationPolicy = &storageSerializationPolicy
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithIcebergMergeOnReadBehavior(icebergMergeOnReadBehavior IcebergTableIcebergMergeOnReadBehavior) *CreateFromIcebergRestIcebergTableRequest {
+	s.IcebergMergeOnReadBehavior = &icebergMergeOnReadBehavior
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithEnableIcebergMergeOnRead(enableIcebergMergeOnRead bool) *CreateFromIcebergRestIcebergTableRequest {
+	s.EnableIcebergMergeOnRead = &enableIcebergMergeOnRead
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithTag(tag []TagAssociation) *CreateFromIcebergRestIcebergTableRequest {
+	s.Tag = tag
+	return s
+}
+
+func (s *CreateFromIcebergRestIcebergTableRequest) WithContact(contact []TableContact) *CreateFromIcebergRestIcebergTableRequest {
+	s.Contact = contact
+	return s
+}
+
 func NewAlterIcebergTableRequest(
 	name SchemaObjectIdentifier,
 ) *AlterIcebergTableRequest {

--- a/pkg/sdk/iceberg_tables_dto_gen.go
+++ b/pkg/sdk/iceberg_tables_dto_gen.go
@@ -8,6 +8,7 @@ var (
 	_ optionsProvider[CreateIcebergTableOptions]                 = new(CreateIcebergTableRequest)
 	_ optionsProvider[CreateFromIcebergFilesIcebergTableOptions] = new(CreateFromIcebergFilesIcebergTableRequest)
 	_ optionsProvider[CreateFromDeltaLakeIcebergTableOptions]    = new(CreateFromDeltaLakeIcebergTableRequest)
+	_ optionsProvider[CreateFromIcebergRestIcebergTableOptions]  = new(CreateFromIcebergRestIcebergTableRequest)
 	_ optionsProvider[AlterIcebergTableOptions]                  = new(AlterIcebergTableRequest)
 	_ optionsProvider[DropIcebergTableOptions]                   = new(DropIcebergTableRequest)
 	_ optionsProvider[ShowIcebergTableOptions]                   = new(ShowIcebergTableRequest)
@@ -259,6 +260,26 @@ type CreateFromDeltaLakeIcebergTableRequest struct {
 	Comment                  *string
 	Tag                      []TagAssociation
 	Contact                  []TableContact
+}
+
+type CreateFromIcebergRestIcebergTableRequest struct {
+	OrReplace                  *bool
+	IfNotExists                *bool
+	name                       SchemaObjectIdentifier // required
+	ExternalVolume             *AccountObjectIdentifier
+	Catalog                    *AccountObjectIdentifier
+	CatalogTableName           string // required
+	CatalogNamespace           *string
+	PathLayout                 *IcebergTablePathLayout
+	TargetFileSize             *IcebergTableTargetFileSize
+	ReplaceInvalidCharacters   *bool
+	AutoRefresh                *bool
+	Comment                    *string
+	StorageSerializationPolicy *StorageSerializationPolicy
+	IcebergMergeOnReadBehavior *IcebergTableIcebergMergeOnReadBehavior
+	EnableIcebergMergeOnRead   *bool
+	Tag                        []TagAssociation
+	Contact                    []TableContact
 }
 
 type AlterIcebergTableRequest struct {

--- a/pkg/sdk/iceberg_tables_enums_gen.go
+++ b/pkg/sdk/iceberg_tables_enums_gen.go
@@ -218,3 +218,31 @@ func ToStorageSerializationPolicy(s string) (StorageSerializationPolicy, error) 
 		return "", fmt.Errorf("invalid storage serialization policy: %s", s)
 	}
 }
+
+type IcebergTableIcebergMergeOnReadBehavior string
+
+const (
+	IcebergTableIcebergMergeOnReadBehaviorAuto     IcebergTableIcebergMergeOnReadBehavior = "AUTO"
+	IcebergTableIcebergMergeOnReadBehaviorEnabled  IcebergTableIcebergMergeOnReadBehavior = "ENABLED"
+	IcebergTableIcebergMergeOnReadBehaviorDisabled IcebergTableIcebergMergeOnReadBehavior = "DISABLED"
+)
+
+var AllIcebergTableIcebergMergeOnReadBehaviors = []IcebergTableIcebergMergeOnReadBehavior{
+	IcebergTableIcebergMergeOnReadBehaviorAuto,
+	IcebergTableIcebergMergeOnReadBehaviorEnabled,
+	IcebergTableIcebergMergeOnReadBehaviorDisabled,
+}
+
+func ToIcebergTableIcebergMergeOnReadBehavior(s string) (IcebergTableIcebergMergeOnReadBehavior, error) {
+	s = strings.ToUpper(s)
+	switch s {
+	case string(IcebergTableIcebergMergeOnReadBehaviorAuto):
+		return IcebergTableIcebergMergeOnReadBehaviorAuto, nil
+	case string(IcebergTableIcebergMergeOnReadBehaviorEnabled):
+		return IcebergTableIcebergMergeOnReadBehaviorEnabled, nil
+	case string(IcebergTableIcebergMergeOnReadBehaviorDisabled):
+		return IcebergTableIcebergMergeOnReadBehaviorDisabled, nil
+	default:
+		return "", fmt.Errorf("invalid iceberg table iceberg merge on read behavior: %s", s)
+	}
+}

--- a/pkg/sdk/iceberg_tables_gen.go
+++ b/pkg/sdk/iceberg_tables_gen.go
@@ -14,6 +14,7 @@ type IcebergTables interface {
 	Create(ctx context.Context, request *CreateIcebergTableRequest) error
 	CreateFromIcebergFiles(ctx context.Context, request *CreateFromIcebergFilesIcebergTableRequest) error
 	CreateFromDeltaLake(ctx context.Context, request *CreateFromDeltaLakeIcebergTableRequest) error
+	CreateFromIcebergRest(ctx context.Context, request *CreateFromIcebergRestIcebergTableRequest) error
 	Alter(ctx context.Context, request *AlterIcebergTableRequest) error
 	Drop(ctx context.Context, request *DropIcebergTableRequest) error
 	DropSafely(ctx context.Context, id SchemaObjectIdentifier) error
@@ -291,6 +292,29 @@ type CreateFromDeltaLakeIcebergTableOptions struct {
 	Comment                  *string                  `ddl:"parameter,single_quotes" sql:"COMMENT"`
 	Tag                      []TagAssociation         `ddl:"keyword,parentheses" sql:"TAG"`
 	Contact                  []TableContact           `ddl:"keyword,parentheses" sql:"WITH CONTACT"`
+}
+
+// CreateFromIcebergRestIcebergTableOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-iceberg-table-rest.
+type CreateFromIcebergRestIcebergTableOptions struct {
+	create                     bool                                    `ddl:"static" sql:"CREATE"`
+	OrReplace                  *bool                                   `ddl:"keyword" sql:"OR REPLACE"`
+	icebergTable               bool                                    `ddl:"static" sql:"ICEBERG TABLE"`
+	IfNotExists                *bool                                   `ddl:"keyword" sql:"IF NOT EXISTS"`
+	name                       SchemaObjectIdentifier                  `ddl:"identifier"`
+	ExternalVolume             *AccountObjectIdentifier                `ddl:"identifier,single_quotes,equals" sql:"EXTERNAL_VOLUME"`
+	Catalog                    *AccountObjectIdentifier                `ddl:"identifier,single_quotes,equals" sql:"CATALOG"`
+	CatalogTableName           string                                  `ddl:"parameter,single_quotes" sql:"CATALOG_TABLE_NAME"`
+	CatalogNamespace           *string                                 `ddl:"parameter,single_quotes" sql:"CATALOG_NAMESPACE"`
+	PathLayout                 *IcebergTablePathLayout                 `ddl:"parameter,no_quotes" sql:"PATH_LAYOUT"`
+	TargetFileSize             *IcebergTableTargetFileSize             `ddl:"parameter,single_quotes" sql:"TARGET_FILE_SIZE"`
+	ReplaceInvalidCharacters   *bool                                   `ddl:"parameter" sql:"REPLACE_INVALID_CHARACTERS"`
+	AutoRefresh                *bool                                   `ddl:"parameter" sql:"AUTO_REFRESH"`
+	Comment                    *string                                 `ddl:"parameter,single_quotes" sql:"COMMENT"`
+	StorageSerializationPolicy *StorageSerializationPolicy             `ddl:"parameter,no_quotes" sql:"STORAGE_SERIALIZATION_POLICY"`
+	IcebergMergeOnReadBehavior *IcebergTableIcebergMergeOnReadBehavior `ddl:"parameter,single_quotes" sql:"ICEBERG_MERGE_ON_READ_BEHAVIOR"`
+	EnableIcebergMergeOnRead   *bool                                   `ddl:"parameter" sql:"ENABLE_ICEBERG_MERGE_ON_READ"`
+	Tag                        []TagAssociation                        `ddl:"keyword,parentheses" sql:"TAG"`
+	Contact                    []TableContact                          `ddl:"keyword,parentheses" sql:"WITH CONTACT"`
 }
 
 // AlterIcebergTableOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-iceberg-table.

--- a/pkg/sdk/iceberg_tables_gen_test.go
+++ b/pkg/sdk/iceberg_tables_gen_test.go
@@ -15,6 +15,7 @@ func init() {
 	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[IcebergTableType]{"IcebergTableType", AllIcebergTableTypes, ToIcebergTableType})
 	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[IcebergTableCatalog]{"IcebergTableCatalog", AllIcebergTableCatalogs, ToIcebergTableCatalog})
 	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[StorageSerializationPolicy]{"StorageSerializationPolicy", AllStorageSerializationPolicies, ToStorageSerializationPolicy})
+	allEnumConversionTests = append(allEnumConversionTests, typedEnumTestProvider[IcebergTableIcebergMergeOnReadBehavior]{"IcebergTableIcebergMergeOnReadBehavior", AllIcebergTableIcebergMergeOnReadBehaviors, ToIcebergTableIcebergMergeOnReadBehavior})
 }
 
 func TestIcebergTables_Create(t *testing.T) {
@@ -1064,6 +1065,96 @@ func TestIcebergTables_CreateFromDeltaLake(t *testing.T) {
 				`REPLACE_INVALID_CHARACTERS = true `+
 				`AUTO_REFRESH = true `+
 				`COMMENT = 'some comment' `+
+				`TAG (%s = 'v1', %s = 'v2') `+
+				`WITH CONTACT (SUPPORT = %s)`,
+			id.FullyQualifiedName(),
+			externalVolumeId.Name(),
+			catalogId.Name(),
+			tagId1.FullyQualifiedName(), tagId2.FullyQualifiedName(),
+			contactId.FullyQualifiedName(),
+		)
+	})
+}
+
+func TestIcebergTables_CreateFromIcebergRest(t *testing.T) {
+	id := randomSchemaObjectIdentifier()
+	externalVolumeId := NewAccountObjectIdentifier("vol1")
+	catalogId := NewAccountObjectIdentifier("cat1")
+	tagId1 := randomSchemaObjectIdentifier()
+	tagId2 := randomSchemaObjectIdentifier()
+
+	defaultOpts := func() *CreateFromIcebergRestIcebergTableOptions {
+		return &CreateFromIcebergRestIcebergTableOptions{
+			name:             id,
+			CatalogTableName: "my_remote_table",
+		}
+	}
+
+	t.Run("validation: nil options", func(t *testing.T) {
+		opts := (*CreateFromIcebergRestIcebergTableOptions)(nil)
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
+	})
+
+	t.Run("validation: valid identifier for [opts.name]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.name = emptySchemaObjectIdentifier
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: conflicting fields for [opts.OrReplace opts.IfNotExists]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.OrReplace = new(true)
+		opts.IfNotExists = new(true)
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("CreateFromIcebergRestIcebergTableOptions", "OrReplace", "IfNotExists"))
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		opts := defaultOpts()
+		assertOptsValidAndSQLEquals(t, opts, `CREATE ICEBERG TABLE %s CATALOG_TABLE_NAME = 'my_remote_table'`, id.FullyQualifiedName())
+	})
+
+	t.Run("if not exists", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.IfNotExists = new(true)
+		assertOptsValidAndSQLEquals(t, opts, `CREATE ICEBERG TABLE IF NOT EXISTS %s CATALOG_TABLE_NAME = 'my_remote_table'`, id.FullyQualifiedName())
+	})
+
+	t.Run("all options", func(t *testing.T) {
+		contactId := randomSchemaObjectIdentifier()
+		opts := defaultOpts()
+		opts.OrReplace = new(true)
+		opts.ExternalVolume = &externalVolumeId
+		opts.Catalog = &catalogId
+		opts.CatalogNamespace = new("my_namespace")
+		opts.PathLayout = new(IcebergTablePathLayoutHierarchical)
+		opts.TargetFileSize = new(IcebergTableTargetFileSize64mb)
+		opts.ReplaceInvalidCharacters = new(true)
+		opts.AutoRefresh = new(true)
+		opts.Comment = new("some comment")
+		opts.StorageSerializationPolicy = new(StorageSerializationPolicyOptimized)
+		opts.IcebergMergeOnReadBehavior = new(IcebergTableIcebergMergeOnReadBehaviorEnabled)
+		opts.EnableIcebergMergeOnRead = new(true)
+		opts.Tag = []TagAssociation{
+			{Name: tagId1, Value: "v1"},
+			{Name: tagId2, Value: "v2"},
+		}
+		opts.Contact = []TableContact{
+			{Purpose: "SUPPORT", Contact: contactId},
+		}
+		assertOptsValidAndSQLEquals(t, opts,
+			`CREATE OR REPLACE ICEBERG TABLE %s `+
+				`EXTERNAL_VOLUME = '\"%s\"' `+
+				`CATALOG = '\"%s\"' `+
+				`CATALOG_TABLE_NAME = 'my_remote_table' `+
+				`CATALOG_NAMESPACE = 'my_namespace' `+
+				`PATH_LAYOUT = HIERARCHICAL `+
+				`TARGET_FILE_SIZE = '64MB' `+
+				`REPLACE_INVALID_CHARACTERS = true `+
+				`AUTO_REFRESH = true `+
+				`COMMENT = 'some comment' `+
+				`STORAGE_SERIALIZATION_POLICY = OPTIMIZED `+
+				`ICEBERG_MERGE_ON_READ_BEHAVIOR = 'ENABLED' `+
+				`ENABLE_ICEBERG_MERGE_ON_READ = true `+
 				`TAG (%s = 'v1', %s = 'v2') `+
 				`WITH CONTACT (SUPPORT = %s)`,
 			id.FullyQualifiedName(),

--- a/pkg/sdk/iceberg_tables_impl_gen.go
+++ b/pkg/sdk/iceberg_tables_impl_gen.go
@@ -36,6 +36,11 @@ func (v *icebergTables) CreateFromDeltaLake(ctx context.Context, request *Create
 	return validateAndExec(v.client, ctx, opts)
 }
 
+func (v *icebergTables) CreateFromIcebergRest(ctx context.Context, request *CreateFromIcebergRestIcebergTableRequest) error {
+	opts := request.toOpts()
+	return validateAndExec(v.client, ctx, opts)
+}
+
 func (v *icebergTables) Alter(ctx context.Context, request *AlterIcebergTableRequest) error {
 	opts := request.toOpts()
 	return validateAndExec(v.client, ctx, opts)
@@ -338,6 +343,29 @@ func (r *CreateFromDeltaLakeIcebergTableRequest) toOpts() *CreateFromDeltaLakeIc
 		Comment:                  r.Comment,
 		Tag:                      r.Tag,
 		Contact:                  r.Contact,
+	}
+	return opts
+}
+
+func (r *CreateFromIcebergRestIcebergTableRequest) toOpts() *CreateFromIcebergRestIcebergTableOptions {
+	opts := &CreateFromIcebergRestIcebergTableOptions{
+		OrReplace:                  r.OrReplace,
+		IfNotExists:                r.IfNotExists,
+		name:                       r.name,
+		ExternalVolume:             r.ExternalVolume,
+		Catalog:                    r.Catalog,
+		CatalogTableName:           r.CatalogTableName,
+		CatalogNamespace:           r.CatalogNamespace,
+		PathLayout:                 r.PathLayout,
+		TargetFileSize:             r.TargetFileSize,
+		ReplaceInvalidCharacters:   r.ReplaceInvalidCharacters,
+		AutoRefresh:                r.AutoRefresh,
+		Comment:                    r.Comment,
+		StorageSerializationPolicy: r.StorageSerializationPolicy,
+		IcebergMergeOnReadBehavior: r.IcebergMergeOnReadBehavior,
+		EnableIcebergMergeOnRead:   r.EnableIcebergMergeOnRead,
+		Tag:                        r.Tag,
+		Contact:                    r.Contact,
 	}
 	return opts
 }

--- a/pkg/sdk/iceberg_tables_validations_gen.go
+++ b/pkg/sdk/iceberg_tables_validations_gen.go
@@ -6,6 +6,7 @@ var (
 	_ validatable = new(CreateIcebergTableOptions)
 	_ validatable = new(CreateFromIcebergFilesIcebergTableOptions)
 	_ validatable = new(CreateFromDeltaLakeIcebergTableOptions)
+	_ validatable = new(CreateFromIcebergRestIcebergTableOptions)
 	_ validatable = new(AlterIcebergTableOptions)
 	_ validatable = new(DropIcebergTableOptions)
 	_ validatable = new(ShowIcebergTableOptions)
@@ -68,6 +69,20 @@ func (opts *CreateFromDeltaLakeIcebergTableOptions) validate() error {
 	}
 	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
 		errs = append(errs, errOneOf("CreateFromDeltaLakeIcebergTableOptions", "OrReplace", "IfNotExists"))
+	}
+	return JoinErrors(errs...)
+}
+
+func (opts *CreateFromIcebergRestIcebergTableOptions) validate() error {
+	if opts == nil {
+		return ErrNilOptions
+	}
+	var errs []error
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
+		errs = append(errs, errOneOf("CreateFromIcebergRestIcebergTableOptions", "OrReplace", "IfNotExists"))
 	}
 	return JoinErrors(errs...)
 }


### PR DESCRIPTION
## Summary

- Adds `CreateFromIcebergRest` SDK operation for creating Iceberg tables from a REST catalog
- Introduces `IcebergTableIcebergMergeOnReadBehavior` enum (AUTO, ENABLED, DISABLED)
- Follows the same pattern as existing `CreateFromIcebergFiles` and `CreateFromDeltaLake` operations
- Covers full SDK layer: options struct, DTO, builder methods, validation, implementation, and unit tests