### PR TITLE
feat: Revoke future grants on delete in snowflake_grant_ownership

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -26,6 +26,11 @@ for changes required after enabling given [Snowflake BCR Bundle](https://docs.sn
 
 ## v2.17.0 ➞ v2.18.0
 
+### *(improvement)* snowflake_grant_ownership: deleting a resource with on_future now properly revokes the grant
+If you use the future option in the snowflake_grant_ownership, it now issues REVOKE OWNERSHIP ON FUTURE ... TO ROLE ... during destroy.
+
+No changes required for existing configurations.
+
 ### *(new feature)* New Postgres instance resource
 
 We have added a new preview resource for managing Postgres instances: [snowflake_postgres_instance](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/postgres_instance).

--- a/docs/guides/grant_ownership_resource_overview.md
+++ b/docs/guides/grant_ownership_resource_overview.md
@@ -63,15 +63,6 @@ Most of the rules are described in the [official documentation for grant ownersh
 which we highly recommend reading. Due to the complexity and risk of partial or full operation failures during creation or deletion,
 it is advised to use ownership grants on these objects with caution and report any unexpected errors.
 
-### Granting ownership on future objects
-
-When creating this resource, we were unsure about certain parts of granting ownership of future objects.
-Because of that, we decided to provide this functionality partially.
-You can still grant ownership of future objects with grant ownership resources, but it cannot be revoked.
-Currently, the revoking part has to be done manually.
-This behavior was documented, and recently, we confirmed how this feature can be added, so stay tuned (e.g. [\#3317](https://github.com/snowflakedb/terraform-provider-snowflake/issues/3317);
-more on that in the “Future Plans” section).
-
 ## Future plans
 
 We already have some ideas about how to expand this resource, but we wanted to start with only essential features and extend it according to further customer requirements.

--- a/docs/resources/grant_ownership.md
+++ b/docs/resources/grant_ownership.md
@@ -13,8 +13,6 @@ description: |-
 
 ~> **Warning** Be careful when using this resource on managed schema or any object within it, as in Snowflake managed schemas follow different ownership and privilege model. For more details, please visit [Schema documentation](https://docs.snowflake.com/en/sql-reference/sql/create-schema#optional-parameters) (scroll to `WITH MANAGED ACCESS` option).
 
-!> **Warning** Grant ownership resource still has some limitations. Delete operation is not implemented for on_future grants (you have to remove the config and then revoke ownership grant on future X manually).
-
 # snowflake_grant_ownership (Resource)
 
 

--- a/pkg/resources/grant_ownership.go
+++ b/pkg/resources/grant_ownership.go
@@ -297,8 +297,34 @@ func DeleteGrantOwnership(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	if grantOn.Future != nil {
-		// TODO (SNOW-1182623): Still waiting for the response on the behavior/SQL syntax we should use here
-		log.Printf("[WARN] Unsupported operation, please revoke ownership transfer manually")
+		// OWNERSHIP of existing objects cannot be revoked (it can only be transferred to another role),
+		// but ownership granted on FUTURE objects can and must be revoked, otherwise the future ownership
+		// grant silently survives the resource deletion (see SNOW-1182623 / SNOW-3649903).
+		grantFrom, err := getOwnershipGrantTo(d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		err = client.Grants.RevokeOwnership(
+			ctx,
+			sdk.RevokeOwnershipGrantOn{
+				Future: grantOn.Future,
+			},
+			grantFrom,
+			new(sdk.RevokeOwnershipOptions),
+		)
+		if errors.Is(err, sdk.ErrObjectNotExistOrAuthorized) && experimentalfeatures.IsExperimentEnabled(experimentalfeatures.GrantsSafeDestroy, providerCtx.EnabledExperiments) {
+			err = nil
+		}
+		if err != nil {
+			return diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "An error occurred when revoking ownership of future objects",
+					Detail:   fmt.Sprintf("Id: %s\nError: %s", d.Id(), err),
+				},
+			}
+		}
 	} else {
 		accountRoleName, err := client.ContextFunctions.CurrentRole(ctx)
 		if err != nil {

--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -18,6 +18,7 @@ type Grants interface {
 	RevokePrivilegeFromShare(ctx context.Context, privileges []ObjectPrivilege, on *ShareGrantOn, from AccountObjectIdentifier) error
 	RevokePrivilegeFromShareSafely(ctx context.Context, privileges []ObjectPrivilege, on *ShareGrantOn, from AccountObjectIdentifier) error
 	GrantOwnership(ctx context.Context, on OwnershipGrantOn, to OwnershipGrantTo, opts *GrantOwnershipOptions) error
+	RevokeOwnership(ctx context.Context, on RevokeOwnershipGrantOn, from OwnershipGrantTo, opts *RevokeOwnershipOptions) error
 
 	Show(ctx context.Context, opts *ShowGrantOptions) ([]Grant, error)
 }
@@ -334,3 +335,23 @@ const (
 	Revoke OwnershipCurrentGrantsOutboundPrivileges = "REVOKE"
 	Copy   OwnershipCurrentGrantsOutboundPrivileges = "COPY"
 )
+
+// RevokeOwnershipOptions is based on https://docs.snowflake.com/en/sql-reference/sql/revoke-privilege#syntax.
+// Note: per https://docs.snowflake.com/en/sql-reference/sql/grant-ownership, OWNERSHIP of an existing object
+// cannot be revoked - it can only be transferred to another role with GRANT OWNERSHIP. OWNERSHIP can, however,
+// be revoked for future grants, i.e. REVOKE OWNERSHIP ON FUTURE <object_type_plural> IN { DATABASE | SCHEMA } FROM ROLE.
+type RevokeOwnershipOptions struct {
+	revokeOwnership bool                   `ddl:"static" sql:"REVOKE OWNERSHIP"`
+	On              RevokeOwnershipGrantOn `ddl:"keyword" sql:"ON"`
+	From            OwnershipGrantTo       `ddl:"keyword" sql:"FROM"`
+	Restrict        *bool                  `ddl:"keyword" sql:"RESTRICT"`
+	Cascade         *bool                  `ddl:"keyword" sql:"CASCADE"`
+}
+
+// RevokeOwnershipGrantOn only allows revoking OWNERSHIP of future grants - per
+// https://docs.snowflake.com/en/sql-reference/sql/grant-ownership, OWNERSHIP of an existing object cannot be
+// revoked (it can only be transferred to another role with GRANT OWNERSHIP), so unlike OwnershipGrantOn this
+// type intentionally does not expose the Object/All variants.
+type RevokeOwnershipGrantOn struct {
+	Future *GrantOnSchemaObjectIn `ddl:"keyword" sql:"FUTURE"`
+}

--- a/pkg/sdk/grants_impl.go
+++ b/pkg/sdk/grants_impl.go
@@ -291,6 +291,20 @@ func (v *grants) GrantOwnership(ctx context.Context, on OwnershipGrantOn, to Own
 	return validateAndExec(v.client, ctx, opts)
 }
 
+// RevokeOwnership revokes an OWNERSHIP grant. Note that Snowflake only allows revoking ownership of FUTURE objects;
+// ownership of existing objects must be transferred to another role with GrantOwnership instead - this is enforced
+// by the RevokeOwnershipGrantOn type, which only exposes the Future variant.
+func (v *grants) RevokeOwnership(ctx context.Context, on RevokeOwnershipGrantOn, from OwnershipGrantTo, opts *RevokeOwnershipOptions) error {
+	if opts == nil {
+		opts = &RevokeOwnershipOptions{}
+	}
+
+	opts.On = on
+	opts.From = from
+
+	return validateAndExec(v.client, ctx, opts)
+}
+
 // TODO(SNOW-2097063): Improve SHOW GRANTS implementation
 func (v *grants) Show(ctx context.Context, opts *ShowGrantOptions) ([]Grant, error) {
 	if opts == nil {

--- a/pkg/sdk/grants_test.go
+++ b/pkg/sdk/grants_test.go
@@ -1015,6 +1015,90 @@ func TestGrants_GrantOwnership(t *testing.T) {
 	})
 }
 
+func TestGrants_RevokeOwnership(t *testing.T) {
+	dbId := randomAccountObjectIdentifier()
+	schemaId := randomDatabaseObjectIdentifierInDatabase(dbId)
+	roleId := randomAccountObjectIdentifier()
+	databaseRoleId := randomDatabaseObjectIdentifierInDatabase(dbId)
+
+	defaultOpts := func() *RevokeOwnershipOptions {
+		return &RevokeOwnershipOptions{
+			On: RevokeOwnershipGrantOn{
+				Future: &GrantOnSchemaObjectIn{
+					PluralObjectType: PluralObjectTypeTables,
+					InDatabase:       Pointer(dbId),
+				},
+			},
+			From: OwnershipGrantTo{
+				AccountRoleName: Pointer(roleId),
+			},
+		}
+	}
+
+	t.Run("validation: nil options", func(t *testing.T) {
+		var opts *RevokeOwnershipOptions
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
+	})
+
+	t.Run("validation: revoke on empty (future not set)", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.On = RevokeOwnershipGrantOn{}
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("RevokeOwnershipGrantOn", "Future"))
+	})
+
+	t.Run("validation: revoke from empty", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.From = OwnershipGrantTo{}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("OwnershipGrantTo", "databaseRoleName", "accountRoleName"))
+	})
+
+	t.Run("validation: revoke from role and database role", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.From = OwnershipGrantTo{
+			DatabaseRoleName: Pointer(databaseRoleId),
+			AccountRoleName:  Pointer(roleId),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("OwnershipGrantTo", "databaseRoleName", "accountRoleName"))
+	})
+
+	t.Run("validation: restrict and cascade", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.Restrict = Bool(true)
+		opts.Cascade = Bool(true)
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("RevokeOwnershipOptions", "Restrict", "Cascade"))
+	})
+
+	t.Run("on future schema object in database to role", func(t *testing.T) {
+		opts := defaultOpts()
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE OWNERSHIP ON FUTURE TABLES IN DATABASE %s FROM ROLE %s`, dbId.FullyQualifiedName(), roleId.FullyQualifiedName())
+	})
+
+	t.Run("on future schema object in schema to role", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.On = RevokeOwnershipGrantOn{
+			Future: &GrantOnSchemaObjectIn{
+				PluralObjectType: PluralObjectTypeTables,
+				InSchema:         Pointer(schemaId),
+			},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE OWNERSHIP ON FUTURE TABLES IN SCHEMA %s FROM ROLE %s`, schemaId.FullyQualifiedName(), roleId.FullyQualifiedName())
+	})
+
+	t.Run("on future schema object in database to database role", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.From = OwnershipGrantTo{
+			DatabaseRoleName: Pointer(databaseRoleId),
+		}
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE OWNERSHIP ON FUTURE TABLES IN DATABASE %s FROM DATABASE ROLE %s`, dbId.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
+	})
+
+	t.Run("on future schema object with cascade", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.Cascade = Bool(true)
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE OWNERSHIP ON FUTURE TABLES IN DATABASE %s FROM ROLE %s CASCADE`, dbId.FullyQualifiedName(), roleId.FullyQualifiedName())
+	})
+}
+
 func TestGrantShow(t *testing.T) {
 	t.Run("no options", func(t *testing.T) {
 		opts := &ShowGrantOptions{}

--- a/pkg/sdk/grants_validations.go
+++ b/pkg/sdk/grants_validations.go
@@ -14,6 +14,7 @@ var (
 	_ validatable = new(grantPrivilegeToShareOptions)
 	_ validatable = new(revokePrivilegeFromShareOptions)
 	_ validatable = new(GrantOwnershipOptions)
+	_ validatable = new(RevokeOwnershipOptions)
 	_ validatable = new(ShowGrantOptions)
 )
 
@@ -563,6 +564,35 @@ func (v *OwnershipGrantTo) validate() error {
 		return errExactlyOneOf("OwnershipGrantTo", "databaseRoleName", "accountRoleName")
 	}
 	return nil
+}
+
+func (opts *RevokeOwnershipOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
+	var errs []error
+	if err := opts.On.validate(); err != nil {
+		errs = append(errs, err)
+	}
+	if err := opts.From.validate(); err != nil {
+		errs = append(errs, err)
+	}
+	if everyValueSet(opts.Restrict, opts.Cascade) {
+		errs = append(errs, errOneOf("RevokeOwnershipOptions", "Restrict", "Cascade"))
+	}
+	return errors.Join(errs...)
+}
+
+func (v *RevokeOwnershipGrantOn) validate() error {
+	var errs []error
+	// Snowflake only supports revoking OWNERSHIP for future grants; ownership of existing objects must be
+	// transferred with GRANT OWNERSHIP instead, hence Future is the only allowed variant here.
+	if !valueSet(v.Future) {
+		errs = append(errs, errNotSet("RevokeOwnershipGrantOn", "Future"))
+	} else if err := v.Future.validate(); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }
 
 // TODO: add validations for ShowGrantsOn, ShowGrantsTo, ShowGrantsOf and ShowGrantsIn

--- a/pkg/sdk/testint/grants_integration_test.go
+++ b/pkg/sdk/testint/grants_integration_test.go
@@ -2231,6 +2231,126 @@ func TestInt_GrantOwnership(t *testing.T) {
 	})
 }
 
