### PR TITLE
docs: Adjust migration guide

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -64,6 +64,57 @@ Provider will issue a warning if a stable feature is still present in the `previ
 
 Read more about preview and stable features in our [documentation](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs#support).
 
+### *(new feature)* A new experiment for handling renames in object hierarchy
+
+A new `HIERARCHY_RENAMES` experiment has been added. When enabled, changing the parent identifier fields (`database` on `snowflake_schema`, or `database`/`schema` on `snowflake_table`) no longer forces resource recreation. Instead, the provider detects whether a parent was renamed or the object should be moved, and handles it in-place.
+
+Currently supported by: [`snowflake_schema`](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/schema), [`snowflake_table`](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/table).
+
+The provider handles the following use cases:
+
+**2-level hierarchy** (e.g. `snowflake_schema`):
+1. **Database rename**: The parent database was renamed (e.g. from `A` to `B`). The provider detects that the old database no longer exists while the schema already exists under the new name, and updates the resource ID without performing any Snowflake modification.
+2. **Schema move**: Both the old and new databases exist. The provider executes `ALTER SCHEMA A.X RENAME TO B.X` to move the schema to the target database.
+
+**3-level hierarchy** (e.g. `snowflake_table`):
+- When only the `database` field changes, the provider applies the same rename/move logic at the database level.
+- When only the `schema` field changes, the provider applies the same rename/move logic at the schema level.
+- When both `database` and `schema` change simultaneously, the provider evaluates all combinations of database and schema existence to determine the correct action (e.g. both were renamed, or one was renamed while the other was moved).
+
+To enable, add `HIERARCHY_RENAMES` to your provider's `experimental_features_enabled` list:
+```hcl
+provider "snowflake" {
+  experimental_features_enabled = ["HIERARCHY_RENAMES"]
+}
+```
+
+Example configuration using implicit dependencies (recommended):
+```hcl
+resource "snowflake_database" "example" {
+  name = "my_database"
+}
+
+resource "snowflake_schema" "example" {
+  name     = "my_schema"
+  database = snowflake_database.example.name
+}
+
+resource "snowflake_table" "example" {
+  name     = "my_table"
+  database = snowflake_database.example.name
+  schema   = snowflake_schema.example.name
+
+  column {
+    name = "id"
+    type = "NUMBER(38,0)"
+  }
+}
+```
+
+With the experiment enabled, renaming `snowflake_database.example` from `my_database` to `my_new_database` will cause both the schema and table resources to detect the rename and update their state accordingly — without recreating the objects or losing any data within them.
+
+For more details, see the [Object Renaming Guide](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/object_renaming_guide).
+
 ### *(new feature)* New Postgres instance resource
 
 We have added a new preview resource for managing Postgres instances: [snowflake_postgres_instance](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/postgres_instance).
@@ -203,6 +254,7 @@ The `parameters` output of the related data sources (`snowflake_databases`, `sno
 No changes are required for existing configurations.
 
 ### *(new feature)* New instance families in the compute_pool resource
