### PR TITLE
feat: add interactive warehouse to the SDK

### DIFF
--- a/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert/warehouse_show_output_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert/warehouse_show_output_gen.go
@@ -414,3 +414,8 @@ func (w *WarehouseShowOutputAssert) HasNoQueryThroughputMultiplier() *WarehouseS
 	w.ValueNotSet("query_throughput_multiplier")
 	return w
 }
+
+func (w *WarehouseShowOutputAssert) HasNoTables() *WarehouseShowOutputAssert {
+	w.ValueSet("tables.#", "0")
+	return w
+}

--- a/pkg/sdk/generator/defs/warehouse_def.go
+++ b/pkg/sdk/generator/defs/warehouse_def.go
@@ -9,7 +9,7 @@ import (
 
 var warehouseTypeEnum = g.NewEnum(
 	"WarehouseType", "WarehouseTypes",
-	"STANDARD", "SNOWPARK-OPTIMIZED", "ADAPTIVE",
+	"STANDARD", "SNOWPARK-OPTIMIZED", "ADAPTIVE", "INTERACTIVE",
 )
 
 var warehouseSizeEnum = g.NewEnum(
@@ -83,7 +83,8 @@ var warehousePairs = g.StructPair("warehouseDBRow", "Warehouse").
 	OptionalEnum("resource_constraint", warehouseResourceConstraintEnum, g.WithManualConvert()).
 	Field("generation", "sql.NullString", "*WarehouseGeneration", g.WithManualConvert()).
 	OptionalEnum("max_query_performance_level", maxQueryPerformanceLevelEnum).
-	OptionalNumber("query_throughput_multiplier")
+	OptionalNumber("query_throughput_multiplier").
+	Field("tables", "sql.NullString", "[]SchemaObjectIdentifier", g.WithManualConvert())
 
 var warehouseDetailsPairs = g.StructPair("warehouseDetailsRow", "WarehouseDetails").
 	Time("created_on").
@@ -110,7 +111,8 @@ var warehouseSetStruct = g.NewQueryStruct("WarehouseSet").
 	OptionalNumberAssignment("MAX_CONCURRENCY_LEVEL", g.ParameterOptions()).
 	OptionalNumberAssignment("STATEMENT_QUEUED_TIMEOUT_IN_SECONDS", g.ParameterOptions()).
 	OptionalNumberAssignment("STATEMENT_TIMEOUT_IN_SECONDS", g.ParameterOptions()).
-	WithValidation(g.AtLeastOneValueSet, "WarehouseType", "WarehouseSize", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "QueryThroughputMultiplier", "MaxQueryPerformanceLevel", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds").
+	OptionalIdentifier("FallbackWarehouse", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("FALLBACK_WAREHOUSE").Equals()).
+	WithValidation(g.AtLeastOneValueSet, "WarehouseType", "WarehouseSize", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "QueryThroughputMultiplier", "MaxQueryPerformanceLevel", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds", "FallbackWarehouse").
 	WithAdditionalValidations()
 
 var warehouseUnsetStruct = g.NewQueryStruct("WarehouseUnset").
@@ -132,7 +134,8 @@ var warehouseUnsetStruct = g.NewQueryStruct("WarehouseUnset").
 	OptionalSQL("STATEMENT_TIMEOUT_IN_SECONDS").
 	OptionalSQL("QUERY_THROUGHPUT_MULTIPLIER").
 	OptionalSQL("MAX_QUERY_PERFORMANCE_LEVEL").
-	WithValidation(g.AtLeastOneValueSet, "WarehouseType", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds", "QueryThroughputMultiplier", "MaxQueryPerformanceLevel")
+	OptionalSQL("FALLBACK_WAREHOUSE").
+	WithValidation(g.AtLeastOneValueSet, "WarehouseType", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds", "QueryThroughputMultiplier", "MaxQueryPerformanceLevel", "FallbackWarehouse")
 
 var warehousesDef = g.NewInterface(
 	"Warehouses",
@@ -186,6 +189,31 @@ var warehousesDef = g.NewInterface(
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists").
 		WithAdditionalValidations(),
+).CustomOperation(
+	"CreateInteractive",
+	"https://docs.snowflake.com/en/user-guide/warehouses-interactive",
+	g.NewQueryStruct("CreateInteractiveWarehouse").
+		Create().
+		OrReplace().
+		SQL("INTERACTIVE WAREHOUSE").
+		IfNotExists().
+		Name().
+		ListAssignment("TABLES", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.ParameterOptions().Parentheses().NoEquals()).
+		OptionalEnumAssignment("WAREHOUSE_SIZE", warehouseSizeEnum, g.ParameterOptions().SingleQuotes()).
+		OptionalNumberAssignment("MAX_CLUSTER_COUNT", g.ParameterOptions()).
+		OptionalNumberAssignment("MIN_CLUSTER_COUNT", g.ParameterOptions()).
+		OptionalNumberAssignment("AUTO_SUSPEND", g.ParameterOptions()).
+		OptionalBooleanAssignment("AUTO_RESUME", nil).
+		OptionalBooleanAssignment("INITIALLY_SUSPENDED", nil).
+		OptionalIdentifier("ResourceMonitor", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RESOURCE_MONITOR").Equals()).
+		OptionalComment().
+		OptionalNumberAssignment("MAX_CONCURRENCY_LEVEL", g.ParameterOptions()).
+		OptionalNumberAssignment("STATEMENT_QUEUED_TIMEOUT_IN_SECONDS", g.ParameterOptions()).
+		OptionalNumberAssignment("STATEMENT_TIMEOUT_IN_SECONDS", g.ParameterOptions()).
+		OptionalTags().
+		WithValidation(g.ValidIdentifier, "name").
+		WithValidation(g.ConflictingFields, "OrReplace", "IfNotExists").
+		WithAdditionalValidations(),
 ).AlterOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/alter-warehouse",
 	g.NewQueryStruct("AlterWarehouse").
@@ -200,10 +228,12 @@ var warehousesDef = g.NewInterface(
 		OptionalIdentifier("RenameTo", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
 		OptionalQueryStructField("Set", warehouseSetStruct, g.KeywordOptions().SQL("SET")).
 		OptionalQueryStructField("Unset", warehouseUnsetStruct, g.ListOptions().NoParentheses().SQL("UNSET")).
+		ListAssignment("ADD TABLES", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.ParameterOptions().Parentheses().NoEquals()).
+		ListAssignment("DROP TABLES", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.ParameterOptions().Parentheses().NoEquals()).
 		OptionalSetTags().
 		OptionalUnsetTags().
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ExactlyOneValueSet, "Suspend", "Resume", "AbortAllQueries", "RenameTo", "Set", "Unset", "SetTags", "UnsetTags").
+		WithValidation(g.ExactlyOneValueSet, "Suspend", "Resume", "AbortAllQueries", "RenameTo", "Set", "Unset", "AddTables", "DropTables", "SetTags", "UnsetTags").
 		WithAdditionalValidations(),
 ).DropOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/drop-warehouse",

--- a/pkg/sdk/parsers.go
+++ b/pkg/sdk/parsers.go
@@ -110,3 +110,27 @@ func emptyIfNull(s string) string {
 	}
 	return s
 }
+
+// splitCommaSeparatedIdentifiers splits a comma-separated list of identifiers, treating commas
+// enclosed in double quotes as part of an identifier rather than separators. Snowflake identifiers
+// may contain commas when quoted (e.g. `DB.SCHEMA."a,b"`), so a naive strings.Split(",") would break
+// such identifiers apart. The returned parts are raw (not trimmed or parsed).
+func splitCommaSeparatedIdentifiers(s string) []string {
+	var parts []string
+	var current strings.Builder
+	inQuotes := false
+	for _, r := range s {
+		switch {
+		case r == '"':
+			inQuotes = !inQuotes
+			current.WriteRune(r)
+		case r == ',' && !inQuotes:
+			parts = append(parts, current.String())
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	parts = append(parts, current.String())
+	return parts
+}

--- a/pkg/sdk/parsers_test.go
+++ b/pkg/sdk/parsers_test.go
@@ -348,3 +348,24 @@ func TestParseCommaSeparatedAccountIdentifierArray_Invalid(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitCommaSeparatedIdentifiers(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"", []string{""}},
+		{"A.B.C", []string{"A.B.C"}},
+		{"A.B.C,D.E.F", []string{"A.B.C", "D.E.F"}},
+		{`TESTDB.TESTSCHEMA.IT1,TESTDB.TESTSCHEMA."I,T2"`, []string{"TESTDB.TESTSCHEMA.IT1", `TESTDB.TESTSCHEMA."I,T2"`}},
+		{`A."x,y",B."z,w"`, []string{`A."x,y"`, `B."z,w"`}},
+		// doubled quotes ("") escape a quote inside a quoted identifier; the comma inside stays protected
+		{`A.B."a""b,c",D.E.F`, []string{`A.B."a""b,c"`, "D.E.F"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := splitCommaSeparatedIdentifiers(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/sdk/warehouses_dto_builders_gen.go
+++ b/pkg/sdk/warehouses_dto_builders_gen.go
@@ -158,6 +158,89 @@ func (s *CreateAdaptiveWarehouseRequest) WithStatementTimeoutInSeconds(statement
 	return s
 }
 
+func NewCreateInteractiveWarehouseRequest(
+	name AccountObjectIdentifier,
+) *CreateInteractiveWarehouseRequest {
+	s := CreateInteractiveWarehouseRequest{}
+	s.name = name
+	return &s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithOrReplace(orReplace bool) *CreateInteractiveWarehouseRequest {
+	s.OrReplace = &orReplace
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithIfNotExists(ifNotExists bool) *CreateInteractiveWarehouseRequest {
+	s.IfNotExists = &ifNotExists
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithTables(tables []SchemaObjectIdentifier) *CreateInteractiveWarehouseRequest {
+	s.Tables = tables
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithWarehouseSize(warehouseSize WarehouseSize) *CreateInteractiveWarehouseRequest {
+	s.WarehouseSize = &warehouseSize
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithMaxClusterCount(maxClusterCount int) *CreateInteractiveWarehouseRequest {
+	s.MaxClusterCount = &maxClusterCount
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithMinClusterCount(minClusterCount int) *CreateInteractiveWarehouseRequest {
+	s.MinClusterCount = &minClusterCount
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithAutoSuspend(autoSuspend int) *CreateInteractiveWarehouseRequest {
+	s.AutoSuspend = &autoSuspend
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithAutoResume(autoResume bool) *CreateInteractiveWarehouseRequest {
+	s.AutoResume = &autoResume
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithInitiallySuspended(initiallySuspended bool) *CreateInteractiveWarehouseRequest {
+	s.InitiallySuspended = &initiallySuspended
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithResourceMonitor(resourceMonitor AccountObjectIdentifier) *CreateInteractiveWarehouseRequest {
+	s.ResourceMonitor = &resourceMonitor
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithComment(comment string) *CreateInteractiveWarehouseRequest {
+	s.Comment = &comment
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithMaxConcurrencyLevel(maxConcurrencyLevel int) *CreateInteractiveWarehouseRequest {
+	s.MaxConcurrencyLevel = &maxConcurrencyLevel
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithStatementQueuedTimeoutInSeconds(statementQueuedTimeoutInSeconds int) *CreateInteractiveWarehouseRequest {
+	s.StatementQueuedTimeoutInSeconds = &statementQueuedTimeoutInSeconds
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithStatementTimeoutInSeconds(statementTimeoutInSeconds int) *CreateInteractiveWarehouseRequest {
+	s.StatementTimeoutInSeconds = &statementTimeoutInSeconds
+	return s
+}
+
+func (s *CreateInteractiveWarehouseRequest) WithTag(tag []TagAssociation) *CreateInteractiveWarehouseRequest {
+	s.Tag = tag
+	return s
+}
+
 func NewAlterWarehouseRequest(
 	name AccountObjectIdentifier,
 ) *AlterWarehouseRequest {
@@ -203,6 +286,16 @@ func (s *AlterWarehouseRequest) WithSet(set WarehouseSetRequest) *AlterWarehouse
 
 func (s *AlterWarehouseRequest) WithUnset(unset WarehouseUnsetRequest) *AlterWarehouseRequest {
 	s.Unset = &unset
+	return s
+}
+
+func (s *AlterWarehouseRequest) WithAddTables(addTables []SchemaObjectIdentifier) *AlterWarehouseRequest {
+	s.AddTables = addTables
+	return s
+}
+
+func (s *AlterWarehouseRequest) WithDropTables(dropTables []SchemaObjectIdentifier) *AlterWarehouseRequest {
+	s.DropTables = dropTables
 	return s
 }
 
@@ -316,6 +409,11 @@ func (s *WarehouseSetRequest) WithStatementTimeoutInSeconds(statementTimeoutInSe
 	return s
 }
 
+func (s *WarehouseSetRequest) WithFallbackWarehouse(fallbackWarehouse AccountObjectIdentifier) *WarehouseSetRequest {
+	s.FallbackWarehouse = &fallbackWarehouse
+	return s
+}
+
 func NewWarehouseUnsetRequest() *WarehouseUnsetRequest {
 	s := WarehouseUnsetRequest{}
 	return &s
@@ -408,6 +506,11 @@ func (s *WarehouseUnsetRequest) WithQueryThroughputMultiplier(queryThroughputMul
 
 func (s *WarehouseUnsetRequest) WithMaxQueryPerformanceLevel(maxQueryPerformanceLevel bool) *WarehouseUnsetRequest {
 	s.MaxQueryPerformanceLevel = &maxQueryPerformanceLevel
+	return s
+}
+
+func (s *WarehouseUnsetRequest) WithFallbackWarehouse(fallbackWarehouse bool) *WarehouseUnsetRequest {
+	s.FallbackWarehouse = &fallbackWarehouse
 	return s
 }
 

--- a/pkg/sdk/warehouses_dto_gen.go
+++ b/pkg/sdk/warehouses_dto_gen.go
@@ -3,12 +3,13 @@
 package sdk
 
 var (
-	_ optionsProvider[CreateWarehouseOptions]         = new(CreateWarehouseRequest)
-	_ optionsProvider[CreateAdaptiveWarehouseOptions] = new(CreateAdaptiveWarehouseRequest)
-	_ optionsProvider[AlterWarehouseOptions]          = new(AlterWarehouseRequest)
-	_ optionsProvider[DropWarehouseOptions]           = new(DropWarehouseRequest)
-	_ optionsProvider[ShowWarehouseOptions]           = new(ShowWarehouseRequest)
-	_ optionsProvider[DescribeWarehouseOptions]       = new(DescribeWarehouseRequest)
+	_ optionsProvider[CreateWarehouseOptions]            = new(CreateWarehouseRequest)
+	_ optionsProvider[CreateAdaptiveWarehouseOptions]    = new(CreateAdaptiveWarehouseRequest)
+	_ optionsProvider[CreateInteractiveWarehouseOptions] = new(CreateInteractiveWarehouseRequest)
+	_ optionsProvider[AlterWarehouseOptions]             = new(AlterWarehouseRequest)
+	_ optionsProvider[DropWarehouseOptions]              = new(DropWarehouseRequest)
+	_ optionsProvider[ShowWarehouseOptions]              = new(ShowWarehouseRequest)
+	_ optionsProvider[DescribeWarehouseOptions]          = new(DescribeWarehouseRequest)
 )
 
 type CreateWarehouseRequest struct {
@@ -47,6 +48,25 @@ type CreateAdaptiveWarehouseRequest struct {
 	StatementTimeoutInSeconds       *int
 }
 
+type CreateInteractiveWarehouseRequest struct {
+	OrReplace                       *bool
+	IfNotExists                     *bool
+	name                            AccountObjectIdentifier // required
+	Tables                          []SchemaObjectIdentifier
+	WarehouseSize                   *WarehouseSize
+	MaxClusterCount                 *int
+	MinClusterCount                 *int
+	AutoSuspend                     *int
+	AutoResume                      *bool
+	InitiallySuspended              *bool
+	ResourceMonitor                 *AccountObjectIdentifier
+	Comment                         *string
+	MaxConcurrencyLevel             *int
+	StatementQueuedTimeoutInSeconds *int
+	StatementTimeoutInSeconds       *int
+	Tag                             []TagAssociation
+}
+
 type AlterWarehouseRequest struct {
 	IfExists        *bool
 	name            AccountObjectIdentifier // required
@@ -57,6 +77,8 @@ type AlterWarehouseRequest struct {
 	RenameTo        *AccountObjectIdentifier
 	Set             *WarehouseSetRequest
 	Unset           *WarehouseUnsetRequest
+	AddTables       []SchemaObjectIdentifier
+	DropTables      []SchemaObjectIdentifier
 	SetTags         []TagAssociation
 	UnsetTags       []ObjectIdentifier
 }
@@ -81,6 +103,7 @@ type WarehouseSetRequest struct {
 	MaxConcurrencyLevel             *int
 	StatementQueuedTimeoutInSeconds *int
 	StatementTimeoutInSeconds       *int
+	FallbackWarehouse               *AccountObjectIdentifier
 }
 
 type WarehouseUnsetRequest struct {
@@ -102,6 +125,7 @@ type WarehouseUnsetRequest struct {
 	StatementTimeoutInSeconds       *bool
 	QueryThroughputMultiplier       *bool
 	MaxQueryPerformanceLevel        *bool
+	FallbackWarehouse               *bool
 }
 
 type DropWarehouseRequest struct {

--- a/pkg/sdk/warehouses_enums_gen.go
+++ b/pkg/sdk/warehouses_enums_gen.go
@@ -13,12 +13,14 @@ const (
 	WarehouseTypeStandard          WarehouseType = "STANDARD"
 	WarehouseTypeSnowparkOptimized WarehouseType = "SNOWPARK-OPTIMIZED"
 	WarehouseTypeAdaptive          WarehouseType = "ADAPTIVE"
+	WarehouseTypeInteractive       WarehouseType = "INTERACTIVE"
 )
 
 var AllWarehouseTypes = []WarehouseType{
 	WarehouseTypeStandard,
 	WarehouseTypeSnowparkOptimized,
 	WarehouseTypeAdaptive,
+	WarehouseTypeInteractive,
 }
 
 func ToWarehouseType(s string) (WarehouseType, error) {
@@ -30,6 +32,8 @@ func ToWarehouseType(s string) (WarehouseType, error) {
 		return WarehouseTypeSnowparkOptimized, nil
 	case string(WarehouseTypeAdaptive):
 		return WarehouseTypeAdaptive, nil
+	case string(WarehouseTypeInteractive):
+		return WarehouseTypeInteractive, nil
 	default:
 		return "", fmt.Errorf("invalid warehouse type: %s", s)
 	}

--- a/pkg/sdk/warehouses_ext.go
+++ b/pkg/sdk/warehouses_ext.go
@@ -274,6 +274,25 @@ func (r warehouseDBRow) additionalConvert(wh *Warehouse) error {
 		}
 	}
 
+	// Tables - only present for interactive warehouses; may be NULL. SHOW WAREHOUSES returns the
+	// associated tables as a comma-separated list of fully-qualified names. Identifiers can contain
+	// commas when quoted, so we split in a quote-aware manner rather than using strings.Split.
+	if r.Tables.Valid {
+		if tables := strings.TrimSpace(r.Tables.String); tables != "" {
+			for _, raw := range splitCommaSeparatedIdentifiers(tables) {
+				raw = strings.TrimSpace(raw)
+				if raw == "" {
+					continue
+				}
+				id, err := ParseSchemaObjectIdentifier(raw)
+				if err != nil {
+					return fmt.Errorf("parsing table identifier %q: %w", raw, err)
+				}
+				wh.Tables = append(wh.Tables, id)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -297,6 +316,15 @@ func (opts *CreateAdaptiveWarehouseOptions) additionalValidations() error {
 	var errs []error
 	if valueSet(opts.QueryThroughputMultiplier) && !validateIntGreaterThanOrEqual(*opts.QueryThroughputMultiplier, 0) {
 		errs = append(errs, fmt.Errorf("QueryThroughputMultiplier must be greater than or equal to 0"))
+	}
+	return JoinErrors(errs...)
+}
+
+// additionalValidations for CreateInteractiveWarehouseOptions.
+func (opts *CreateInteractiveWarehouseOptions) additionalValidations() error {
+	var errs []error
+	if valueSet(opts.MinClusterCount) && valueSet(opts.MaxClusterCount) && !validateIntGreaterThanOrEqual(*opts.MaxClusterCount, *opts.MinClusterCount) {
+		errs = append(errs, fmt.Errorf("MinClusterCount must be less than or equal to MaxClusterCount"))
 	}
 	return JoinErrors(errs...)
 }
@@ -345,5 +373,9 @@ func (s *CreateWarehouseRequest) ID() AccountObjectIdentifier {
 }
 
 func (s *CreateAdaptiveWarehouseRequest) ID() AccountObjectIdentifier {
+	return s.name
+}
+
+func (s *CreateInteractiveWarehouseRequest) ID() AccountObjectIdentifier {
 	return s.name
 }

--- a/pkg/sdk/warehouses_gen.go
+++ b/pkg/sdk/warehouses_gen.go
@@ -11,6 +11,7 @@ import (
 type Warehouses interface {
 	Create(ctx context.Context, request *CreateWarehouseRequest) error
 	CreateAdaptive(ctx context.Context, request *CreateAdaptiveWarehouseRequest) error
+	CreateInteractive(ctx context.Context, request *CreateInteractiveWarehouseRequest) error
 	Alter(ctx context.Context, request *AlterWarehouseRequest) error
 	Drop(ctx context.Context, request *DropWarehouseRequest) error
 	DropSafely(ctx context.Context, id AccountObjectIdentifier) error
@@ -69,6 +70,28 @@ type CreateAdaptiveWarehouseOptions struct {
 	StatementTimeoutInSeconds       *int                      `ddl:"parameter" sql:"STATEMENT_TIMEOUT_IN_SECONDS"`
 }
 
+// CreateInteractiveWarehouseOptions is based on https://docs.snowflake.com/en/user-guide/warehouses-interactive.
+type CreateInteractiveWarehouseOptions struct {
+	create                          bool                     `ddl:"static" sql:"CREATE"`
+	OrReplace                       *bool                    `ddl:"keyword" sql:"OR REPLACE"`
+	interactiveWarehouse            bool                     `ddl:"static" sql:"INTERACTIVE WAREHOUSE"`
+	IfNotExists                     *bool                    `ddl:"keyword" sql:"IF NOT EXISTS"`
+	name                            AccountObjectIdentifier  `ddl:"identifier"`
+	Tables                          []SchemaObjectIdentifier `ddl:"parameter,parentheses,no_equals" sql:"TABLES"`
+	WarehouseSize                   *WarehouseSize           `ddl:"parameter,single_quotes" sql:"WAREHOUSE_SIZE"`
+	MaxClusterCount                 *int                     `ddl:"parameter" sql:"MAX_CLUSTER_COUNT"`
+	MinClusterCount                 *int                     `ddl:"parameter" sql:"MIN_CLUSTER_COUNT"`
+	AutoSuspend                     *int                     `ddl:"parameter" sql:"AUTO_SUSPEND"`
+	AutoResume                      *bool                    `ddl:"parameter" sql:"AUTO_RESUME"`
+	InitiallySuspended              *bool                    `ddl:"parameter" sql:"INITIALLY_SUSPENDED"`
+	ResourceMonitor                 *AccountObjectIdentifier `ddl:"identifier,equals" sql:"RESOURCE_MONITOR"`
+	Comment                         *string                  `ddl:"parameter,single_quotes" sql:"COMMENT"`
+	MaxConcurrencyLevel             *int                     `ddl:"parameter" sql:"MAX_CONCURRENCY_LEVEL"`
+	StatementQueuedTimeoutInSeconds *int                     `ddl:"parameter" sql:"STATEMENT_QUEUED_TIMEOUT_IN_SECONDS"`
+	StatementTimeoutInSeconds       *int                     `ddl:"parameter" sql:"STATEMENT_TIMEOUT_IN_SECONDS"`
+	Tag                             []TagAssociation         `ddl:"keyword,parentheses" sql:"TAG"`
+}
+
 // AlterWarehouseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-warehouse.
 type AlterWarehouseOptions struct {
 	alter           bool                     `ddl:"static" sql:"ALTER"`
@@ -82,6 +105,8 @@ type AlterWarehouseOptions struct {
 	RenameTo        *AccountObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
 	Set             *WarehouseSet            `ddl:"keyword" sql:"SET"`
 	Unset           *WarehouseUnset          `ddl:"list,no_parentheses" sql:"UNSET"`
+	AddTables       []SchemaObjectIdentifier `ddl:"parameter,parentheses,no_equals" sql:"ADD TABLES"`
+	DropTables      []SchemaObjectIdentifier `ddl:"parameter,parentheses,no_equals" sql:"DROP TABLES"`
 	SetTags         []TagAssociation         `ddl:"keyword" sql:"SET TAG"`
 	UnsetTags       []ObjectIdentifier       `ddl:"keyword" sql:"UNSET TAG"`
 }
@@ -106,6 +131,7 @@ type WarehouseSet struct {
 	MaxConcurrencyLevel             *int                         `ddl:"parameter" sql:"MAX_CONCURRENCY_LEVEL"`
 	StatementQueuedTimeoutInSeconds *int                         `ddl:"parameter" sql:"STATEMENT_QUEUED_TIMEOUT_IN_SECONDS"`
 	StatementTimeoutInSeconds       *int                         `ddl:"parameter" sql:"STATEMENT_TIMEOUT_IN_SECONDS"`
+	FallbackWarehouse               *AccountObjectIdentifier     `ddl:"identifier,equals" sql:"FALLBACK_WAREHOUSE"`
 }
 
 type WarehouseUnset struct {
@@ -127,6 +153,7 @@ type WarehouseUnset struct {
 	StatementTimeoutInSeconds       *bool `ddl:"keyword" sql:"STATEMENT_TIMEOUT_IN_SECONDS"`
 	QueryThroughputMultiplier       *bool `ddl:"keyword" sql:"QUERY_THROUGHPUT_MULTIPLIER"`
 	MaxQueryPerformanceLevel        *bool `ddl:"keyword" sql:"MAX_QUERY_PERFORMANCE_LEVEL"`
+	FallbackWarehouse               *bool `ddl:"keyword" sql:"FALLBACK_WAREHOUSE"`
 }
 
 // DropWarehouseOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-warehouse.
@@ -183,6 +210,7 @@ type warehouseDBRow struct {
 	Generation                      sql.NullString `db:"generation"`
 	MaxQueryPerformanceLevel        sql.NullString `db:"max_query_performance_level"`
 	QueryThroughputMultiplier       sql.NullInt64  `db:"query_throughput_multiplier"`
+	Tables                          sql.NullString `db:"tables"`
 }
 
 type Warehouse struct {
@@ -222,6 +250,7 @@ type Warehouse struct {
 	Generation                      *WarehouseGeneration
 	MaxQueryPerformanceLevel        *MaxQueryPerformanceLevel
 	QueryThroughputMultiplier       *int
+	Tables                          []SchemaObjectIdentifier
 }
 
 func (v *Warehouse) ID() AccountObjectIdentifier {

--- a/pkg/sdk/warehouses_impl_gen.go
+++ b/pkg/sdk/warehouses_impl_gen.go
@@ -29,6 +29,11 @@ func (v *warehouses) CreateAdaptive(ctx context.Context, request *CreateAdaptive
 	return validateAndExec(v.client, ctx, opts)
 }
 
+func (v *warehouses) CreateInteractive(ctx context.Context, request *CreateInteractiveWarehouseRequest) error {
+	opts := request.toOpts()
+	return validateAndExec(v.client, ctx, opts)
+}
+
 func (v *warehouses) Alter(ctx context.Context, request *AlterWarehouseRequest) error {
 	opts := request.toOpts()
 	return validateAndExec(v.client, ctx, opts)
@@ -119,6 +124,28 @@ func (r *CreateAdaptiveWarehouseRequest) toOpts() *CreateAdaptiveWarehouseOption
 	return opts
 }
 
+func (r *CreateInteractiveWarehouseRequest) toOpts() *CreateInteractiveWarehouseOptions {
+	opts := &CreateInteractiveWarehouseOptions{
+		OrReplace:                       r.OrReplace,
+		IfNotExists:                     r.IfNotExists,
+		name:                            r.name,
+		Tables:                          r.Tables,
+		WarehouseSize:                   r.WarehouseSize,
+		MaxClusterCount:                 r.MaxClusterCount,
+		MinClusterCount:                 r.MinClusterCount,
+		AutoSuspend:                     r.AutoSuspend,
+		AutoResume:                      r.AutoResume,
+		InitiallySuspended:              r.InitiallySuspended,
+		ResourceMonitor:                 r.ResourceMonitor,
+		Comment:                         r.Comment,
+		MaxConcurrencyLevel:             r.MaxConcurrencyLevel,
+		StatementQueuedTimeoutInSeconds: r.StatementQueuedTimeoutInSeconds,
+		StatementTimeoutInSeconds:       r.StatementTimeoutInSeconds,
+		Tag:                             r.Tag,
+	}
+	return opts
+}
+
 func (r *AlterWarehouseRequest) toOpts() *AlterWarehouseOptions {
 	opts := &AlterWarehouseOptions{
 		IfExists:        r.IfExists,
@@ -128,6 +155,8 @@ func (r *AlterWarehouseRequest) toOpts() *AlterWarehouseOptions {
 		IfSuspended:     r.IfSuspended,
 		AbortAllQueries: r.AbortAllQueries,
 		RenameTo:        r.RenameTo,
+		AddTables:       r.AddTables,
+		DropTables:      r.DropTables,
 		SetTags:         r.SetTags,
 		UnsetTags:       r.UnsetTags,
 	}
@@ -152,6 +181,7 @@ func (r *AlterWarehouseRequest) toOpts() *AlterWarehouseOptions {
 			MaxConcurrencyLevel:             r.Set.MaxConcurrencyLevel,
 			StatementQueuedTimeoutInSeconds: r.Set.StatementQueuedTimeoutInSeconds,
 			StatementTimeoutInSeconds:       r.Set.StatementTimeoutInSeconds,
+			FallbackWarehouse:               r.Set.FallbackWarehouse,
 		}
 	}
 	if r.Unset != nil {
@@ -174,6 +204,7 @@ func (r *AlterWarehouseRequest) toOpts() *AlterWarehouseOptions {
 			StatementTimeoutInSeconds:       r.Unset.StatementTimeoutInSeconds,
 			QueryThroughputMultiplier:       r.Unset.QueryThroughputMultiplier,
 			MaxQueryPerformanceLevel:        r.Unset.MaxQueryPerformanceLevel,
+			FallbackWarehouse:               r.Unset.FallbackWarehouse,
 		}
 	}
 	return opts

--- a/pkg/sdk/warehouses_test.go
+++ b/pkg/sdk/warehouses_test.go
@@ -126,6 +126,110 @@ func TestWarehouseCreateAdaptive(t *testing.T) {
 	})
 }
 
+func TestWarehouseCreateInteractive(t *testing.T) {
+	t.Run("only name", func(t *testing.T) {
+		opts := &CreateInteractiveWarehouseOptions{
+			name: NewAccountObjectIdentifier("mywarehouse"),
+		}
+		assertOptsValidAndSQLEquals(t, opts, `CREATE INTERACTIVE WAREHOUSE "mywarehouse"`)
+	})
+
+	t.Run("with tables and options", func(t *testing.T) {
+		tableId1 := randomSchemaObjectIdentifier()
+		tableId2 := randomSchemaObjectIdentifierInSchema(tableId1.SchemaId())
+		opts := &CreateInteractiveWarehouseOptions{
+			OrReplace:                       Bool(true),
+			name:                            NewAccountObjectIdentifier("myinteractivewh"),
+			Tables:                          []SchemaObjectIdentifier{tableId1, tableId2},
+			WarehouseSize:                   Pointer(WarehouseSizeXSmall),
+			MaxClusterCount:                 Int(2),
+			MinClusterCount:                 Int(1),
+			AutoSuspend:                     Int(86400),
+			AutoResume:                      Bool(true),
+			InitiallySuspended:              Bool(true),
+			ResourceMonitor:                 Pointer(NewAccountObjectIdentifier("resmon")),
+			Comment:                         String("interactive warehouse"),
+			MaxConcurrencyLevel:             Int(8),
+			StatementQueuedTimeoutInSeconds: Int(30),
+			StatementTimeoutInSeconds:       Int(5),
+		}
+		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE INTERACTIVE WAREHOUSE "myinteractivewh" TABLES (%s, %s) WAREHOUSE_SIZE = 'XSMALL' MAX_CLUSTER_COUNT = 2 MIN_CLUSTER_COUNT = 1 AUTO_SUSPEND = 86400 AUTO_RESUME = true INITIALLY_SUSPENDED = true RESOURCE_MONITOR = "resmon" COMMENT = 'interactive warehouse' MAX_CONCURRENCY_LEVEL = 8 STATEMENT_QUEUED_TIMEOUT_IN_SECONDS = 30 STATEMENT_TIMEOUT_IN_SECONDS = 5`,
+			tableId1.FullyQualifiedName(), tableId2.FullyQualifiedName())
+	})
+
+	t.Run("validation: nil options", func(t *testing.T) {
+		var opts *CreateInteractiveWarehouseOptions
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
+	})
+
+	t.Run("validation: invalid identifier", func(t *testing.T) {
+		opts := &CreateInteractiveWarehouseOptions{
+			name: emptyAccountObjectIdentifier,
+		}
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: conflicting OrReplace and IfNotExists", func(t *testing.T) {
+		opts := &CreateInteractiveWarehouseOptions{
+			name:        NewAccountObjectIdentifier("mywarehouse"),
+			OrReplace:   Bool(true),
+			IfNotExists: Bool(true),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, errOneOf("CreateInteractiveWarehouseOptions", "OrReplace", "IfNotExists"))
+	})
+
+	t.Run("validation: min bigger than max cluster count", func(t *testing.T) {
+		opts := &CreateInteractiveWarehouseOptions{
+			name:            NewAccountObjectIdentifier("mywarehouse"),
+			MaxClusterCount: Int(1),
+			MinClusterCount: Int(2),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, fmt.Errorf("MinClusterCount must be less than or equal to MaxClusterCount"))
+	})
+}
+
+func TestWarehouseAlterInteractiveTablesAndFallback(t *testing.T) {
+	t.Run("add tables", func(t *testing.T) {
+		tableId1 := randomSchemaObjectIdentifier()
+		tableId2 := randomSchemaObjectIdentifierInSchema(tableId1.SchemaId())
+		opts := &AlterWarehouseOptions{
+			name:      NewAccountObjectIdentifier("mywarehouse"),
+			AddTables: []SchemaObjectIdentifier{tableId1, tableId2},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER WAREHOUSE "mywarehouse" ADD TABLES (%s, %s)`,
+			tableId1.FullyQualifiedName(), tableId2.FullyQualifiedName())
+	})
+
+	t.Run("drop tables", func(t *testing.T) {
+		tableId1 := randomSchemaObjectIdentifier()
+		opts := &AlterWarehouseOptions{
+			name:       NewAccountObjectIdentifier("mywarehouse"),
+			DropTables: []SchemaObjectIdentifier{tableId1},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER WAREHOUSE "mywarehouse" DROP TABLES (%s)`, tableId1.FullyQualifiedName())
+	})
+
+	t.Run("set fallback warehouse", func(t *testing.T) {
+		opts := &AlterWarehouseOptions{
+			name: NewAccountObjectIdentifier("mywarehouse"),
+			Set: &WarehouseSet{
+				FallbackWarehouse: Pointer(NewAccountObjectIdentifier("fallbackwh")),
+			},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER WAREHOUSE "mywarehouse" SET FALLBACK_WAREHOUSE = "fallbackwh"`)
+	})
+
+	t.Run("unset fallback warehouse", func(t *testing.T) {
+		opts := &AlterWarehouseOptions{
+			name: NewAccountObjectIdentifier("mywarehouse"),
+			Unset: &WarehouseUnset{
+				FallbackWarehouse: Bool(true),
+			},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `ALTER WAREHOUSE "mywarehouse" UNSET FALLBACK_WAREHOUSE`)
+	})
+}
+
 func TestWarehouseSizing(t *testing.T) {
 	t.Run("validation: Min bigger than Max", func(t *testing.T) {
 		opts := &CreateWarehouseOptions{

--- a/pkg/sdk/warehouses_validations_gen.go
+++ b/pkg/sdk/warehouses_validations_gen.go
@@ -5,6 +5,7 @@ package sdk
 var (
 	_ validatable = new(CreateWarehouseOptions)
 	_ validatable = new(CreateAdaptiveWarehouseOptions)
+	_ validatable = new(CreateInteractiveWarehouseOptions)
 	_ validatable = new(AlterWarehouseOptions)
 	_ validatable = new(DropWarehouseOptions)
 	_ validatable = new(ShowWarehouseOptions)
@@ -41,6 +42,21 @@ func (opts *CreateAdaptiveWarehouseOptions) validate() error {
 	return JoinErrors(errs...)
 }
 
+func (opts *CreateInteractiveWarehouseOptions) validate() error {
+	if opts == nil {
+		return ErrNilOptions
+	}
+	var errs []error
+	if !ValidObjectIdentifier(opts.name) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	if everyValueSet(opts.OrReplace, opts.IfNotExists) {
+		errs = append(errs, errOneOf("CreateInteractiveWarehouseOptions", "OrReplace", "IfNotExists"))
+	}
+	errs = append(errs, opts.additionalValidations())
+	return JoinErrors(errs...)
+}
+
 func (opts *AlterWarehouseOptions) validate() error {
 	if opts == nil {
 		return ErrNilOptions
@@ -49,19 +65,19 @@ func (opts *AlterWarehouseOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.Suspend, opts.Resume, opts.AbortAllQueries, opts.RenameTo, opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags) {
-		errs = append(errs, errExactlyOneOf("AlterWarehouseOptions", "Suspend", "Resume", "AbortAllQueries", "RenameTo", "Set", "Unset", "SetTags", "UnsetTags"))
+	if !exactlyOneValueSet(opts.Suspend, opts.Resume, opts.AbortAllQueries, opts.RenameTo, opts.Set, opts.Unset, opts.AddTables, opts.DropTables, opts.SetTags, opts.UnsetTags) {
+		errs = append(errs, errExactlyOneOf("AlterWarehouseOptions", "Suspend", "Resume", "AbortAllQueries", "RenameTo", "Set", "Unset", "AddTables", "DropTables", "SetTags", "UnsetTags"))
 	}
 	errs = append(errs, opts.additionalValidations())
 	if valueSet(opts.Set) {
-		if !anyValueSet(opts.Set.WarehouseType, opts.Set.WarehouseSize, opts.Set.WaitForCompletion, opts.Set.MaxClusterCount, opts.Set.MinClusterCount, opts.Set.ScalingPolicy, opts.Set.AutoSuspend, opts.Set.AutoResume, opts.Set.ResourceMonitor, opts.Set.Comment, opts.Set.EnableQueryAcceleration, opts.Set.QueryAccelerationMaxScaleFactor, opts.Set.ResourceConstraint, opts.Set.Generation, opts.Set.QueryThroughputMultiplier, opts.Set.MaxQueryPerformanceLevel, opts.Set.MaxConcurrencyLevel, opts.Set.StatementQueuedTimeoutInSeconds, opts.Set.StatementTimeoutInSeconds) {
-			errs = append(errs, errAtLeastOneOf("AlterWarehouseOptions.Set", "WarehouseType", "WarehouseSize", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "QueryThroughputMultiplier", "MaxQueryPerformanceLevel", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds"))
+		if !anyValueSet(opts.Set.WarehouseType, opts.Set.WarehouseSize, opts.Set.WaitForCompletion, opts.Set.MaxClusterCount, opts.Set.MinClusterCount, opts.Set.ScalingPolicy, opts.Set.AutoSuspend, opts.Set.AutoResume, opts.Set.ResourceMonitor, opts.Set.Comment, opts.Set.EnableQueryAcceleration, opts.Set.QueryAccelerationMaxScaleFactor, opts.Set.ResourceConstraint, opts.Set.Generation, opts.Set.QueryThroughputMultiplier, opts.Set.MaxQueryPerformanceLevel, opts.Set.MaxConcurrencyLevel, opts.Set.StatementQueuedTimeoutInSeconds, opts.Set.StatementTimeoutInSeconds, opts.Set.FallbackWarehouse) {
+			errs = append(errs, errAtLeastOneOf("AlterWarehouseOptions.Set", "WarehouseType", "WarehouseSize", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "QueryThroughputMultiplier", "MaxQueryPerformanceLevel", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds", "FallbackWarehouse"))
 		}
 		errs = append(errs, opts.Set.additionalValidations())
 	}
 	if valueSet(opts.Unset) {
-		if !anyValueSet(opts.Unset.WarehouseType, opts.Unset.WaitForCompletion, opts.Unset.MaxClusterCount, opts.Unset.MinClusterCount, opts.Unset.ScalingPolicy, opts.Unset.AutoSuspend, opts.Unset.AutoResume, opts.Unset.ResourceMonitor, opts.Unset.Comment, opts.Unset.EnableQueryAcceleration, opts.Unset.QueryAccelerationMaxScaleFactor, opts.Unset.ResourceConstraint, opts.Unset.Generation, opts.Unset.MaxConcurrencyLevel, opts.Unset.StatementQueuedTimeoutInSeconds, opts.Unset.StatementTimeoutInSeconds, opts.Unset.QueryThroughputMultiplier, opts.Unset.MaxQueryPerformanceLevel) {
-			errs = append(errs, errAtLeastOneOf("AlterWarehouseOptions.Unset", "WarehouseType", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds", "QueryThroughputMultiplier", "MaxQueryPerformanceLevel"))
+		if !anyValueSet(opts.Unset.WarehouseType, opts.Unset.WaitForCompletion, opts.Unset.MaxClusterCount, opts.Unset.MinClusterCount, opts.Unset.ScalingPolicy, opts.Unset.AutoSuspend, opts.Unset.AutoResume, opts.Unset.ResourceMonitor, opts.Unset.Comment, opts.Unset.EnableQueryAcceleration, opts.Unset.QueryAccelerationMaxScaleFactor, opts.Unset.ResourceConstraint, opts.Unset.Generation, opts.Unset.MaxConcurrencyLevel, opts.Unset.StatementQueuedTimeoutInSeconds, opts.Unset.StatementTimeoutInSeconds, opts.Unset.QueryThroughputMultiplier, opts.Unset.MaxQueryPerformanceLevel, opts.Unset.FallbackWarehouse) {
+			errs = append(errs, errAtLeastOneOf("AlterWarehouseOptions.Unset", "WarehouseType", "WaitForCompletion", "MaxClusterCount", "MinClusterCount", "ScalingPolicy", "AutoSuspend", "AutoResume", "ResourceMonitor", "Comment", "EnableQueryAcceleration", "QueryAccelerationMaxScaleFactor", "ResourceConstraint", "Generation", "MaxConcurrencyLevel", "StatementQueuedTimeoutInSeconds", "StatementTimeoutInSeconds", "QueryThroughputMultiplier", "MaxQueryPerformanceLevel", "FallbackWarehouse"))
 		}
 	}
 	return JoinErrors(errs...)


### PR DESCRIPTION
## Description

Adds SDK support for [interactive warehouses](https://docs.snowflake.com/en/user-guide/warehouses-interactive). This is the first PR in a series adding first-class Terraform support for the `INTERACTIVE` warehouse type; it covers only the SDK layer (definitions + unit tests). Integration tests and the resource follow in subsequent PRs.

## Changes

- **New warehouse type + create operation.** Add `INTERACTIVE` to the warehouse type enum and a `CreateInteractive` custom operation.
- **ALTER extensions.** `ALTER WAREHOUSE` gains `ADD TABLES (...)` / `DROP TABLES (...)` (each its own top-level clause) and `SET`/`UNSET FALLBACK_WAREHOUSE`.
- **SHOW parsing.** The `SHOW WAREHOUSES` row parses the `tables` column (a comma-separated list of fully-qualified table names) into `[]SchemaObjectIdentifier`.
   - Parsing is **quote-aware**: identifiers can contain commas when quoted (e.g. `DB.SCHEMA."a,b"`), so a naive `strings.Split(",")` would break them apart. Existing methods don't handle this correctly.

## Test Plan

- Added unit tests for the generated DDL asserting the exact SQL.
- Added `TestSplitCommaOutsideQuotes` covering the quote-aware splitter, including commas inside quoted identifiers and doubled-quote (`""`) escaping.

## References

Part of the interactive-warehouse feature. Follow-up PRs: SDK integration tests, then the `snowflake_warehouse_interactive` resource.