### PR TITLE
chore: Clarify saml2_snowflake_x509_cert field availability

### DIFF
--- a/docs/resources/saml2_integration.md
+++ b/docs/resources/saml2_integration.md
@@ -10,7 +10,7 @@ description: |-
 !> **Note** To use `allowed_user_domains` and `allowed_email_patterns` fields, first enable [identifier-first logins](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-security-integration-multiple#enable-identifier-first-login). This can be managed with [account_parameter](./account_parameter).
 
 ~> **Missing fields** The `saml2_snowflake_x509_cert` and `saml2_x509_cert` fields are not present in the `describe_output` on purpose due to Terraform SDK limitations (more on that in the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#removal-of-sensitive-fields)).
-This may have impact on detecting external changes for the `saml2_x509_cert` field.
+This may have impact on detecting external changes for the `saml2_x509_cert` field. The `saml2_snowflake_x509_cert` field is also not present for user configuration and will be added in the future. Please use the [execute](./execute) resource as a workaround.
 
 # snowflake_saml2_integration (Resource)
 
@@ -44,7 +44,6 @@ resource "snowflake_saml2_integration" "test" {
   saml2_sign_request                  = true
   saml2_snowflake_acs_url             = "example.snowflakecomputing.com/fed/login"
   saml2_snowflake_issuer_url          = "example.snowflakecomputing.com/fed/login"
-  saml2_snowflake_x509_cert           = file("snowflake_cert.pem")
   saml2_sp_initiated_login_page_label = "foo"
   saml2_sso_url                       = "https://example.com"
   saml2_x509_cert                     = file("cert.pem")

--- a/examples/resources/snowflake_saml2_integration/resource.tf
+++ b/examples/resources/snowflake_saml2_integration/resource.tf
@@ -23,7 +23,6 @@ resource "snowflake_saml2_integration" "test" {
   saml2_sign_request                  = true
   saml2_snowflake_acs_url             = "example.snowflakecomputing.com/fed/login"
   saml2_snowflake_issuer_url          = "example.snowflakecomputing.com/fed/login"
-  saml2_snowflake_x509_cert           = file("snowflake_cert.pem")
   saml2_sp_initiated_login_page_label = "foo"
   saml2_sso_url                       = "https://example.com"
   saml2_x509_cert                     = file("cert.pem")

--- a/templates/resources/saml2_integration.md.tmpl
+++ b/templates/resources/saml2_integration.md.tmpl
@@ -14,7 +14,7 @@ description: |-
 !> **Note** To use `allowed_user_domains` and `allowed_email_patterns` fields, first enable [identifier-first logins](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-security-integration-multiple#enable-identifier-first-login). This can be managed with [account_parameter](./account_parameter).
 
 ~> **Missing fields** The `saml2_snowflake_x509_cert` and `saml2_x509_cert` fields are not present in the `describe_output` on purpose due to Terraform SDK limitations (more on that in the [migration guide](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/MIGRATION_GUIDE.md#removal-of-sensitive-fields)).
-This may have impact on detecting external changes for the `saml2_x509_cert` field.
+This may have impact on detecting external changes for the `saml2_x509_cert` field. The `saml2_snowflake_x509_cert` field is also not present for user configuration and will be added in the future. Please use the [execute](./execute) resource as a workaround.
 
 # {{.Name}} ({{.Type}})
 


### PR DESCRIPTION
## Changes

Clarify in the `snowflake_saml2_integration` docs that the `saml2_snowflake_x509_cert` field is not currently available for user configuration and will be added in the future. Suggest the [execute](./execute) resource as a workaround.

- Updated the note in the resource docs template and generated docs.
- Removed the `saml2_snowflake_x509_cert` line from the example, since it is not settable.