### PR TITLE
feat: Add ALLOWED_ROLES_LIST to OAuth for partner applications and custom clients

### DIFF
--- a/pkg/sdk/generator/defs/security_integrations_def.go
+++ b/pkg/sdk/generator/defs/security_integrations_def.go
@@ -212,10 +212,12 @@ var oauthForPartnerApplicationsIntegrationSetDef = g.NewQueryStruct("OauthForPar
 		"OAUTH_USE_SECONDARY_ROLES", OauthSecurityIntegrationUseSecondaryRolesOptionEnumDef,
 		g.ParameterOptions(),
 	).
+	// AllowedRolesList can only be set when OAUTH_USE_SECONDARY_ROLES = NONE (the default); it is incompatible with IMPLICIT.
+	OptionalQueryStructField("AllowedRolesList", allowedRolesListDef, g.ParameterOptions().SQL("ALLOWED_ROLES_LIST").Parentheses()).
 	OptionalQueryStructField("BlockedRolesList", blockedRolesListDef, g.ParameterOptions().SQL("BLOCKED_ROLES_LIST").Parentheses()).
 	OptionalAssignment("COMMENT", "StringAllowEmpty", g.ParameterOptions()).
 	WithValidation(g.AtLeastOneValueSet, "Enabled", "OauthIssueRefreshTokens", "OauthRedirectUri", "OauthRefreshTokenValidity", "OauthUseSecondaryRoles",
-		"BlockedRolesList", "Comment")
+		"AllowedRolesList", "BlockedRolesList", "Comment")
 
 var oauthForPartnerApplicationsIntegrationUnsetDef = g.NewQueryStruct("OauthForPartnerApplicationsIntegrationUnset").
 	OptionalSQL("ENABLED").
@@ -228,6 +230,8 @@ var oauthForCustomClientsIntegrationSetDef = g.NewQueryStruct("OauthForCustomCli
 	OptionalBooleanAssignment("OAUTH_ALLOW_NON_TLS_REDIRECT_URI", g.ParameterOptions()).
 	OptionalBooleanAssignment("OAUTH_ENFORCE_PKCE", g.ParameterOptions()).
 	OptionalQueryStructField("PreAuthorizedRolesList", preAuthorizedRolesListDef, g.ParameterOptions().SQL("PRE_AUTHORIZED_ROLES_LIST").Parentheses()).
+	// AllowedRolesList can only be set when OAUTH_USE_SECONDARY_ROLES = NONE (the default); it is incompatible with IMPLICIT.
+	OptionalQueryStructField("AllowedRolesList", allowedRolesListDef, g.ParameterOptions().SQL("ALLOWED_ROLES_LIST").Parentheses()).
 	OptionalQueryStructField("BlockedRolesList", blockedRolesListDef, g.ParameterOptions().SQL("BLOCKED_ROLES_LIST").Parentheses()).
 	OptionalBooleanAssignment("OAUTH_ISSUE_REFRESH_TOKENS", g.ParameterOptions()).
 	OptionalNumberAssignment("OAUTH_REFRESH_TOKEN_VALIDITY", g.ParameterOptions()).
@@ -240,7 +244,7 @@ var oauthForCustomClientsIntegrationSetDef = g.NewQueryStruct("OauthForCustomCli
 	OptionalTextAssignment("OAUTH_CLIENT_RSA_PUBLIC_KEY_2", g.ParameterOptions().SingleQuotes()).
 	OptionalComment().
 	WithValidation(g.AtLeastOneValueSet, "Enabled", "OauthRedirectUri", "OauthAllowNonTlsRedirectUri", "OauthEnforcePkce", "PreAuthorizedRolesList",
-		"BlockedRolesList", "OauthIssueRefreshTokens", "OauthRefreshTokenValidity", "OauthUseSecondaryRoles", "NetworkPolicy", "OauthClientRsaPublicKey",
+		"AllowedRolesList", "BlockedRolesList", "OauthIssueRefreshTokens", "OauthRefreshTokenValidity", "OauthUseSecondaryRoles", "NetworkPolicy", "OauthClientRsaPublicKey",
 		"OauthClientRsaPublicKey2", "Comment")
 
 var oauthForCustomClientsIntegrationUnsetDef = g.NewQueryStruct("OauthForCustomClientsIntegrationUnset").
@@ -430,6 +434,8 @@ var securityIntegrationsDef = g.NewInterface(
 					"OAUTH_USE_SECONDARY_ROLES", OauthSecurityIntegrationUseSecondaryRolesOptionEnumDef,
 					g.ParameterOptions(),
 				).
+				// AllowedRolesList can only be set when OAUTH_USE_SECONDARY_ROLES = NONE (the default); it is incompatible with IMPLICIT.
+				OptionalQueryStructField("AllowedRolesList", allowedRolesListDef, g.ParameterOptions().SQL("ALLOWED_ROLES_LIST").Parentheses()).
 				OptionalQueryStructField("BlockedRolesList", blockedRolesListDef, g.ParameterOptions().SQL("BLOCKED_ROLES_LIST").Parentheses())
 		}).WithAdditionalValidations(),
 		preAuthorizedRolesListDef,
@@ -455,6 +461,8 @@ var securityIntegrationsDef = g.NewInterface(
 					g.ParameterOptions(),
 				).
 				OptionalQueryStructField("PreAuthorizedRolesList", preAuthorizedRolesListDef, g.ParameterOptions().SQL("PRE_AUTHORIZED_ROLES_LIST").Parentheses()).
+				// AllowedRolesList can only be set when OAUTH_USE_SECONDARY_ROLES = NONE (the default); it is incompatible with IMPLICIT.
+				OptionalQueryStructField("AllowedRolesList", allowedRolesListDef, g.ParameterOptions().SQL("ALLOWED_ROLES_LIST").Parentheses()).
 				OptionalQueryStructField("BlockedRolesList", blockedRolesListDef, g.ParameterOptions().SQL("BLOCKED_ROLES_LIST").Parentheses()).
 				OptionalBooleanAssignment("OAUTH_ISSUE_REFRESH_TOKENS", g.ParameterOptions()).
 				OptionalNumberAssignment("OAUTH_REFRESH_TOKEN_VALIDITY", g.ParameterOptions()).

--- a/pkg/sdk/security_integrations_dto_builders_gen.go
+++ b/pkg/sdk/security_integrations_dto_builders_gen.go
@@ -333,6 +333,11 @@ func (s *CreateOauthForPartnerApplicationsSecurityIntegrationRequest) WithOauthU
 	return s
 }
 