+
 Added missing instance families that are available in Snowflake: `GEN_ARM_G1_2`, `GEN_ARM_G1_4`, `GEN_ARM_G1_8`, `GEN_ARM_G1_16`, `GEN_ARM_G1_32`, `GEN_X64_G2_2`, `GEN_X64_G2_4`, `GEN_X64_G2_8`, `GEN_X64_G2_16`, `GEN_X64_G2_32`, `MEM_X64_G2_8`, `MEM_X64_G2_32`, `MEM_X64_G2_64`, `MEM_X64_G2_96`, `MEM_X64_G2_192`, `GPU_L40S_G1_8`, `GPU_L40S_G1_16`, `GPU_L40S_G1_48`, `GPU_L40S_G1_192`, `GPU_R6K_G1_8`, `GPU_R6K_G1_16`, `GPU_R6K_G1_32`, `GPU_R6K_G1_48`, `GPU_R6K_G1_96`, `GPU_R6K_G1_192`, `GPU_A100_G1_12`, and `GPU_A100_G1_48`.
 
 References: [#4916](https://github.com/snowflakedb/terraform-provider-snowflake/issues/4916)
@@ -277,6 +329,7 @@ Multiple legacy SQL builders and provider resources previously interpolated user
 No action required.
 
 ### *(bug fix)* Explicit false in the provider block now correctly overrides TOML profile values
+
 When a Boolean provider field was explicitly set to false in the provider block or environmental variables, the TOML value incorrectly took precedence. Affected fields: passcode_in_password, keep_session_alive, disable_query_context_cache, enable_single_use_refresh_tokens, log_query_text, log_query_parameters, crl_in_memory_cache_disabled, crl_on_disk_cache_disabled, disable_ocsp_checks / insecure_mode.
 
 This behavior is now fixed: the values set explicitly in the provider block or in environmental variables take precedence.
@@ -301,58 +354,8 @@ provider "snowflake" {
 
 No changes to existing configurations are required. The experiment is intended for large RBAC configurations (thousands of `snowflake_grant_account_role` resources) where plan and apply time is dominated by redundant `SHOW GRANTS OF ROLE` calls.
 
-### *(new feature)* A new experiment for handling renames in object hierarchy
-
-A new `HIERARCHY_RENAMES` experiment has been added. When enabled, changing the parent identifier fields (`database` on `snowflake_schema`, or `database`/`schema` on `snowflake_table`) no longer forces resource recreation. Instead, the provider detects whether a parent was renamed or the object should be moved, and handles it in-place.
-
-Currently supported by: [`snowflake_schema`](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/schema), [`snowflake_table`](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/table).
-
-The provider handles the following use cases:
-
-**2-level hierarchy** (e.g. `snowflake_schema`):
-1. **Database rename**: The parent database was renamed (e.g. from `A` to `B`). The provider detects that the old database no longer exists while the schema already exists under the new name, and updates the resource ID without performing any Snowflake modification.
-2. **Schema move**: Both the old and new databases exist. The provider executes `ALTER SCHEMA A.X RENAME TO B.X` to move the schema to the target database.
-
-**3-level hierarchy** (e.g. `snowflake_table`):
-- When only the `database` field changes, the provider applies the same rename/move logic at the database level.
-- When only the `schema` field changes, the provider applies the same rename/move logic at the schema level.
-- When both `database` and `schema` change simultaneously, the provider evaluates all combinations of database and schema existence to determine the correct action (e.g. both were renamed, or one was renamed while the other was moved).
-
-To enable, add `HIERARCHY_RENAMES` to your provider's `experimental_features_enabled` list:
-```hcl
-provider "snowflake" {
-  experimental_features_enabled = ["HIERARCHY_RENAMES"]
-}
-```
-
-Example configuration using implicit dependencies (recommended):
-```hcl
-resource "snowflake_database" "example" {
-  name = "my_database"
-}
-
-resource "snowflake_schema" "example" {
-  name     = "my_schema"
-  database = snowflake_database.example.name
-}
-
-resource "snowflake_table" "example" {
-  name     = "my_table"
-  database = snowflake_database.example.name
-  schema   = snowflake_schema.example.name
-
-  column {
-    name = "id"
-    type = "NUMBER(38,0)"
-  }
-}
-```
-
-With the experiment enabled, renaming `snowflake_database.example` from `my_database` to `my_new_database` will cause both the schema and table resources to detect the rename and update their state accordingly — without recreating the objects or losing any data within them.
-
-For more details, see the [Object Renaming Guide](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/object_renaming_guide).
-
 ### *(improvement)* snowflake_grant_ownership: deleting a resource with on_future now properly revokes the grant
+
 If you use the future option in the snowflake_grant_ownership, it now issues REVOKE OWNERSHIP ON FUTURE ... TO ROLE ... during destroy.
 
 No changes required for existing configurations


### PR DESCRIPTION
## Changes
- Adjust migration guide entries
  - Moved the new experiment about renames to the top
  - The rest was left as is, following the rank pattern of new feature > bug fix > improvement