+func TestInt_RevokeOwnership(t *testing.T) {
+	client := testClient(t)
+	ctx := testContext(t)
+
+	// Snowflake only allows revoking OWNERSHIP of future grants (ownership of existing objects can only be
+	// transferred with GRANT OWNERSHIP), so all cases below operate on future grants.
+
+	findFutureOwnershipGrant := func(t *testing.T, grants []sdk.Grant, grantee sdk.ObjectIdentifier) (*sdk.Grant, error) {
+		t.Helper()
+		return collections.FindFirst(grants, func(g sdk.Grant) bool {
+			return g.Privilege == sdk.SchemaObjectOwnership.String() && g.GranteeName.Name() == grantee.Name()
+		})
+	}
+
+	t.Run("validation: revoke on non-future is rejected", func(t *testing.T) {
+		err := client.Grants.RevokeOwnership(ctx, sdk.RevokeOwnershipGrantOn{}, sdk.OwnershipGrantTo{
+			AccountRoleName: sdk.Pointer(testClientHelper().Ids.RandomAccountObjectIdentifier()),
+		}, new(sdk.RevokeOwnershipOptions))
+		require.Error(t, err)
+	})
+
+	t.Run("on future schema object in database from role", func(t *testing.T) {
+		role, roleCleanup := testClientHelper().Role.CreateRole(t)
+		t.Cleanup(roleCleanup)
+		roleId := role.ID()
+
+		futureExternalTablesInDatabase := &sdk.GrantOnSchemaObjectIn{
+			PluralObjectType: sdk.PluralObjectTypeExternalTables,
+			InDatabase:       sdk.Pointer(testClientHelper().Ids.DatabaseId()),
+		}
+
+		err := client.Grants.GrantOwnership(ctx, sdk.OwnershipGrantOn{Future: futureExternalTablesInDatabase}, sdk.OwnershipGrantTo{AccountRoleName: &roleId}, nil)
+		require.NoError(t, err)
+
+		grants, err := testClientHelper().Grant.ShowFutureGrantsInDatabase(t, testClientHelper().Ids.DatabaseId())
+		require.NoError(t, err)
+		ownershipGrant, err := findFutureOwnershipGrant(t, grants, roleId)
+		require.NoError(t, err)
+		assert.Equal(t, sdk.ObjectTypeExternalTable, ownershipGrant.GrantOn)
+
+		err = client.Grants.RevokeOwnership(
+			ctx,
+			sdk.RevokeOwnershipGrantOn{Future: futureExternalTablesInDatabase},
+			sdk.OwnershipGrantTo{AccountRoleName: &roleId},
+			new(sdk.RevokeOwnershipOptions),
+		)
+		require.NoError(t, err)
+
+		grants, err = testClientHelper().Grant.ShowFutureGrantsInDatabase(t, testClientHelper().Ids.DatabaseId())
+		require.NoError(t, err)
+		_, err = findFutureOwnershipGrant(t, grants, roleId)
+		assert.Error(t, err)
+	})
+
+	t.Run("on future schema object in schema from role with cascade", func(t *testing.T) {
+		role, roleCleanup := testClientHelper().Role.CreateRole(t)
+		t.Cleanup(roleCleanup)
+		roleId := role.ID()
+
+		futureExternalTablesInSchema := &sdk.GrantOnSchemaObjectIn{
+			PluralObjectType: sdk.PluralObjectTypeExternalTables,
+			InSchema:         sdk.Pointer(testClientHelper().Ids.SchemaId()),
+		}
+
+		err := client.Grants.GrantOwnership(ctx, sdk.OwnershipGrantOn{Future: futureExternalTablesInSchema}, sdk.OwnershipGrantTo{AccountRoleName: &roleId}, nil)
+		require.NoError(t, err)
+
+		grants, err := testClientHelper().Grant.ShowFutureGrantsInSchema(t, testClientHelper().Ids.SchemaId())
+		require.NoError(t, err)
+		_, err = findFutureOwnershipGrant(t, grants, roleId)
+		require.NoError(t, err)
+
+		err = client.Grants.RevokeOwnership(
+			ctx,
+			sdk.RevokeOwnershipGrantOn{Future: futureExternalTablesInSchema},
+			sdk.OwnershipGrantTo{AccountRoleName: &roleId},
+			&sdk.RevokeOwnershipOptions{Cascade: sdk.Bool(true)},
+		)
+		require.NoError(t, err)
+
+		grants, err = testClientHelper().Grant.ShowFutureGrantsInSchema(t, testClientHelper().Ids.SchemaId())
+		require.NoError(t, err)
+		_, err = findFutureOwnershipGrant(t, grants, roleId)
+		assert.ErrorIs(t, err, sdk.ErrObjectNotFound)
+	})
+
+	t.Run("on future schema object in database from database role with restrict", func(t *testing.T) {
+		databaseRole, databaseRoleCleanup := testClientHelper().DatabaseRole.CreateDatabaseRole(t)
+		t.Cleanup(databaseRoleCleanup)
+		databaseRoleId := testClientHelper().Ids.NewDatabaseObjectIdentifier(databaseRole.Name)
+
+		futureExternalTablesInDatabase := &sdk.GrantOnSchemaObjectIn{
+			PluralObjectType: sdk.PluralObjectTypeExternalTables,
+			InDatabase:       sdk.Pointer(testClientHelper().Ids.DatabaseId()),
+		}
+
+		err := client.Grants.GrantOwnership(ctx, sdk.OwnershipGrantOn{Future: futureExternalTablesInDatabase}, sdk.OwnershipGrantTo{DatabaseRoleName: &databaseRoleId}, nil)
+		require.NoError(t, err)
+
+		grants, err := testClientHelper().Grant.ShowFutureGrantsInDatabase(t, testClientHelper().Ids.DatabaseId())
+		require.NoError(t, err)
+		ownershipGrant, err := findFutureOwnershipGrant(t, grants, databaseRoleId)
+		require.NoError(t, err)
+		assert.Equal(t, sdk.ObjectTypeExternalTable, ownershipGrant.GrantOn)
+
+		err = client.Grants.RevokeOwnership(
+			ctx,
+			sdk.RevokeOwnershipGrantOn{Future: futureExternalTablesInDatabase},
+			sdk.OwnershipGrantTo{DatabaseRoleName: &databaseRoleId},
+			&sdk.RevokeOwnershipOptions{Restrict: sdk.Bool(true)},
+		)
+		require.NoError(t, err)
+
+		grants, err = testClientHelper().Grant.ShowFutureGrantsInDatabase(t, testClientHelper().Ids.DatabaseId())
+		require.NoError(t, err)
+		_, err = findFutureOwnershipGrant(t, grants, databaseRoleId)
+		assert.ErrorIs(t, err, sdk.ErrObjectNotFound)
+	})
+}
+
 func TestInt_ShowGrants(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)

