### PR TITLE
fix: respect explicit false boolean provider fields over TOML profile

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -26,6 +26,13 @@ for changes required after enabling given [Snowflake BCR Bundle](https://docs.sn
 
 ## v2.17.0 ➞ v2.18.0
 
+### *(bug fix)* Explicit false in the provider block now correctly overrides TOML profile values
+When a Boolean provider field was explicitly set to false in the provider block or environmental variables, the TOML value incorrectly took precedence. Affected fields: passcode_in_password, keep_session_alive, disable_query_context_cache, enable_single_use_refresh_tokens, log_query_text, log_query_parameters, crl_in_memory_cache_disabled, crl_on_disk_cache_disabled, disable_ocsp_checks / insecure_mode.
+
+This behavior is now fixed: the values set explicitly in the provider block or in environmental variables take precedence.
+
+No action required.
+
 ### *(new feature)* New Postgres instance resource
 
 We have added a new preview resource for managing Postgres instances: [snowflake_postgres_instance](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/postgres_instance).

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -806,6 +806,7 @@ func ConfigureProvider(_ context.Context, s *schema.ResourceData) (any, diag.Dia
 			return nil, diag.FromErr(err)
 		}
 		config = sdk.MergeConfig(config, tomlConfig)
+		fixBooleanConfigFields(s, config)
 	}
 	// If authenticator was not set but the token was, we set to OAuth for backward compatibility. Will be removed in v3.
 	if config.Authenticator == sdk.GosnowflakeAuthTypeEmpty {
@@ -841,6 +842,31 @@ func ConfigureProvider(_ context.Context, s *schema.ResourceData) (any, diag.Dia
 	}
 
 	return providerCtx, diags
+}
+
+// fixBooleanConfigFields is a temporary function to fix the boolean config fields that are set in the Terraform configuration.
+// Without this function, if the users set a value to false explicitly, it will be overridden by the TOML profile value because of MergeConfig logic.
+// Instead, MergeConfig should have an abstraction that does this correctly, so this workaround can be removed.
+// TODO(SNOW-3174224): Remove this function after the merging logic is fixed.
+func fixBooleanConfigFields(s *schema.ResourceData, config *gosnowflake.Config) {
+	// MergeConfig prefers the TOML value for plain boolean fields whenever the Terraform value equals
+	// the bool zero value (false), so an explicit `false` in the Terraform configuration would otherwise
+	// be lost. Re-apply the exact values taken from the raw configuration so that the Terraform
+	// configuration always takes precedence over the TOML profile for these fields.
+	overrideBooleanConfigField(s, "passcode_in_password", &config.PasscodeInPassword)
+	overrideBooleanConfigField(s, "keep_session_alive", &config.ServerSessionKeepAlive)
+	overrideBooleanConfigField(s, "disable_query_context_cache", &config.DisableQueryContextCache)
+	overrideBooleanConfigField(s, "enable_single_use_refresh_tokens", &config.EnableSingleUseRefreshTokens)
+	overrideBooleanConfigField(s, "log_query_text", &config.LogQueryText)
+	overrideBooleanConfigField(s, "log_query_parameters", &config.LogQueryParameters)
+	overrideBooleanConfigField(s, "crl_in_memory_cache_disabled", &config.CrlInMemoryCacheDisabled)
+	overrideBooleanConfigField(s, "crl_on_disk_cache_disabled", &config.CrlOnDiskCacheDisabled)
+	// insecure_mode and disable_ocsp_checks both map to DisableOCSPChecks. When at least one of them is set
+	// explicitly in the Terraform configuration, the Terraform value wins over the TOML profile, and true
+	// wins over false between the two (mimicking the pre-v2 driver behavior).
+	if insecureMode, disableOcspChecks := getBooleanConfigValue(s, "insecure_mode"), getBooleanConfigValue(s, "disable_ocsp_checks"); insecureMode != nil || disableOcspChecks != nil {
+		config.DisableOCSPChecks = (insecureMode != nil && *insecureMode) || (disableOcspChecks != nil && *disableOcspChecks)
+	}
 }
 
 // TODO: reuse with the function from resources package

--- a/pkg/provider/provider_helpers.go
+++ b/pkg/provider/provider_helpers.go
@@ -116,6 +116,28 @@ func handleBoolField(d *schema.ResourceData, key string, field *bool) error {
 	return nil
 }
 
+// getBooleanConfigValue extracts the exact boolean value set for the given key in the Terraform
+// configuration. It can distinguish a field that was not set at all from a field explicitly set to false.
+func getBooleanConfigValue(d *schema.ResourceData, key string) *bool {
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() {
+		return nil
+	}
+	value, ok := rawConfig.AsValueMap()[key]
+	if !ok || value.IsNull() {
+		return nil
+	}
+	return new(value.True())
+}
+
+// overrideBooleanConfigField overrides the field with the exact boolean value set for the given key
+// in the Terraform configuration, if it was set. Fields without an explicit value are left untouched.
+func overrideBooleanConfigField(d *schema.ResourceData, key string, field *bool) {
+	if v := getBooleanConfigValue(d, key); v != nil {
+		*field = *v
+	}
+}
+
 func handleDurationInSecondsAttribute(d *schema.ResourceData, key string, field *time.Duration) error {
 	if v, ok := d.GetOk(key); ok {
 		*field = time.Second * time.Duration(int64(v.(int)))

--- a/pkg/testacc/provider_acceptance_test.go
+++ b/pkg/testacc/provider_acceptance_test.go
@@ -337,7 +337,8 @@ func TestAcc_Provider_TomlConfig(t *testing.T) {
 	})
 }
 
