### PR TITLE
chore: Remove replication groups placeholder from SDK

### DIFF
--- a/pkg/sdk/replication_groups.go
+++ b/pkg/sdk/replication_groups.go
@@ -1,4 +1,0 @@
-package sdk
-
-// note: once Replication Groups is implemented, Databases Integration test for CreateSecondary needs to be implemented
-// also: TestInt_AlterReplication


### PR DESCRIPTION
As part of migrating objects to SDK generator