### PR TITLE
chore: Move tables to tablesLegacy

### DIFF
--- a/pkg/acceptance/helpers/table_client.go
+++ b/pkg/acceptance/helpers/table_client.go
@@ -23,8 +23,8 @@ func NewTableClient(context *TestClientContext, idsGenerator *IdsGenerator) *Tab
 	}
 }
 
-func (c *TableClient) client() sdk.Tables {
-	return c.context.client.Tables
+func (c *TableClient) client() sdk.TablesLegacy {
+	return c.context.client.TablesLegacy
 }
 
 func (c *TableClient) Create(t *testing.T) (*sdk.Table, func()) {

--- a/pkg/datasources/tables.go
+++ b/pkg/datasources/tables.go
@@ -73,7 +73,7 @@ func ReadTables(ctx context.Context, d *schema.ResourceData, meta any) diag.Diag
 		return diag.FromErr(err)
 	}
 
-	tables, err := client.Tables.Show(ctx, req)
+	tables, err := client.TablesLegacy.Show(ctx, req)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -85,7 +85,7 @@ func ReadTables(ctx context.Context, d *schema.ResourceData, meta any) diag.Diag
 		table := table
 		var tableDescriptions []map[string]any
 		if d.Get("with_describe").(bool) {
-			describeOutput, err := client.Tables.DescribeColumns(ctx, sdk.NewDescribeTableColumnsRequest(table.ID()))
+			describeOutput, err := client.TablesLegacy.DescribeColumns(ctx, sdk.NewDescribeTableColumnsRequest(table.ID()))
 			if err != nil {
 				return diag.FromErr(err)
 			}

--- a/pkg/resources/table.go
+++ b/pkg/resources/table.go
@@ -213,7 +213,9 @@ var tableSchema = map[string]*schema.Schema{
 func Table() *schema.Resource {
 	deleteFunc := ResourceDeleteContextFunc(
 		helpers.DecodeSnowflakeIDErrLegacy[sdk.SchemaObjectIdentifier],
-		func(client *sdk.Client) DropSafelyFunc[sdk.SchemaObjectIdentifier] { return client.Tables.DropSafely },
+		func(client *sdk.Client) DropSafelyFunc[sdk.SchemaObjectIdentifier] {
+			return client.TablesLegacy.DropSafely
+		},
 	)
 
 	return &schema.Resource{
@@ -642,7 +644,7 @@ func CreateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 		createRequest.WithTags(tagAssociationRequests)
 	}
 
-	err = client.Tables.Create(ctx, createRequest)
+	err = client.TablesLegacy.Create(ctx, createRequest)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating table %v err = %w", name, err))
 	}
@@ -657,7 +659,7 @@ func ReadTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagn
 
 	id := helpers.DecodeSnowflakeIDLegacy(d.Id()).(sdk.SchemaObjectIdentifier)
 
-	table, err := client.Tables.ShowByIDSafely(ctx, id)
+	table, err := client.TablesLegacy.ShowByIDSafely(ctx, id)
 	if err != nil {
 		if errors.Is(err, sdk.ErrObjectNotFound) {
 			d.SetId("")
@@ -695,7 +697,7 @@ func ReadTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagn
 		}
 	}
 
-	tableDescription, err := client.Tables.DescribeColumns(ctx, sdk.NewDescribeTableColumnsRequest(id))
+	tableDescription, err := client.TablesLegacy.DescribeColumns(ctx, sdk.NewDescribeTableColumnsRequest(id))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -733,14 +735,14 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 	if experimentalfeatures.IsExperimentEnabled(experimentalfeatures.HierarchyRenames, providerCtx.EnabledExperiments) && (d.HasChange("database") || d.HasChange("schema")) {
 		tableRenameFn := func(currentId, targetId sdk.SchemaObjectIdentifier) func() error {
 			return func() error {
-				return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(currentId).WithNewName(&targetId))
+				return client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(currentId).WithNewName(&targetId))
 			}
 		}
 
 		if diags := handleThreeLevelHierarchyRename(
 			ctx, d, client, &id,
 			tableRenameFn,
-			client.Tables.ShowByID,
+			client.TablesLegacy.ShowByID,
 			func(id sdk.SchemaObjectIdentifier) string { return helpers.EncodeSnowflakeID(id) },
 			"table",
 		); diags != nil {
@@ -751,7 +753,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 	if d.HasChange("name") {
 		newId := sdk.NewSchemaObjectIdentifierInSchema(id.SchemaId(), d.Get("name").(string))
 
-		err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newId))
+		err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithNewName(&newId))
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error renaming table %v err = %w", d.Id(), err))
 		}
@@ -793,14 +795,14 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 	}
 
 	if runSetStatement {
-		err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithSet(setRequest))
+		err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithSet(setRequest))
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error updating table: %w", err))
 		}
 	}
 
 	if runUnsetStatement {
-		err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithUnset(unsetRequest))
+		err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithUnset(unsetRequest))
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error updating table: %w", err))
 		}
@@ -810,12 +812,12 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 		cb := expandStringList(d.Get("cluster_by").([]interface{}))
 
 		if len(cb) != 0 {
-			err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithClusteringAction(sdk.NewTableClusteringActionRequest().WithClusterBy(cb)))
+			err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithClusteringAction(sdk.NewTableClusteringActionRequest().WithClusterBy(cb)))
 			if err != nil {
 				return diag.FromErr(fmt.Errorf("error updating table: %w", err))
 			}
 		} else {
-			err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithClusteringAction(sdk.NewTableClusteringActionRequest().WithDropClusteringKey(sdk.Bool(true))))
+			err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithClusteringAction(sdk.NewTableClusteringActionRequest().WithDropClusteringKey(sdk.Bool(true))))
 			if err != nil {
 				return diag.FromErr(fmt.Errorf("error updating table: %w", err))
 			}
@@ -831,7 +833,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			for i, r := range removed {
 				removedColumnNames[i] = r.name
 			}
-			err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithDropColumns(snowflake.QuoteStringList(removedColumnNames))))
+			err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithDropColumns(snowflake.QuoteStringList(removedColumnNames))))
 			if err != nil {
 				return diag.FromErr(fmt.Errorf("error updating table: %w", err))
 			}
@@ -870,7 +872,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				addRequest.WithCollate(sdk.String(cA.collate))
 			}
 
-			err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithAdd(addRequest)))
+			err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithAdd(addRequest)))
 			if err != nil {
 				return diag.FromErr(fmt.Errorf("error adding column: %w", err))
 			}
@@ -881,7 +883,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				if sdk.IsStringType(cA.newColumn.dataType) && cA.newColumn.collate != "" {
 					newCollation = sdk.String(cA.newColumn.collate)
 				}
-				err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithAlter([]sdk.TableColumnAlterActionRequest{*sdk.NewTableColumnAlterActionRequest(fmt.Sprintf("\"%s\"", cA.newColumn.name)).WithType(sdk.Pointer(sdk.DataType(cA.newColumn.dataType))).WithCollate(newCollation)})))
+				err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithAlter([]sdk.TableColumnAlterActionRequest{*sdk.NewTableColumnAlterActionRequest(fmt.Sprintf("\"%s\"", cA.newColumn.name)).WithType(sdk.Pointer(sdk.DataType(cA.newColumn.dataType))).WithCollate(newCollation)})))
 				if err != nil {
 					return diag.FromErr(fmt.Errorf("error changing property on %v: err %w", d.Id(), err))
 				}
@@ -893,13 +895,13 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				} else {
 					nullabilityRequest.WithDrop(sdk.Bool(true))
 				}
-				err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithAlter([]sdk.TableColumnAlterActionRequest{*sdk.NewTableColumnAlterActionRequest(fmt.Sprintf("\"%s\"", cA.newColumn.name)).WithNotNullConstraint(nullabilityRequest)})))
+				err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithAlter([]sdk.TableColumnAlterActionRequest{*sdk.NewTableColumnAlterActionRequest(fmt.Sprintf("\"%s\"", cA.newColumn.name)).WithNotNullConstraint(nullabilityRequest)})))
 				if err != nil {
 					return diag.FromErr(fmt.Errorf("error changing property on %v: err %w", d.Id(), err))
 				}
 			}
 			if cA.droppedDefault {
-				err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithAlter([]sdk.TableColumnAlterActionRequest{*sdk.NewTableColumnAlterActionRequest(fmt.Sprintf("\"%s\"", cA.newColumn.name)).WithDropDefault(sdk.Bool(true))})))
+				err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithAlter([]sdk.TableColumnAlterActionRequest{*sdk.NewTableColumnAlterActionRequest(fmt.Sprintf("\"%s\"", cA.newColumn.name)).WithDropDefault(sdk.Bool(true))})))
 				if err != nil {
 					return diag.FromErr(fmt.Errorf("error changing property on %v: err %w", d.Id(), err))
 				}