-func TestAcc_Provider_DisableOcspChecks_atLeastOneSetToTrueInToml(t *testing.T) {
+// disable_ocsp_checks/insecure_mode set to false in the Terraform configuration win over a true coming from the TOML profile.
+func TestAcc_Provider_DisableOcspChecks_falseInTfOverridesTrueInToml(t *testing.T) {
 	tmpServiceUser := testClient().SetUpTemporaryServiceUser(t)
 	tmpServiceUserConfig := testClient().StoreTempTomlConfig(t, func(profile string) string {
 		return helpers.TomlConfigForServiceUserWithModifiers(t, profile, tmpServiceUser, func(cfg *sdk.ConfigDTO) *sdk.ConfigDTO {
@@ -370,7 +371,7 @@ func TestAcc_Provider_DisableOcspChecks_atLeastOneSetToTrueInToml(t *testing.T) 
 				Config: config.FromModels(t, providerModelWithBothSetToFalse, datasourceModel()),
 				Check: func(s *terraform.State) error {
 					config := p.Meta().(*internalprovider.Context).Client.GetConfig()
-					assert.True(t, config.DisableOCSPChecks)
+					assert.False(t, config.DisableOCSPChecks)
 					return nil
 				},
 			},
@@ -412,6 +413,72 @@ func TestAcc_Provider_DisableOcspChecks_trueInTfNotOverriddenByFalseInToml(t *te
 				Check: func(s *terraform.State) error {
 					config := p.Meta().(*internalprovider.Context).Client.GetConfig()
 					assert.True(t, config.DisableOCSPChecks)
+					return nil
+				},
+			},
+		},
+	})
+}
+
+// boolean fields set to false in the Terraform configuration must win over true values coming from the TOML profile.
+func TestAcc_Provider_booleanFieldsFalseInTfNotOverriddenByTrueInToml(t *testing.T) {
+	tmpServiceUser := testClient().SetUpTemporaryServiceUser(t)
+	tmpServiceUserConfig := testClient().StoreTempTomlConfig(t, func(profile string) string {
+		return helpers.TomlConfigForServiceUserWithModifiers(t, profile, tmpServiceUser, func(cfg *sdk.ConfigDTO) *sdk.ConfigDTO {
+			return cfg.
+				WithPasscodeInPassword(true).
+				WithKeepSessionAlive(true).
+				WithDisableQueryContextCache(true).
+				WithEnableSingleUseRefreshTokens(true).
+				WithLogQueryText(true).
+				WithLogQueryParameters(true).
+				WithCrlInMemoryCacheDisabled(true).
+				WithCrlOnDiskCacheDisabled(true).
+				WithInsecureMode(true).
+				WithDisableOCSPChecks(true)
+		})
+	})
+
+	factory, p := providerFactoryWithoutCacheReturningProvider()
+
+	providerModelWithAllFieldsSetToFalse := providermodel.SnowflakeProvider().WithProfile(tmpServiceUserConfig.Profile).
+		WithPasscodeInPassword(false).
+		WithKeepSessionAlive(false).
+		WithDisableQueryContextCache(false).
+		WithEnableSingleUseRefreshTokens(false).
+		WithLogQueryText(false).
+		WithLogQueryParameters(false).
+		WithCrlInMemoryCacheDisabled(false).
+		WithCrlOnDiskCacheDisabled(false).
+		WithInsecureMode(false).
+		WithDisableOcspChecks(false)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: factory,
+		PreCheck: func() {
+			testenvs.AssertEnvNotSet(t, snowflakeenvs.User)
+			testenvs.AssertEnvNotSet(t, snowflakeenvs.Password)
+			testenvs.AssertEnvNotSet(t, snowflakeenvs.ConfigPath)
+
+			t.Setenv(snowflakeenvs.ConfigPath, tmpServiceUserConfig.Path)
+		},
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: config.FromModels(t, providerModelWithAllFieldsSetToFalse, datasourceModel()),
+				Check: func(s *terraform.State) error {
+					config := p.Meta().(*internalprovider.Context).Client.GetConfig()
+					assert.False(t, config.PasscodeInPassword)
+					assert.False(t, config.ServerSessionKeepAlive)
+					assert.False(t, config.DisableQueryContextCache)
+					assert.False(t, config.EnableSingleUseRefreshTokens)
+					assert.False(t, config.LogQueryText)
+					assert.False(t, config.LogQueryParameters)
+					assert.False(t, config.CrlInMemoryCacheDisabled)
+					assert.False(t, config.CrlOnDiskCacheDisabled)
+					assert.False(t, config.DisableOCSPChecks)
 					return nil
 				},
 			},


### PR DESCRIPTION
Boolean provider fields set explicitly to false in the Terraform configuration were overridden by true values from the TOML profile due to MergeConfig's `if !baseConfig.X` logic (GetOk cannot distinguish an explicit false from an unset field).

Re-apply the exact values read via GetRawConfig after MergeConfig for: passcode_in_password, keep_session_alive, disable_query_context_cache, enable_single_use_refresh_tokens, log_query_text, log_query_parameters, crl_in_memory_cache_disabled, crl_on_disk_cache_disabled, and the disable_ocsp_checks/insecure_mode pair (Terraform wins over TOML, true wins over false between the two to mimic pre-v2 driver behavior).