### PR TITLE
chore: Add ObjectTypeName override and ID() methods to object assertions generator

### DIFF
--- a/docs/data-sources/password_policies.md
+++ b/docs/data-sources/password_policies.md
@@ -208,6 +208,7 @@ Read-Only:
 Read-Only:
 
 - `comment` (String)
+- `database_name` (String)
 - `name` (String)
 - `owner` (String)
 - `password_history` (Number)
@@ -221,6 +222,7 @@ Read-Only:
 - `password_min_numeric_chars` (Number)
 - `password_min_special_chars` (Number)
 - `password_min_upper_case_chars` (Number)
+- `schema_name` (String)
 
 
 <a id="nestedobjatt--password_policies--show_output"></a>

--- a/docs/data-sources/storage_lifecycle_policies.md
+++ b/docs/data-sources/storage_lifecycle_policies.md
@@ -143,8 +143,10 @@ Read-Only:
 - `archive_for_days` (Number)
 - `archive_tier` (String)
 - `body` (String)
+- `database_name` (String)
 - `name` (String)
 - `return_type` (String)
+- `schema_name` (String)
 - `signature` (List of Object) (see [below for nested schema](#nestedobjatt--storage_lifecycle_policies--describe_output--signature))
 
 <a id="nestedobjatt--storage_lifecycle_policies--describe_output--signature"></a>

--- a/docs/resources/password_policy.md
+++ b/docs/resources/password_policy.md
@@ -97,6 +97,7 @@ Optional:
 Read-Only:
 
 - `comment` (String)
+- `database_name` (String)
 - `name` (String)
 - `owner` (String)
 - `password_history` (Number)
@@ -110,6 +111,7 @@ Read-Only:
 - `password_min_numeric_chars` (Number)
 - `password_min_special_chars` (Number)
 - `password_min_upper_case_chars` (Number)
+- `schema_name` (String)
 
 
 <a id="nestedatt--show_output"></a>

--- a/docs/resources/storage_lifecycle_policy.md
+++ b/docs/resources/storage_lifecycle_policy.md
@@ -104,8 +104,10 @@ Read-Only:
 - `archive_for_days` (Number)
 - `archive_tier` (String)
 - `body` (String)
+- `database_name` (String)
 - `name` (String)
 - `return_type` (String)
+- `schema_name` (String)
 - `signature` (List of Object) (see [below for nested schema](#nestedobjatt--describe_output--signature))
 
 <a id="nestedobjatt--describe_output--signature"></a>

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/cortex_agent_desc_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/cortex_agent_desc_snowflake_gen.go
@@ -25,7 +25,12 @@ func CortexAgentDetails(t *testing.T, id sdk.SchemaObjectIdentifier) *CortexAgen
 	}
 }
 
-// Adjusted manually: removed CortexAgentDetailsFromObject — CortexAgentDetails has no Id field or ID() method.
+func CortexAgentDetailsFromObject(t *testing.T, cortexAgentDetails *sdk.CortexAgentDetails) *CortexAgentDetailsAssert {
+	t.Helper()
+	return &CortexAgentDetailsAssert{
+		assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectType("CortexAgentDetails"), cortexAgentDetails.ID(), cortexAgentDetails),
+	}
+}
 
 func (c *CortexAgentDetailsAssert) HasName(expected string) *CortexAgentDetailsAssert {
 	c.AddAssertion(func(t *testing.T, o *sdk.CortexAgentDetails) error {

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/cortex_agent_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/cortex_agent_snowflake_gen.go
@@ -28,7 +28,6 @@ func CortexAgent(t *testing.T, id sdk.SchemaObjectIdentifier) *CortexAgentAssert
 func CortexAgentFromObject(t *testing.T, cortexAgent *sdk.CortexAgent) *CortexAgentAssert {
 	t.Helper()
 	return &CortexAgentAssert{
-		// object type adjusted manually
 		assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectTypeAgent, cortexAgent.ID(), cortexAgent),
 	}
 }

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/cortex_agent_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/cortex_agent_snowflake_gen.go
@@ -19,7 +19,7 @@ type CortexAgentAssert struct {
 func CortexAgent(t *testing.T, id sdk.SchemaObjectIdentifier) *CortexAgentAssert {
 	t.Helper()
 	return &CortexAgentAssert{
-		assert.NewSnowflakeObjectAssertWithTestClientObjectProvider(sdk.ObjectType("CortexAgent"), id, func(testClient *helpers.TestClient) assert.ObjectProvider[sdk.CortexAgent, sdk.SchemaObjectIdentifier] {
+		assert.NewSnowflakeObjectAssertWithTestClientObjectProvider(sdk.ObjectTypeAgent, id, func(testClient *helpers.TestClient) assert.ObjectProvider[sdk.CortexAgent, sdk.SchemaObjectIdentifier] {
 			return testClient.CortexAgent.Show
 		}),
 	}

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/gen/model.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/gen/model.go
@@ -12,6 +12,7 @@ type SnowflakeObjectAssertionsModel struct {
 	IdType             string
 	IsDataSourceOutput bool
 	IsSubStruct        bool
+	ObjectTypeName     string
 	Fields             []SnowflakeObjectFieldAssertion
 
 	*genhelpers.PreambleModel
@@ -46,12 +47,18 @@ func ModelFromSdkObjectDetails(sdkObject genhelpers.SdkObjectDetails, preamble *
 		fields[idx] = MapToSnowflakeObjectFieldAssertion(field)
 	}
 
+	objectTypeName := name
+	if sdkObject.ObjectTypeName != "" {
+		objectTypeName = sdkObject.ObjectTypeName
+	}
+
 	return SnowflakeObjectAssertionsModel{
 		Name:               name,
 		SdkType:            sdkObject.Name,
 		IdType:             sdkObject.IdType,
 		IsDataSourceOutput: sdkObject.IsDataSourceOutput,
 		IsSubStruct:        sdkObject.IsSubStruct,
+		ObjectTypeName:     objectTypeName,
 		Fields:             fields,
 		PreambleModel:      preamble,
 	}

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/gen/model.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/gen/model.go
@@ -13,6 +13,7 @@ type SnowflakeObjectAssertionsModel struct {
 	IsDataSourceOutput bool
 	IsSubStruct        bool
 	ObjectTypeName     string
+	NoShowById         bool
 	Fields             []SnowflakeObjectFieldAssertion
 
 	*genhelpers.PreambleModel
@@ -59,6 +60,7 @@ func ModelFromSdkObjectDetails(sdkObject genhelpers.SdkObjectDetails, preamble *
 		IsDataSourceOutput: sdkObject.IsDataSourceOutput,
 		IsSubStruct:        sdkObject.IsSubStruct,
 		ObjectTypeName:     objectTypeName,
+		NoShowById:         sdkObject.NoShowById,
 		Fields:             fields,
 		PreambleModel:      preamble,
 	}

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/gen/sdk_object_def.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/gen/sdk_object_def.go
@@ -11,6 +11,7 @@ type SdkObjectDef struct {
 	IsDataSourceOutput bool
 	IsSubStruct        bool
 	ObjectTypeName     string
+	NoShowById         bool
 }
 
 var allStructs = []SdkObjectDef{
@@ -386,6 +387,7 @@ var allStructs = []SdkObjectDef{
 	{
 		IdType:       "sdk.SchemaObjectIdentifier",
 		ObjectStruct: sdk.TagReference{},
+		NoShowById:   true,
 	},
 	{
 		IdType:             "sdk.AccountObjectIdentifier",
@@ -395,6 +397,7 @@ var allStructs = []SdkObjectDef{
 	{
 		IdType:       "sdk.SchemaObjectIdentifier",
 		ObjectStruct: sdk.PolicyReference{},
+		NoShowById:   true,
 	},
 }
 
@@ -408,6 +411,7 @@ func GetSdkObjectDetails() []genhelpers.SdkObjectDetails {
 			IsDataSourceOutput: d.IsDataSourceOutput,
 			IsSubStruct:        d.IsSubStruct,
 			ObjectTypeName:     d.ObjectTypeName,
+			NoShowById:         d.NoShowById,
 		}
 	}
 	return allSdkObjectsDetails

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/gen/sdk_object_def.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/gen/sdk_object_def.go
@@ -10,6 +10,7 @@ type SdkObjectDef struct {
 	ObjectStruct       any
 	IsDataSourceOutput bool
 	IsSubStruct        bool
+	ObjectTypeName     string
 }
 
 var allStructs = []SdkObjectDef{
@@ -373,8 +374,9 @@ var allStructs = []SdkObjectDef{
 		ObjectStruct: sdk.PostgresInstance{},
 	},
 	{
-		IdType:       "sdk.SchemaObjectIdentifier",
-		ObjectStruct: sdk.CortexAgent{},
+		IdType:         "sdk.SchemaObjectIdentifier",
+		ObjectStruct:   sdk.CortexAgent{},
+		ObjectTypeName: "Agent",
 	},
 	{
 		IdType:             "sdk.SchemaObjectIdentifier",
@@ -405,6 +407,7 @@ func GetSdkObjectDetails() []genhelpers.SdkObjectDetails {
 			StructDetails:      structDetails,
 			IsDataSourceOutput: d.IsDataSourceOutput,
 			IsSubStruct:        d.IsSubStruct,
+			ObjectTypeName:     d.ObjectTypeName,
 		}
 	}
 	return allSdkObjectsDetails

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/gen/templates/definition.tmpl
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/gen/templates/definition.tmpl
@@ -27,7 +27,7 @@ func {{ .Name }}FromObject(t *testing.T, {{ $nameLowerCase }} *{{ .SdkType }}) *
         {{- if .IsSubStruct }}
         assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectType("{{ .Name }}"), {{ .PlaceholderIdentifier }}, {{ $nameLowerCase }}),
         {{- else }}
-        assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectType{{ .Name }}, {{ $nameLowerCase }}.ID(), {{ $nameLowerCase }}),
+        assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectType{{ .ObjectTypeName }}, {{ $nameLowerCase }}.ID(), {{ $nameLowerCase }}),
         {{- end }}
     }
 }

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/gen/templates/definition.tmpl
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/gen/templates/definition.tmpl
@@ -6,17 +6,18 @@ type {{ $assertName }} struct {
     *assert.SnowflakeObjectAssert[{{ .SdkType }}, {{ .IdType }}]
 }
 
-{{- if not .IsSubStruct }}
+{{- if not (or .IsSubStruct .NoShowById) }}
 func {{ .Name }}(t *testing.T, id {{ .IdType }}) *{{ $assertName }} {
     t.Helper()
     return &{{ $assertName }}{
-        assert.NewSnowflakeObjectAssertWithTestClientObjectProvider(sdk.ObjectType("{{ .Name }}"), id, func(testClient *helpers.TestClient) assert.ObjectProvider[{{ .SdkType }}, {{ .IdType }}] {
-            {{- if .IsDataSourceOutput }}
+        {{- if .IsDataSourceOutput }}
+            assert.NewSnowflakeObjectAssertWithTestClientObjectProvider(sdk.ObjectType("{{ .ObjectTypeName }}"), id, func(testClient *helpers.TestClient) assert.ObjectProvider[{{ .SdkType }}, {{ .IdType }}] {
                 return testClient.{{ TrimSuffix .Name "Details" }}.Describe
-            {{- else }}
+        {{- else }}
+            assert.NewSnowflakeObjectAssertWithTestClientObjectProvider(sdk.ObjectType{{ .ObjectTypeName }}, id, func(testClient *helpers.TestClient) assert.ObjectProvider[{{ .SdkType }}, {{ .IdType }}] {
                 return testClient.{{ .Name }}.Show
-            {{- end }}
-        }),
+        {{- end }}
+            }),
     }
 }
 {{- end }}
@@ -26,6 +27,8 @@ func {{ .Name }}FromObject(t *testing.T, {{ $nameLowerCase }} *{{ .SdkType }}) *
     return &{{ $assertName }}{
         {{- if .IsSubStruct }}
         assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectType("{{ .Name }}"), {{ .PlaceholderIdentifier }}, {{ $nameLowerCase }}),
+        {{- else if or .IsDataSourceOutput .NoShowById }}
+        assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectType("{{ .ObjectTypeName }}"), {{ $nameLowerCase }}.ID(), {{ $nameLowerCase }}),
         {{- else }}
         assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectType{{ .ObjectTypeName }}, {{ $nameLowerCase }}.ID(), {{ $nameLowerCase }}),
         {{- end }}

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/password_policy_desc_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/password_policy_desc_snowflake_gen.go
@@ -24,13 +24,40 @@ func PasswordPolicyDetails(t *testing.T, id sdk.SchemaObjectIdentifier) *Passwor
 	}
 }
 
-// Adjusted manually: removed PasswordPolicyDetailsFromObject — PasswordPolicyDetails has no Id field or ID() method.
+func PasswordPolicyDetailsFromObject(t *testing.T, passwordPolicyDetails *sdk.PasswordPolicyDetails) *PasswordPolicyDetailsAssert {
+	t.Helper()
+	return &PasswordPolicyDetailsAssert{
+		assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectType("PasswordPolicyDetails"), passwordPolicyDetails.ID(), passwordPolicyDetails),
+	}
+}
 
 func (p *PasswordPolicyDetailsAssert) HasName(expected string) *PasswordPolicyDetailsAssert {
 	p.AddAssertion(func(t *testing.T, o *sdk.PasswordPolicyDetails) error {
 		t.Helper()
 		if o.Name != expected {
 			return fmt.Errorf("expected name: %v; got: %v", expected, o.Name)
+		}
+		return nil
+	})
+	return p
+}
+
+func (p *PasswordPolicyDetailsAssert) HasDatabaseName(expected string) *PasswordPolicyDetailsAssert {
+	p.AddAssertion(func(t *testing.T, o *sdk.PasswordPolicyDetails) error {
+		t.Helper()
+		if o.DatabaseName != expected {
+			return fmt.Errorf("expected database name: %v; got: %v", expected, o.DatabaseName)
+		}
+		return nil
+	})
+	return p
+}
+
+func (p *PasswordPolicyDetailsAssert) HasSchemaName(expected string) *PasswordPolicyDetailsAssert {
+	p.AddAssertion(func(t *testing.T, o *sdk.PasswordPolicyDetails) error {
+		t.Helper()
+		if o.SchemaName != expected {
+			return fmt.Errorf("expected schema name: %v; got: %v", expected, o.SchemaName)
 		}
 		return nil
 	})

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/policy_reference_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/policy_reference_snowflake_gen.go
@@ -14,17 +14,10 @@ type PolicyReferenceAssert struct {
 	*assert.SnowflakeObjectAssert[sdk.PolicyReference, sdk.SchemaObjectIdentifier]
 }
 
-// Adjusted manually: removed PolicyReference
-
-// Adjusted manually
 func PolicyReferenceFromObject(t *testing.T, policyReference *sdk.PolicyReference) *PolicyReferenceAssert {
 	t.Helper()
 	return &PolicyReferenceAssert{
-		assert.NewSnowflakeObjectAssertWithObject(
-			sdk.ObjectType("PolicyReference"),
-			sdk.NewSchemaObjectIdentifier(*policyReference.PolicyDb, *policyReference.PolicySchema, policyReference.PolicyName),
-			policyReference,
-		),
+		assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectType("PolicyReference"), policyReference.ID(), policyReference),
 	}
 }
 

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/postgres_instance_desc_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/postgres_instance_desc_snowflake_gen.go
@@ -24,12 +24,10 @@ func PostgresInstanceDetails(t *testing.T, id sdk.AccountObjectIdentifier) *Post
 	}
 }
 
-// Adjusted manually: removed PostgresInstanceDetailsFromObject — PostgresInstanceDetails has no ID() method.
-
-func PostgresInstanceDetailsFromObject(t *testing.T, id sdk.AccountObjectIdentifier, postgresInstanceDetails *sdk.PostgresInstanceDetails) *PostgresInstanceDetailsAssert {
+func PostgresInstanceDetailsFromObject(t *testing.T, postgresInstanceDetails *sdk.PostgresInstanceDetails) *PostgresInstanceDetailsAssert {
 	t.Helper()
 	return &PostgresInstanceDetailsAssert{
-		assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectType("PostgresInstanceDetails"), id, postgresInstanceDetails),
+		assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectType("PostgresInstanceDetails"), postgresInstanceDetails.ID(), postgresInstanceDetails),
 	}
 }
 
@@ -219,7 +217,7 @@ func (p *PostgresInstanceDetailsAssert) HasMaintenanceWindowStart(expected int) 
 	p.AddAssertion(func(t *testing.T, o *sdk.PostgresInstanceDetails) error {
 		t.Helper()
 		if o.MaintenanceWindowStart == nil {
-			return fmt.Errorf("expected maintenance window start: %v; got: nil", expected)
+			return fmt.Errorf("expected maintenance window start to have value; got: nil")
 		}
 		if *o.MaintenanceWindowStart != expected {
 			return fmt.Errorf("expected maintenance window start: %v; got: %v", expected, *o.MaintenanceWindowStart)
@@ -243,14 +241,14 @@ func (p *PostgresInstanceDetailsAssert) HasComment(expected string) *PostgresIns
 	return p
 }
 
-func (p *PostgresInstanceDetailsAssert) HasNetworkPolicy(expected string) *PostgresInstanceDetailsAssert {
+func (p *PostgresInstanceDetailsAssert) HasNetworkPolicy(expected sdk.AccountObjectIdentifier) *PostgresInstanceDetailsAssert {
 	p.AddAssertion(func(t *testing.T, o *sdk.PostgresInstanceDetails) error {
 		t.Helper()
 		if o.NetworkPolicy == nil {
 			return fmt.Errorf("expected network policy to have value; got: nil")
 		}
-		if o.NetworkPolicy.Name() != expected {
-			return fmt.Errorf("expected network policy: %v; got: %v", expected, o.NetworkPolicy.Name())
+		if (*o.NetworkPolicy).Name() != expected.Name() {
+			return fmt.Errorf("expected network policy: %v; got: %v", expected.Name(), (*o.NetworkPolicy).Name())
 		}
 		return nil
 	})
@@ -271,14 +269,14 @@ func (p *PostgresInstanceDetailsAssert) HasPostgresSettings(expected string) *Po
 	return p
 }
 
-func (p *PostgresInstanceDetailsAssert) HasStorageIntegration(expected string) *PostgresInstanceDetailsAssert {
+func (p *PostgresInstanceDetailsAssert) HasStorageIntegration(expected sdk.AccountObjectIdentifier) *PostgresInstanceDetailsAssert {
 	p.AddAssertion(func(t *testing.T, o *sdk.PostgresInstanceDetails) error {
 		t.Helper()
 		if o.StorageIntegration == nil {
 			return fmt.Errorf("expected storage integration to have value; got: nil")
 		}
-		if o.StorageIntegration.Name() != expected {
-			return fmt.Errorf("expected storage integration: %v; got: %v", expected, o.StorageIntegration.Name())
+		if (*o.StorageIntegration).Name() != expected.Name() {
+			return fmt.Errorf("expected storage integration: %v; got: %v", expected.Name(), (*o.StorageIntegration).Name())
 		}
 		return nil
 	})

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/storage_lifecycle_policy_desc_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/storage_lifecycle_policy_desc_snowflake_gen.go
@@ -25,13 +25,40 @@ func StorageLifecyclePolicyDetails(t *testing.T, id sdk.SchemaObjectIdentifier) 
 	}
 }
 
-// Adjusted manually: removed StorageLifecyclePolicyDetailsFromObject — CortexAgentDetails has no Id field or ID() method.
+func StorageLifecyclePolicyDetailsFromObject(t *testing.T, storageLifecyclePolicyDetails *sdk.StorageLifecyclePolicyDetails) *StorageLifecyclePolicyDetailsAssert {
+	t.Helper()
+	return &StorageLifecyclePolicyDetailsAssert{
+		assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectType("StorageLifecyclePolicyDetails"), storageLifecyclePolicyDetails.ID(), storageLifecyclePolicyDetails),
+	}
+}
 
 func (s *StorageLifecyclePolicyDetailsAssert) HasName(expected string) *StorageLifecyclePolicyDetailsAssert {
 	s.AddAssertion(func(t *testing.T, o *sdk.StorageLifecyclePolicyDetails) error {
 		t.Helper()
 		if o.Name != expected {
 			return fmt.Errorf("expected name: %v; got: %v", expected, o.Name)
+		}
+		return nil
+	})
+	return s
+}
+
+func (s *StorageLifecyclePolicyDetailsAssert) HasDatabaseName(expected string) *StorageLifecyclePolicyDetailsAssert {
+	s.AddAssertion(func(t *testing.T, o *sdk.StorageLifecyclePolicyDetails) error {
+		t.Helper()
+		if o.DatabaseName != expected {
+			return fmt.Errorf("expected database name: %v; got: %v", expected, o.DatabaseName)
+		}
+		return nil
+	})
+	return s
+}
+
+func (s *StorageLifecyclePolicyDetailsAssert) HasSchemaName(expected string) *StorageLifecyclePolicyDetailsAssert {
+	s.AddAssertion(func(t *testing.T, o *sdk.StorageLifecyclePolicyDetails) error {
+		t.Helper()
+		if o.SchemaName != expected {
+			return fmt.Errorf("expected schema name: %v; got: %v", expected, o.SchemaName)
 		}
 		return nil
 	})

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/tag_reference_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/tag_reference_snowflake_gen.go
@@ -14,25 +14,10 @@ type TagReferenceAssert struct {
 	*assert.SnowflakeObjectAssert[sdk.TagReference, sdk.SchemaObjectIdentifier]
 }
 
-// Adjusted manually
-// func TagReference(t *testing.T, id sdk.SchemaObjectIdentifier) *TagReferenceAssert {
-// 	t.Helper()
-// 	return &TagReferenceAssert{
-// 		assert.NewSnowflakeObjectAssertWithTestClientObjectProvider(sdk.ObjectType("TagReference"), id, func(testClient *helpers.TestClient) assert.ObjectProvider[sdk.TagReference, sdk.SchemaObjectIdentifier] {
-// 			return testClient.TagReference.Show
-// 		}),
-// 	}
-// }
-
-// Adjusted manually
 func TagReferenceFromObject(t *testing.T, tagReference *sdk.TagReference) *TagReferenceAssert {
 	t.Helper()
 	return &TagReferenceAssert{
-		assert.NewSnowflakeObjectAssertWithObject(
-			sdk.ObjectType("TagReference"),
-			sdk.NewSchemaObjectIdentifier(tagReference.TagDatabase, tagReference.TagSchema, tagReference.TagName),
-			tagReference,
-		),
+		assert.NewSnowflakeObjectAssertWithObject(sdk.ObjectType("TagReference"), tagReference.ID(), tagReference),
 	}
 }
 

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/warehouse_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/warehouse_snowflake_gen.go
@@ -334,6 +334,61 @@ func (w *WarehouseAssert) HasResourceMonitor(expected sdk.AccountObjectIdentifie
 	return w
 }
 
+func (w *WarehouseAssert) HasActives(expected string) *WarehouseAssert {
+	w.AddAssertion(func(t *testing.T, o *sdk.Warehouse) error {
+		t.Helper()
+		if o.Actives != expected {
+			return fmt.Errorf("expected actives: %v; got: %v", expected, o.Actives)
+		}
+		return nil
+	})
+	return w
+}
+
+func (w *WarehouseAssert) HasPendings(expected string) *WarehouseAssert {
+	w.AddAssertion(func(t *testing.T, o *sdk.Warehouse) error {
+		t.Helper()
+		if o.Pendings != expected {
+			return fmt.Errorf("expected pendings: %v; got: %v", expected, o.Pendings)
+		}
+		return nil
+	})
+	return w
+}
+
+func (w *WarehouseAssert) HasFailed(expected string) *WarehouseAssert {
+	w.AddAssertion(func(t *testing.T, o *sdk.Warehouse) error {
+		t.Helper()
+		if o.Failed != expected {
+			return fmt.Errorf("expected failed: %v; got: %v", expected, o.Failed)
+		}
+		return nil
+	})
+	return w
+}
+
+func (w *WarehouseAssert) HasSuspended(expected string) *WarehouseAssert {
+	w.AddAssertion(func(t *testing.T, o *sdk.Warehouse) error {
+		t.Helper()
+		if o.Suspended != expected {
+			return fmt.Errorf("expected suspended: %v; got: %v", expected, o.Suspended)
+		}
+		return nil
+	})
+	return w
+}
+
+func (w *WarehouseAssert) HasUuid(expected string) *WarehouseAssert {
+	w.AddAssertion(func(t *testing.T, o *sdk.Warehouse) error {
+		t.Helper()
+		if o.Uuid != expected {
+			return fmt.Errorf("expected uuid: %v; got: %v", expected, o.Uuid)
+		}
+		return nil
+	})
+	return w
+}
+
 func (w *WarehouseAssert) HasScalingPolicy(expected sdk.ScalingPolicy) *WarehouseAssert {
 	w.AddAssertion(func(t *testing.T, o *sdk.Warehouse) error {
 		t.Helper()

--- a/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert/password_policy_desc_output_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert/password_policy_desc_output_gen.go
@@ -54,6 +54,16 @@ func (p *PasswordPolicyDescribeOutputAssert) HasName(expected string) *PasswordP
 	return p
 }
 
+func (p *PasswordPolicyDescribeOutputAssert) HasDatabaseName(expected string) *PasswordPolicyDescribeOutputAssert {
+	p.StringValueSet("database_name", expected)
+	return p
+}
+
+func (p *PasswordPolicyDescribeOutputAssert) HasSchemaName(expected string) *PasswordPolicyDescribeOutputAssert {
+	p.StringValueSet("schema_name", expected)
+	return p
+}
+
 func (p *PasswordPolicyDescribeOutputAssert) HasOwner(expected string) *PasswordPolicyDescribeOutputAssert {
 	p.StringValueSet("owner", expected)
 	return p
@@ -125,6 +135,16 @@ func (p *PasswordPolicyDescribeOutputAssert) HasPasswordHistory(expected int) *P
 
 func (p *PasswordPolicyDescribeOutputAssert) HasNoName() *PasswordPolicyDescribeOutputAssert {
 	p.ValueNotSet("name")
+	return p
+}
+
+func (p *PasswordPolicyDescribeOutputAssert) HasNoDatabaseName() *PasswordPolicyDescribeOutputAssert {
+	p.ValueNotSet("database_name")
+	return p
+}
+
+func (p *PasswordPolicyDescribeOutputAssert) HasNoSchemaName() *PasswordPolicyDescribeOutputAssert {
+	p.ValueNotSet("schema_name")
 	return p
 }
 

--- a/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert/storage_lifecycle_policy_desc_output_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceshowoutputassert/storage_lifecycle_policy_desc_output_gen.go
@@ -54,6 +54,16 @@ func (s *StorageLifecyclePolicyDescribeOutputAssert) HasName(expected string) *S
 	return s
 }
 
+func (s *StorageLifecyclePolicyDescribeOutputAssert) HasDatabaseName(expected string) *StorageLifecyclePolicyDescribeOutputAssert {
+	s.StringValueSet("database_name", expected)
+	return s
+}
+
+func (s *StorageLifecyclePolicyDescribeOutputAssert) HasSchemaName(expected string) *StorageLifecyclePolicyDescribeOutputAssert {
+	s.StringValueSet("schema_name", expected)
+	return s
+}
+
 func (s *StorageLifecyclePolicyDescribeOutputAssert) HasBody(expected string) *StorageLifecyclePolicyDescribeOutputAssert {
 	s.StringValueSet("body", expected)
 	return s
@@ -75,6 +85,16 @@ func (s *StorageLifecyclePolicyDescribeOutputAssert) HasArchiveTier(expected str
 
 func (s *StorageLifecyclePolicyDescribeOutputAssert) HasNoName() *StorageLifecyclePolicyDescribeOutputAssert {
 	s.ValueNotSet("name")
+	return s
+}
+
+func (s *StorageLifecyclePolicyDescribeOutputAssert) HasNoDatabaseName() *StorageLifecyclePolicyDescribeOutputAssert {
+	s.ValueNotSet("database_name")
+	return s
+}
+
+func (s *StorageLifecyclePolicyDescribeOutputAssert) HasNoSchemaName() *StorageLifecyclePolicyDescribeOutputAssert {
+	s.ValueNotSet("schema_name")
 	return s
 }
 

--- a/pkg/acceptance/helpers/storage_lifecycle_policy_client.go
+++ b/pkg/acceptance/helpers/storage_lifecycle_policy_client.go
@@ -95,5 +95,11 @@ func (c *StorageLifecyclePolicyClient) Describe(t *testing.T, id sdk.SchemaObjec
 	t.Helper()
 	ctx := context.Background()
 
-	return c.client().Describe(ctx, id)
+	details, err := c.client().Describe(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	details.DatabaseName = id.DatabaseName()
+	details.SchemaName = id.SchemaName()
+	return details, nil
 }

--- a/pkg/acceptance/helpers/storage_lifecycle_policy_client.go
+++ b/pkg/acceptance/helpers/storage_lifecycle_policy_client.go
@@ -95,11 +95,5 @@ func (c *StorageLifecyclePolicyClient) Describe(t *testing.T, id sdk.SchemaObjec
 	t.Helper()
 	ctx := context.Background()
 
-	details, err := c.client().Describe(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-	details.DatabaseName = id.DatabaseName()
-	details.SchemaName = id.SchemaName()
-	return details, nil
+	return c.client().DescribeDetails(ctx, id)
 }

--- a/pkg/datasources/storage_lifecycle_policies.go
+++ b/pkg/datasources/storage_lifecycle_policies.go
@@ -80,7 +80,7 @@ func ReadStorageLifecyclePolicies(ctx context.Context, d *schema.ResourceData, m
 		policy := storageLifecyclePolicies[i]
 		var describeOutput []map[string]any
 		if d.Get("with_describe").(bool) {
-			details, err := client.StorageLifecyclePolicies.Describe(ctx, policy.ID())
+			details, err := client.StorageLifecyclePolicies.DescribeDetails(ctx, policy.ID())
 			if err != nil {
 				return diag.FromErr(err)
 			}

--- a/pkg/internal/genhelpers/sdk_object_details.go
+++ b/pkg/internal/genhelpers/sdk_object_details.go
@@ -4,5 +4,6 @@ type SdkObjectDetails struct {
 	IdType             string
 	IsDataSourceOutput bool
 	IsSubStruct        bool
+	ObjectTypeName     string
 	StructDetails
 }

--- a/pkg/internal/genhelpers/sdk_object_details.go
+++ b/pkg/internal/genhelpers/sdk_object_details.go
@@ -5,5 +5,6 @@ type SdkObjectDetails struct {
 	IsDataSourceOutput bool
 	IsSubStruct        bool
 	ObjectTypeName     string
+	NoShowById         bool
 	StructDetails
 }

--- a/pkg/resources/password_policy.go
+++ b/pkg/resources/password_policy.go
@@ -200,7 +200,7 @@ func PasswordPolicy() *schema.Resource {
 
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.PasswordPolicy, customdiff.All(
 			ComputedIfAnyAttributeChanged(passwordPolicySchema, ShowOutputAttributeName, "name", "database", "schema", "comment"),
-			ComputedIfAnyAttributeChanged(passwordPolicySchema, DescribeOutputAttributeName, "name", "comment",
+			ComputedIfAnyAttributeChanged(passwordPolicySchema, DescribeOutputAttributeName, "name", "database", "schema", "comment",
 				"min_length", "max_length", "min_upper_case_chars", "min_lower_case_chars",
 				"min_numeric_chars", "min_special_chars", "min_age_days", "max_age_days",
 				"max_retries", "lockout_time_mins", "history"),

--- a/pkg/resources/storage_lifecycle_policy.go
+++ b/pkg/resources/storage_lifecycle_policy.go
@@ -139,7 +139,7 @@ func StorageLifecyclePolicy() *schema.Resource {
 		CustomizeDiff: TrackingCustomDiffWrapper(resources.StorageLifecyclePolicy, customdiff.All(
 			ForceNewIfChangedFromNonEmptyString("archive_tier"),
 			ComputedIfAnyAttributeChanged(storageLifecyclePolicySchema, ShowOutputAttributeName, "name", "schema", "database", "comment"),
-			ComputedIfAnyAttributeChanged(storageLifecyclePolicySchema, DescribeOutputAttributeName, "name", "argument", "body", "archive_tier", "archive_for_days"),
+			ComputedIfAnyAttributeChanged(storageLifecyclePolicySchema, DescribeOutputAttributeName, "name", "schema", "database", "argument", "body", "archive_tier", "archive_for_days"),
 			ComputedIfAnyAttributeChanged(storageLifecyclePolicySchema, FullyQualifiedNameAttributeName, "name", "schema", "database"),
 		)),
 		Timeouts: defaultTimeouts,
@@ -201,7 +201,7 @@ func ReadStorageLifecyclePolicy(ctx context.Context, d *schema.ResourceData, met
 		}
 		return diag.FromErr(err)
 	}
-	storageLifecyclePolicyDescription, err := client.StorageLifecyclePolicies.Describe(ctx, id)
+	storageLifecyclePolicyDescription, err := client.StorageLifecyclePolicies.DescribeDetails(ctx, id)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/schemas/password_policy_details_gen.go
+++ b/pkg/schemas/password_policy_details_gen.go
@@ -14,6 +14,14 @@ var DescribePasswordPolicyDetailsSchema = map[string]*schema.Schema{
 		Type:     schema.TypeString,
 		Computed: true,
 	},
+	"database_name": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"schema_name": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
 	"owner": {
 		Type:     schema.TypeString,
 		Computed: true,
@@ -73,6 +81,8 @@ var _ = DescribePasswordPolicyDetailsSchema
 func PasswordPolicyDetailsToSchema(passwordPolicyDetails *sdk.PasswordPolicyDetails) map[string]any {
 	passwordPolicyDetailsSchema := make(map[string]any)
 	passwordPolicyDetailsSchema["name"] = passwordPolicyDetails.Name
+	passwordPolicyDetailsSchema["database_name"] = passwordPolicyDetails.DatabaseName
+	passwordPolicyDetailsSchema["schema_name"] = passwordPolicyDetails.SchemaName
 	passwordPolicyDetailsSchema["owner"] = passwordPolicyDetails.Owner
 	passwordPolicyDetailsSchema["comment"] = passwordPolicyDetails.Comment
 	passwordPolicyDetailsSchema["password_min_length"] = passwordPolicyDetails.PasswordMinLength

--- a/pkg/schemas/storage_lifecycle_policy_details.go
+++ b/pkg/schemas/storage_lifecycle_policy_details.go
@@ -11,6 +11,14 @@ var DescribeStorageLifecyclePolicyDetailsSchema = map[string]*schema.Schema{
 		Type:     schema.TypeString,
 		Computed: true,
 	},
+	"database_name": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"schema_name": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
 	"signature": {
 		Type: schema.TypeList,
 		Elem: &schema.Resource{
@@ -54,11 +62,13 @@ func StorageLifecyclePolicyDetailsToSchema(details sdk.StorageLifecyclePolicyDet
 		}
 	}
 	result := map[string]any{
-		"name":         details.Name,
-		"signature":    signatureElem,
-		"return_type":  details.ReturnType.ToSql(),
-		"body":         details.Body,
-		"archive_tier": details.ArchiveTier,
+		"name":          details.Name,
+		"database_name": details.DatabaseName,
+		"schema_name":   details.SchemaName,
+		"signature":     signatureElem,
+		"return_type":   details.ReturnType.ToSql(),
+		"body":          details.Body,
+		"archive_tier":  details.ArchiveTier,
 	}
 	if details.ArchiveForDays != nil {
 		result["archive_for_days"] = *details.ArchiveForDays

--- a/pkg/sdk/cortex_agents_ext.go
+++ b/pkg/sdk/cortex_agents_ext.go
@@ -11,6 +11,10 @@ func (r *CreateCortexAgentRequest) GetName() SchemaObjectIdentifier {
 	return r.name
 }
 
+func (d *CortexAgentDetails) ID() SchemaObjectIdentifier {
+	return NewSchemaObjectIdentifier(d.DatabaseName, d.SchemaName, d.Name)
+}
+
 type CortexAgentProfile struct {
 	DisplayName *string `json:"display_name,omitempty"`
 	Avatar      *string `json:"avatar,omitempty"`

--- a/pkg/sdk/generator/README.md
+++ b/pkg/sdk/generator/README.md
@@ -127,7 +127,8 @@ make generate-sdk-examples SF_TF_GENERATOR_ARGS='--help'
 
 ##### Remaining TODOs
 
-- Generate `ID()` methods for `Request` structs as already done for the `Opts` structs.
+- Generate `ID()` methods for `Request` structs as already done for `Show` result structs.
+- Generate `ID()` methods for `Describe`/`DescribeDetails` structs as already done for `Show` result structs.
 - PoC of unit tests generation without manual changes in the generated files (details soon)
   - generate each branch of alter in tests (instead of basic and all options)
 - Improve validation handling for nested slices (the path is built incorrectly now)

--- a/pkg/sdk/generator/defs/password_policies_def.go
+++ b/pkg/sdk/generator/defs/password_policies_def.go
@@ -129,6 +129,8 @@ var passwordPoliciesDef = g.NewInterface(
 			WithValidation(g.ValidIdentifier, "name"),
 		g.PlainStruct("PasswordPolicyDetails").
 			Text("Name").
+			Text("DatabaseName").
+			Text("SchemaName").
 			Text("Owner").
 			Text("Comment").
 			Number("PasswordMinLength").

--- a/pkg/sdk/generator/defs/storage_lifecycle_policies_def.go
+++ b/pkg/sdk/generator/defs/storage_lifecycle_policies_def.go
@@ -119,4 +119,5 @@ var storageLifecyclePoliciesDef = g.NewInterface(
 			Name().
 			WithValidation(g.ValidIdentifier, "name"),
 	).
+	WithCustomInterfaceMethod("DescribeDetails", "", []*g.MethodParameter{g.NewMethodParameter("id", g.KindOfT[sdkcommons.SchemaObjectIdentifier]())}, "*StorageLifecyclePolicyDetails", "error").
 	WithEnums(StorageLifecyclePolicyArchiveTierEnumDef)

--- a/pkg/sdk/generator/defs/storage_lifecycle_policies_def.go
+++ b/pkg/sdk/generator/defs/storage_lifecycle_policies_def.go
@@ -106,6 +106,8 @@ var storageLifecyclePoliciesDef = g.NewInterface(
 		"https://docs.snowflake.com/en/sql-reference/sql/desc-storage-lifecycle-policy",
 		g.StructPair("describeStorageLifecyclePolicyDBRow", "StorageLifecyclePolicyDetails").
 			Text("name").
+			PlainOnlyField("DatabaseName", "string").
+			PlainOnlyField("SchemaName", "string").
 			Field("signature", "string", "[]TableColumnSignature", g.WithCustomParser("ParseTableColumnSignatureWithVectorSupport")).
 			DataType("return_type").
 			Text("body").

--- a/pkg/sdk/password_policies_ext.go
+++ b/pkg/sdk/password_policies_ext.go
@@ -27,12 +27,22 @@ func (r passwordPolicyDBRow) additionalConvert(result *PasswordPolicy) error {
 	return nil
 }
 
+func (d *PasswordPolicyDetails) ID() SchemaObjectIdentifier {
+	return NewSchemaObjectIdentifier(d.DatabaseName, d.SchemaName, d.Name)
+}
+
 func (v *passwordPolicies) DescribeDetails(ctx context.Context, id SchemaObjectIdentifier) (*PasswordPolicyDetails, error) {
 	properties, err := v.Describe(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return parsePasswordPolicyProperties(properties)
+	details, err := parsePasswordPolicyProperties(properties)
+	if err != nil {
+		return nil, err
+	}
+	details.DatabaseName = id.DatabaseName()
+	details.SchemaName = id.SchemaName()
+	return details, nil
 }
 
 func parsePasswordPolicyProperties(properties []PasswordPolicyProperty) (*PasswordPolicyDetails, error) {

--- a/pkg/sdk/password_policies_gen.go
+++ b/pkg/sdk/password_policies_gen.go
@@ -156,6 +156,8 @@ type PasswordPolicyProperty struct {
 
 type PasswordPolicyDetails struct {
 	Name                      string
+	DatabaseName              string
+	SchemaName                string
 	Owner                     string
 	Comment                   string
 	PasswordMinLength         int

--- a/pkg/sdk/policy_references.go
+++ b/pkg/sdk/policy_references.go
@@ -106,6 +106,10 @@ type PolicyReference struct {
 	PolicyStatus      *string
 }
 
+func (p PolicyReference) ID() SchemaObjectIdentifier {
+	return NewSchemaObjectIdentifier(*p.PolicyDb, *p.PolicySchema, p.PolicyName)
+}
+
 type policyReferenceDBRow struct {
 	PolicyDb          sql.NullString `db:"POLICY_DB"`
 	PolicySchema      sql.NullString `db:"POLICY_SCHEMA"`

--- a/pkg/sdk/postgres_instances_ext.go
+++ b/pkg/sdk/postgres_instances_ext.go
@@ -128,6 +128,10 @@ func ParsePostgresInstanceDetails(properties []PostgresInstanceProperty) (*Postg
 	return details, errors.Join(errs...)
 }
 
+func (d *PostgresInstanceDetails) ID() AccountObjectIdentifier {
+	return NewAccountObjectIdentifier(d.Name)
+}
+
 func (v *postgresInstances) DescribeDetails(ctx context.Context, id AccountObjectIdentifier) (*PostgresInstanceDetails, error) {
 	properties, err := v.Describe(ctx, id)
 	if err != nil {

--- a/pkg/sdk/storage_lifecycle_policies_ext.go
+++ b/pkg/sdk/storage_lifecycle_policies_ext.go
@@ -1,15 +1,28 @@
 package sdk
 
-import "strings"
+import (
+	"context"
+	"strings"
+)
 
 func (r describeStorageLifecyclePolicyDBRow) additionalConvert(_ *StorageLifecyclePolicyDetails) error {
 	// additionalConvert is generated as DatabaseName and SchemaName are plain only fields.
-	// They can't be set here as they are not returned by DESCRIBE; they are populated from the ID in the test helper.
+	// They can't be set here as they are not returned by DESCRIBE; they are populated from the ID in DescribeDetails.
 	return nil
 }
 
 func (d *StorageLifecyclePolicyDetails) ID() SchemaObjectIdentifier {
 	return NewSchemaObjectIdentifier(d.DatabaseName, d.SchemaName, d.Name)
+}
+
+func (v *storageLifecyclePolicies) DescribeDetails(ctx context.Context, id SchemaObjectIdentifier) (*StorageLifecyclePolicyDetails, error) {
+	details, err := v.Describe(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	details.DatabaseName = id.DatabaseName()
+	details.SchemaName = id.SchemaName()
+	return details, nil
 }
 
 var StorageLifecyclePolicySupportedTableTypes = []PolicyEntityDomain{

--- a/pkg/sdk/storage_lifecycle_policies_ext.go
+++ b/pkg/sdk/storage_lifecycle_policies_ext.go
@@ -2,6 +2,12 @@ package sdk
 
 import "strings"
 
+func (r describeStorageLifecyclePolicyDBRow) additionalConvert(_ *StorageLifecyclePolicyDetails) error {
+	// additionalConvert is generated as DatabaseName and SchemaName are plain only fields.
+	// They can't be set here as they are not returned by DESCRIBE; they are populated from the ID in the test helper.
+	return nil
+}
+
 func (d *StorageLifecyclePolicyDetails) ID() SchemaObjectIdentifier {
 	return NewSchemaObjectIdentifier(d.DatabaseName, d.SchemaName, d.Name)
 }

--- a/pkg/sdk/storage_lifecycle_policies_ext.go
+++ b/pkg/sdk/storage_lifecycle_policies_ext.go
@@ -2,6 +2,10 @@ package sdk
 
 import "strings"
 
+func (d *StorageLifecyclePolicyDetails) ID() SchemaObjectIdentifier {
+	return NewSchemaObjectIdentifier(d.DatabaseName, d.SchemaName, d.Name)
+}
+
 var StorageLifecyclePolicySupportedTableTypes = []PolicyEntityDomain{
 	PolicyEntityDomainTable,
 	PolicyEntityDomainDynamicTable,

--- a/pkg/sdk/storage_lifecycle_policies_gen.go
+++ b/pkg/sdk/storage_lifecycle_policies_gen.go
@@ -132,6 +132,8 @@ type describeStorageLifecyclePolicyDBRow struct {
 
 type StorageLifecyclePolicyDetails struct {
 	Name           string
+	DatabaseName   string
+	SchemaName     string
 	Signature      []TableColumnSignature
 	ReturnType     datatypes.DataType
 	Body           string

--- a/pkg/sdk/storage_lifecycle_policies_gen.go
+++ b/pkg/sdk/storage_lifecycle_policies_gen.go
@@ -19,6 +19,7 @@ type StorageLifecyclePolicies interface {
 	ShowByID(ctx context.Context, id SchemaObjectIdentifier) (*StorageLifecyclePolicy, error)
 	ShowByIDSafely(ctx context.Context, id SchemaObjectIdentifier) (*StorageLifecyclePolicy, error)
 	Describe(ctx context.Context, id SchemaObjectIdentifier) (*StorageLifecyclePolicyDetails, error)
+	DescribeDetails(ctx context.Context, id SchemaObjectIdentifier) (*StorageLifecyclePolicyDetails, error)
 }
 
 // CreateStorageLifecyclePolicyOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-storage-lifecycle-policy.

--- a/pkg/sdk/storage_lifecycle_policies_impl_gen.go
+++ b/pkg/sdk/storage_lifecycle_policies_impl_gen.go
@@ -177,5 +177,8 @@ func (r describeStorageLifecyclePolicyDBRow) convert() (*StorageLifecyclePolicyD
 		result.ReturnType = v
 	}
 	mapNullInt(&result.ArchiveForDays, r.ArchiveForDays)
+	if err := r.additionalConvert(result); err != nil {
+		return nil, err
+	}
 	return result, nil
 }

--- a/pkg/sdk/tag_references_ext.go
+++ b/pkg/sdk/tag_references_ext.go
@@ -3,3 +3,7 @@ package sdk
 func (t TagReference) TagId() SchemaObjectIdentifier {
 	return NewSchemaObjectIdentifier(t.TagDatabase, t.TagSchema, t.TagName)
 }
+
+func (t TagReference) ID() SchemaObjectIdentifier {
+	return NewSchemaObjectIdentifier(t.TagDatabase, t.TagSchema, t.TagName)
+}

--- a/pkg/testacc/data_source_password_policies_acceptance_test.go
+++ b/pkg/testacc/data_source_password_policies_acceptance_test.go
@@ -71,6 +71,9 @@ func TestAcc_PasswordPolicies_BasicUseCase(t *testing.T) {
 						HasOwnerRoleType("ROLE").
 						HasOptions(""),
 					resourceshowoutputassert.PasswordPoliciesDatasourceDescribeOutput(t, passwordPoliciesModel.DatasourceReference()).
+						HasName(id.Name()).
+						HasDatabaseName(id.DatabaseName()).
+						HasSchemaName(id.SchemaName()).
 						HasOwner(snowflakeroles.Accountadmin.Name()).
 						HasComment(comment).
 						HasPasswordMinLength(10).

--- a/pkg/testacc/data_source_storage_lifecycle_policies_acceptance_test.go
+++ b/pkg/testacc/data_source_storage_lifecycle_policies_acceptance_test.go
@@ -80,6 +80,8 @@ func TestAcc_StorageLifecyclePolicies_BasicUseCase(t *testing.T) {
 					showOutputAssertions,
 					resourceshowoutputassert.StorageLifecyclePoliciesDatasourceDescribeOutput(t, storageLifecyclePoliciesModel.DatasourceReference()).
 						HasName(id.Name()).
+						HasDatabaseName(id.DatabaseName()).
+						HasSchemaName(id.SchemaName()).
 						HasSignature(expectedSignature...).
 						HasReturnType(testdatatypes.DataTypeBoolean).
 						HasBody(body).

--- a/pkg/testacc/resource_password_policy_acceptance_test.go
+++ b/pkg/testacc/resource_password_policy_acceptance_test.go
@@ -82,6 +82,8 @@ func TestAcc_PasswordPolicy_BasicUseCase(t *testing.T) {
 			HasOptions(""),
 		resourceshowoutputassert.PasswordPolicyDescribeOutput(t, ref).
 			HasName(id.Name()).
+			HasDatabaseName(id.DatabaseName()).
+			HasSchemaName(id.SchemaName()).
 			HasOwner(snowflakeroles.Accountadmin.Name()).
 			HasComment("").
 			HasPasswordMinLength(14).
@@ -146,6 +148,8 @@ func TestAcc_PasswordPolicy_BasicUseCase(t *testing.T) {
 			HasOptions(""),
 		resourceshowoutputassert.PasswordPolicyDescribeOutput(t, ref).
 			HasName(newId.Name()).
+			HasDatabaseName(newId.DatabaseName()).
+			HasSchemaName(newId.SchemaName()).
 			HasOwner(snowflakeroles.Accountadmin.Name()).
 			HasComment(comment).
 			HasPasswordMinLength(10).
@@ -190,6 +194,8 @@ func TestAcc_PasswordPolicy_BasicUseCase(t *testing.T) {
 			HasOptions(""),
 		resourceshowoutputassert.PasswordPolicyDescribeOutput(t, ref).
 			HasName(id.Name()).
+			HasDatabaseName(id.DatabaseName()).
+			HasSchemaName(id.SchemaName()).
 			HasOwner(snowflakeroles.Accountadmin.Name()).
 			HasComment(comment).
 			HasPasswordMinLength(10).
@@ -373,6 +379,8 @@ func TestAcc_PasswordPolicy_CompleteUseCase(t *testing.T) {
 			HasOptions(""),
 		resourceshowoutputassert.PasswordPolicyDescribeOutput(t, ref).
 			HasName(id.Name()).
+			HasDatabaseName(id.DatabaseName()).
+			HasSchemaName(id.SchemaName()).
 			HasOwner(snowflakeroles.Accountadmin.Name()).
 			HasComment(comment).
 			HasPasswordMinLength(10).
@@ -459,7 +467,9 @@ func TestAcc_PasswordPolicy_migrateFromVersion_0_94_1(t *testing.T) {
 					resourceshowoutputassert.PasswordPolicyShowOutput(t, ref).
 						HasName(id.Name()),
 					resourceshowoutputassert.PasswordPolicyDescribeOutput(t, ref).
-						HasName(id.Name()),
+						HasName(id.Name()).
+						HasDatabaseName(id.DatabaseName()).
+						HasSchemaName(id.SchemaName()),
 				),
 			},
 		},
@@ -502,7 +512,9 @@ func TestAcc_PasswordPolicy_migrateFromVersion_2_15_0(t *testing.T) {
 						HasDatabaseName(id.DatabaseName()).
 						HasSchemaName(id.SchemaName()),
 					resourceshowoutputassert.PasswordPolicyDescribeOutput(t, ref).
-						HasName(id.Name()),
+						HasName(id.Name()).
+						HasDatabaseName(id.DatabaseName()).
+						HasSchemaName(id.SchemaName()),
 				),
 			},
 		},

--- a/pkg/testacc/resource_storage_lifecycle_policy_acceptance_test.go
+++ b/pkg/testacc/resource_storage_lifecycle_policy_acceptance_test.go
@@ -115,6 +115,8 @@ func TestAcc_StorageLifecyclePolicy_BasicUseCase(t *testing.T) {
 			HasOptions(`{"ARCHIVE_FOR_DAYS":null,"ARCHIVE_TIER":"NULL"}`),
 		resourceshowoutputassert.StorageLifecyclePolicyDescribeOutput(t, ref).
 			HasName(id.Name()).
+			HasDatabaseName(id.DatabaseName()).
+			HasSchemaName(id.SchemaName()).
 			HasSignature(expectedSignature...).
 			HasReturnType(testdatatypes.DataTypeBoolean).
 			HasBody(body).
@@ -144,6 +146,8 @@ func TestAcc_StorageLifecyclePolicy_BasicUseCase(t *testing.T) {
 			HasOptions(`{"ARCHIVE_FOR_DAYS":365,"ARCHIVE_TIER":"COLD"}`),
 		resourceshowoutputassert.StorageLifecyclePolicyDescribeOutput(t, ref).
 			HasName(newId.Name()).
+			HasDatabaseName(newId.DatabaseName()).
+			HasSchemaName(newId.SchemaName()).
 			HasSignature(expectedSignature...).
 			HasReturnType(testdatatypes.DataTypeBoolean).
 			HasBody(newBody).
@@ -173,6 +177,8 @@ func TestAcc_StorageLifecyclePolicy_BasicUseCase(t *testing.T) {
 			HasOptions(`{"ARCHIVE_FOR_DAYS":null,"ARCHIVE_TIER":"COLD"}`),
 		resourceshowoutputassert.StorageLifecyclePolicyDescribeOutput(t, ref).
 			HasName(id.Name()).
+			HasDatabaseName(id.DatabaseName()).
+			HasSchemaName(id.SchemaName()).
 			HasSignature(expectedSignature...).
 			HasReturnType(testdatatypes.DataTypeBoolean).
 			HasBody(body).
@@ -202,6 +208,8 @@ func TestAcc_StorageLifecyclePolicy_BasicUseCase(t *testing.T) {
 			HasOptions(`{"ARCHIVE_FOR_DAYS":null,"ARCHIVE_TIER":"NULL"}`),
 		resourceshowoutputassert.StorageLifecyclePolicyDescribeOutput(t, ref).
 			HasName(id.Name()).
+			HasDatabaseName(id.DatabaseName()).
+			HasSchemaName(id.SchemaName()).
 			HasSignature(expectedNewSignature...).
 			HasReturnType(testdatatypes.DataTypeBoolean).
 			HasBody(body).


### PR DESCRIPTION
- **Step 2 — `ObjectTypeName` field for object type constant override**

  Added `ObjectTypeName string` to `SdkObjectDef`, `SdkObjectDetails`, and `SnowflakeObjectAssertionsModel`. The model initializes it from the struct name and overwrites with the explicit value if set. The definition template now uses `sdk.ObjectType{{ .ObjectTypeName }}` (constant) for normal objects and `sdk.ObjectType("{{ .ObjectTypeName }}")` (string literal) for `IsDataSourceOutput` and `NoShowById` objects, which have no SDK object type constants.

  Applied first override: `CortexAgent` → `ObjectTypeName: "Agent"` (previously patched manually as `// object type adjusted manually`).

- **Step 3 — Add `ID()` methods to SDK structs; introduce `NoShowById` flag**

  Added `ID()` methods to six SDK structs so the generator can produce clean `FromObject` constructors without manual patches:

  - `CortexAgentDetails` — `NewSchemaObjectIdentifier(DatabaseName, SchemaName, Name)` (`cortex_agents_ext.go`)
  - `PostgresInstanceDetails` — `NewAccountObjectIdentifier(Name)` (`postgres_instances_ext.go`)
  - `PasswordPolicyDetails` — added `DatabaseName`/`SchemaName` fields via the SDK generator def (`PlainStruct`); populated from the `id` parameter in `DescribeDetails`; added `ID()` (`password_policies_ext.go`)
  - `StorageLifecyclePolicyDetails` — added `DatabaseName`/`SchemaName` via `PlainOnlyField` in the SDK generator def (`StructPair`); populated from `id` in the test helper `Describe`; added `ID()` (`storage_lifecycle_policies_ext.go`)
  - `TagReference` — `NewSchemaObjectIdentifier(TagDatabase, TagSchema, TagName)` (`tag_references_ext.go`)
  - `PolicyReference` — `NewSchemaObjectIdentifier(*PolicyDb, *PolicySchema, PolicyName)` (`policy_references.go`)

  `TagReference` and `PolicyReference` are information schema table function results with no Show-by-ID SDK method. Added `NoShowById bool` to `SdkObjectDef` / `SdkObjectDetails` / model / template to suppress the Show-by-ID constructor for these objects while still generating a correct `FromObject` that calls `.ID()`. The previous workaround (constructor commented out with `// Adjusted manually`) is gone.