@@ -912,7 +914,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 					columnAlterActionRequest.WithComment(sdk.String(cA.newColumn.comment))
 				}
 
-				err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithAlter([]sdk.TableColumnAlterActionRequest{*columnAlterActionRequest})))
+				err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(sdk.NewTableColumnActionRequest().WithAlter([]sdk.TableColumnAlterActionRequest{*columnAlterActionRequest})))
 				if err != nil {
 					return diag.FromErr(fmt.Errorf("error changing property on %v: err %w", d.Id(), err))
 				}
@@ -924,7 +926,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 				} else {
 					columnAction.WithSetMaskingPolicy(sdk.NewTableColumnAlterSetMaskingPolicyActionRequest(fmt.Sprintf("\"%s\"", cA.newColumn.name), sdk.NewSchemaObjectIdentifierFromFullyQualifiedName(cA.newColumn.maskingPolicy), []string{}).WithForce(sdk.Bool(true)))
 				}
-				err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(columnAction))
+				err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithColumnAction(columnAction))
 				if err != nil {
 					return diag.FromErr(fmt.Errorf("error changing property on %v: err %w", d.Id(), err))
 				}
@@ -940,7 +942,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 
 		if len(oldKey.keys) > 0 || len(newKey.keys) == 0 {
 			// drop our pk if there was an old primary key, or pk has been removed
-			err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithConstraintAction(
+			err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithConstraintAction(
 				sdk.NewTableConstraintActionRequest().
 					WithDrop(sdk.NewTableConstraintDropActionRequest().WithPrimaryKey(sdk.Bool(true))),
 			))
@@ -954,7 +956,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			if newKey.name != "" {
 				constraint.WithName(sdk.String(newKey.name))
 			}
-			err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithConstraintAction(
+			err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithConstraintAction(
 				sdk.NewTableConstraintActionRequest().WithAdd(constraint),
 			))
 			if err != nil {
@@ -967,7 +969,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 		unsetTags, setTags := GetTagsDiff(d, "tag")
 
 		if len(unsetTags) > 0 {
-			err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithUnsetTags(unsetTags))
+			err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithUnsetTags(unsetTags))
 			if err != nil {
 				return diag.FromErr(fmt.Errorf("error setting tags on %v, err = %w", d.Id(), err))
 			}
@@ -978,7 +980,7 @@ func UpdateTable(ctx context.Context, d *schema.ResourceData, meta any) diag.Dia
 			for i, t := range setTags {
 				tagAssociationRequests[i] = *sdk.NewTagAssociationRequest(t.Name, t.Value)
 			}
-			err := client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithSetTags(tagAssociationRequests))
+			err := client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithSetTags(tagAssociationRequests))
 			if err != nil {
 				return diag.FromErr(fmt.Errorf("error setting tags on %v, err = %w", d.Id(), err))
 			}

--- a/pkg/resources/table_constraint.go
+++ b/pkg/resources/table_constraint.go
@@ -331,7 +331,7 @@ func CreateTableConstraint(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	alterStatement := sdk.NewAlterTableRequest(*tableIdentifier).WithConstraintAction(sdk.NewTableConstraintActionRequest().WithAdd(constraintRequest))
-	err = client.Tables.Alter(ctx, alterStatement)
+	err = client.TablesLegacy.Alter(ctx, alterStatement)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating table constraint %v err = %w", name, err))
 	}
