### PR TITLE
fix: Fix overriding resource fields in task resource during upgrading from v0.98.0

### DIFF
--- a/pkg/resources/task_state_upgraders.go
+++ b/pkg/resources/task_state_upgraders.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"log"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 )
@@ -26,7 +27,14 @@ func v098TaskStateUpgrader(ctx context.Context, rawState map[string]any, meta an
 	if rawState["session_parameters"] != nil {
 		if sessionParamsMap, okType := rawState["session_parameters"].(map[string]any); okType {
 			for k, v := range sessionParamsMap {
-				rawState[k] = v
+				// Skip reserved schema fields for task identification.
+				switch k {
+				case "id", "schema", "name", "database":
+					log.Printf("[DEBUG] v098TaskStateUpgrader: skipping reserved session parameter key %q to prevent overwriting task identification fields", k)
+					continue
+				default:
+					rawState[k] = v
+				}
 			}
 		}
 	}

--- a/pkg/resources/task_state_upgraders_test.go
+++ b/pkg/resources/task_state_upgraders_test.go
@@ -1,0 +1,52 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestV098TaskStateUpgrader_sessionParametersDoNotHijackIdentificationFields verifies the fix for SNOW-3649833:
+// the v0.98 state upgrader must not let arbitrary keys from the legacy free-form session_parameters map
+// overwrite the reserved task identification fields ("id", "schema", "name", "database").
+//
+// This behavior is only exercisable as a unit test, not an acceptance/migration test. The
+// key/value pairs would have to live in the persisted state under session_parameters WITHOUT appearing
+// in the configuration first. An acceptance test creates the resource through a real provider from config, so
+// these keys would either be rejected by Snowflake (they are not valid session parameters) during the
+// old-provider create step.
+func TestV098TaskStateUpgrader_sessionParametersDoNotHijackIdentificationFields(t *testing.T) {
+	rawState := map[string]any{
+		"id":                          "MYDB|MYSCHEMA|MYTASK",
+		"database":                    "MYDB",
+		"schema":                      "MYSCHEMA",
+		"name":                        "MYTASK",
+		"when":                        "",
+		"enabled":                     false,
+		"allow_overlapping_execution": false,
+		"session_parameters": map[string]any{
+			// Malicious entries attempting to clobber identification fields.
+			"id":       "A|B|C",
+			"database": "D",
+			"schema":   "E",
+			"name":     "F",
+			// A legitimate session parameter that must still be carried over to the top level.
+			"LOG_LEVEL": "INFO",
+		},
+	}
+
+	result, err := v098TaskStateUpgrader(context.Background(), rawState, nil)
+	require.NoError(t, err)
+
+	// Identification fields must keep the original task's values, not the hijacked ones.
+	assert.Equal(t, `"MYDB"."MYSCHEMA"."MYTASK"`, result["id"])
+	assert.Equal(t, "MYDB", result["database"])
+	assert.Equal(t, "MYSCHEMA", result["schema"])
+	assert.Equal(t, "MYTASK", result["name"])
+
+	// Legitimate session parameters are still copied up, and the original map is removed.
+	assert.Equal(t, "INFO", result["LOG_LEVEL"])
+	assert.NotContains(t, result, "session_parameters")
+}


### PR DESCRIPTION
The v098TaskStateUpgrader copied every key from the legacy free-form session_parameters map into top-level rawState. A malicious key such as id/schema/name/database in the persisted state could therefore overwrite the reserved task identification fields, redirecting subsequent ALTER/DROP operations at an unrelated task.

Skip the reserved keys (id, schema, name, database) when copying and log each skipped key at DEBUG level. Add a unit test covering the behavior.