### PR TITLE
chore: Fix pipes integration tests and ApiIntegrationGitRepositoryPrivateLink acceptance test

### DIFF
--- a/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert/api_integration_git_https_api_desc_output_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert/api_integration_git_https_api_desc_output_ext.go
@@ -29,7 +29,7 @@ func (a *ApiIntegrationGitHttpsApiDescribeOutputAssert) HasBlockedPrefixes(expec
 	return a
 }
 
-func (a *ApiIntegrationGitHttpsApiDescribeOutputAssert) HasTlsTrustedCertificates(expected string) *ApiIntegrationGitHttpsApiDescribeOutputAssert {
-	a.StringValueSet("tls_trusted_certificates", expected)
+func (a *ApiIntegrationGitHttpsApiDescribeOutputAssert) HasTlsTrustedCertificates(expected ...string) *ApiIntegrationGitHttpsApiDescribeOutputAssert {
+	a.ListContainsExactlyStringValuesInOrder("tls_trusted_certificates", expected...)
 	return a
 }

--- a/pkg/sdk/testint/pipes_integration_test.go
+++ b/pkg/sdk/testint/pipes_integration_test.go
@@ -37,9 +37,10 @@ func TestInt_CreatePipeWithStrangeSchemaName(t *testing.T) {
 	t.Cleanup(stageCleanup)
 
 	t.Run("if we have special characters in db or schema name, create pipe succeeds", func(t *testing.T) {
+		id := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(schema.ID())
 		err := itc.client.Pipes.Create(
 			itc.ctx,
-			sdk.NewCreatePipeRequest(testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(schema.ID()), createPipeCopyStatement(t, table, stage)),
+			sdk.NewCreatePipeRequest(id, createPipeCopyStatement(t, table, stage)),
 		)
 
 		require.NoError(t, err)
@@ -116,10 +117,12 @@ func TestInt_PipesShowAndDescribe(t *testing.T) {
 	})
 
 	t.Run("describe: existing pipe", func(t *testing.T) {
-		pipe, err := itc.client.Pipes.Describe(itc.ctx, pipe1.ID())
+		pipeDetails, err := itc.client.Pipes.Describe(itc.ctx, pipe1.ID())
+		// TODO [next PRs]: generate assertions for pipe details, currently same as show ouput
+		p := sdk.Pipe(*pipeDetails)
 
 		require.NoError(t, err)
-		assertThatObject(t, objectassert.PipeFromObject(t, pipe).
+		assertThatObject(t, objectassert.PipeFromObject(t, &p).
 			HasName(pipe1.Name))
 	})
 


### PR DESCRIPTION
- Fix compilation of pipes integration tests
- Fix `TestAcc_ApiIntegrationGitRepositoryPrivateLink_BasicUseCase`