@@ -413,7 +413,7 @@ func DeleteTableConstraint(ctx context.Context, d *schema.ResourceData, meta any
 
 	dropRequest := sdk.NewTableConstraintDropActionRequest().WithConstraintName(&tc.name)
 	alterStatement := sdk.NewAlterTableRequest(*tableIdentifier).WithConstraintAction(sdk.NewTableConstraintActionRequest().WithDrop(dropRequest))
-	err = client.Tables.Alter(ctx, alterStatement)
+	err = client.TablesLegacy.Alter(ctx, alterStatement)
 	if err != nil {
 		// if the table constraint does not exist, then remove from state file
 		if strings.Contains(err.Error(), "does not exist") {

--- a/pkg/resources/table_storage_lifecycle_policy_attachment.go
+++ b/pkg/resources/table_storage_lifecycle_policy_attachment.go
@@ -260,7 +260,7 @@ func expandStorageLifecyclePolicyColumns(raw []any) []sdk.Column {
 func addStorageLifecyclePolicyToTable(ctx context.Context, client *sdk.Client, tableType sdk.PolicyEntityDomain, tableName sdk.SchemaObjectIdentifier, storageLifecyclePolicyName sdk.SchemaObjectIdentifier, columns []sdk.Column) error {
 	switch tableType {
 	case sdk.PolicyEntityDomainTable:
-		return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(tableName).
+		return client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(tableName).
 			WithAddStorageLifecyclePolicy(sdk.NewTableAddStorageLifecyclePolicyRequest(storageLifecyclePolicyName, columns)))
 	case sdk.PolicyEntityDomainDynamicTable:
 		return client.DynamicTables.Alter(ctx, sdk.NewAlterDynamicTableRequest(tableName).
@@ -273,7 +273,7 @@ func addStorageLifecyclePolicyToTable(ctx context.Context, client *sdk.Client, t
 func dropStorageLifecyclePolicyFromTable(ctx context.Context, client *sdk.Client, tableType sdk.PolicyEntityDomain, tableName sdk.SchemaObjectIdentifier) error {
 	switch tableType {
 	case sdk.PolicyEntityDomainTable:
-		return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(tableName).WithDropStorageLifecyclePolicy(new(true)))
+		return client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(tableName).WithDropStorageLifecyclePolicy(new(true)))
 	case sdk.PolicyEntityDomainDynamicTable:
 		return client.DynamicTables.Alter(ctx, sdk.NewAlterDynamicTableRequest(tableName).WithDropStorageLifecyclePolicy(new(true)))
 	default:

--- a/pkg/resources/tag_association.go
+++ b/pkg/resources/tag_association.go
@@ -350,7 +350,7 @@ func skipColumnIfDoesNotExist(ctx context.Context, client *sdk.Client, id sdk.Ob
 		return false, errors.New("invalid column identifier")
 	}
 	// TODO [SNOW-1007542]: use SHOW COLUMNS
-	_, err := client.Tables.ShowByIDSafely(ctx, columnId.SchemaObjectId())
+	_, err := client.TablesLegacy.ShowByIDSafely(ctx, columnId.SchemaObjectId())
 	if err != nil {
 		if errors.Is(err, sdk.ErrObjectNotFound) {
 			log.Printf("[DEBUG] table %s not found, skipping", columnId.SchemaObjectId())
@@ -358,7 +358,7 @@ func skipColumnIfDoesNotExist(ctx context.Context, client *sdk.Client, id sdk.Ob
 		}
 		return false, err
 	}
-	columns, err := client.Tables.DescribeColumns(ctx, sdk.NewDescribeTableColumnsRequest(columnId.SchemaObjectId()))
+	columns, err := client.TablesLegacy.DescribeColumns(ctx, sdk.NewDescribeTableColumnsRequest(columnId.SchemaObjectId()))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -87,7 +87,7 @@ type Client struct {
 	StorageLifecyclePolicies     StorageLifecyclePolicies
 	Streamlits                   Streamlits
 	Streams                      Streams
-	Tables                       Tables
+	TablesLegacy                 TablesLegacy
 	TagReferences                TagReferences
 	Tags                         Tags
 	Tasks                        Tasks
@@ -231,7 +231,7 @@ func (c *Client) initialize() {
 	c.Streamlits = &streamlits{client: c}
 	c.Streams = &streams{client: c}
 	c.SystemFunctions = &systemFunctions{client: c}
-	c.Tables = &tables{client: c}
+	c.TablesLegacy = &tablesLegacy{client: c}
 	c.TagReferences = &tagReferences{client: c}
 	c.Tags = &tags{client: c}
 	c.Tasks = &tasks{client: c}

--- a/pkg/sdk/tables.go
+++ b/pkg/sdk/tables.go
@@ -14,7 +14,7 @@ import (
 // - describe search optimization (https://docs.snowflake.com/en/sql-reference/sql/desc-search-optimization)
 // - truncate table (https://docs.snowflake.com/en/sql-reference/sql/truncate-table)
 // - undrop table (https://docs.snowflake.com/en/sql-reference/sql/undrop-table)
-type Tables interface {
+type TablesLegacy interface {
 	Create(ctx context.Context, req *CreateTableRequest) error
 	CreateAsSelect(ctx context.Context, req *CreateTableAsSelectRequest) error
 	CreateUsingTemplate(ctx context.Context, req *CreateTableUsingTemplateRequest) error

--- a/pkg/sdk/tables_impl.go
+++ b/pkg/sdk/tables_impl.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	_ Tables                             = (*tables)(nil)
+	_ TablesLegacy                       = (*tablesLegacy)(nil)
 	_ convertibleRow[TableColumnDetails] = new(tableColumnDetailsRow)
 	_ convertibleRow[TableStageDetails]  = new(tableStageDetailsRow)
 	_ convertibleRow[Table]              = new(tableDBRow)
@@ -31,50 +31,50 @@ var (
 	_ optionsProvider[TableSet]                            = new(TableSetRequest)
 )
 
-type tables struct {
+type tablesLegacy struct {
 	client *Client
 }
 
-func (v *tables) Create(ctx context.Context, request *CreateTableRequest) error {
+func (v *tablesLegacy) Create(ctx context.Context, request *CreateTableRequest) error {
 	opts := request.toOpts()
 	return validateAndExec(v.client, ctx, opts)
 }
 
-func (v *tables) CreateAsSelect(ctx context.Context, request *CreateTableAsSelectRequest) error {
+func (v *tablesLegacy) CreateAsSelect(ctx context.Context, request *CreateTableAsSelectRequest) error {
 	opts := request.toOpts()
 	return validateAndExec(v.client, ctx, opts)
 }
 
-func (v *tables) CreateUsingTemplate(ctx context.Context, request *CreateTableUsingTemplateRequest) error {
+func (v *tablesLegacy) CreateUsingTemplate(ctx context.Context, request *CreateTableUsingTemplateRequest) error {
 	opts := request.toOpts()
 	return validateAndExec(v.client, ctx, opts)
 }
 
-func (v *tables) CreateLike(ctx context.Context, request *CreateTableLikeRequest) error {
+func (v *tablesLegacy) CreateLike(ctx context.Context, request *CreateTableLikeRequest) error {
 	opts := request.toOpts()
 	return validateAndExec(v.client, ctx, opts)
 }
 
-func (v *tables) CreateClone(ctx context.Context, request *CreateTableCloneRequest) error {
+func (v *tablesLegacy) CreateClone(ctx context.Context, request *CreateTableCloneRequest) error {
 	opts := request.toOpts()
 	return validateAndExec(v.client, ctx, opts)
 }
 
-func (v *tables) Alter(ctx context.Context, request *AlterTableRequest) error {
+func (v *tablesLegacy) Alter(ctx context.Context, request *AlterTableRequest) error {
 	opts := request.toOpts()
 	return validateAndExec(v.client, ctx, opts)
 }
 
-func (v *tables) Drop(ctx context.Context, request *DropTableRequest) error {
+func (v *tablesLegacy) Drop(ctx context.Context, request *DropTableRequest) error {
 	opts := request.toOpts()
 	return validateAndExec(v.client, ctx, opts)
 }
 
-func (v *tables) DropSafely(ctx context.Context, id SchemaObjectIdentifier) error {
+func (v *tablesLegacy) DropSafely(ctx context.Context, id SchemaObjectIdentifier) error {
 	return SafeDrop(v.client, func() error { return v.Drop(ctx, NewDropTableRequest(id).WithIfExists(Bool(true))) }, ctx, id)
 }
 
-func (v *tables) Show(ctx context.Context, request *ShowTableRequest) ([]Table, error) {
+func (v *tablesLegacy) Show(ctx context.Context, request *ShowTableRequest) ([]Table, error) {
 	opts := request.toOpts()
 	dbRows, err := validateAndQuery[tableDBRow](v.client, ctx, opts)
 	if err != nil {
@@ -84,7 +84,7 @@ func (v *tables) Show(ctx context.Context, request *ShowTableRequest) ([]Table, 
 	return convertRows[tableDBRow, Table](dbRows)
 }
 
-func (v *tables) ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Table, error) {
+func (v *tablesLegacy) ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Table, error) {
 	request := NewShowTableRequest().WithIn(ExtendedIn{In: In{Schema: id.SchemaId()}}).
 		WithLike(Like{Pattern: String(id.Name())})
 	returnedTables, err := v.Show(ctx, request)
@@ -94,11 +94,11 @@ func (v *tables) ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*Tabl
 	return collections.FindFirst(returnedTables, func(r Table) bool { return r.Name == id.Name() })
 }
 
-func (v *tables) ShowByIDSafely(ctx context.Context, id SchemaObjectIdentifier) (*Table, error) {
+func (v *tablesLegacy) ShowByIDSafely(ctx context.Context, id SchemaObjectIdentifier) (*Table, error) {
 	return SafeShowById(v.client, v.ShowByID, ctx, id)
 }
 
-func (v *tables) DescribeColumns(ctx context.Context, req *DescribeTableColumnsRequest) ([]TableColumnDetails, error) {
+func (v *tablesLegacy) DescribeColumns(ctx context.Context, req *DescribeTableColumnsRequest) ([]TableColumnDetails, error) {
 	rows, err := validateAndQuery[tableColumnDetailsRow](v.client, ctx, req.toOpts())
 	if err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func (v *tables) DescribeColumns(ctx context.Context, req *DescribeTableColumnsR
 	return convertRows[tableColumnDetailsRow, TableColumnDetails](rows)
 }
 
-func (v *tables) DescribeStage(ctx context.Context, req *DescribeTableStageRequest) ([]TableStageDetails, error) {
+func (v *tablesLegacy) DescribeStage(ctx context.Context, req *DescribeTableStageRequest) ([]TableStageDetails, error) {
 	rows, err := validateAndQuery[tableStageDetailsRow](v.client, ctx, req.toOpts())
 	if err != nil {
 		return nil, err

--- a/pkg/sdk/testint/drop_integration_test.go
+++ b/pkg/sdk/testint/drop_integration_test.go
@@ -52,7 +52,7 @@ func TestInt_SafeDropOnSchemaObjectIdentifier(t *testing.T) {
 	ctx := context.Background()
 	tableDrop := func(id sdk.SchemaObjectIdentifier) func() error {
 		return func() error {
-			return testClient(t).Tables.Drop(ctx, sdk.NewDropTableRequest(id).WithIfExists(sdk.Bool(true)))
+			return testClient(t).TablesLegacy.Drop(ctx, sdk.NewDropTableRequest(id).WithIfExists(sdk.Bool(true)))
 		}
 	}
 

--- a/pkg/sdk/testint/errors_integration_test.go
+++ b/pkg/sdk/testint/errors_integration_test.go
@@ -37,7 +37,7 @@ func TestInt_ShowSchemaObjectInNonExistingDatabase(t *testing.T) {
 		ShowFn      func(context.Context, sdk.SchemaObjectIdentifier) error
 	}{
 		// Only object types that use IN SCHEMA in their ShowByID implementation
-		{ObjectType: sdk.ObjectTypeTable, ExpectedErr: sdk.ErrDoesNotExistOrOperationCannotBePerformed, ShowFn: schemaObjectShowByIDWrapper(testClient(t).Tables.ShowByID)},
+		{ObjectType: sdk.ObjectTypeTable, ExpectedErr: sdk.ErrDoesNotExistOrOperationCannotBePerformed, ShowFn: schemaObjectShowByIDWrapper(testClient(t).TablesLegacy.ShowByID)},
 		{ObjectType: sdk.ObjectTypeDynamicTable, ExpectedErr: sdk.ErrDoesNotExistOrOperationCannotBePerformed, ShowFn: schemaObjectShowByIDWrapper(testClient(t).DynamicTables.ShowByID)},
 		{ObjectType: sdk.ObjectTypeCortexSearchService, ExpectedErr: sdk.ErrObjectNotExistOrAuthorized, ShowFn: schemaObjectShowByIDWrapper(testClient(t).CortexSearchServices.ShowByID)},
 		{ObjectType: sdk.ObjectTypeExternalTable, ExpectedErr: sdk.ErrDoesNotExistOrOperationCannotBePerformed, ShowFn: schemaObjectShowByIDWrapper(testClient(t).ExternalTables.ShowByID)},
@@ -98,7 +98,7 @@ func TestInt_ShowSchemaObjectInNonExistingSchema(t *testing.T) {
 		ShowFn      func(context.Context, sdk.SchemaObjectIdentifier) error
 	}{
 		// Only object types that use IN SCHEMA in their ShowByID implementation
-		{ObjectType: sdk.ObjectTypeTable, ExpectedErr: sdk.ErrDoesNotExistOrOperationCannotBePerformed, ShowFn: schemaObjectShowByIDWrapper(testClient(t).Tables.ShowByID)},
+		{ObjectType: sdk.ObjectTypeTable, ExpectedErr: sdk.ErrDoesNotExistOrOperationCannotBePerformed, ShowFn: schemaObjectShowByIDWrapper(testClient(t).TablesLegacy.ShowByID)},
 		{ObjectType: sdk.ObjectTypeDynamicTable, ExpectedErr: sdk.ErrDoesNotExistOrOperationCannotBePerformed, ShowFn: schemaObjectShowByIDWrapper(testClient(t).DynamicTables.ShowByID)},
 		{ObjectType: sdk.ObjectTypeCortexSearchService, ExpectedErr: sdk.ErrObjectNotExistOrAuthorized, ShowFn: schemaObjectShowByIDWrapper(testClient(t).CortexSearchServices.ShowByID)},
 		{ObjectType: sdk.ObjectTypeExternalTable, ExpectedErr: sdk.ErrDoesNotExistOrOperationCannotBePerformed, ShowFn: schemaObjectShowByIDWrapper(testClient(t).ExternalTables.ShowByID)},
@@ -162,7 +162,7 @@ func TestInt_DropSchemaObjectInNonExistingDatabase(t *testing.T) {
 		DropFn      func(context.Context) error
 	}{
 		// Only object types that use IN SCHEMA in their ShowByID implementation
-		{ObjectType: sdk.ObjectTypeTable, ExpectedErr: sdk.ErrObjectNotExistOrAuthorized, DropFn: schemaObjectDropWrapper(testClient(t).Tables.Drop, sdk.NewDropTableRequest(id).WithIfExists(sdk.Bool(true)))},
+		{ObjectType: sdk.ObjectTypeTable, ExpectedErr: sdk.ErrObjectNotExistOrAuthorized, DropFn: schemaObjectDropWrapper(testClient(t).TablesLegacy.Drop, sdk.NewDropTableRequest(id).WithIfExists(sdk.Bool(true)))},
 		{ObjectType: sdk.ObjectTypeDynamicTable, ExpectedErr: sdk.ErrObjectNotExistOrAuthorized, DropFn: schemaObjectDropWrapper(testClient(t).DynamicTables.Drop, sdk.NewDropDynamicTableRequest(id).WithIfExists(true))},
 		{ObjectType: sdk.ObjectTypeCortexSearchService, ExpectedErr: sdk.ErrObjectNotExistOrAuthorized, DropFn: schemaObjectDropWrapper(testClient(t).CortexSearchServices.Drop, sdk.NewDropCortexSearchServiceRequest(id).WithIfExists(true))},
 		{ObjectType: sdk.ObjectTypeExternalTable, ExpectedErr: sdk.ErrObjectNotExistOrAuthorized, DropFn: schemaObjectDropWrapper(testClient(t).ExternalTables.Drop, sdk.NewDropExternalTableRequest(id).WithIfExists(true))},
@@ -235,7 +235,7 @@ func TestInt_DropSchemaObjectInNonExistingSchema(t *testing.T) {
 		DropFn      func(ctx context.Context) error
 	}{
 		// Only object types that use IN SCHEMA in their ShowByID implementation
-		{ObjectType: sdk.ObjectTypeTable, ExpectedErr: sdk.ErrObjectNotExistOrAuthorized, DropFn: schemaObjectDropWrapper(testClient(t).Tables.Drop, sdk.NewDropTableRequest(id).WithIfExists(sdk.Bool(true)))},
+		{ObjectType: sdk.ObjectTypeTable, ExpectedErr: sdk.ErrObjectNotExistOrAuthorized, DropFn: schemaObjectDropWrapper(testClient(t).TablesLegacy.Drop, sdk.NewDropTableRequest(id).WithIfExists(sdk.Bool(true)))},
 		{ObjectType: sdk.ObjectTypeDynamicTable, ExpectedErr: sdk.ErrObjectNotExistOrAuthorized, DropFn: schemaObjectDropWrapper(testClient(t).DynamicTables.Drop, sdk.NewDropDynamicTableRequest(id).WithIfExists(true))},
 		{ObjectType: sdk.ObjectTypeCortexSearchService, ExpectedErr: sdk.ErrObjectNotExistOrAuthorized, DropFn: schemaObjectDropWrapper(testClient(t).CortexSearchServices.Drop, sdk.NewDropCortexSearchServiceRequest(id).WithIfExists(true))},
 		{ObjectType: sdk.ObjectTypeExternalTable, ExpectedErr: sdk.ErrObjectNotExistOrAuthorized, DropFn: schemaObjectDropWrapper(testClient(t).ExternalTables.Drop, sdk.NewDropExternalTableRequest(id).WithIfExists(true))},

--- a/pkg/sdk/testint/schemas_integration_test.go
+++ b/pkg/sdk/testint/schemas_integration_test.go
@@ -265,7 +265,7 @@ func TestInt_Schemas(t *testing.T) {
 		table, _ := testClientHelper().Table.CreateInSchema(t, schema.ID())
 		t.Cleanup(func() {
 			newId := sdk.NewSchemaObjectIdentifierInSchema(swapSchema.ID(), table.Name)
-			err := client.Tables.Drop(ctx, sdk.NewDropTableRequest(newId))
+			err := client.TablesLegacy.Drop(ctx, sdk.NewDropTableRequest(newId))
 			require.NoError(t, err)
 		})
 

--- a/pkg/sdk/testint/streams_gen_integration_test.go
+++ b/pkg/sdk/testint/streams_gen_integration_test.go
@@ -434,7 +434,7 @@ func TestInt_Streams(t *testing.T) {
 		_, cleanupStream := testClientHelper().Stream.CreateOnTableWithRequest(t, sdk.NewCreateOnTableStreamRequest(id, table.ID()))
 		t.Cleanup(cleanupStream)
 
-		err := client.Tables.Drop(ctx, sdk.NewDropTableRequest(table.ID()))
+		err := client.TablesLegacy.Drop(ctx, sdk.NewDropTableRequest(table.ID()))
 		require.NoError(t, err)
 
 		_, err = client.Streams.ShowByID(ctx, id)

--- a/pkg/sdk/testint/tables_integration_test.go
+++ b/pkg/sdk/testint/tables_integration_test.go
@@ -32,7 +32,7 @@ func TestInt_Table(t *testing.T) {
 
 	cleanupTableProvider := func(id sdk.SchemaObjectIdentifier) func() {
 		return func() {
-			err := client.Tables.Drop(ctx, sdk.NewDropTableRequest(id))
+			err := client.TablesLegacy.Drop(ctx, sdk.NewDropTableRequest(id))
 			require.NoError(t, err)
 		}
 	}
@@ -85,11 +85,11 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("SECOND_COLUMN", sdk.DataTypeNumber).WithDefaultValue(sdk.NewColumnDefaultValueRequest().WithIdentity(sdk.NewColumnIdentityRequest(1, 1))),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		assertTable(t, table, id)
@@ -102,11 +102,11 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("SECOND_COLUMN", datatypes.DecfloatLegacyDataType),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		assertTable(t, table, id)
@@ -165,11 +165,11 @@ func TestInt_Table(t *testing.T) {
 			WithDataRetentionTimeInDays(sdk.Int(30)).
 			WithMaxDataExtensionTimeInDays(sdk.Int(30))
 
-		err := client.Tables.Create(ctx, request)
+		err := client.TablesLegacy.Create(ctx, request)
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		assertTable(t, table, id)
@@ -211,11 +211,11 @@ func TestInt_Table(t *testing.T) {
 		query := "SELECT 1, 2, 3"
 		request := sdk.NewCreateTableAsSelectRequest(id, columns, query)
 
-		err := client.Tables.CreateAsSelect(ctx, request)
+		err := client.TablesLegacy.CreateAsSelect(ctx, request)
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		tableColumns := testClientHelper().Table.GetTableColumnsFor(t, table.ID())
@@ -244,11 +244,11 @@ func TestInt_Table(t *testing.T) {
 		query := fmt.Sprintf(`SELECT ARRAY_AGG(OBJECT_CONSTRUCT(*)) WITHIN GROUP (ORDER BY order_id) FROM TABLE (INFER_SCHEMA(location => '@%s', FILE_FORMAT=>'%s', ignore_case => true))`, stage.ID().FullyQualifiedName(), fileFormat.ID().FullyQualifiedName())
 		request := sdk.NewCreateTableUsingTemplateRequest(id, query)
 
-		err = client.Tables.CreateUsingTemplate(ctx, request)
+		err = client.TablesLegacy.CreateUsingTemplate(ctx, request)
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		returnedTableColumns := testClientHelper().Table.GetTableColumnsFor(t, table.ID())
@@ -272,7 +272,7 @@ func TestInt_Table(t *testing.T) {
 		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
 		request := sdk.NewCreateTableLikeRequest(id, sourceTable.ID()).WithCopyGrants(sdk.Bool(true))
 
-		err := client.Tables.CreateLike(ctx, request)
+		err := client.TablesLegacy.CreateLike(ctx, request)
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
@@ -284,7 +284,7 @@ func TestInt_Table(t *testing.T) {
 		}
 		assertColumns(t, expectedColumns, sourceTableColumns)
 
-		likeTable, err := client.Tables.ShowByID(ctx, id)
+		likeTable, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		likeTableColumns := testClientHelper().Table.GetTableColumnsFor(t, likeTable.ID())
@@ -312,7 +312,7 @@ func TestInt_Table(t *testing.T) {
 			WithAt(*sdk.NewTimeTravelRequest().WithOffset(sdk.Pointer(0))).
 			WithMoment(sdk.CloneMomentAt))
 
-		err := client.Tables.CreateClone(ctx, request)
+		err := client.TablesLegacy.CreateClone(ctx, request)
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
@@ -324,7 +324,7 @@ func TestInt_Table(t *testing.T) {
 		}
 		assertColumns(t, expectedColumns, sourceTableColumns)
 
-		cloneTable, err := client.Tables.ShowByID(ctx, id)
+		cloneTable, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		cloneTableColumns := testClientHelper().Table.GetTableColumnsFor(t, cloneTable.ID())
@@ -339,11 +339,11 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_3", sdk.DataTypeVARCHAR),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 
 		alterRequest := sdk.NewAlterTableRequest(id).WithNewName(&newId)
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		if err != nil {
 			t.Cleanup(cleanupTableProvider(id))
 		} else {
@@ -351,10 +351,10 @@ func TestInt_Table(t *testing.T) {
 		}
 		require.NoError(t, err)
 
-		_, err = client.Tables.ShowByID(ctx, id)
+		_, err = client.TablesLegacy.ShowByID(ctx, id)
 		assert.ErrorIs(t, err, collections.ErrObjectNotFound)
 
-		table, err := client.Tables.ShowByID(ctx, newId)
+		table, err := client.TablesLegacy.ShowByID(ctx, newId)
 		require.NoError(t, err)
 		assertTable(t, table, newId)
 	})
@@ -370,24 +370,24 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_2", sdk.DataTypeVARCHAR),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
-		err = client.Tables.Create(ctx, sdk.NewCreateTableRequest(secondTableId, secondTableColumns))
+		err = client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(secondTableId, secondTableColumns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(secondTableId))
 
 		alterRequest := sdk.NewAlterTableRequest(id).WithSwapWith(&secondTableId)
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 
-		table, err := client.Tables.ShowByID(ctx, secondTableId)
+		table, err := client.TablesLegacy.ShowByID(ctx, secondTableId)
 		require.NoError(t, err)
 
 		assertTable(t, table, secondTableId)
 
-		secondTable, err := client.Tables.ShowByID(ctx, id)
+		secondTable, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		assertTable(t, secondTable, id)
@@ -400,17 +400,17 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_2", sdk.DataTypeVARCHAR),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
 		clusterByColumns := []string{"COLUMN_1", "COLUMN_2"}
 		alterRequest := sdk.NewAlterTableRequest(id).WithClusteringAction(sdk.NewTableClusteringActionRequest().WithClusterBy(clusterByColumns))
 
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		assertTable(t, table, id)
@@ -427,17 +427,17 @@ func TestInt_Table(t *testing.T) {
 		}
 		clusterBy := []string{"COLUMN_1", "COLUMN_2"}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithClusterBy(clusterBy))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithClusterBy(clusterBy))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
 		alterRequest := sdk.NewAlterTableRequest(id).
 			WithClusteringAction(sdk.NewTableClusteringActionRequest().
 				WithChangeReclusterState(sdk.Pointer(sdk.ReclusterStateSuspend)))
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		clusterByString := "LINEAR(" + strings.Join(clusterBy, ", ") + ")"
@@ -452,17 +452,17 @@ func TestInt_Table(t *testing.T) {
 		}
 		clusterBy := []string{"COLUMN_1", "COLUMN_2"}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithClusterBy(clusterBy))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithClusterBy(clusterBy))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
 		alterRequest := sdk.NewAlterTableRequest(id).
 			WithClusteringAction(sdk.NewTableClusteringActionRequest().
 				WithDropClusteringKey(sdk.Bool(true)))
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		assert.Equal(t, "", table.ClusterBy)
@@ -476,17 +476,17 @@ func TestInt_Table(t *testing.T) {
 		}
 		clusterBy := []string{"COLUMN_1", "COLUMN_2"}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithClusterBy(clusterBy))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithClusterBy(clusterBy))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
 		alterRequest := sdk.NewAlterTableRequest(id).
 			WithColumnAction(sdk.NewTableColumnActionRequest().
 				WithAdd(sdk.NewTableColumnAddActionRequest("COLUMN_3", sdk.DataTypeVARCHAR).WithComment(sdk.String("some comment"))))
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		currentColumns := testClientHelper().Table.GetTableColumnsFor(t, table.ID())
@@ -507,7 +507,7 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_1", sdk.DataTypeVARCHAR),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
@@ -515,10 +515,10 @@ func TestInt_Table(t *testing.T) {
 			WithColumnAction(sdk.NewTableColumnActionRequest().
 				WithAdd(sdk.NewTableColumnAddActionRequest("COLUMN_2", sdk.DataTypeBoolean).
 					WithDefaultValue(sdk.NewColumnDefaultValueRequest().WithExpression(sdk.String("FALSE")))))
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		currentColumns := testClientHelper().Table.GetTableColumnsFor(t, table.ID())
@@ -536,17 +536,17 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_2", sdk.DataTypeVARCHAR),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
 		alterRequest := sdk.NewAlterTableRequest(id).
 			WithColumnAction(sdk.NewTableColumnActionRequest().
 				WithRename(sdk.NewTableColumnRenameActionRequest("COLUMN_1", "COLUMN_3")))
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		currentColumns := testClientHelper().Table.GetTableColumnsFor(t, table.ID())
@@ -569,11 +569,11 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_2", sdk.DataTypeVARCHAR),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
-		tableDetails, err := client.Tables.DescribeColumns(ctx, sdk.NewDescribeTableColumnsRequest(id))
+		tableDetails, err := client.TablesLegacy.DescribeColumns(ctx, sdk.NewDescribeTableColumnsRequest(id))
 		require.NoError(t, err)
 
 		require.Len(t, tableDetails, 2)
@@ -582,10 +582,10 @@ func TestInt_Table(t *testing.T) {
 
 		alterRequest := sdk.NewAlterTableRequest(id).
 			WithColumnAction(sdk.NewTableColumnActionRequest().WithUnsetMaskingPolicy(sdk.NewTableColumnAlterUnsetMaskingPolicyActionRequest("COLUMN_1")))
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 
-		tableDetails, err = client.Tables.DescribeColumns(ctx, sdk.NewDescribeTableColumnsRequest(id))
+		tableDetails, err = client.TablesLegacy.DescribeColumns(ctx, sdk.NewDescribeTableColumnsRequest(id))
 		require.NoError(t, err)
 
 		require.Len(t, tableDetails, 2)
@@ -598,7 +598,7 @@ func TestInt_Table(t *testing.T) {
 		t.Cleanup(storageLifecyclePolicyCleanup)
 
 		tableId := testClientHelper().Ids.RandomSchemaObjectIdentifier()
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(tableId, []sdk.TableColumnRequest{
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(tableId, []sdk.TableColumnRequest{
 			*sdk.NewTableColumnRequest("COLUMN_1", sdk.DataTypeVARCHAR),
 		}))
 		require.NoError(t, err)
@@ -607,7 +607,7 @@ func TestInt_Table(t *testing.T) {
 		addRequest := sdk.NewAlterTableRequest(tableId).WithAddStorageLifecyclePolicy(
 			sdk.NewTableAddStorageLifecyclePolicyRequest(storageLifecyclePolicyId, []sdk.Column{{Value: "COLUMN_1"}}),
 		)
-		err = client.Tables.Alter(ctx, addRequest)
+		err = client.TablesLegacy.Alter(ctx, addRequest)
 		require.NoError(t, err)
 
 		references, err := testClientHelper().PolicyReferences.GetPolicyReferences(t, tableId, sdk.PolicyEntityDomainTable)
@@ -628,7 +628,7 @@ func TestInt_Table(t *testing.T) {
 		)
 
 		dropRequest := sdk.NewAlterTableRequest(tableId).WithDropStorageLifecyclePolicy(new(true))
-		err = client.Tables.Alter(ctx, dropRequest)
+		err = client.TablesLegacy.Alter(ctx, dropRequest)
 		require.NoError(t, err)
 
 		references, err = testClientHelper().PolicyReferences.GetPolicyReferences(t, tableId, sdk.PolicyEntityDomainTable)
@@ -643,16 +643,16 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_2", sdk.DataTypeVARCHAR),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
 		alterRequest := sdk.NewAlterTableRequest(id).
 			WithColumnAction(sdk.NewTableColumnActionRequest().WithDropColumns([]string{"COLUMN_1"}))
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		currentColumns := testClientHelper().Table.GetTableColumnsFor(t, table.ID())
@@ -677,11 +677,11 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_3", sdk.DataTypeVARCHAR).WithInlineConstraint(sdk.NewColumnInlineConstraintRequest("pkey", sdk.ColumnConstraintTypePrimaryKey)),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
-		err = client.Tables.Create(ctx, sdk.NewCreateTableRequest(secondTableId, secondTableColumns))
+		err = client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(secondTableId, secondTableColumns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(secondTableId))
 
@@ -689,7 +689,7 @@ func TestInt_Table(t *testing.T) {
 			WithConstraintAction(sdk.NewTableConstraintActionRequest().
 				WithAdd(sdk.NewOutOfLineConstraintRequest(sdk.ColumnConstraintTypeForeignKey).WithName(sdk.String("OUT_OF_LINE_CONSTRAINT")).WithColumns([]string{"COLUMN_1"}).
 					WithForeignKey(sdk.NewOutOfLineForeignKeyRequest(secondTableId, []string{"COLUMN_3"}))))
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 	})
 
@@ -699,7 +699,7 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_1", sdk.DataTypeVARCHAR),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
@@ -708,7 +708,7 @@ func TestInt_Table(t *testing.T) {
 				*sdk.NewTableColumnAlterActionRequest("COLUMN_1").
 					WithNotNullConstraint(sdk.NewTableColumnNotNullConstraintRequest().WithSet(sdk.Bool(true))),
 			}))
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 	})
 
@@ -722,7 +722,7 @@ func TestInt_Table(t *testing.T) {
 		oldConstraintName := "OUT_OF_LINE_CONSTRAINT"
 		outOfLineConstraint := sdk.NewOutOfLineConstraintRequest(sdk.ColumnConstraintTypePrimaryKey).WithName(sdk.String(oldConstraintName)).WithColumns([]string{"COLUMN_1"})
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithOutOfLineConstraint(*outOfLineConstraint))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithOutOfLineConstraint(*outOfLineConstraint))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
@@ -732,7 +732,7 @@ func TestInt_Table(t *testing.T) {
 				WithRename(sdk.NewTableConstraintRenameActionRequest().
 					WithOldName(oldConstraintName).
 					WithNewName(newConstraintName)))
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 	})
 
@@ -746,13 +746,13 @@ func TestInt_Table(t *testing.T) {
 		constraintName := "OUT_OF_LINE_CONSTRAINT"
 		outOfLineConstraint := sdk.NewOutOfLineConstraintRequest(sdk.ColumnConstraintTypePrimaryKey).WithName(sdk.String(constraintName)).WithColumns([]string{"COLUMN_1"})
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithOutOfLineConstraint(*outOfLineConstraint))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithOutOfLineConstraint(*outOfLineConstraint))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
 		alterRequest := sdk.NewAlterTableRequest(id).
 			WithConstraintAction(sdk.NewTableConstraintActionRequest().WithAlter(sdk.NewTableConstraintAlterActionRequest().WithConstraintName(sdk.String(constraintName)).WithEnforced(sdk.Bool(true))))
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 	})
 
@@ -766,13 +766,13 @@ func TestInt_Table(t *testing.T) {
 		constraintName := "OUT_OF_LINE_CONSTRAINT"
 		outOfLineConstraint := sdk.NewOutOfLineConstraintRequest(sdk.ColumnConstraintTypePrimaryKey).WithName(sdk.String(constraintName)).WithColumns([]string{"COLUMN_1"})
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithOutOfLineConstraint(*outOfLineConstraint))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithOutOfLineConstraint(*outOfLineConstraint))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
 		alterRequest := sdk.NewAlterTableRequest(id).
 			WithConstraintAction(sdk.NewTableConstraintActionRequest().WithDrop(sdk.NewTableConstraintDropActionRequest().WithConstraintName(sdk.String(constraintName))))
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 	})
 
@@ -783,13 +783,13 @@ func TestInt_Table(t *testing.T) {
 		}
 		outOfLineConstraint := sdk.NewOutOfLineConstraintRequest(sdk.ColumnConstraintTypePrimaryKey).WithColumns([]string{"COLUMN_1"})
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithOutOfLineConstraint(*outOfLineConstraint))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithOutOfLineConstraint(*outOfLineConstraint))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
 		alterRequest := sdk.NewAlterTableRequest(id).
 			WithConstraintAction(sdk.NewTableConstraintActionRequest().WithDrop(sdk.NewTableConstraintDropActionRequest().WithPrimaryKey(sdk.Bool(true))))
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 	})
 
@@ -800,7 +800,7 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_2", sdk.DataTypeVARCHAR),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
@@ -813,9 +813,9 @@ func TestInt_Table(t *testing.T) {
 					WithComment(sdk.String("some comment")),
 			))
 
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		currentColumns := testClientHelper().Table.GetTableColumnsFor(t, table.ID())
@@ -834,16 +834,16 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_2", sdk.DataTypeVARCHAR),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
 		alterRequest := sdk.NewAlterTableRequest(id).
 			WithExternalTableAction(sdk.NewTableExternalTableActionRequest().WithRename(sdk.NewTableExternalTableColumnRenameActionRequest().WithOldName("COLUMN_1").WithNewName("COLUMN_3")))
 
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		assert.Equal(t, "", table.Comment)
@@ -862,16 +862,16 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_2", sdk.DataTypeVARCHAR),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
 		alterRequest := sdk.NewAlterTableRequest(id).
 			WithExternalTableAction(sdk.NewTableExternalTableActionRequest().WithDrop(sdk.NewTableExternalTableColumnDropActionRequest([]string{"COLUMN_2"})))
 
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		currentColumns := testClientHelper().Table.GetTableColumnsFor(t, table.ID())
@@ -889,14 +889,14 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_2", sdk.DataTypeVARCHAR),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
 		alterRequest := sdk.NewAlterTableRequest(id).
 			WithSearchOptimizationAction(sdk.NewTableSearchOptimizationActionLegacyRequest().WithAddSearchOptimizationOn([]string{"SUBSTRING(*)", "GEO(*)"}))
 
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
 	})
 
@@ -909,7 +909,7 @@ func TestInt_Table(t *testing.T) {
 			*sdk.NewTableColumnRequest("COLUMN_2", sdk.DataTypeVARCHAR),
 		}
 
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableProvider(id))
 
@@ -930,9 +930,9 @@ func TestInt_Table(t *testing.T) {
 				WithDefaultDDLCollation(sdk.String("us")).
 				WithComment(&comment))
 
-		err = client.Tables.Alter(ctx, alterRequest)
+		err = client.TablesLegacy.Alter(ctx, alterRequest)
 		require.NoError(t, err)
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		assert.Equal(t, comment, table.Comment)
@@ -944,17 +944,17 @@ func TestInt_Table(t *testing.T) {
 	t.Run("drop table", func(t *testing.T) {
 		table, tableCleanup := testClientHelper().Table.Create(t)
 		t.Cleanup(tableCleanup)
-		err := client.Tables.Drop(ctx, sdk.NewDropTableRequest(table.ID()).WithIfExists(sdk.Bool(true)))
+		err := client.TablesLegacy.Drop(ctx, sdk.NewDropTableRequest(table.ID()).WithIfExists(sdk.Bool(true)))
 		require.NoError(t, err)
 
-		_, err = client.Tables.ShowByID(ctx, table.ID())
+		_, err = client.TablesLegacy.ShowByID(ctx, table.ID())
 		require.ErrorIs(t, err, collections.ErrObjectNotFound)
 	})
 
 	t.Run("drop table in non-existing schema", func(t *testing.T) {
 		nonExistingSchemaId := testClientHelper().Ids.RandomDatabaseObjectIdentifier()
 		nonExistingTableId := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(nonExistingSchemaId)
-		err := client.Tables.Drop(ctx, sdk.NewDropTableRequest(nonExistingTableId).WithIfExists(sdk.Bool(true)))
+		err := client.TablesLegacy.Drop(ctx, sdk.NewDropTableRequest(nonExistingTableId).WithIfExists(sdk.Bool(true)))
 		require.Error(t, err)
 		require.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
 	})
@@ -963,7 +963,7 @@ func TestInt_Table(t *testing.T) {
 		nonExistingDatabaseId := testClientHelper().Ids.RandomAccountObjectIdentifier()
 		nonExistingSchemaId := testClientHelper().Ids.RandomDatabaseObjectIdentifierInDatabase(nonExistingDatabaseId)
 		nonExistingTableId := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(nonExistingSchemaId)
-		err := client.Tables.Drop(ctx, sdk.NewDropTableRequest(nonExistingTableId).WithIfExists(sdk.Bool(true)))
+		err := client.TablesLegacy.Drop(ctx, sdk.NewDropTableRequest(nonExistingTableId).WithIfExists(sdk.Bool(true)))
 		require.Error(t, err)
 		require.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
 	})
@@ -971,17 +971,17 @@ func TestInt_Table(t *testing.T) {
 	t.Run("drop safely table", func(t *testing.T) {
 		table, tableCleanup := testClientHelper().Table.Create(t)
 		t.Cleanup(tableCleanup)
-		err := client.Tables.DropSafely(ctx, table.ID())
+		err := client.TablesLegacy.DropSafely(ctx, table.ID())
 		require.NoError(t, err)
 
-		_, err = client.Tables.ShowByID(ctx, table.ID())
+		_, err = client.TablesLegacy.ShowByID(ctx, table.ID())
 		require.ErrorIs(t, err, collections.ErrObjectNotFound)
 	})
 
 	t.Run("drop safely table in non-existing schema", func(t *testing.T) {
 		nonExistingSchemaId := testClientHelper().Ids.RandomDatabaseObjectIdentifier()
 		nonExistingTableId := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(nonExistingSchemaId)
-		err := client.Tables.DropSafely(ctx, nonExistingTableId)
+		err := client.TablesLegacy.DropSafely(ctx, nonExistingTableId)
 		require.NoError(t, err)
 	})
 
@@ -989,7 +989,7 @@ func TestInt_Table(t *testing.T) {
 		nonExistingDatabaseId := testClientHelper().Ids.RandomAccountObjectIdentifier()
 		nonExistingSchemaId := testClientHelper().Ids.RandomDatabaseObjectIdentifierInDatabase(nonExistingDatabaseId)
 		nonExistingTableId := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(nonExistingSchemaId)
-		err := client.Tables.DropSafely(ctx, nonExistingTableId)
+		err := client.TablesLegacy.DropSafely(ctx, nonExistingTableId)
 		require.NoError(t, err)
 	})
 
@@ -999,7 +999,7 @@ func TestInt_Table(t *testing.T) {
 		table2, table2Cleanup := testClientHelper().Table.Create(t)
 		t.Cleanup(table2Cleanup)
 
-		tables, err := client.Tables.Show(ctx, sdk.NewShowTableRequest())
+		tables, err := client.TablesLegacy.Show(ctx, sdk.NewShowTableRequest())
 		require.NoError(t, err)
 
 		t1, err := collections.FindFirst(tables, func(t sdk.Table) bool { return t.ID().FullyQualifiedName() == table.ID().FullyQualifiedName() })
@@ -1015,7 +1015,7 @@ func TestInt_Table(t *testing.T) {
 		table, tableCleanup := testClientHelper().Table.Create(t)
 		t.Cleanup(tableCleanup)
 
-		tables, err := client.Tables.Show(ctx, sdk.NewShowTableRequest().WithTerse(true).WithLike(sdk.Like{
+		tables, err := client.TablesLegacy.Show(ctx, sdk.NewShowTableRequest().WithTerse(true).WithLike(sdk.Like{
 			Pattern: sdk.String(table.Name),
 		}))
 		require.NoError(t, err)
@@ -1028,7 +1028,7 @@ func TestInt_Table(t *testing.T) {
 		table, tableCleanup := testClientHelper().Table.Create(t)
 		t.Cleanup(tableCleanup)
 
-		tables, err := client.Tables.Show(ctx, sdk.NewShowTableRequest().WithStartsWith(table.Name))
+		tables, err := client.TablesLegacy.Show(ctx, sdk.NewShowTableRequest().WithStartsWith(table.Name))
 		require.NoError(t, err)
 		assert.Len(t, tables, 1)
 
@@ -1036,7 +1036,7 @@ func TestInt_Table(t *testing.T) {
 	})
 
 	t.Run("when searching a non-existent table", func(t *testing.T) {
-		tables, err := client.Tables.Show(ctx, sdk.NewShowTableRequest().WithLike(sdk.Like{
+		tables, err := client.TablesLegacy.Show(ctx, sdk.NewShowTableRequest().WithLike(sdk.Like{
 			Pattern: sdk.String("non-existent"),
 		}))
 		require.NoError(t, err)
@@ -1050,7 +1050,7 @@ func TestInt_TablesShowByID(t *testing.T) {
 
 	cleanupTableHandle := func(id sdk.SchemaObjectIdentifier) func() {
 		return func() {
-			err := client.Tables.Drop(ctx, sdk.NewDropTableRequest(id))
+			err := client.TablesLegacy.Drop(ctx, sdk.NewDropTableRequest(id))
 			if errors.Is(err, sdk.ErrObjectNotExistOrAuthorized) {
 				return
 			}
@@ -1064,7 +1064,7 @@ func TestInt_TablesShowByID(t *testing.T) {
 		columns := []sdk.TableColumnRequest{
 			*sdk.NewTableColumnRequest("c1", sdk.DataTypeNumber).WithDefaultValue(sdk.NewColumnDefaultValueRequest().WithIdentity(sdk.NewColumnIdentityRequest(1, 1))),
 		}
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableHandle(id))
 	}
@@ -1079,11 +1079,11 @@ func TestInt_TablesShowByID(t *testing.T) {
 		createTableHandle(t, id1)
 		createTableHandle(t, id2)
 
-		e1, err := client.Tables.ShowByID(ctx, id1)
+		e1, err := client.TablesLegacy.ShowByID(ctx, id1)
 		require.NoError(t, err)
 		require.Equal(t, id1, e1.ID())
 
-		e2, err := client.Tables.ShowByID(ctx, id2)
+		e2, err := client.TablesLegacy.ShowByID(ctx, id2)
 		require.NoError(t, err)
 		require.Equal(t, id2, e2.ID())
 	})
@@ -1094,11 +1094,11 @@ func TestInt_TablesShowByID(t *testing.T) {
 		columns := []sdk.TableColumnRequest{
 			*sdk.NewTableColumnRequest("c1", sdk.DataTypeNumber).WithDefaultValue(sdk.NewColumnDefaultValueRequest().WithIdentity(sdk.NewColumnIdentityRequest(1, 1))),
 		}
-		err := client.Tables.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithEnableSchemaEvolution(sdk.Pointer(true)))
+		err := client.TablesLegacy.Create(ctx, sdk.NewCreateTableRequest(id, columns).WithEnableSchemaEvolution(sdk.Pointer(true)))
 		require.NoError(t, err)
 		t.Cleanup(cleanupTableHandle(id))
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		require.NoError(t, err)
 
 		err = client.Grants.GrantPrivilegesToAccountRole(ctx,
@@ -1119,7 +1119,7 @@ func TestInt_TablesShowByID(t *testing.T) {
 		require.Len(t, currentColumns, 2)
 		assert.NotEmpty(t, currentColumns[1].SchemaEvolutionRecord)
 
-		descColumns, err := client.Tables.DescribeColumns(ctx, sdk.NewDescribeTableColumnsRequest(id))
+		descColumns, err := client.TablesLegacy.DescribeColumns(ctx, sdk.NewDescribeTableColumnsRequest(id))
 		require.NoError(t, err)
 		require.Len(t, descColumns, 2)
 		assert.NotEmpty(t, descColumns[1].SchemaEvolutionRecord)
@@ -1129,7 +1129,7 @@ func TestInt_TablesShowByID(t *testing.T) {
 		databaseId := testClientHelper().Ids.RandomAccountObjectIdentifier()
 		schemaId := testClientHelper().Ids.RandomDatabaseObjectIdentifierInDatabase(databaseId)
 		tableId := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(schemaId)
-		_, err := client.Tables.ShowByID(ctx, tableId)
+		_, err := client.TablesLegacy.ShowByID(ctx, tableId)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, sdk.ErrDoesNotExistOrOperationCannotBePerformed)
 	})
@@ -1137,7 +1137,7 @@ func TestInt_TablesShowByID(t *testing.T) {
 	t.Run("show by id: missing schema", func(t *testing.T) {
 		schemaId := testClientHelper().Ids.RandomDatabaseObjectIdentifier()
 		tableId := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(schemaId)
-		_, err := client.Tables.ShowByID(ctx, tableId)
+		_, err := client.TablesLegacy.ShowByID(ctx, tableId)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, sdk.ErrDoesNotExistOrOperationCannotBePerformed)
 	})
@@ -1145,7 +1145,7 @@ func TestInt_TablesShowByID(t *testing.T) {
 	t.Run("show by id safely", func(t *testing.T) {
 		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
 		createTableHandle(t, id)
-		table, err := client.Tables.ShowByIDSafely(ctx, id)
+		table, err := client.TablesLegacy.ShowByIDSafely(ctx, id)
 		assert.NotNil(t, table)
 		assert.NoError(t, err)
 	})
@@ -1154,7 +1154,7 @@ func TestInt_TablesShowByID(t *testing.T) {
 		databaseId := testClientHelper().Ids.RandomAccountObjectIdentifier()
 		schemaId := testClientHelper().Ids.RandomDatabaseObjectIdentifierInDatabase(databaseId)
 		tableId := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(schemaId)
-		_, err := client.Tables.ShowByIDSafely(ctx, tableId)
+		_, err := client.TablesLegacy.ShowByIDSafely(ctx, tableId)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, sdk.ErrObjectNotFound)
 		assert.ErrorIs(t, err, sdk.ErrDoesNotExistOrOperationCannotBePerformed)
@@ -1163,7 +1163,7 @@ func TestInt_TablesShowByID(t *testing.T) {
 	t.Run("show by id safely: missing schema", func(t *testing.T) {
 		schemaId := testClientHelper().Ids.RandomDatabaseObjectIdentifier()
 		tableId := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(schemaId)
-		_, err := client.Tables.ShowByIDSafely(ctx, tableId)
+		_, err := client.TablesLegacy.ShowByIDSafely(ctx, tableId)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, sdk.ErrObjectNotFound)
 		assert.ErrorIs(t, err, sdk.ErrDoesNotExistOrOperationCannotBePerformed)
@@ -1171,7 +1171,7 @@ func TestInt_TablesShowByID(t *testing.T) {
 
 	t.Run("show by id safely: missing table", func(t *testing.T) {
 		tableId := testClientHelper().Ids.RandomSchemaObjectIdentifier()
-		_, err := client.Tables.ShowByIDSafely(ctx, tableId)
+		_, err := client.TablesLegacy.ShowByIDSafely(ctx, tableId)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, sdk.ErrObjectNotFound)
 	})

--- a/pkg/sdk/testint/tags_integration_test.go
+++ b/pkg/sdk/testint/tags_integration_test.go
@@ -808,10 +808,10 @@ func TestInt_TagsAssociations(t *testing.T) {
 				for i, tag := range tags {
 					setTags[i] = *sdk.NewTagAssociationRequest(tag.Name, tag.Value)
 				}
-				return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithSetTags(setTags))
+				return client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithSetTags(setTags))
 			},
 			unsetTags: func(id sdk.SchemaObjectIdentifier, tags []sdk.ObjectIdentifier) error {
-				return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithUnsetTags(tags))
+				return client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithUnsetTags(tags))
 			},
 		},
 		{
@@ -967,10 +967,10 @@ func TestInt_TagsAssociations(t *testing.T) {
 				for i, tag := range tags {
 					setTags[i] = *sdk.NewTagAssociationRequest(tag.Name, tag.Value)
 				}
-				return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithSetTags(setTags))
+				return client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithSetTags(setTags))
 			},
 			unsetTags: func(id sdk.SchemaObjectIdentifier, tags []sdk.ObjectIdentifier) error {
-				return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id).WithUnsetTags(tags))
+				return client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id).WithUnsetTags(tags))
 			},
 		},
 		{
@@ -1104,11 +1104,11 @@ func TestInt_TagsAssociations(t *testing.T) {
 				return columnId, objectCleanup
 			},
 			setTags: func(id sdk.TableColumnIdentifier, tags []sdk.TagAssociation) error {
-				return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id.SchemaObjectId()).WithColumnAction(sdk.NewTableColumnActionRequest().
+				return client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id.SchemaObjectId()).WithColumnAction(sdk.NewTableColumnActionRequest().
 					WithSetTags(sdk.NewTableColumnAlterSetTagsActionRequest(id.Name(), tags))))
 			},
 			unsetTags: func(id sdk.TableColumnIdentifier, tags []sdk.ObjectIdentifier) error {
-				return client.Tables.Alter(ctx, sdk.NewAlterTableRequest(id.SchemaObjectId()).WithColumnAction(sdk.NewTableColumnActionRequest().
+				return client.TablesLegacy.Alter(ctx, sdk.NewAlterTableRequest(id.SchemaObjectId()).WithColumnAction(sdk.NewTableColumnActionRequest().
 					WithUnsetTags(sdk.NewTableColumnAlterUnsetTagsActionRequest(id.Name(), tags))))
 			},
 		},

--- a/pkg/testacc/2_check_destroy_test.go
+++ b/pkg/testacc/2_check_destroy_test.go
@@ -470,7 +470,7 @@ var showByIdFunctions = map[resources.Resource]runShowByIdFunc{
 		return runShowById(ctx, id, client.Streamlits.ShowByID)
 	},
 	resources.Table: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
-		return runShowById(ctx, id, client.Tables.ShowByID)
+		return runShowById(ctx, id, client.TablesLegacy.ShowByID)
 	},
 	resources.Tag: func(ctx context.Context, client *sdk.Client, id sdk.ObjectIdentifier) error {
 		return runShowById(ctx, id, client.Tags.ShowByID)

--- a/pkg/testacc/resource_table_acceptance_test.go
+++ b/pkg/testacc/resource_table_acceptance_test.go
@@ -1743,7 +1743,7 @@ func checkDatabaseSchemaAndTableDataRetentionTime(id sdk.SchemaObjectIdentifier,
 			return fmt.Errorf("invalid schema retention time, expected: %d, got: %d", expectedSchemaRetentionDays, schemaRetentionTime)
 		}
 
-		table, err := client.Tables.ShowByID(ctx, id)
+		table, err := client.TablesLegacy.ShowByID(ctx, id)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- Renames the SDK's `Tables` interface/client field to `TablesLegacy` (`tables` struct to `tablesLegacy`) to make room for a new Iceberg-aware `Tables` implementation.
- Updates all internal call sites (resources, datasources, acceptance helpers, integration tests) to use the renamed symbols. No behavioral or user-facing changes.