+func (s *CreateOauthForPartnerApplicationsSecurityIntegrationRequest) WithAllowedRolesList(allowedRolesList AllowedRolesListRequest) *CreateOauthForPartnerApplicationsSecurityIntegrationRequest {
+	s.AllowedRolesList = &allowedRolesList
+	return s
+}
+
 func (s *CreateOauthForPartnerApplicationsSecurityIntegrationRequest) WithBlockedRolesList(blockedRolesList BlockedRolesListRequest) *CreateOauthForPartnerApplicationsSecurityIntegrationRequest {
 	s.BlockedRolesList = &blockedRolesList
 	return s
@@ -387,6 +392,11 @@ func (s *CreateOauthForCustomClientsSecurityIntegrationRequest) WithOauthUseSeco
 
 func (s *CreateOauthForCustomClientsSecurityIntegrationRequest) WithPreAuthorizedRolesList(preAuthorizedRolesList PreAuthorizedRolesListRequest) *CreateOauthForCustomClientsSecurityIntegrationRequest {
 	s.PreAuthorizedRolesList = &preAuthorizedRolesList
+	return s
+}
+
+func (s *CreateOauthForCustomClientsSecurityIntegrationRequest) WithAllowedRolesList(allowedRolesList AllowedRolesListRequest) *CreateOauthForCustomClientsSecurityIntegrationRequest {
+	s.AllowedRolesList = &allowedRolesList
 	return s
 }
 
@@ -1073,6 +1083,11 @@ func (s *OauthForPartnerApplicationsIntegrationSetRequest) WithOauthUseSecondary
 	return s
 }
 