--- a/templates/guides/grant_ownership_resource_overview.md.tmpl
+++ b/templates/guides/grant_ownership_resource_overview.md.tmpl
@@ -63,15 +63,6 @@ Most of the rules are described in the [official documentation for grant ownersh
 which we highly recommend reading. Due to the complexity and risk of partial or full operation failures during creation or deletion,
 it is advised to use ownership grants on these objects with caution and report any unexpected errors.
 
-### Granting ownership on future objects
-
-When creating this resource, we were unsure about certain parts of granting ownership of future objects.
-Because of that, we decided to provide this functionality partially.
-You can still grant ownership of future objects with grant ownership resources, but it cannot be revoked.
-Currently, the revoking part has to be done manually.
-This behavior was documented, and recently, we confirmed how this feature can be added, so stay tuned (e.g. [\#3317](https://github.com/snowflakedb/terraform-provider-snowflake/issues/3317);
-more on that in the “Future Plans” section).
-
 ## Future plans
 
 We already have some ideas about how to expand this resource, but we wanted to start with only essential features and extend it according to further customer requirements.

--- a/templates/resources/grant_ownership.md.tmpl
+++ b/templates/resources/grant_ownership.md.tmpl
@@ -17,8 +17,6 @@ description: |-
 
 ~> **Warning** Be careful when using this resource on managed schema or any object within it, as in Snowflake managed schemas follow different ownership and privilege model. For more details, please visit [Schema documentation](https://docs.snowflake.com/en/sql-reference/sql/create-schema#optional-parameters) (scroll to `WITH MANAGED ACCESS` option).
 
-!> **Warning** Grant ownership resource still has some limitations. Delete operation is not implemented for on_future grants (you have to remove the config and then revoke ownership grant on future X manually).
-
 # {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}


### PR DESCRIPTION
Previously, deleting a snowflake_grant_ownership resource that granted ownership on FUTURE objects only logged a warning and left the future ownership grant in place. Add SDK support for REVOKE OWNERSHIP (future grants only, enforced via the new RevokeOwnershipGrantOn type) and wire it into the resource Delete so future ownership grants are properly revoked.