+func (s *OauthForPartnerApplicationsIntegrationSetRequest) WithAllowedRolesList(allowedRolesList AllowedRolesListRequest) *OauthForPartnerApplicationsIntegrationSetRequest {
+	s.AllowedRolesList = &allowedRolesList
+	return s
+}
+
 func (s *OauthForPartnerApplicationsIntegrationSetRequest) WithBlockedRolesList(blockedRolesList BlockedRolesListRequest) *OauthForPartnerApplicationsIntegrationSetRequest {
 	s.BlockedRolesList = &blockedRolesList
 	return s
@@ -1158,6 +1173,11 @@ func (s *OauthForCustomClientsIntegrationSetRequest) WithOauthEnforcePkce(oauthE
 
 func (s *OauthForCustomClientsIntegrationSetRequest) WithPreAuthorizedRolesList(preAuthorizedRolesList PreAuthorizedRolesListRequest) *OauthForCustomClientsIntegrationSetRequest {
 	s.PreAuthorizedRolesList = &preAuthorizedRolesList
+	return s
+}
+
+func (s *OauthForCustomClientsIntegrationSetRequest) WithAllowedRolesList(allowedRolesList AllowedRolesListRequest) *OauthForCustomClientsIntegrationSetRequest {
+	s.AllowedRolesList = &allowedRolesList
 	return s
 }
 

--- a/pkg/sdk/security_integrations_dto_gen.go
+++ b/pkg/sdk/security_integrations_dto_gen.go
@@ -117,6 +117,7 @@ type CreateOauthForPartnerApplicationsSecurityIntegrationRequest struct {
 	OauthIssueRefreshTokens   *bool
 	OauthRefreshTokenValidity *int
 	OauthUseSecondaryRoles    *OauthSecurityIntegrationUseSecondaryRolesOption
+	AllowedRolesList          *AllowedRolesListRequest
 	BlockedRolesList          *BlockedRolesListRequest
 	Comment                   *string
 }
@@ -132,6 +133,7 @@ type CreateOauthForCustomClientsSecurityIntegrationRequest struct {
 	OauthEnforcePkce            *bool
 	OauthUseSecondaryRoles      *OauthSecurityIntegrationUseSecondaryRolesOption
 	PreAuthorizedRolesList      *PreAuthorizedRolesListRequest
+	AllowedRolesList            *AllowedRolesListRequest
 	BlockedRolesList            *BlockedRolesListRequest
 	OauthIssueRefreshTokens     *bool
 	OauthRefreshTokenValidity   *int
@@ -309,6 +311,7 @@ type OauthForPartnerApplicationsIntegrationSetRequest struct {
 	OauthRedirectUri          *string
 	OauthRefreshTokenValidity *int
 	OauthUseSecondaryRoles    *OauthSecurityIntegrationUseSecondaryRolesOption
+	AllowedRolesList          *AllowedRolesListRequest
 	BlockedRolesList          *BlockedRolesListRequest
 	Comment                   *StringAllowEmpty
 }
@@ -333,6 +336,7 @@ type OauthForCustomClientsIntegrationSetRequest struct {
 	OauthAllowNonTlsRedirectUri *bool
 	OauthEnforcePkce            *bool
 	PreAuthorizedRolesList      *PreAuthorizedRolesListRequest
+	AllowedRolesList            *AllowedRolesListRequest
 	BlockedRolesList            *BlockedRolesListRequest
 	OauthIssueRefreshTokens     *bool
 	OauthRefreshTokenValidity   *int

--- a/pkg/sdk/security_integrations_gen.go
+++ b/pkg/sdk/security_integrations_gen.go
@@ -165,6 +165,7 @@ type CreateOauthForPartnerApplicationsSecurityIntegrationOptions struct {
 	OauthIssueRefreshTokens   *bool                                            `ddl:"parameter" sql:"OAUTH_ISSUE_REFRESH_TOKENS"`
 	OauthRefreshTokenValidity *int                                             `ddl:"parameter" sql:"OAUTH_REFRESH_TOKEN_VALIDITY"`
 	OauthUseSecondaryRoles    *OauthSecurityIntegrationUseSecondaryRolesOption `ddl:"parameter" sql:"OAUTH_USE_SECONDARY_ROLES"`
+	AllowedRolesList          *AllowedRolesList                                `ddl:"parameter,parentheses" sql:"ALLOWED_ROLES_LIST"`
 	BlockedRolesList          *BlockedRolesList                                `ddl:"parameter,parentheses" sql:"BLOCKED_ROLES_LIST"`
 	Comment                   *string                                          `ddl:"parameter,single_quotes" sql:"COMMENT"`
 }
@@ -189,6 +190,7 @@ type CreateOauthForCustomClientsSecurityIntegrationOptions struct {
 	OauthEnforcePkce            *bool                                            `ddl:"parameter" sql:"OAUTH_ENFORCE_PKCE"`
 	OauthUseSecondaryRoles      *OauthSecurityIntegrationUseSecondaryRolesOption `ddl:"parameter" sql:"OAUTH_USE_SECONDARY_ROLES"`
 	PreAuthorizedRolesList      *PreAuthorizedRolesList                          `ddl:"parameter,parentheses" sql:"PRE_AUTHORIZED_ROLES_LIST"`
+	AllowedRolesList            *AllowedRolesList                                `ddl:"parameter,parentheses" sql:"ALLOWED_ROLES_LIST"`
 	BlockedRolesList            *BlockedRolesList                                `ddl:"parameter,parentheses" sql:"BLOCKED_ROLES_LIST"`
 	OauthIssueRefreshTokens     *bool                                            `ddl:"parameter" sql:"OAUTH_ISSUE_REFRESH_TOKENS"`
 	OauthRefreshTokenValidity   *int                                             `ddl:"parameter" sql:"OAUTH_REFRESH_TOKEN_VALIDITY"`
@@ -393,6 +395,7 @@ type OauthForPartnerApplicationsIntegrationSet struct {
 	OauthRedirectUri          *string                                          `ddl:"parameter,single_quotes" sql:"OAUTH_REDIRECT_URI"`
 	OauthRefreshTokenValidity *int                                             `ddl:"parameter" sql:"OAUTH_REFRESH_TOKEN_VALIDITY"`
 	OauthUseSecondaryRoles    *OauthSecurityIntegrationUseSecondaryRolesOption `ddl:"parameter" sql:"OAUTH_USE_SECONDARY_ROLES"`
+	AllowedRolesList          *AllowedRolesList                                `ddl:"parameter,parentheses" sql:"ALLOWED_ROLES_LIST"`
 	BlockedRolesList          *BlockedRolesList                                `ddl:"parameter,parentheses" sql:"BLOCKED_ROLES_LIST"`
 	Comment                   *StringAllowEmpty                                `ddl:"parameter" sql:"COMMENT"`
 }
@@ -420,6 +423,7 @@ type OauthForCustomClientsIntegrationSet struct {
 	OauthAllowNonTlsRedirectUri *bool                                            `ddl:"parameter" sql:"OAUTH_ALLOW_NON_TLS_REDIRECT_URI"`
 	OauthEnforcePkce            *bool                                            `ddl:"parameter" sql:"OAUTH_ENFORCE_PKCE"`
 	PreAuthorizedRolesList      *PreAuthorizedRolesList                          `ddl:"parameter,parentheses" sql:"PRE_AUTHORIZED_ROLES_LIST"`
+	AllowedRolesList            *AllowedRolesList                                `ddl:"parameter,parentheses" sql:"ALLOWED_ROLES_LIST"`
 	BlockedRolesList            *BlockedRolesList                                `ddl:"parameter,parentheses" sql:"BLOCKED_ROLES_LIST"`
 	OauthIssueRefreshTokens     *bool                                            `ddl:"parameter" sql:"OAUTH_ISSUE_REFRESH_TOKENS"`
 	OauthRefreshTokenValidity   *int                                             `ddl:"parameter" sql:"OAUTH_REFRESH_TOKEN_VALIDITY"`

--- a/pkg/sdk/security_integrations_gen_test.go
+++ b/pkg/sdk/security_integrations_gen_test.go
@@ -312,7 +312,7 @@ func TestSecurityIntegrations_CreateOauthForPartnerApplications(t *testing.T) {
 
 	t.Run("all options", func(t *testing.T) {
 		opts := defaultOpts()
-		blockedRoleID := randomAccountObjectIdentifier()
+		allowedRoleID, blockedRoleID := randomAccountObjectIdentifier(), randomAccountObjectIdentifier()
 		opts.IfNotExists = Bool(true)
 		opts.OauthClient = OauthSecurityIntegrationClientOptionLooker
 		opts.OauthRedirectUri = Pointer("uri")
@@ -320,10 +320,12 @@ func TestSecurityIntegrations_CreateOauthForPartnerApplications(t *testing.T) {
 		opts.OauthIssueRefreshTokens = Pointer(true)
 		opts.OauthRefreshTokenValidity = Pointer(42)
 		opts.OauthUseSecondaryRoles = Pointer(OauthSecurityIntegrationUseSecondaryRolesOptionNone)
+		opts.AllowedRolesList = &AllowedRolesList{AllowedRolesList: []AccountObjectIdentifier{allowedRoleID}}
 		opts.BlockedRolesList = &BlockedRolesList{BlockedRolesList: []AccountObjectIdentifier{blockedRoleID}}
 		opts.Comment = Pointer("a")
 		assertOptsValidAndSQLEquals(t, opts, "CREATE SECURITY INTEGRATION IF NOT EXISTS %s TYPE = OAUTH OAUTH_CLIENT = LOOKER OAUTH_REDIRECT_URI = 'uri' ENABLED = true OAUTH_ISSUE_REFRESH_TOKENS = true"+
-			" OAUTH_REFRESH_TOKEN_VALIDITY = 42 OAUTH_USE_SECONDARY_ROLES = NONE BLOCKED_ROLES_LIST = (%s) COMMENT = 'a'", id.FullyQualifiedName(), blockedRoleID.FullyQualifiedName())
+			" OAUTH_REFRESH_TOKEN_VALIDITY = 42 OAUTH_USE_SECONDARY_ROLES = NONE ALLOWED_ROLES_LIST = (%s) BLOCKED_ROLES_LIST = (%s) COMMENT = 'a'",
+			id.FullyQualifiedName(), allowedRoleID.FullyQualifiedName(), blockedRoleID.FullyQualifiedName())
 	})
 }
 
@@ -365,7 +367,7 @@ func TestSecurityIntegrations_CreateOauthForCustomClients(t *testing.T) {
 
 	t.Run("all options", func(t *testing.T) {
 		opts := defaultOpts()
-		roleID, role2ID, npID := randomAccountObjectIdentifier(), randomAccountObjectIdentifier(), randomAccountObjectIdentifier()
+		roleID, allowedRoleID, role2ID, npID := randomAccountObjectIdentifier(), randomAccountObjectIdentifier(), randomAccountObjectIdentifier(), randomAccountObjectIdentifier()
 		opts.IfNotExists = Bool(true)
 		opts.OauthClientType = OauthSecurityIntegrationClientTypeOptionPublic
 		opts.Enabled = Pointer(true)
@@ -373,6 +375,7 @@ func TestSecurityIntegrations_CreateOauthForCustomClients(t *testing.T) {
 		opts.OauthEnforcePkce = Pointer(true)
 		opts.OauthUseSecondaryRoles = Pointer(OauthSecurityIntegrationUseSecondaryRolesOptionNone)
 		opts.PreAuthorizedRolesList = &PreAuthorizedRolesList{PreAuthorizedRolesList: []AccountObjectIdentifier{roleID}}
+		opts.AllowedRolesList = &AllowedRolesList{AllowedRolesList: []AccountObjectIdentifier{allowedRoleID}}
 		opts.BlockedRolesList = &BlockedRolesList{BlockedRolesList: []AccountObjectIdentifier{role2ID}}
 		opts.OauthIssueRefreshTokens = Pointer(true)
 		opts.OauthRefreshTokenValidity = Pointer(42)
@@ -381,9 +384,9 @@ func TestSecurityIntegrations_CreateOauthForCustomClients(t *testing.T) {
 		opts.OauthClientRsaPublicKey2 = Pointer("key2")
 		opts.Comment = Pointer("a")
 		assertOptsValidAndSQLEquals(t, opts, "CREATE SECURITY INTEGRATION IF NOT EXISTS %s TYPE = OAUTH OAUTH_CLIENT = CUSTOM OAUTH_CLIENT_TYPE = 'PUBLIC' OAUTH_REDIRECT_URI = 'uri' ENABLED = true"+
-			" OAUTH_ALLOW_NON_TLS_REDIRECT_URI = true OAUTH_ENFORCE_PKCE = true OAUTH_USE_SECONDARY_ROLES = NONE PRE_AUTHORIZED_ROLES_LIST = (%s) BLOCKED_ROLES_LIST = (%s)"+
+			" OAUTH_ALLOW_NON_TLS_REDIRECT_URI = true OAUTH_ENFORCE_PKCE = true OAUTH_USE_SECONDARY_ROLES = NONE PRE_AUTHORIZED_ROLES_LIST = (%s) ALLOWED_ROLES_LIST = (%s) BLOCKED_ROLES_LIST = (%s)"+
 			" OAUTH_ISSUE_REFRESH_TOKENS = true OAUTH_REFRESH_TOKEN_VALIDITY = 42 NETWORK_POLICY = '\\\"%s\\\"' OAUTH_CLIENT_RSA_PUBLIC_KEY = 'key' OAUTH_CLIENT_RSA_PUBLIC_KEY_2 = 'key2' COMMENT = 'a'",
-			id.FullyQualifiedName(), roleID.FullyQualifiedName(), role2ID.FullyQualifiedName(), npID.Name())
+			id.FullyQualifiedName(), roleID.FullyQualifiedName(), allowedRoleID.FullyQualifiedName(), role2ID.FullyQualifiedName(), npID.Name())
 	})
 }
 
@@ -987,10 +990,10 @@ func TestSecurityIntegrations_AlterOauthForPartnerApplications(t *testing.T) {
 		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterOauthForPartnerApplicationsSecurityIntegrationOptions", "Set", "Unset", "SetTags", "UnsetTags"))
 	})
 
-	t.Run("validation: at least one of the fields [opts.Set.Enabled opts.Set.OauthIssueRefreshTokens opts.Set.OauthRedirectUri opts.Set.OauthRefreshTokenValidity opts.Set.OauthUseSecondaryRoles opts.Set.BlockedRolesList opts.Set.Comment] should be set", func(t *testing.T) {
+	t.Run("validation: at least one of the fields [opts.Set.Enabled opts.Set.OauthIssueRefreshTokens opts.Set.OauthRedirectUri opts.Set.OauthRefreshTokenValidity opts.Set.OauthUseSecondaryRoles opts.Set.AllowedRolesList opts.Set.BlockedRolesList opts.Set.Comment] should be set", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Set = &OauthForPartnerApplicationsIntegrationSet{}
-		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterOauthForPartnerApplicationsSecurityIntegrationOptions.Set", "Enabled", "OauthIssueRefreshTokens", "OauthRedirectUri", "OauthRefreshTokenValidity", "OauthUseSecondaryRoles", "BlockedRolesList", "Comment"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterOauthForPartnerApplicationsSecurityIntegrationOptions.Set", "Enabled", "OauthIssueRefreshTokens", "OauthRedirectUri", "OauthRefreshTokenValidity", "OauthUseSecondaryRoles", "AllowedRolesList", "BlockedRolesList", "Comment"))
 	})
 
 	t.Run("validation: at least one of the fields [opts.Unset.Enabled opts.Unset.OauthUseSecondaryRoles] should be set", func(t *testing.T) {
@@ -1003,25 +1006,28 @@ func TestSecurityIntegrations_AlterOauthForPartnerApplications(t *testing.T) {
 	t.Run("empty roles lists", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Set = &OauthForPartnerApplicationsIntegrationSet{
+			AllowedRolesList: &AllowedRolesList{},
 			BlockedRolesList: &BlockedRolesList{},
 		}
-		assertOptsValidAndSQLEquals(t, opts, "ALTER SECURITY INTEGRATION %s SET BLOCKED_ROLES_LIST = ()", id.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, "ALTER SECURITY INTEGRATION %s SET ALLOWED_ROLES_LIST = (), BLOCKED_ROLES_LIST = ()", id.FullyQualifiedName())
 	})
 
 	t.Run("all options - set", func(t *testing.T) {
 		opts := defaultOpts()
-		roleID := randomAccountObjectIdentifier()
+		allowedRoleID, blockedRoleID := randomAccountObjectIdentifier(), randomAccountObjectIdentifier()
 		opts.Set = &OauthForPartnerApplicationsIntegrationSet{
 			Enabled:                   Pointer(true),
 			OauthRedirectUri:          Pointer("uri"),
 			OauthIssueRefreshTokens:   Pointer(true),
 			OauthRefreshTokenValidity: Pointer(42),
 			OauthUseSecondaryRoles:    Pointer(OauthSecurityIntegrationUseSecondaryRolesOptionNone),
-			BlockedRolesList:          &BlockedRolesList{BlockedRolesList: []AccountObjectIdentifier{roleID}},
+			AllowedRolesList:          &AllowedRolesList{AllowedRolesList: []AccountObjectIdentifier{allowedRoleID}},
+			BlockedRolesList:          &BlockedRolesList{BlockedRolesList: []AccountObjectIdentifier{blockedRoleID}},
 			Comment:                   Pointer(StringAllowEmpty{""}),
 		}
 		assertOptsValidAndSQLEquals(t, opts, "ALTER SECURITY INTEGRATION %s SET ENABLED = true, OAUTH_ISSUE_REFRESH_TOKENS = true, OAUTH_REDIRECT_URI = 'uri', OAUTH_REFRESH_TOKEN_VALIDITY = 42,"+
-			" OAUTH_USE_SECONDARY_ROLES = NONE, BLOCKED_ROLES_LIST = (%s), COMMENT = ''", id.FullyQualifiedName(), roleID.FullyQualifiedName())
+			" OAUTH_USE_SECONDARY_ROLES = NONE, ALLOWED_ROLES_LIST = (%s), BLOCKED_ROLES_LIST = (%s), COMMENT = ''",
+			id.FullyQualifiedName(), allowedRoleID.FullyQualifiedName(), blockedRoleID.FullyQualifiedName())
 	})
 
 	t.Run("all options - unset", func(t *testing.T) {
@@ -1090,10 +1096,10 @@ func TestSecurityIntegrations_AlterOauthForCustomClients(t *testing.T) {
 		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterOauthForCustomClientsSecurityIntegrationOptions", "Set", "Unset", "SetTags", "UnsetTags"))
 	})
 
-	t.Run("validation: at least one of the fields [opts.Set.Enabled opts.Set.OauthRedirectUri opts.Set.OauthAllowNonTlsRedirectUri opts.Set.OauthEnforcePkce opts.Set.PreAuthorizedRolesList opts.Set.BlockedRolesList opts.Set.OauthIssueRefreshTokens opts.Set.OauthRefreshTokenValidity opts.Set.OauthUseSecondaryRoles opts.Set.NetworkPolicy opts.Set.OauthClientRsaPublicKey opts.Set.OauthClientRsaPublicKey2 opts.Set.Comment] should be set", func(t *testing.T) {
+	t.Run("validation: at least one of the fields [opts.Set.Enabled opts.Set.OauthRedirectUri opts.Set.OauthAllowNonTlsRedirectUri opts.Set.OauthEnforcePkce opts.Set.PreAuthorizedRolesList opts.Set.AllowedRolesList opts.Set.BlockedRolesList opts.Set.OauthIssueRefreshTokens opts.Set.OauthRefreshTokenValidity opts.Set.OauthUseSecondaryRoles opts.Set.NetworkPolicy opts.Set.OauthClientRsaPublicKey opts.Set.OauthClientRsaPublicKey2 opts.Set.Comment] should be set", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Set = &OauthForCustomClientsIntegrationSet{}
-		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterOauthForCustomClientsSecurityIntegrationOptions.Set", "Enabled", "OauthRedirectUri", "OauthAllowNonTlsRedirectUri", "OauthEnforcePkce", "PreAuthorizedRolesList", "BlockedRolesList", "OauthIssueRefreshTokens", "OauthRefreshTokenValidity", "OauthUseSecondaryRoles", "NetworkPolicy", "OauthClientRsaPublicKey", "OauthClientRsaPublicKey2", "Comment"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterOauthForCustomClientsSecurityIntegrationOptions.Set", "Enabled", "OauthRedirectUri", "OauthAllowNonTlsRedirectUri", "OauthEnforcePkce", "PreAuthorizedRolesList", "AllowedRolesList", "BlockedRolesList", "OauthIssueRefreshTokens", "OauthRefreshTokenValidity", "OauthUseSecondaryRoles", "NetworkPolicy", "OauthClientRsaPublicKey", "OauthClientRsaPublicKey2", "Comment"))
 	})
 
 	t.Run("validation: at least one of the fields [opts.Unset.Enabled opts.Unset.NetworkPolicy opts.Unset.OauthUseSecondaryRoles opts.Unset.OauthClientRsaPublicKey opts.Unset.OauthClientRsaPublicKey2] should be set", func(t *testing.T) {
@@ -1107,14 +1113,15 @@ func TestSecurityIntegrations_AlterOauthForCustomClients(t *testing.T) {
 		opts := defaultOpts()
 		opts.Set = &OauthForCustomClientsIntegrationSet{
 			PreAuthorizedRolesList: &PreAuthorizedRolesList{},
+			AllowedRolesList:       &AllowedRolesList{},
 			BlockedRolesList:       &BlockedRolesList{},
 		}
-		assertOptsValidAndSQLEquals(t, opts, "ALTER SECURITY INTEGRATION %s SET PRE_AUTHORIZED_ROLES_LIST = (), BLOCKED_ROLES_LIST = ()", id.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, "ALTER SECURITY INTEGRATION %s SET PRE_AUTHORIZED_ROLES_LIST = (), ALLOWED_ROLES_LIST = (), BLOCKED_ROLES_LIST = ()", id.FullyQualifiedName())
 	})
 
 	t.Run("all options - set", func(t *testing.T) {
 		opts := defaultOpts()
-		roleID, role2ID, npID := randomAccountObjectIdentifier(), randomAccountObjectIdentifier(), randomAccountObjectIdentifier()
+		roleID, allowedRoleID, role2ID, npID := randomAccountObjectIdentifier(), randomAccountObjectIdentifier(), randomAccountObjectIdentifier(), randomAccountObjectIdentifier()
 		opts.Set = &OauthForCustomClientsIntegrationSet{
 			Enabled:                     Pointer(true),
 			OauthRedirectUri:            Pointer("uri"),
@@ -1122,6 +1129,7 @@ func TestSecurityIntegrations_AlterOauthForCustomClients(t *testing.T) {
 			OauthEnforcePkce:            Pointer(true),
 			OauthUseSecondaryRoles:      Pointer(OauthSecurityIntegrationUseSecondaryRolesOptionNone),
 			PreAuthorizedRolesList:      &PreAuthorizedRolesList{PreAuthorizedRolesList: []AccountObjectIdentifier{roleID}},
+			AllowedRolesList:            &AllowedRolesList{AllowedRolesList: []AccountObjectIdentifier{allowedRoleID}},
 			BlockedRolesList:            &BlockedRolesList{BlockedRolesList: []AccountObjectIdentifier{role2ID}},
 			OauthIssueRefreshTokens:     Pointer(true),
 			OauthRefreshTokenValidity:   Pointer(42),
@@ -1131,8 +1139,9 @@ func TestSecurityIntegrations_AlterOauthForCustomClients(t *testing.T) {
 			Comment:                     Pointer("a"),
 		}
 		assertOptsValidAndSQLEquals(t, opts, "ALTER SECURITY INTEGRATION %s SET ENABLED = true, OAUTH_REDIRECT_URI = 'uri', OAUTH_ALLOW_NON_TLS_REDIRECT_URI = true, OAUTH_ENFORCE_PKCE = true,"+
-			" PRE_AUTHORIZED_ROLES_LIST = (%s), BLOCKED_ROLES_LIST = (%s), OAUTH_ISSUE_REFRESH_TOKENS = true, OAUTH_REFRESH_TOKEN_VALIDITY = 42, OAUTH_USE_SECONDARY_ROLES = NONE,"+
-			" NETWORK_POLICY = '\\\"%s\\\"', OAUTH_CLIENT_RSA_PUBLIC_KEY = 'key', OAUTH_CLIENT_RSA_PUBLIC_KEY_2 = 'key2', COMMENT = 'a'", id.FullyQualifiedName(), roleID.FullyQualifiedName(), role2ID.FullyQualifiedName(), npID.Name())
+			" PRE_AUTHORIZED_ROLES_LIST = (%s), ALLOWED_ROLES_LIST = (%s), BLOCKED_ROLES_LIST = (%s), OAUTH_ISSUE_REFRESH_TOKENS = true, OAUTH_REFRESH_TOKEN_VALIDITY = 42, OAUTH_USE_SECONDARY_ROLES = NONE,"+
+			" NETWORK_POLICY = '\\\"%s\\\"', OAUTH_CLIENT_RSA_PUBLIC_KEY = 'key', OAUTH_CLIENT_RSA_PUBLIC_KEY_2 = 'key2', COMMENT = 'a'",
+			id.FullyQualifiedName(), roleID.FullyQualifiedName(), allowedRoleID.FullyQualifiedName(), role2ID.FullyQualifiedName(), npID.Name())
 	})
 
 	t.Run("all options - unset", func(t *testing.T) {

--- a/pkg/sdk/security_integrations_impl_gen.go
+++ b/pkg/sdk/security_integrations_impl_gen.go
@@ -249,6 +249,11 @@ func (r *CreateOauthForPartnerApplicationsSecurityIntegrationRequest) toOpts() *
 		OauthUseSecondaryRoles:    r.OauthUseSecondaryRoles,
 		Comment:                   r.Comment,
 	}
+	if r.AllowedRolesList != nil {
+		opts.AllowedRolesList = &AllowedRolesList{
+			AllowedRolesList: r.AllowedRolesList.AllowedRolesList,
+		}
+	}
 	if r.BlockedRolesList != nil {
 		opts.BlockedRolesList = &BlockedRolesList{
 			BlockedRolesList: r.BlockedRolesList.BlockedRolesList,
@@ -278,6 +283,11 @@ func (r *CreateOauthForCustomClientsSecurityIntegrationRequest) toOpts() *Create
 	if r.PreAuthorizedRolesList != nil {
 		opts.PreAuthorizedRolesList = &PreAuthorizedRolesList{
 			PreAuthorizedRolesList: r.PreAuthorizedRolesList.PreAuthorizedRolesList,
+		}
+	}
+	if r.AllowedRolesList != nil {
+		opts.AllowedRolesList = &AllowedRolesList{
+			AllowedRolesList: r.AllowedRolesList.AllowedRolesList,
 		}
 	}
 	if r.BlockedRolesList != nil {
@@ -483,6 +493,11 @@ func (r *AlterOauthForPartnerApplicationsSecurityIntegrationRequest) toOpts() *A
 			OauthUseSecondaryRoles:    r.Set.OauthUseSecondaryRoles,
 			Comment:                   r.Set.Comment,
 		}
+		if r.Set.AllowedRolesList != nil {
+			opts.Set.AllowedRolesList = &AllowedRolesList{
+				AllowedRolesList: r.Set.AllowedRolesList.AllowedRolesList,
+			}
+		}
 		if r.Set.BlockedRolesList != nil {
 			opts.Set.BlockedRolesList = &BlockedRolesList{
 				BlockedRolesList: r.Set.BlockedRolesList.BlockedRolesList,
@@ -522,6 +537,11 @@ func (r *AlterOauthForCustomClientsSecurityIntegrationRequest) toOpts() *AlterOa
 		if r.Set.PreAuthorizedRolesList != nil {
 			opts.Set.PreAuthorizedRolesList = &PreAuthorizedRolesList{
 				PreAuthorizedRolesList: r.Set.PreAuthorizedRolesList.PreAuthorizedRolesList,
+			}
+		}
+		if r.Set.AllowedRolesList != nil {
+			opts.Set.AllowedRolesList = &AllowedRolesList{
+				AllowedRolesList: r.Set.AllowedRolesList.AllowedRolesList,
 			}
 		}
 		if r.Set.BlockedRolesList != nil {

--- a/pkg/sdk/security_integrations_validations_gen.go
+++ b/pkg/sdk/security_integrations_validations_gen.go
@@ -264,8 +264,8 @@ func (opts *AlterOauthForPartnerApplicationsSecurityIntegrationOptions) validate
 		errs = append(errs, errExactlyOneOf("AlterOauthForPartnerApplicationsSecurityIntegrationOptions", "Set", "Unset", "SetTags", "UnsetTags"))
 	}
 	if valueSet(opts.Set) {
-		if !anyValueSet(opts.Set.Enabled, opts.Set.OauthIssueRefreshTokens, opts.Set.OauthRedirectUri, opts.Set.OauthRefreshTokenValidity, opts.Set.OauthUseSecondaryRoles, opts.Set.BlockedRolesList, opts.Set.Comment) {
-			errs = append(errs, errAtLeastOneOf("AlterOauthForPartnerApplicationsSecurityIntegrationOptions.Set", "Enabled", "OauthIssueRefreshTokens", "OauthRedirectUri", "OauthRefreshTokenValidity", "OauthUseSecondaryRoles", "BlockedRolesList", "Comment"))
+		if !anyValueSet(opts.Set.Enabled, opts.Set.OauthIssueRefreshTokens, opts.Set.OauthRedirectUri, opts.Set.OauthRefreshTokenValidity, opts.Set.OauthUseSecondaryRoles, opts.Set.AllowedRolesList, opts.Set.BlockedRolesList, opts.Set.Comment) {
+			errs = append(errs, errAtLeastOneOf("AlterOauthForPartnerApplicationsSecurityIntegrationOptions.Set", "Enabled", "OauthIssueRefreshTokens", "OauthRedirectUri", "OauthRefreshTokenValidity", "OauthUseSecondaryRoles", "AllowedRolesList", "BlockedRolesList", "Comment"))
 		}
 	}
 	if valueSet(opts.Unset) {
@@ -288,8 +288,8 @@ func (opts *AlterOauthForCustomClientsSecurityIntegrationOptions) validate() err
 		errs = append(errs, errExactlyOneOf("AlterOauthForCustomClientsSecurityIntegrationOptions", "Set", "Unset", "SetTags", "UnsetTags"))
 	}
 	if valueSet(opts.Set) {
-		if !anyValueSet(opts.Set.Enabled, opts.Set.OauthRedirectUri, opts.Set.OauthAllowNonTlsRedirectUri, opts.Set.OauthEnforcePkce, opts.Set.PreAuthorizedRolesList, opts.Set.BlockedRolesList, opts.Set.OauthIssueRefreshTokens, opts.Set.OauthRefreshTokenValidity, opts.Set.OauthUseSecondaryRoles, opts.Set.NetworkPolicy, opts.Set.OauthClientRsaPublicKey, opts.Set.OauthClientRsaPublicKey2, opts.Set.Comment) {
-			errs = append(errs, errAtLeastOneOf("AlterOauthForCustomClientsSecurityIntegrationOptions.Set", "Enabled", "OauthRedirectUri", "OauthAllowNonTlsRedirectUri", "OauthEnforcePkce", "PreAuthorizedRolesList", "BlockedRolesList", "OauthIssueRefreshTokens", "OauthRefreshTokenValidity", "OauthUseSecondaryRoles", "NetworkPolicy", "OauthClientRsaPublicKey", "OauthClientRsaPublicKey2", "Comment"))
+		if !anyValueSet(opts.Set.Enabled, opts.Set.OauthRedirectUri, opts.Set.OauthAllowNonTlsRedirectUri, opts.Set.OauthEnforcePkce, opts.Set.PreAuthorizedRolesList, opts.Set.AllowedRolesList, opts.Set.BlockedRolesList, opts.Set.OauthIssueRefreshTokens, opts.Set.OauthRefreshTokenValidity, opts.Set.OauthUseSecondaryRoles, opts.Set.NetworkPolicy, opts.Set.OauthClientRsaPublicKey, opts.Set.OauthClientRsaPublicKey2, opts.Set.Comment) {
+			errs = append(errs, errAtLeastOneOf("AlterOauthForCustomClientsSecurityIntegrationOptions.Set", "Enabled", "OauthRedirectUri", "OauthAllowNonTlsRedirectUri", "OauthEnforcePkce", "PreAuthorizedRolesList", "AllowedRolesList", "BlockedRolesList", "OauthIssueRefreshTokens", "OauthRefreshTokenValidity", "OauthUseSecondaryRoles", "NetworkPolicy", "OauthClientRsaPublicKey", "OauthClientRsaPublicKey2", "Comment"))
 		}
 	}
 	if valueSet(opts.Unset) {

--- a/pkg/sdk/testint/security_integrations_gen_integration_test.go
+++ b/pkg/sdk/testint/security_integrations_gen_integration_test.go
@@ -249,6 +249,7 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 		refreshTokenValidity    string
 		useSecondaryRoles       string
 		preAuthorizedRolesList  string
+		allowedRolesList        string
 		blockedRolesList        string
 		networkPolicy           string
 		comment                 string
@@ -260,6 +261,7 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 		assert.Contains(t, details, sdk.SecurityIntegrationProperty{Name: "OAUTH_REFRESH_TOKEN_VALIDITY", Type: "Long", Value: d.refreshTokenValidity, Default: "7776000"})
 		assert.Contains(t, details, sdk.SecurityIntegrationProperty{Name: "OAUTH_USE_SECONDARY_ROLES", Type: "String", Value: d.useSecondaryRoles, Default: "NONE"})
 		assert.Contains(t, details, sdk.SecurityIntegrationProperty{Name: "PRE_AUTHORIZED_ROLES_LIST", Type: "List", Value: d.preAuthorizedRolesList, Default: "[]"})
+		assertFieldContainsList(details, "ALLOWED_ROLES_LIST", d.allowedRolesList, ",")
 		assert.Contains(t, details, sdk.SecurityIntegrationProperty{Name: "NETWORK_POLICY", Type: "String", Value: d.networkPolicy, Default: ""})
 		assert.Contains(t, details, sdk.SecurityIntegrationProperty{Name: "COMMENT", Type: "String", Value: d.comment, Default: ""})
 		assertFieldContainsList(details, "BLOCKED_ROLES_LIST", d.blockedRolesList, ",")
@@ -465,14 +467,19 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 	t.Run("CreateOauthPartner", func(t *testing.T) {
 		role1, role1Cleanup := testClientHelper().Role.CreateRole(t)
 		t.Cleanup(role1Cleanup)
+		role2, role2Cleanup := testClientHelper().Role.CreateRole(t)
+		t.Cleanup(role2Cleanup)
+		role3, role3Cleanup := testClientHelper().Role.CreateRole(t)
+		t.Cleanup(role3Cleanup)
 
 		integration, id := createOauthPartner(t, func(r *sdk.CreateOauthForPartnerApplicationsSecurityIntegrationRequest) {
-			r.WithBlockedRolesList(sdk.BlockedRolesListRequest{BlockedRolesList: []sdk.AccountObjectIdentifier{role1.ID()}}).
+			r.WithAllowedRolesList(sdk.AllowedRolesListRequest{AllowedRolesList: []sdk.AccountObjectIdentifier{role2.ID(), role3.ID()}}).
+				WithBlockedRolesList(sdk.BlockedRolesListRequest{BlockedRolesList: []sdk.AccountObjectIdentifier{role1.ID()}}).
 				WithComment("a").
 				WithEnabled(true).
 				WithOauthIssueRefreshTokens(true).
 				WithOauthRefreshTokenValidity(12345).
-				WithOauthUseSecondaryRoles(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionImplicit)
+				WithOauthUseSecondaryRoles(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionNone)
 		})
 		details, err := client.SecurityIntegrations.Describe(ctx, id)
 		require.NoError(t, err)
@@ -481,7 +488,8 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 			enabled:                 "true",
 			oauthIssueRefreshTokens: "true",
 			refreshTokenValidity:    "12345",
-			useSecondaryRoles:       string(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionImplicit),
+			useSecondaryRoles:       string(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionNone),
+			allowedRolesList:        fmt.Sprintf("%s,%s", role2.Name, role3.Name),
 			blockedRolesList:        role1.Name,
 			comment:                 "a",
 		})
@@ -496,9 +504,12 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 		t.Cleanup(role1Cleanup)
 		role2, role2Cleanup := testClientHelper().Role.CreateRole(t)
 		t.Cleanup(role2Cleanup)
+		role3, role3Cleanup := testClientHelper().Role.CreateRole(t)
+		t.Cleanup(role3Cleanup)
 
 		integration, id := createOauthCustom(t, func(r *sdk.CreateOauthForCustomClientsSecurityIntegrationRequest) {
-			r.WithBlockedRolesList(sdk.BlockedRolesListRequest{BlockedRolesList: []sdk.AccountObjectIdentifier{role1.ID()}}).
+			r.WithAllowedRolesList(sdk.AllowedRolesListRequest{AllowedRolesList: []sdk.AccountObjectIdentifier{role3.ID()}}).
+				WithBlockedRolesList(sdk.BlockedRolesListRequest{BlockedRolesList: []sdk.AccountObjectIdentifier{role1.ID()}}).
 				WithComment("a").
 				WithEnabled(true).
 				WithNetworkPolicy(networkPolicy.ID()).
@@ -508,7 +519,7 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 				WithOauthEnforcePkce(true).
 				WithOauthIssueRefreshTokens(true).
 				WithOauthRefreshTokenValidity(12345).
-				WithOauthUseSecondaryRoles(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionImplicit).
+				WithOauthUseSecondaryRoles(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionNone).
 				WithPreAuthorizedRolesList(sdk.PreAuthorizedRolesListRequest{PreAuthorizedRolesList: []sdk.AccountObjectIdentifier{role2.ID()}})
 		})
 		details, err := client.SecurityIntegrations.Describe(ctx, id)
@@ -518,8 +529,9 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 			enabled:                 "true",
 			oauthIssueRefreshTokens: "true",
 			refreshTokenValidity:    "12345",
-			useSecondaryRoles:       string(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionImplicit),
+			useSecondaryRoles:       string(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionNone),
 			preAuthorizedRolesList:  role2.Name,
+			allowedRolesList:        role3.Name,
 			blockedRolesList:        role1.Name,
 			networkPolicy:           networkPolicy.Name,
 			comment:                 "a",
@@ -844,17 +856,20 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 		})
 		role1, role1Cleanup := testClientHelper().Role.CreateRole(t)
 		t.Cleanup(role1Cleanup)
+		role2, role2Cleanup := testClientHelper().Role.CreateRole(t)
+		t.Cleanup(role2Cleanup)
 
 		setRequest := sdk.NewAlterOauthForPartnerApplicationsSecurityIntegrationRequest(id).
 			WithSet(
 				*sdk.NewOauthForPartnerApplicationsIntegrationSetRequest().
+					WithAllowedRolesList(sdk.AllowedRolesListRequest{AllowedRolesList: []sdk.AccountObjectIdentifier{role2.ID()}}).
 					WithBlockedRolesList(sdk.BlockedRolesListRequest{BlockedRolesList: []sdk.AccountObjectIdentifier{role1.ID()}}).
 					WithComment(sdk.StringAllowEmpty{Value: "a"}).
 					WithEnabled(true).
 					WithOauthIssueRefreshTokens(true).
 					WithOauthRedirectUri("http://example2.com").
 					WithOauthRefreshTokenValidity(22222).
-					WithOauthUseSecondaryRoles(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionImplicit),
+					WithOauthUseSecondaryRoles(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionNone),
 			)
 		err := client.SecurityIntegrations.AlterOauthForPartnerApplications(ctx, setRequest)
 		require.NoError(t, err)
@@ -866,8 +881,8 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 			enabled:                 "true",
 			oauthIssueRefreshTokens: "true",
 			refreshTokenValidity:    "22222",
-			useSecondaryRoles:       string(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionImplicit),
-			preAuthorizedRolesList:  "",
+			useSecondaryRoles:       string(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionNone),
+			allowedRolesList:        role2.Name,
 			blockedRolesList:        "ACCOUNTADMIN,SECURITYADMIN",
 			networkPolicy:           "",
 			comment:                 "a",
@@ -898,10 +913,13 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 		t.Cleanup(role1Cleanup)
 		role2, role2Cleanup := testClientHelper().Role.CreateRole(t)
 		t.Cleanup(role2Cleanup)
+		role3, role3Cleanup := testClientHelper().Role.CreateRole(t)
+		t.Cleanup(role3Cleanup)
 
 		setRequest := sdk.NewAlterOauthForCustomClientsSecurityIntegrationRequest(id).
 			WithSet(
 				*sdk.NewOauthForCustomClientsIntegrationSetRequest().
+					WithAllowedRolesList(sdk.AllowedRolesListRequest{AllowedRolesList: []sdk.AccountObjectIdentifier{role3.ID()}}).
 					WithEnabled(true).
 					WithBlockedRolesList(sdk.BlockedRolesListRequest{BlockedRolesList: []sdk.AccountObjectIdentifier{role1.ID()}}).
 					WithComment("a").
@@ -913,7 +931,7 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 					WithOauthIssueRefreshTokens(true).
 					WithOauthRedirectUri("http://example2.com").
 					WithOauthRefreshTokenValidity(22222).
-					WithOauthUseSecondaryRoles(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionImplicit).
+					WithOauthUseSecondaryRoles(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionNone).
 					WithPreAuthorizedRolesList(sdk.PreAuthorizedRolesListRequest{PreAuthorizedRolesList: []sdk.AccountObjectIdentifier{role2.ID()}}),
 			)
 		err := client.SecurityIntegrations.AlterOauthForCustomClients(ctx, setRequest)
@@ -926,8 +944,9 @@ func TestInt_SecurityIntegrations(t *testing.T) {
 			enabled:                 "true",
 			oauthIssueRefreshTokens: "true",
 			refreshTokenValidity:    "22222",
-			useSecondaryRoles:       string(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionImplicit),
+			useSecondaryRoles:       string(sdk.OauthSecurityIntegrationUseSecondaryRolesOptionNone),
 			preAuthorizedRolesList:  role2.Name,
+			allowedRolesList:        role3.Name,
 			blockedRolesList:        role1.Name,
 			networkPolicy:           networkPolicy.Name,
 			comment:                 "a",


### PR DESCRIPTION
Add ALLOWED_ROLES_LIST parameter to both OAuth security integration variants (partner applications and custom clients) in the SDK layer.