### PR TITLE
chore: Standardize the rename field name and extract a `RenameTo()` generator helper

### DIFF
--- a/pkg/resources/database.go
+++ b/pkg/resources/database.go
@@ -246,7 +246,7 @@ func UpdateDatabase(ctx context.Context, d *schema.ResourceData, meta any) diag.
 			return diag.FromErr(err)
 		}
 
-		err = client.Databases.Alter(ctx, sdk.NewAlterDatabaseRequest(id).WithNewName(newId))
+		err = client.Databases.Alter(ctx, sdk.NewAlterDatabaseRequest(id).WithRenameTo(newId))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/database_role.go
+++ b/pkg/resources/database_role.go
@@ -160,7 +160,7 @@ func UpdateDatabaseRole(ctx context.Context, d *schema.ResourceData, meta any) d
 	if d.HasChange("name") {
 		newId := sdk.NewDatabaseObjectIdentifier(id.DatabaseName(), d.Get("name").(string))
 
-		err = client.DatabaseRoles.Alter(ctx, sdk.NewAlterDatabaseRoleRequest(id).WithRename(newId))
+		err = client.DatabaseRoles.Alter(ctx, sdk.NewAlterDatabaseRoleRequest(id).WithRenameTo(newId))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/hybrid_table.go
+++ b/pkg/resources/hybrid_table.go
@@ -877,7 +877,7 @@ func UpdateHybridTable(ctx context.Context, d *schema.ResourceData, meta any) di
 			d.Get("name").(string),
 		)
 
-		if err := client.HybridTables.Alter(ctx, sdk.NewAlterHybridTableRequest(id).WithNewName(newId)); err != nil {
+		if err := client.HybridTables.Alter(ctx, sdk.NewAlterHybridTableRequest(id).WithRenameTo(newId)); err != nil {
 			d.Partial(true)
 			return diag.FromErr(fmt.Errorf("error renaming hybrid table from %v to %v: %w", id.FullyQualifiedName(), newId.FullyQualifiedName(), err))
 		}

--- a/pkg/resources/masking_policy.go
+++ b/pkg/resources/masking_policy.go
@@ -336,7 +336,7 @@ func UpdateMaskingPolicy(ctx context.Context, d *schema.ResourceData, meta any) 
 	if d.HasChange("name") {
 		newID := sdk.NewSchemaObjectIdentifierInSchema(id.SchemaId(), d.Get("name").(string))
 
-		err := client.MaskingPolicies.Alter(ctx, sdk.NewAlterMaskingPolicyRequest(id).WithNewName(newID))
+		err := client.MaskingPolicies.Alter(ctx, sdk.NewAlterMaskingPolicyRequest(id).WithRenameTo(newID))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/password_policy.go
+++ b/pkg/resources/password_policy.go
@@ -311,7 +311,7 @@ func UpdatePasswordPolicy(ctx context.Context, d *schema.ResourceData, meta any)
 
 	if d.HasChange("database") || d.HasChange("schema") || d.HasChange("name") {
 		newId := sdk.NewSchemaObjectIdentifier(d.Get("database").(string), d.Get("schema").(string), d.Get("name").(string))
-		if err := client.PasswordPolicies.Alter(ctx, sdk.NewAlterPasswordPolicyRequest(id).WithNewName(newId)); err != nil {
+		if err := client.PasswordPolicies.Alter(ctx, sdk.NewAlterPasswordPolicyRequest(id).WithRenameTo(newId)); err != nil {
 			return diag.FromErr(fmt.Errorf("error renaming password policy from %v to %v, err = %w", id.FullyQualifiedName(), newId.FullyQualifiedName(), err))
 		}
 		d.SetId(helpers.EncodeResourceIdentifier(newId))

--- a/pkg/resources/schema.go
+++ b/pkg/resources/schema.go
@@ -321,7 +321,7 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 	if experimentalfeatures.IsExperimentEnabled(experimentalfeatures.HierarchyRenames, providerCtx.EnabledExperiments) && d.HasChange("database") {
 		schemaRenameFn := func(currentId, targetId sdk.DatabaseObjectIdentifier) func() error {
 			return func() error {
-				return client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(currentId).WithNewName(targetId))
+				return client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(currentId).WithRenameTo(targetId))
 			}
 		}
 
@@ -338,7 +338,7 @@ func UpdateContextSchema(ctx context.Context, d *schema.ResourceData, meta any) 
 
 	if d.HasChange("name") && !d.GetRawState().IsNull() {
 		newId := sdk.NewDatabaseObjectIdentifier(d.Get("database").(string), d.Get("name").(string))
-		err := client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(id).WithNewName(newId))
+		err := client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(id).WithRenameTo(newId))
 		if err != nil {
 			d.Partial(true)
 			return diag.FromErr(err)

--- a/pkg/resources/secondary_database.go
+++ b/pkg/resources/secondary_database.go
@@ -121,7 +121,7 @@ func UpdateSecondaryDatabase(ctx context.Context, d *schema.ResourceData, meta a
 			return diag.FromErr(err)
 		}
 
-		err = client.Databases.Alter(ctx, sdk.NewAlterDatabaseRequest(secondaryDatabaseId).WithNewName(newId))
+		err = client.Databases.Alter(ctx, sdk.NewAlterDatabaseRequest(secondaryDatabaseId).WithRenameTo(newId))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/shared_database.go
+++ b/pkg/resources/shared_database.go
@@ -121,7 +121,7 @@ func UpdateSharedDatabase(ctx context.Context, d *schema.ResourceData, meta any)
 			return diag.FromErr(err)
 		}
 
-		err = client.Databases.Alter(ctx, sdk.NewAlterDatabaseRequest(id).WithNewName(newId))
+		err = client.Databases.Alter(ctx, sdk.NewAlterDatabaseRequest(id).WithRenameTo(newId))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/resources/tag.go
+++ b/pkg/resources/tag.go
@@ -388,7 +388,7 @@ func UpdateContextTag(ctx context.Context, d *schema.ResourceData, meta any) dia
 	if d.HasChange("name") {
 		newId := sdk.NewSchemaObjectIdentifierInSchema(id.SchemaId(), d.Get("name").(string))
 
-		err := client.Tags.Alter(ctx, sdk.NewAlterTagRequest(id).WithRename(*sdk.NewTagRenameRequest(newId)))
+		err := client.Tags.Alter(ctx, sdk.NewAlterTagRequest(id).WithRenameTo(newId))
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error renaming tag %v err = %w", d.Id(), err))
 		}

--- a/pkg/resources/user.go
+++ b/pkg/resources/user.go
@@ -595,7 +595,7 @@ func GetUpdateUserFunc(userType sdk.UserType) func(ctx context.Context, d *schem
 		if d.HasChange("name") {
 			newID := sdk.NewAccountObjectIdentifier(d.Get("name").(string))
 
-			err := client.Users.Alter(ctx, sdk.NewAlterUserRequest(id).WithNewName(newID))
+			err := client.Users.Alter(ctx, sdk.NewAlterUserRequest(id).WithRenameTo(newID))
 			if err != nil {
 				return diag.FromErr(err)
 			}

--- a/pkg/sdk/database_roles_dto_builders_gen.go
+++ b/pkg/sdk/database_roles_dto_builders_gen.go
@@ -38,8 +38,8 @@ func (s *AlterDatabaseRoleRequest) WithIfExists(ifExists bool) *AlterDatabaseRol
 	return s
 }
 
-func (s *AlterDatabaseRoleRequest) WithRename(rename DatabaseObjectIdentifier) *AlterDatabaseRoleRequest {
-	s.Rename = &rename
+func (s *AlterDatabaseRoleRequest) WithRenameTo(renameTo DatabaseObjectIdentifier) *AlterDatabaseRoleRequest {
+	s.RenameTo = &renameTo
 	return s
 }
 

--- a/pkg/sdk/database_roles_dto_gen.go
+++ b/pkg/sdk/database_roles_dto_gen.go
@@ -23,7 +23,7 @@ type CreateDatabaseRoleRequest struct {
 type AlterDatabaseRoleRequest struct {
 	IfExists  *bool
 	name      DatabaseObjectIdentifier // required
-	Rename    *DatabaseObjectIdentifier
+	RenameTo  *DatabaseObjectIdentifier
 	Set       *DatabaseRoleSetRequest
 	Unset     *DatabaseRoleUnsetRequest
 	SetTags   []TagAssociation

--- a/pkg/sdk/database_roles_ext.go
+++ b/pkg/sdk/database_roles_ext.go
@@ -55,8 +55,8 @@ func (s *RevokeDatabaseRoleRequest) WithDatabaseRole(databaseRole DatabaseObject
 }
 
 func (opts *AlterDatabaseRoleOptions) additionalValidations() error {
-	if opts.Rename != nil {
-		if opts.name.DatabaseName() != opts.Rename.DatabaseName() {
+	if opts.RenameTo != nil {
+		if opts.name.DatabaseName() != opts.RenameTo.DatabaseName() {
 			return errors.Join(ErrDifferentDatabase)
 		}
 	}

--- a/pkg/sdk/database_roles_gen.go
+++ b/pkg/sdk/database_roles_gen.go
@@ -39,7 +39,7 @@ type AlterDatabaseRoleOptions struct {
 	databaseRole bool                      `ddl:"static" sql:"DATABASE ROLE"`
 	IfExists     *bool                     `ddl:"keyword" sql:"IF EXISTS"`
 	name         DatabaseObjectIdentifier  `ddl:"identifier"`
-	Rename       *DatabaseObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
+	RenameTo     *DatabaseObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
 	Set          *DatabaseRoleSet          `ddl:"list,no_parentheses" sql:"SET"`
 	Unset        *DatabaseRoleUnset        `ddl:"list,no_parentheses" sql:"UNSET"`
 	SetTags      []TagAssociation          `ddl:"keyword" sql:"SET TAG"`

--- a/pkg/sdk/database_roles_impl_gen.go
+++ b/pkg/sdk/database_roles_impl_gen.go
@@ -77,7 +77,7 @@ func (r *AlterDatabaseRoleRequest) toOpts() *AlterDatabaseRoleOptions {
 	opts := &AlterDatabaseRoleOptions{
 		IfExists:  r.IfExists,
 		name:      r.name,
-		Rename:    r.Rename,
+		RenameTo:  r.RenameTo,
 		SetTags:   r.SetTags,
 		UnsetTags: r.UnsetTags,
 	}

--- a/pkg/sdk/database_roles_test.go
+++ b/pkg/sdk/database_roles_test.go
@@ -74,7 +74,7 @@ func TestDatabaseRoleAlter(t *testing.T) {
 
 	t.Run("validation: no alter action", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterDatabaseRoleOptions", "Rename", "Set", "Unset", "SetTags", "UnsetTags"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterDatabaseRoleOptions", "RenameTo", "Set", "Unset", "SetTags", "UnsetTags"))
 	})
 
 	t.Run("validation: multiple alter actions", func(t *testing.T) {
@@ -87,12 +87,12 @@ func TestDatabaseRoleAlter(t *testing.T) {
 		}
 		opts.SetTags = []TagAssociation{}
 		opts.UnsetTags = []ObjectIdentifier{}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterDatabaseRoleOptions", "Rename", "Set", "Unset", "SetTags", "UnsetTags"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterDatabaseRoleOptions", "RenameTo", "Set", "Unset", "SetTags", "UnsetTags"))
 	})
 
 	t.Run("validation: invalid new name", func(t *testing.T) {
 		opts := defaultOpts()
-		opts.Rename = &emptyDatabaseObjectIdentifier
+		opts.RenameTo = &emptyDatabaseObjectIdentifier
 		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
@@ -100,7 +100,7 @@ func TestDatabaseRoleAlter(t *testing.T) {
 		newId := randomDatabaseObjectIdentifier()
 
 		opts := defaultOpts()
-		opts.Rename = &newId
+		opts.RenameTo = &newId
 		assertOptsInvalidJoinedErrors(t, opts, ErrDifferentDatabase)
 	})
 
@@ -114,7 +114,7 @@ func TestDatabaseRoleAlter(t *testing.T) {
 		newId := randomDatabaseObjectIdentifierInDatabase(id.DatabaseId())
 
 		opts := defaultOpts()
-		opts.Rename = &newId
+		opts.RenameTo = &newId
 		assertOptsValidAndSQLEquals(t, opts, `ALTER DATABASE ROLE %s RENAME TO %s`, id.FullyQualifiedName(), newId.FullyQualifiedName())
 	})
 

--- a/pkg/sdk/database_roles_validations_gen.go
+++ b/pkg/sdk/database_roles_validations_gen.go
@@ -35,10 +35,10 @@ func (opts *AlterDatabaseRoleOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.Rename, opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags) {
-		errs = append(errs, errExactlyOneOf("AlterDatabaseRoleOptions", "Rename", "Set", "Unset", "SetTags", "UnsetTags"))
+	if !exactlyOneValueSet(opts.RenameTo, opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags) {
+		errs = append(errs, errExactlyOneOf("AlterDatabaseRoleOptions", "RenameTo", "Set", "Unset", "SetTags", "UnsetTags"))
 	}
-	if opts.Rename != nil && !ValidObjectIdentifier(opts.Rename) {
+	if opts.RenameTo != nil && !ValidObjectIdentifier(opts.RenameTo) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	errs = append(errs, opts.additionalValidations())

--- a/pkg/sdk/databases_dto_builders_gen.go
+++ b/pkg/sdk/databases_dto_builders_gen.go
@@ -396,8 +396,8 @@ func (s *AlterDatabaseRequest) WithIfExists(ifExists bool) *AlterDatabaseRequest
 	return s
 }
 
-func (s *AlterDatabaseRequest) WithNewName(newName AccountObjectIdentifier) *AlterDatabaseRequest {
-	s.NewName = &newName
+func (s *AlterDatabaseRequest) WithRenameTo(renameTo AccountObjectIdentifier) *AlterDatabaseRequest {
+	s.RenameTo = &renameTo
 	return s
 }
 

--- a/pkg/sdk/databases_dto_gen.go
+++ b/pkg/sdk/databases_dto_gen.go
@@ -109,7 +109,7 @@ type CreateFromListingDatabaseRequest struct {
 type AlterDatabaseRequest struct {
 	IfExists  *bool
 	name      AccountObjectIdentifier // required
-	NewName   *AccountObjectIdentifier
+	RenameTo  *AccountObjectIdentifier
 	SwapWith  *AccountObjectIdentifier
 	Set       *DatabaseSetRequest
 	Unset     *DatabaseUnsetRequest

--- a/pkg/sdk/databases_gen.go
+++ b/pkg/sdk/databases_gen.go
@@ -141,7 +141,7 @@ type AlterDatabaseOptions struct {
 	database  bool                     `ddl:"static" sql:"DATABASE"`
 	IfExists  *bool                    `ddl:"keyword" sql:"IF EXISTS"`
 	name      AccountObjectIdentifier  `ddl:"identifier"`
-	NewName   *AccountObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
+	RenameTo  *AccountObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
 	SwapWith  *AccountObjectIdentifier `ddl:"identifier" sql:"SWAP WITH"`
 	Set       *DatabaseSet             `ddl:"list,no_parentheses" sql:"SET"`
 	Unset     *DatabaseUnset           `ddl:"list,no_parentheses" sql:"UNSET"`

--- a/pkg/sdk/databases_impl_gen.go
+++ b/pkg/sdk/databases_impl_gen.go
@@ -203,7 +203,7 @@ func (r *AlterDatabaseRequest) toOpts() *AlterDatabaseOptions {
 	opts := &AlterDatabaseOptions{
 		IfExists:  r.IfExists,
 		name:      r.name,
-		NewName:   r.NewName,
+		RenameTo:  r.RenameTo,
 		SwapWith:  r.SwapWith,
 		SetTags:   r.SetTags,
 		UnsetTags: r.UnsetTags,

--- a/pkg/sdk/databases_test.go
+++ b/pkg/sdk/databases_test.go
@@ -336,7 +336,7 @@ func TestDatabasesAlter(t *testing.T) {
 		opts := defaultOpts()
 		opts.Set = &DatabaseSet{}
 		opts.Unset = &DatabaseUnset{}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterDatabaseOptions", "NewName", "Set", "Unset", "SwapWith", "SetTags", "UnsetTags"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterDatabaseOptions", "RenameTo", "Set", "Unset", "SwapWith", "SetTags", "UnsetTags"))
 	})
 
 	t.Run("validation: at least one set option", func(t *testing.T) {
@@ -407,9 +407,9 @@ func TestDatabasesAlter(t *testing.T) {
 		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
-	t.Run("validation: invalid NewName identifier", func(t *testing.T) {
+	t.Run("validation: invalid RenameTo identifier", func(t *testing.T) {
 		opts := defaultOpts()
-		opts.NewName = Pointer(emptyAccountObjectIdentifier)
+		opts.RenameTo = Pointer(emptyAccountObjectIdentifier)
 		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
@@ -422,8 +422,8 @@ func TestDatabasesAlter(t *testing.T) {
 	t.Run("rename", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.IfExists = Bool(true)
-		opts.NewName = Pointer(randomAccountObjectIdentifier())
-		assertOptsValidAndSQLEquals(t, opts, `ALTER DATABASE IF EXISTS %s RENAME TO %s`, opts.name.FullyQualifiedName(), opts.NewName.FullyQualifiedName())
+		opts.RenameTo = Pointer(randomAccountObjectIdentifier())
+		assertOptsValidAndSQLEquals(t, opts, `ALTER DATABASE IF EXISTS %s RENAME TO %s`, opts.name.FullyQualifiedName(), opts.RenameTo.FullyQualifiedName())
 	})
 
 	t.Run("swap with", func(t *testing.T) {

--- a/pkg/sdk/databases_validations_gen.go
+++ b/pkg/sdk/databases_validations_gen.go
@@ -117,10 +117,10 @@ func (opts *AlterDatabaseOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.NewName, opts.Set, opts.Unset, opts.SwapWith, opts.SetTags, opts.UnsetTags) {
-		errs = append(errs, errExactlyOneOf("AlterDatabaseOptions", "NewName", "Set", "Unset", "SwapWith", "SetTags", "UnsetTags"))
+	if !exactlyOneValueSet(opts.RenameTo, opts.Set, opts.Unset, opts.SwapWith, opts.SetTags, opts.UnsetTags) {
+		errs = append(errs, errExactlyOneOf("AlterDatabaseOptions", "RenameTo", "Set", "Unset", "SwapWith", "SetTags", "UnsetTags"))
 	}
-	if opts.NewName != nil && !ValidObjectIdentifier(opts.NewName) {
+	if opts.RenameTo != nil && !ValidObjectIdentifier(opts.RenameTo) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if opts.SwapWith != nil && !ValidObjectIdentifier(opts.SwapWith) {

--- a/pkg/sdk/generator/defs/authentication_policies_def.go
+++ b/pkg/sdk/generator/defs/authentication_policies_def.go
@@ -157,7 +157,7 @@ var authenticationPoliciesDef = g.NewInterface(
 					WithValidation(g.AtLeastOneValueSet, "ClientTypes", "ClientPolicy", "AuthenticationMethods", "Comment", "SecurityIntegrations", "MfaEnrollment", "MfaPolicy", "PatPolicy", "WorkloadIdentityPolicy"),
 				g.ListOptions().NoParentheses().SQL("UNSET"),
 			).
-			Identifier("RenameTo", g.KindOfTPointer[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			RenameTo().
 			WithValidation(g.ValidIdentifier, "name").
 			WithValidation(g.ExactlyOneValueSet, "Set", "Unset", "RenameTo").
 			WithValidation(g.ValidIdentifierIfSet, "RenameTo"),

--- a/pkg/sdk/generator/defs/database_role_def.go
+++ b/pkg/sdk/generator/defs/database_role_def.go
@@ -34,7 +34,7 @@ var databaseRolesDef = g.NewInterface(
 		SQL("DATABASE ROLE").
 		IfExists().
 		Name().
-		OptionalIdentifier("Rename", g.KindOfT[sdkcommons.DatabaseObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.DatabaseObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
 		OptionalQueryStructField(
 			"Set", g.NewQueryStruct("DatabaseRoleSet").
 				OptionalComment().
@@ -50,8 +50,8 @@ var databaseRolesDef = g.NewInterface(
 		OptionalSetTags().
 		OptionalUnsetTags().
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ExactlyOneValueSet, "Rename", "Set", "Unset", "SetTags", "UnsetTags").
-		WithValidation(g.ValidIdentifierIfSet, "Rename").
+		WithValidation(g.ExactlyOneValueSet, "RenameTo", "Set", "Unset", "SetTags", "UnsetTags").
+		WithValidation(g.ValidIdentifierIfSet, "RenameTo").
 		WithValidation(g.AdditionalValidations),
 ).DropOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/drop-database-role",

--- a/pkg/sdk/generator/defs/database_role_def.go
+++ b/pkg/sdk/generator/defs/database_role_def.go
@@ -34,7 +34,7 @@ var databaseRolesDef = g.NewInterface(
 		SQL("DATABASE ROLE").
 		IfExists().
 		Name().
-		OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.DatabaseObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		OptionalQueryStructField(
 			"Set", g.NewQueryStruct("DatabaseRoleSet").
 				OptionalComment().

--- a/pkg/sdk/generator/defs/databases_def.go
+++ b/pkg/sdk/generator/defs/databases_def.go
@@ -212,15 +212,15 @@ var databasesDef = g.NewInterface(
 		SQL("DATABASE").
 		IfExists().
 		Name().
-		Identifier("NewName", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		Identifier("RenameTo", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
 		Identifier("SwapWith", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("SWAP WITH")).
 		OptionalQueryStructField("Set", databaseSetStruct, g.ListOptions().NoParentheses().SQL("SET")).
 		OptionalQueryStructField("Unset", databaseUnsetStruct, g.ListOptions().NoParentheses().SQL("UNSET")).
 		OptionalSetTags().
 		OptionalUnsetTags().
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ExactlyOneValueSet, "NewName", "Set", "Unset", "SwapWith", "SetTags", "UnsetTags").
-		WithValidation(g.ValidIdentifierIfSet, "NewName").
+		WithValidation(g.ExactlyOneValueSet, "RenameTo", "Set", "Unset", "SwapWith", "SetTags", "UnsetTags").
+		WithValidation(g.ValidIdentifierIfSet, "RenameTo").
 		WithValidation(g.ValidIdentifierIfSet, "SwapWith"),
 ).CustomOperation(
 	"AlterReplication",

--- a/pkg/sdk/generator/defs/databases_def.go
+++ b/pkg/sdk/generator/defs/databases_def.go
@@ -212,7 +212,7 @@ var databasesDef = g.NewInterface(
 		SQL("DATABASE").
 		IfExists().
 		Name().
-		Identifier("RenameTo", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		Identifier("SwapWith", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("SWAP WITH")).
 		OptionalQueryStructField("Set", databaseSetStruct, g.ListOptions().NoParentheses().SQL("SET")).
 		OptionalQueryStructField("Unset", databaseUnsetStruct, g.ListOptions().NoParentheses().SQL("UNSET")).

--- a/pkg/sdk/generator/defs/event_tables_def.go
+++ b/pkg/sdk/generator/defs/event_tables_def.go
@@ -152,7 +152,7 @@ var eventTablesDef = g.NewInterface(
 		).
 		OptionalSetTags().
 		OptionalUnsetTags().
-		Identifier("RenameTo", g.KindOfTPointer[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ExactlyOneValueSet, "RenameTo", "Set", "Unset", "SetTags", "UnsetTags", "AddRowAccessPolicy", "DropRowAccessPolicy", "DropAndAddRowAccessPolicy", "DropAllRowAccessPolicies", "ClusteringAction", "SearchOptimizationAction"),
 )

--- a/pkg/sdk/generator/defs/hybrid_tables_def.go
+++ b/pkg/sdk/generator/defs/hybrid_tables_def.go
@@ -178,7 +178,7 @@ var hybridTablesDef = g.NewInterface(
 		SQL("TABLE").
 		IfExists().
 		Name().
-		OptionalIdentifier("NewName", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
 		OptionalQueryStructField(
 			"AddColumnAction",
 			hybridTableAddColumnAction,
@@ -220,7 +220,7 @@ var hybridTablesDef = g.NewInterface(
 			g.ListOptions().NoParentheses().SQL("UNSET"),
 		).
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ExactlyOneValueSet, "NewName", "AddColumnAction", "ConstraintAction", "AlterColumnAction", "DropColumnAction", "DropIndexAction", "ClusteringAction", "Set", "Unset"),
+		WithValidation(g.ExactlyOneValueSet, "RenameTo", "AddColumnAction", "ConstraintAction", "AlterColumnAction", "DropColumnAction", "DropIndexAction", "ClusteringAction", "Set", "Unset"),
 ).DropOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/drop-table",
 	g.NewQueryStruct("DropHybridTable").

--- a/pkg/sdk/generator/defs/hybrid_tables_def.go
+++ b/pkg/sdk/generator/defs/hybrid_tables_def.go
@@ -178,7 +178,7 @@ var hybridTablesDef = g.NewInterface(
 		SQL("TABLE").
 		IfExists().
 		Name().
-		OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		OptionalQueryStructField(
 			"AddColumnAction",
 			hybridTableAddColumnAction,

--- a/pkg/sdk/generator/defs/listings_def.go
+++ b/pkg/sdk/generator/defs/listings_def.go
@@ -179,7 +179,7 @@ var listingsDef = g.NewInterface(
 					OptionalComment(),
 				g.KeywordOptions().SQL("ADD VERSION"),
 			).
-			OptionalIdentifier("RenameTo", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			RenameTo().
 			OptionalQueryStructField(
 				"Set",
 				g.NewQueryStruct("ListingSet").

--- a/pkg/sdk/generator/defs/masking_policies_def.go
+++ b/pkg/sdk/generator/defs/masking_policies_def.go
@@ -46,7 +46,7 @@ var maskingPoliciesDef = g.NewInterface(
 			SQL("MASKING POLICY").
 			IfExists().
 			Name().
-			OptionalIdentifier("NewName", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
 			OptionalSetBodyWithPrecedingArrow().
 			SetComment().
 			OptionalSQL("UNSET BODY").
@@ -54,7 +54,7 @@ var maskingPoliciesDef = g.NewInterface(
 			OptionalSetTags().
 			OptionalUnsetTags().
 			WithValidation(g.ValidIdentifier, "name").
-			WithValidation(g.ExactlyOneValueSet, "NewName", "SetBody", "SetComment", "UnsetBody", "UnsetComment", "SetTags", "UnsetTags").
+			WithValidation(g.ExactlyOneValueSet, "RenameTo", "SetBody", "SetComment", "UnsetBody", "UnsetComment", "SetTags", "UnsetTags").
 			WithAdditionalValidations(),
 	).
 	DropOperation(

--- a/pkg/sdk/generator/defs/masking_policies_def.go
+++ b/pkg/sdk/generator/defs/masking_policies_def.go
@@ -46,7 +46,7 @@ var maskingPoliciesDef = g.NewInterface(
 			SQL("MASKING POLICY").
 			IfExists().
 			Name().
-			OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			RenameTo().
 			OptionalSetBodyWithPrecedingArrow().
 			SetComment().
 			OptionalSQL("UNSET BODY").

--- a/pkg/sdk/generator/defs/materialized_views_def.go
+++ b/pkg/sdk/generator/defs/materialized_views_def.go
@@ -111,7 +111,7 @@ var materializedViewsDef = g.NewInterface(
 			Alter().
 			SQL("MATERIALIZED VIEW").
 			Name().
-			OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			RenameTo().
 			OptionalQueryStructField("ClusterBy", materializedViewClusterBy(), g.KeywordOptions()).
 			OptionalSQL("DROP CLUSTERING KEY").
 			OptionalSQL("SUSPEND RECLUSTER").

--- a/pkg/sdk/generator/defs/network_policies_def.go
+++ b/pkg/sdk/generator/defs/network_policies_def.go
@@ -90,7 +90,7 @@ var (
 					networkPoliciesRemoveNetworkRule,
 					g.KeywordOptions().SQL("REMOVE"),
 				).
-				Identifier("RenameTo", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+				RenameTo().
 				WithValidation(g.ValidIdentifier, "name").
 				WithValidation(g.ExactlyOneValueSet, "Set", "Unset", "RenameTo", "Add", "Remove").
 				WithValidation(g.ValidIdentifierIfSet, "RenameTo"),

--- a/pkg/sdk/generator/defs/notebooks_def.go
+++ b/pkg/sdk/generator/defs/notebooks_def.go
@@ -87,7 +87,7 @@ var notebooksDef = g.NewInterface(
 		SQL("NOTEBOOK").
 		IfExists().
 		Name().
-		Identifier("RenameTo", g.KindOfTPointer[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		OptionalQueryStructField(
 			"Set",
 			g.NewQueryStruct("NotebookSet").

--- a/pkg/sdk/generator/defs/openflow_deployments_def.go
+++ b/pkg/sdk/generator/defs/openflow_deployments_def.go
@@ -50,7 +50,7 @@ var openflowDeploymentsDef = g.NewInterface(
 		Name().
 		OptionalSQL("UPGRADE").
 		OptionalSQL("TERMINATE").
-		OptionalIdentifier("RenameTo", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		OptionalQueryStructField(
 			"Set",
 			g.NewQueryStruct("OpenflowDeploymentSet").

--- a/pkg/sdk/generator/defs/openflow_runtimes_def.go
+++ b/pkg/sdk/generator/defs/openflow_runtimes_def.go
@@ -60,7 +60,7 @@ var openflowRuntimesDef = g.NewInterface(
 		OptionalSQL("TERMINATE").
 		OptionalSQL("TERMINATE CASCADE").
 		OptionalSQL("UPGRADE").
-		OptionalIdentifier("RenameTo", g.KindOfTPointer[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		OptionalQueryStructField(
 			"Set",
 			g.NewQueryStruct("OpenflowRuntimeSet").

--- a/pkg/sdk/generator/defs/organization_accounts_def.go
+++ b/pkg/sdk/generator/defs/organization_accounts_def.go
@@ -70,7 +70,7 @@ var organizationAccountsDef = g.NewInterface(
 			OptionalQueryStructField(
 				"RenameTo",
 				g.NewQueryStruct("OrganizationAccountRename").
-					Identifier("NewName", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().Required().SQL("RENAME TO")).
+					Identifier("RenameTo", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().Required().SQL("RENAME TO")).
 					OptionalBooleanAssignment("SAVE_OLD_URL", g.ParameterOptions()),
 				g.KeywordOptions(),
 			).

--- a/pkg/sdk/generator/defs/password_policies_def.go
+++ b/pkg/sdk/generator/defs/password_policies_def.go
@@ -41,7 +41,7 @@ var passwordPoliciesDef = g.NewInterface(
 			SQL("PASSWORD POLICY").
 			IfExists().
 			Name().
-			OptionalIdentifier("NewName", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
 			OptionalQueryStructField(
 				"Set",
 				g.NewQueryStruct("PasswordPolicySet").
@@ -79,7 +79,7 @@ var passwordPoliciesDef = g.NewInterface(
 				g.ListOptions().NoParentheses().SQL("UNSET"),
 			).
 			WithValidation(g.ValidIdentifier, "name").
-			WithValidation(g.ExactlyOneValueSet, "Set", "Unset", "NewName"),
+			WithValidation(g.ExactlyOneValueSet, "Set", "Unset", "RenameTo"),
 	).
 	DropOperation(
 		"https://docs.snowflake.com/en/sql-reference/sql/drop-password-policy",

--- a/pkg/sdk/generator/defs/password_policies_def.go
+++ b/pkg/sdk/generator/defs/password_policies_def.go
@@ -41,7 +41,7 @@ var passwordPoliciesDef = g.NewInterface(
 			SQL("PASSWORD POLICY").
 			IfExists().
 			Name().
-			OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			RenameTo().
 			OptionalQueryStructField(
 				"Set",
 				g.NewQueryStruct("PasswordPolicySet").

--- a/pkg/sdk/generator/defs/postgres_instances_def.go
+++ b/pkg/sdk/generator/defs/postgres_instances_def.go
@@ -116,7 +116,7 @@ var postgresInstancesDef = g.NewInterface(
 		SQL("POSTGRES INSTANCE").
 		IfExists().
 		Name().
-		Identifier("RenameTo", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		OptionalQueryStructField(
 			"Set",
 			g.NewQueryStruct("PostgresInstanceSet").

--- a/pkg/sdk/generator/defs/roles_def.go
+++ b/pkg/sdk/generator/defs/roles_def.go
@@ -42,7 +42,7 @@ var rolesDef = g.NewInterface(
 		SQL("ROLE").
 		IfExists().
 		Name().
-		OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		OptionalTextAssignment("SET COMMENT", g.ParameterOptions().SingleQuotes()).
 		OptionalSetTags().
 		OptionalSQLWithCustomFieldName("UnsetComment", "UNSET COMMENT").

--- a/pkg/sdk/generator/defs/row_access_policies_def.go
+++ b/pkg/sdk/generator/defs/row_access_policies_def.go
@@ -41,7 +41,7 @@ var rowAccessPoliciesDef = g.NewInterface(
 			Alter().
 			SQL("ROW ACCESS POLICY").
 			Name().
-			OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			RenameTo().
 			OptionalSetBodyWithPrecedingArrow().
 			OptionalSetTags().
 			OptionalUnsetTags().

--- a/pkg/sdk/generator/defs/schemas_def.go
+++ b/pkg/sdk/generator/defs/schemas_def.go
@@ -136,7 +136,7 @@ var schemasDef = g.NewInterface(
 		SQL("SCHEMA").
 		IfExists().
 		Name().
-		Identifier("RenameTo", g.KindOfTPointer[sdkcommons.DatabaseObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		Identifier("SwapWith", g.KindOfTPointer[sdkcommons.DatabaseObjectIdentifier](), g.IdentifierOptions().SQL("SWAP WITH")).
 		OptionalQueryStructField("Set", schemaSetStruct, g.ListOptions().NoParentheses().SQL("SET")).
 		OptionalQueryStructField("Unset", schemaUnsetStruct, g.ListOptions().NoParentheses().SQL("UNSET")).

--- a/pkg/sdk/generator/defs/schemas_def.go
+++ b/pkg/sdk/generator/defs/schemas_def.go
@@ -136,7 +136,7 @@ var schemasDef = g.NewInterface(
 		SQL("SCHEMA").
 		IfExists().
 		Name().
-		Identifier("NewName", g.KindOfTPointer[sdkcommons.DatabaseObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		Identifier("RenameTo", g.KindOfTPointer[sdkcommons.DatabaseObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
 		Identifier("SwapWith", g.KindOfTPointer[sdkcommons.DatabaseObjectIdentifier](), g.IdentifierOptions().SQL("SWAP WITH")).
 		OptionalQueryStructField("Set", schemaSetStruct, g.ListOptions().NoParentheses().SQL("SET")).
 		OptionalQueryStructField("Unset", schemaUnsetStruct, g.ListOptions().NoParentheses().SQL("UNSET")).
@@ -145,8 +145,8 @@ var schemasDef = g.NewInterface(
 		OptionalSQL("ENABLE MANAGED ACCESS").
 		OptionalSQL("DISABLE MANAGED ACCESS").
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ExactlyOneValueSet, "NewName", "SwapWith", "Set", "Unset", "SetTags", "UnsetTags", "EnableManagedAccess", "DisableManagedAccess").
-		WithValidation(g.ValidIdentifierIfSet, "NewName").
+		WithValidation(g.ExactlyOneValueSet, "RenameTo", "SwapWith", "Set", "Unset", "SetTags", "UnsetTags", "EnableManagedAccess", "DisableManagedAccess").
+		WithValidation(g.ValidIdentifierIfSet, "RenameTo").
 		WithValidation(g.ValidIdentifierIfSet, "SwapWith"),
 ).DropOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/drop-schema",

--- a/pkg/sdk/generator/defs/semantic_views_def.go
+++ b/pkg/sdk/generator/defs/semantic_views_def.go
@@ -57,7 +57,7 @@ var semanticViewsDef = g.NewInterface(
 			Name().
 			OptionalTextAssignment("SET COMMENT", g.ParameterOptions().SingleQuotes()).
 			OptionalSQL("UNSET COMMENT").
-			OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			RenameTo().
 			WithValidation(g.ValidIdentifier, "name").
 			WithValidation(g.ExactlyOneValueSet, "SetComment", "UnsetComment", "RenameTo"),
 	).

--- a/pkg/sdk/generator/defs/sequences_def.go
+++ b/pkg/sdk/generator/defs/sequences_def.go
@@ -40,7 +40,7 @@ var sequencesDef = g.NewInterface(
 		SQL("SEQUENCE").
 		IfExists().
 		Name().
-		Identifier("RenameTo", g.KindOfTPointer[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		OptionalNumberAssignment("SET INCREMENT", g.ParameterOptions().NoQuotes()).
 		OptionalQueryStructField(
 			"Set",

--- a/pkg/sdk/generator/defs/session_policies_def.go
+++ b/pkg/sdk/generator/defs/session_policies_def.go
@@ -42,7 +42,7 @@ var sessionPoliciesDef = g.NewInterface(
 			SQL("SESSION POLICY").
 			IfExists().
 			Name().
-			OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			RenameTo().
 			OptionalQueryStructField(
 				"Set",
 				g.NewQueryStruct("SessionPolicySet").

--- a/pkg/sdk/generator/defs/stages_def.go
+++ b/pkg/sdk/generator/defs/stages_def.go
@@ -320,7 +320,7 @@ var stagesDef = g.NewInterface(
 			SQL("STAGE").
 			IfExists().
 			Name().
-			OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			RenameTo().
 			OptionalSetTags().
 			OptionalUnsetTags().
 			WithValidation(g.ValidIdentifierIfSet, "RenameTo").

--- a/pkg/sdk/generator/defs/storage_lifecycle_policies_def.go
+++ b/pkg/sdk/generator/defs/storage_lifecycle_policies_def.go
@@ -48,7 +48,7 @@ var storageLifecyclePoliciesDef = g.NewInterface(
 			Alter().
 			SQL("STORAGE LIFECYCLE POLICY").
 			Name().
-			OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			RenameTo().
 			OptionalSetBodyWithPrecedingArrow().
 			OptionalQueryStructField(
 				"Set",

--- a/pkg/sdk/generator/defs/streamlits_def.go
+++ b/pkg/sdk/generator/defs/streamlits_def.go
@@ -63,7 +63,7 @@ var streamlitsDef = g.NewInterface(
 			streamlitUnset,
 			g.ListOptions().NoParentheses().SQL("UNSET"),
 		).
-		Identifier("RenameTo", g.KindOfTPointer[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ValidIdentifierIfSet, "RenameTo").
 		WithValidation(g.ExactlyOneValueSet, "RenameTo", "Set", "Unset"),

--- a/pkg/sdk/generator/defs/tags_def.go
+++ b/pkg/sdk/generator/defs/tags_def.go
@@ -123,6 +123,7 @@ var tagsDef = g.NewInterface(
 		OptionalQueryStructField("Unset", tagUnset(), g.KeywordOptions().SQL("UNSET")).
 		OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
 		WithValidation(g.ValidIdentifier, "name").
+		WithValidation(g.ValidIdentifierIfSet, "RenameTo").
 		WithValidation(g.ExactlyOneValueSet, "Add", "Drop", "Set", "Unset", "RenameTo"),
 ).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-tags",

--- a/pkg/sdk/generator/defs/tags_def.go
+++ b/pkg/sdk/generator/defs/tags_def.go
@@ -79,12 +79,6 @@ func unsetTagQueryStruct() *g.QueryStruct {
 		WithAdditionalValidations()
 }
 
-func tagRename() *g.QueryStruct {
-	return g.NewQueryStruct("TagRename").
-		Identifier("Name", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().Required()).
-		WithValidation(g.ValidIdentifier, "Name")
-}
-
 func tagSet() *g.QueryStruct {
 	return g.NewQueryStruct("TagSet").
 		OptionalQueryStructField("MaskingPolicies", tagSetMaskingPolicies(), g.KeywordOptions()).
@@ -127,9 +121,9 @@ var tagsDef = g.NewInterface(
 		OptionalQueryStructField("Drop", tagDrop(), g.KeywordOptions().SQL("DROP")).
 		OptionalQueryStructField("Set", tagSet(), g.KeywordOptions().SQL("SET")).
 		OptionalQueryStructField("Unset", tagUnset(), g.KeywordOptions().SQL("UNSET")).
-		OptionalQueryStructField("Rename", tagRename(), g.KeywordOptions().SQL("RENAME TO")).
+		OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ExactlyOneValueSet, "Add", "Drop", "Set", "Unset", "Rename"),
+		WithValidation(g.ExactlyOneValueSet, "Add", "Drop", "Set", "Unset", "RenameTo"),
 ).ShowOperationWithPairedStructs(
 	"https://docs.snowflake.com/en/sql-reference/sql/show-tags",
 	g.StructPair("tagRow", "Tag").

--- a/pkg/sdk/generator/defs/tags_def.go
+++ b/pkg/sdk/generator/defs/tags_def.go
@@ -121,7 +121,7 @@ var tagsDef = g.NewInterface(
 		OptionalQueryStructField("Drop", tagDrop(), g.KeywordOptions().SQL("DROP")).
 		OptionalQueryStructField("Set", tagSet(), g.KeywordOptions().SQL("SET")).
 		OptionalQueryStructField("Unset", tagUnset(), g.KeywordOptions().SQL("UNSET")).
-		OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		WithValidation(g.ValidIdentifier, "name").
 		WithValidation(g.ValidIdentifierIfSet, "RenameTo").
 		WithValidation(g.ExactlyOneValueSet, "Add", "Drop", "Set", "Unset", "RenameTo"),

--- a/pkg/sdk/generator/defs/users_def.go
+++ b/pkg/sdk/generator/defs/users_def.go
@@ -263,7 +263,7 @@ var usersDef = g.NewInterface(
 		SQL("USER").
 		IfExists().
 		Name().
-		OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		OptionalSQL("RESET PASSWORD").
 		OptionalSQL("ABORT ALL QUERIES").
 		OptionalQueryStructField("AddDelegatedAuthorization", addDelegatedAuthorizationStruct(), g.KeywordOptions()).

--- a/pkg/sdk/generator/defs/users_def.go
+++ b/pkg/sdk/generator/defs/users_def.go
@@ -263,7 +263,7 @@ var usersDef = g.NewInterface(
 		SQL("USER").
 		IfExists().
 		Name().
-		OptionalIdentifier("NewName", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
 		OptionalSQL("RESET PASSWORD").
 		OptionalSQL("ABORT ALL QUERIES").
 		OptionalQueryStructField("AddDelegatedAuthorization", addDelegatedAuthorizationStruct(), g.KeywordOptions()).
@@ -273,7 +273,7 @@ var usersDef = g.NewInterface(
 		OptionalSetTags().
 		OptionalUnsetTags().
 		WithValidation(g.ValidIdentifier, "name").
-		WithValidation(g.ExactlyOneValueSet, "NewName", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset", "SetTags", "UnsetTags"),
+		WithValidation(g.ExactlyOneValueSet, "RenameTo", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset", "SetTags", "UnsetTags"),
 ).DropOperation(
 	"https://docs.snowflake.com/en/sql-reference/sql/drop-user",
 	g.NewQueryStruct("DropUser").

--- a/pkg/sdk/generator/defs/views_def.go
+++ b/pkg/sdk/generator/defs/views_def.go
@@ -222,7 +222,7 @@ var viewsDef = g.NewInterface(
 			SQL("VIEW").
 			IfExists().
 			Name().
-			OptionalIdentifier("RenameTo", g.KindOfT[sdkcommons.SchemaObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+			RenameTo().
 			OptionalTextAssignment("SET COMMENT", g.ParameterOptions().SingleQuotes()).
 			OptionalSQL("UNSET COMMENT").
 			OptionalSQL("SET SECURE").

--- a/pkg/sdk/generator/defs/warehouse_def.go
+++ b/pkg/sdk/generator/defs/warehouse_def.go
@@ -195,7 +195,7 @@ var warehousesDef = g.NewInterface(
 		OptionalSQL("RESUME").
 		OptionalSQL("IF SUSPENDED").
 		OptionalSQL("ABORT ALL QUERIES").
-		OptionalIdentifier("RenameTo", g.KindOfTPointer[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().SQL("RENAME TO")).
+		RenameTo().
 		OptionalQueryStructField("Set", warehouseSetStruct, g.KeywordOptions().SQL("SET")).
 		OptionalQueryStructField("Unset", warehouseUnsetStruct, g.ListOptions().NoParentheses().SQL("UNSET")).
 		OptionalSetTags().

--- a/pkg/sdk/generator/gen/0_defs.go
+++ b/pkg/sdk/generator/gen/0_defs.go
@@ -31,6 +31,7 @@ func preprocessDefinition(definition *Interface) {
 			o.OptsField.Name = fmt.Sprintf("%s%sOptions", o.Name, o.ObjectInterface.NameSingular)
 			o.OptsField.Kind = fmt.Sprintf("%s%sOptions", o.Name, o.ObjectInterface.NameSingular)
 			setParent(o.OptsField)
+			resolveInterfaceIdentifierKinds(o.OptsField, definition.IdentifierKind)
 
 			// TODO [SNOW-2324252]: this logic is currently the old logic adjusted. Let's clean it after new generation is working.
 			// fill out StructsToGenerate; it replaces the old generateOptionsStruct and generateStruct
@@ -93,6 +94,20 @@ func preprocessDefinition(definition *Interface) {
 				seenMappingReceivers = append(seenMappingReceivers, mapping.From.Name)
 			}
 		}
+	}
+}
+
+// resolveInterfaceIdentifierKinds walks all fields recursively and replaces sentinel kind values
+// with the actual identifier type from the interface definition.
+func resolveInterfaceIdentifierKinds(field *Field, identifierKind string) {
+	switch field.Kind {
+	case InterfaceIdentifierKind:
+		field.Kind = identifierKind
+	case InterfaceIdentifierPointerKind:
+		field.Kind = KindOfPointer(identifierKind)
+	}
+	for idx := range field.Fields {
+		resolveInterfaceIdentifierKinds(&field.Fields[idx], identifierKind)
 	}
 }
 

--- a/pkg/sdk/generator/gen/identifier_builders.go
+++ b/pkg/sdk/generator/gen/identifier_builders.go
@@ -1,10 +1,23 @@
 package gen
 
-// Name adds identifier with field name "name" and type will be inferred from interface definition
+// InterfaceIdentifierKind is a sentinel kind value meaning "the interface's own identifier type".
+const InterfaceIdentifierKind = "<interface identifier type>"
+
+// InterfaceIdentifierPointerKind is a sentinel kind value meaning "pointer to the interface's own identifier type".
+const InterfaceIdentifierPointerKind = "<interface identifier pointer type>"
+
+// Name adds identifier with field name "name" and type inferred from the interface definition.
 func (v *QueryStruct) Name() *QueryStruct {
-	identifier := NewField("name", "<will be replaced>", Tags().Identifier(), IdentifierOptions().Required())
-	v.identifierField = identifier
+	identifier := NewField("name", InterfaceIdentifierKind, Tags().Identifier(), IdentifierOptions().Required())
 	v.fields = append(v.fields, identifier)
+	return v
+}
+
+// RenameTo adds an optional "RenameTo" identifier field with SQL "RENAME TO".
+// The type is inferred from the interface's identifier kind (pointer), same mechanism as Name().
+func (v *QueryStruct) RenameTo() *QueryStruct {
+	field := NewField("RenameTo", InterfaceIdentifierPointerKind, Tags().Identifier(), IdentifierOptions().SQL("RENAME TO"))
+	v.fields = append(v.fields, field)
 	return v
 }
 

--- a/pkg/sdk/generator/gen/instance_method_builders.go
+++ b/pkg/sdk/generator/gen/instance_method_builders.go
@@ -10,8 +10,7 @@ import "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/genh
 func (i *Interface) newInstanceMethodCallStruct(structName string, methodName string, argsQueryStruct *QueryStruct) *QueryStruct {
 	qs := NewQueryStruct(structName)
 	qs.Call()
-	identifier := NewField("name", "<will be replaced>", Tags().Identifier().InstanceMethod().SQL(methodName), IdentifierOptions().Required())
-	qs.identifierField = identifier
+	identifier := NewField("name", InterfaceIdentifierKind, Tags().Identifier().InstanceMethod().SQL(methodName), IdentifierOptions().Required())
 	qs.fields = append(qs.fields, identifier)
 	if argsQueryStruct == nil {
 		qs.QueryStructField("args", NewQueryStruct(sqlToFieldName(genhelpers.ToSnakeCase(i.NameSingular)+"_"+methodName, false)+"Args"), ListOptions().MustParentheses())

--- a/pkg/sdk/generator/gen/operation.go
+++ b/pkg/sdk/generator/gen/operation.go
@@ -205,9 +205,6 @@ func newNoSqlOperation(kind string) *Operation {
 
 // TODO [next PRs]: add functional options to modify the operation on creation
 func (i *Interface) newSimpleOperation(kind string, doc string, queryStruct *QueryStruct, helperStructs ...IntoField) *Interface {
-	if queryStruct.identifierField != nil {
-		queryStruct.identifierField.Kind = i.IdentifierKind
-	}
 	f := make([]*Field, len(helperStructs))
 	if len(f) > 0 {
 		for i, hs := range helperStructs {
@@ -222,9 +219,6 @@ func (i *Interface) newSimpleOperation(kind string, doc string, queryStruct *Que
 }
 
 func (i *Interface) newSimpleScalarOperation(kind string, doc string, queryStruct *QueryStruct, scalarReturnType string, helperStructs ...IntoField) *Interface {
-	if queryStruct.identifierField != nil {
-		queryStruct.identifierField.Kind = i.IdentifierKind
-	}
 	f := make([]*Field, len(helperStructs))
 	if len(f) > 0 {
 		for i, hs := range helperStructs {
@@ -250,9 +244,6 @@ func (i *Interface) newOperationWithDBMapping(
 ) *Operation {
 	db := dbRepresentation.IntoField()
 	res := resourceRepresentation.IntoField()
-	if queryStruct.identifierField != nil {
-		queryStruct.identifierField.Kind = i.IdentifierKind
-	}
 	f := make([]*Field, len(helperStructs))
 	if len(f) > 0 {
 		for i, hs := range helperStructs {

--- a/pkg/sdk/generator/gen/query_struct.go
+++ b/pkg/sdk/generator/gen/query_struct.go
@@ -7,11 +7,10 @@ package gen
 //		...additional fields that are not present in the Field
 //	}
 type QueryStruct struct {
-	name            string
-	fields          []*Field
-	identifierField *Field
-	validations     []*Validation
-	sharedToOpts    bool
+	name         string
+	fields       []*Field
+	validations  []*Validation
+	sharedToOpts bool
 }
 
 func NewQueryStruct(name string) *QueryStruct {

--- a/pkg/sdk/hybrid_tables_dto_builders_gen.go
+++ b/pkg/sdk/hybrid_tables_dto_builders_gen.go
@@ -143,8 +143,8 @@ func (s *AlterHybridTableRequest) WithIfExists(ifExists bool) *AlterHybridTableR
 	return s
 }
 
-func (s *AlterHybridTableRequest) WithNewName(newName SchemaObjectIdentifier) *AlterHybridTableRequest {
-	s.NewName = &newName
+func (s *AlterHybridTableRequest) WithRenameTo(renameTo SchemaObjectIdentifier) *AlterHybridTableRequest {
+	s.RenameTo = &renameTo
 	return s
 }
 

--- a/pkg/sdk/hybrid_tables_dto_gen.go
+++ b/pkg/sdk/hybrid_tables_dto_gen.go
@@ -58,7 +58,7 @@ type HybridTableOutOfLineIndexRequest struct {
 type AlterHybridTableRequest struct {
 	IfExists          *bool
 	name              SchemaObjectIdentifier // required
-	NewName           *SchemaObjectIdentifier
+	RenameTo          *SchemaObjectIdentifier
 	AddColumnAction   *HybridTableAddColumnActionRequest
 	ConstraintAction  *HybridTableConstraintActionRequest
 	AlterColumnAction []HybridTableAlterColumnActionRequest

--- a/pkg/sdk/hybrid_tables_gen.go
+++ b/pkg/sdk/hybrid_tables_gen.go
@@ -76,7 +76,7 @@ type AlterHybridTableOptions struct {
 	table             bool                           `ddl:"static" sql:"TABLE"`
 	IfExists          *bool                          `ddl:"keyword" sql:"IF EXISTS"`
 	name              SchemaObjectIdentifier         `ddl:"identifier"`
-	NewName           *SchemaObjectIdentifier        `ddl:"identifier" sql:"RENAME TO"`
+	RenameTo          *SchemaObjectIdentifier        `ddl:"identifier" sql:"RENAME TO"`
 	AddColumnAction   *HybridTableAddColumnAction    `ddl:"keyword"`
 	ConstraintAction  *HybridTableConstraintAction   `ddl:"keyword"`
 	AlterColumnAction []HybridTableAlterColumnAction `ddl:"keyword"`

--- a/pkg/sdk/hybrid_tables_gen_test.go
+++ b/pkg/sdk/hybrid_tables_gen_test.go
@@ -144,7 +144,7 @@ func TestHybridTables_Alter(t *testing.T) {
 
 	t.Run("validation: exactly one field from alter actions should be present", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterHybridTableOptions", "NewName", "AddColumnAction", "ConstraintAction", "AlterColumnAction", "DropColumnAction", "DropIndexAction", "ClusteringAction", "Set", "Unset"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterHybridTableOptions", "RenameTo", "AddColumnAction", "ConstraintAction", "AlterColumnAction", "DropColumnAction", "DropIndexAction", "ClusteringAction", "Set", "Unset"))
 	})
 
 	t.Run("validation: constraint action - exactly one of Rename, Drop required", func(t *testing.T) {
@@ -348,7 +348,7 @@ func TestHybridTables_Alter(t *testing.T) {
 	t.Run("alter: rename to", func(t *testing.T) {
 		newID := randomSchemaObjectIdentifierInSchema(id.SchemaId())
 		opts := defaultOpts()
-		opts.NewName = &newID
+		opts.RenameTo = &newID
 		assertOptsValidAndSQLEquals(t, opts, `ALTER TABLE %s RENAME TO %s`, id.FullyQualifiedName(), newID.FullyQualifiedName())
 	})
 

--- a/pkg/sdk/hybrid_tables_impl_gen.go
+++ b/pkg/sdk/hybrid_tables_impl_gen.go
@@ -177,7 +177,7 @@ func (r *AlterHybridTableRequest) toOpts() *AlterHybridTableOptions {
 	opts := &AlterHybridTableOptions{
 		IfExists: r.IfExists,
 		name:     r.name,
-		NewName:  r.NewName,
+		RenameTo: r.RenameTo,
 	}
 	if r.AddColumnAction != nil {
 		opts.AddColumnAction = &HybridTableAddColumnAction{

--- a/pkg/sdk/hybrid_tables_validations_gen.go
+++ b/pkg/sdk/hybrid_tables_validations_gen.go
@@ -38,8 +38,8 @@ func (opts *AlterHybridTableOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.NewName, opts.AddColumnAction, opts.ConstraintAction, opts.AlterColumnAction, opts.DropColumnAction, opts.DropIndexAction, opts.ClusteringAction, opts.Set, opts.Unset) {
-		errs = append(errs, errExactlyOneOf("AlterHybridTableOptions", "NewName", "AddColumnAction", "ConstraintAction", "AlterColumnAction", "DropColumnAction", "DropIndexAction", "ClusteringAction", "Set", "Unset"))
+	if !exactlyOneValueSet(opts.RenameTo, opts.AddColumnAction, opts.ConstraintAction, opts.AlterColumnAction, opts.DropColumnAction, opts.DropIndexAction, opts.ClusteringAction, opts.Set, opts.Unset) {
+		errs = append(errs, errExactlyOneOf("AlterHybridTableOptions", "RenameTo", "AddColumnAction", "ConstraintAction", "AlterColumnAction", "DropColumnAction", "DropIndexAction", "ClusteringAction", "Set", "Unset"))
 	}
 	if valueSet(opts.ConstraintAction) {
 		if !exactlyOneValueSet(opts.ConstraintAction.Rename, opts.ConstraintAction.Drop) {

--- a/pkg/sdk/masking_policies_dto_builders_gen.go
+++ b/pkg/sdk/masking_policies_dto_builders_gen.go
@@ -61,8 +61,8 @@ func (s *AlterMaskingPolicyRequest) WithIfExists(ifExists bool) *AlterMaskingPol
 	return s
 }
 
-func (s *AlterMaskingPolicyRequest) WithNewName(newName SchemaObjectIdentifier) *AlterMaskingPolicyRequest {
-	s.NewName = &newName
+func (s *AlterMaskingPolicyRequest) WithRenameTo(renameTo SchemaObjectIdentifier) *AlterMaskingPolicyRequest {
+	s.RenameTo = &renameTo
 	return s
 }
 

--- a/pkg/sdk/masking_policies_dto_gen.go
+++ b/pkg/sdk/masking_policies_dto_gen.go
@@ -31,7 +31,7 @@ type CreateMaskingPolicySignatureRequest struct {
 type AlterMaskingPolicyRequest struct {
 	IfExists     *bool
 	name         SchemaObjectIdentifier // required
-	NewName      *SchemaObjectIdentifier
+	RenameTo     *SchemaObjectIdentifier
 	SetBody      *string
 	SetComment   *string
 	UnsetBody    *bool

--- a/pkg/sdk/masking_policies_ext.go
+++ b/pkg/sdk/masking_policies_ext.go
@@ -14,15 +14,15 @@ func (r maskingPolicyDBRow) additionalConvert(result *MaskingPolicy) error {
 
 // additionalValidations checks that NewName stays within the same database and schema.
 func (opts *AlterMaskingPolicyOptions) additionalValidations() error {
-	if opts.NewName != nil {
+	if opts.RenameTo != nil {
 		var errs []error
-		if !ValidObjectIdentifier(opts.NewName) {
-			errs = append(errs, errInvalidIdentifier("AlterMaskingPolicyOptions", "NewName"))
+		if !ValidObjectIdentifier(opts.RenameTo) {
+			errs = append(errs, errInvalidIdentifier("AlterMaskingPolicyOptions", "RenameTo"))
 		}
-		if opts.name.DatabaseName() != opts.NewName.DatabaseName() {
+		if opts.name.DatabaseName() != opts.RenameTo.DatabaseName() {
 			errs = append(errs, ErrDifferentDatabase)
 		}
-		if opts.name.SchemaName() != opts.NewName.SchemaName() {
+		if opts.name.SchemaName() != opts.RenameTo.SchemaName() {
 			errs = append(errs, ErrDifferentSchema)
 		}
 		return JoinErrors(errs...)

--- a/pkg/sdk/masking_policies_gen.go
+++ b/pkg/sdk/masking_policies_gen.go
@@ -47,7 +47,7 @@ type AlterMaskingPolicyOptions struct {
 	maskingPolicy bool                    `ddl:"static" sql:"MASKING POLICY"`
 	IfExists      *bool                   `ddl:"keyword" sql:"IF EXISTS"`
 	name          SchemaObjectIdentifier  `ddl:"identifier"`
-	NewName       *SchemaObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
+	RenameTo      *SchemaObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
 	SetBody       *string                 `ddl:"parameter,no_quotes,no_equals" sql:"SET BODY ->"`
 	SetComment    *string                 `ddl:"parameter,single_quotes" sql:"SET COMMENT"`
 	UnsetBody     *bool                   `ddl:"keyword" sql:"UNSET BODY"`

--- a/pkg/sdk/masking_policies_impl_gen.go
+++ b/pkg/sdk/masking_policies_impl_gen.go
@@ -102,7 +102,7 @@ func (r *AlterMaskingPolicyRequest) toOpts() *AlterMaskingPolicyOptions {
 	opts := &AlterMaskingPolicyOptions{
 		IfExists:     r.IfExists,
 		name:         r.name,
-		NewName:      r.NewName,
+		RenameTo:     r.RenameTo,
 		SetBody:      r.SetBody,
 		SetComment:   r.SetComment,
 		UnsetBody:    r.UnsetBody,

--- a/pkg/sdk/masking_policies_validations_gen.go
+++ b/pkg/sdk/masking_policies_validations_gen.go
@@ -41,8 +41,8 @@ func (opts *AlterMaskingPolicyOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.NewName, opts.SetBody, opts.SetComment, opts.UnsetBody, opts.UnsetComment, opts.SetTags, opts.UnsetTags) {
-		errs = append(errs, errExactlyOneOf("AlterMaskingPolicyOptions", "NewName", "SetBody", "SetComment", "UnsetBody", "UnsetComment", "SetTags", "UnsetTags"))
+	if !exactlyOneValueSet(opts.RenameTo, opts.SetBody, opts.SetComment, opts.UnsetBody, opts.UnsetComment, opts.SetTags, opts.UnsetTags) {
+		errs = append(errs, errExactlyOneOf("AlterMaskingPolicyOptions", "RenameTo", "SetBody", "SetComment", "UnsetBody", "UnsetComment", "SetTags", "UnsetTags"))
 	}
 	errs = append(errs, opts.additionalValidations())
 	return JoinErrors(errs...)

--- a/pkg/sdk/masking_policy_test.go
+++ b/pkg/sdk/masking_policy_test.go
@@ -98,7 +98,7 @@ func TestMaskingPolicyAlter(t *testing.T) {
 		opts := &AlterMaskingPolicyOptions{
 			name: id,
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterMaskingPolicyOptions", "NewName", "SetBody", "SetComment", "UnsetBody", "UnsetComment", "SetTags", "UnsetTags"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterMaskingPolicyOptions", "RenameTo", "SetBody", "SetComment", "UnsetBody", "UnsetComment", "SetTags", "UnsetTags"))
 	})
 
 	t.Run("validation: incorrect identifier", func(t *testing.T) {
@@ -112,7 +112,7 @@ func TestMaskingPolicyAlter(t *testing.T) {
 		newId := randomSchemaObjectIdentifier()
 
 		opts := &AlterMaskingPolicyOptions{
-			NewName: &newId,
+			RenameTo: &newId,
 		}
 		assertOptsInvalidJoinedErrors(t, opts, ErrDifferentDatabase)
 		assertOptsInvalidJoinedErrors(t, opts, ErrDifferentSchema)
@@ -122,10 +122,10 @@ func TestMaskingPolicyAlter(t *testing.T) {
 		newID := randomSchemaObjectIdentifierInSchema(id.SchemaId())
 		opts := &AlterMaskingPolicyOptions{
 			name:       id,
-			NewName:    &newID,
+			RenameTo:   &newID,
 			SetComment: new("foo"),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterMaskingPolicyOptions", "NewName", "SetBody", "SetComment", "UnsetBody", "UnsetComment", "SetTags", "UnsetTags"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterMaskingPolicyOptions", "RenameTo", "SetBody", "SetComment", "UnsetBody", "UnsetComment", "SetTags", "UnsetTags"))
 	})
 
 	t.Run("with set comment", func(t *testing.T) {
@@ -148,8 +148,8 @@ func TestMaskingPolicyAlter(t *testing.T) {
 	t.Run("rename", func(t *testing.T) {
 		newID := randomSchemaObjectIdentifierInSchema(id.SchemaId())
 		opts := &AlterMaskingPolicyOptions{
-			name:    id,
-			NewName: &newID,
+			name:     id,
+			RenameTo: &newID,
 		}
 		assertOptsValidAndSQLEquals(t, opts, "ALTER MASKING POLICY %s RENAME TO %s", id.FullyQualifiedName(), newID.FullyQualifiedName())
 	})

--- a/pkg/sdk/organization_accounts_dto_builders_gen.go
+++ b/pkg/sdk/organization_accounts_dto_builders_gen.go
@@ -157,10 +157,10 @@ func (s *OrganizationAccountUnsetRequest) WithComment(comment bool) *Organizatio
 }
 
 func NewOrganizationAccountRenameRequest(
-	newName *AccountObjectIdentifier,
+	renameTo *AccountObjectIdentifier,
 ) *OrganizationAccountRenameRequest {
 	s := OrganizationAccountRenameRequest{}
-	s.NewName = newName
+	s.RenameTo = renameTo
 	return &s
 }
 

--- a/pkg/sdk/organization_accounts_dto_gen.go
+++ b/pkg/sdk/organization_accounts_dto_gen.go
@@ -50,7 +50,7 @@ type OrganizationAccountUnsetRequest struct {
 }
 
 type OrganizationAccountRenameRequest struct {
-	NewName    *AccountObjectIdentifier // required
+	RenameTo   *AccountObjectIdentifier // required
 	SaveOldUrl *bool
 }
 

--- a/pkg/sdk/organization_accounts_gen.go
+++ b/pkg/sdk/organization_accounts_gen.go
@@ -73,7 +73,7 @@ type OrganizationAccountUnset struct {
 }
 
 type OrganizationAccountRename struct {
-	NewName    *AccountObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
+	RenameTo   *AccountObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
 	SaveOldUrl *bool                    `ddl:"parameter" sql:"SAVE_OLD_URL"`
 }
 

--- a/pkg/sdk/organization_accounts_gen_test.go
+++ b/pkg/sdk/organization_accounts_gen_test.go
@@ -504,7 +504,7 @@ func TestOrganizationAccounts_Alter(t *testing.T) {
 		opts := defaultOpts()
 		opts.Name = &id
 		opts.RenameTo = &OrganizationAccountRename{
-			NewName:    &newId,
+			RenameTo:   &newId,
 			SaveOldUrl: Bool(false),
 		}
 		assertOptsValidAndSQLEquals(t, opts, "ALTER ORGANIZATION ACCOUNT %s RENAME TO %s SAVE_OLD_URL = false", id.FullyQualifiedName(), newId.FullyQualifiedName())

--- a/pkg/sdk/organization_accounts_impl_gen.go
+++ b/pkg/sdk/organization_accounts_impl_gen.go
@@ -95,7 +95,7 @@ func (r *AlterOrganizationAccountRequest) toOpts() *AlterOrganizationAccountOpti
 	}
 	if r.RenameTo != nil {
 		opts.RenameTo = &OrganizationAccountRename{
-			NewName:    r.RenameTo.NewName,
+			RenameTo:   r.RenameTo.RenameTo,
 			SaveOldUrl: r.RenameTo.SaveOldUrl,
 		}
 	}

--- a/pkg/sdk/password_policies_dto_builders_gen.go
+++ b/pkg/sdk/password_policies_dto_builders_gen.go
@@ -93,8 +93,8 @@ func (s *AlterPasswordPolicyRequest) WithIfExists(ifExists bool) *AlterPasswordP
 	return s
 }
 
-func (s *AlterPasswordPolicyRequest) WithNewName(newName SchemaObjectIdentifier) *AlterPasswordPolicyRequest {
-	s.NewName = &newName
+func (s *AlterPasswordPolicyRequest) WithRenameTo(renameTo SchemaObjectIdentifier) *AlterPasswordPolicyRequest {
+	s.RenameTo = &renameTo
 	return s
 }
 

--- a/pkg/sdk/password_policies_dto_gen.go
+++ b/pkg/sdk/password_policies_dto_gen.go
@@ -31,7 +31,7 @@ type CreatePasswordPolicyRequest struct {
 type AlterPasswordPolicyRequest struct {
 	IfExists *bool
 	name     SchemaObjectIdentifier // required
-	NewName  *SchemaObjectIdentifier
+	RenameTo *SchemaObjectIdentifier
 	Set      *PasswordPolicySetRequest
 	Unset    *PasswordPolicyUnsetRequest
 }

--- a/pkg/sdk/password_policies_gen.go
+++ b/pkg/sdk/password_policies_gen.go
@@ -47,7 +47,7 @@ type AlterPasswordPolicyOptions struct {
 	passwordPolicy bool                    `ddl:"static" sql:"PASSWORD POLICY"`
 	IfExists       *bool                   `ddl:"keyword" sql:"IF EXISTS"`
 	name           SchemaObjectIdentifier  `ddl:"identifier"`
-	NewName        *SchemaObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
+	RenameTo       *SchemaObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
 	Set            *PasswordPolicySet      `ddl:"list,no_parentheses" sql:"SET"`
 	Unset          *PasswordPolicyUnset    `ddl:"list,no_parentheses" sql:"UNSET"`
 }

--- a/pkg/sdk/password_policies_gen_test.go
+++ b/pkg/sdk/password_policies_gen_test.go
@@ -75,9 +75,9 @@ func TestPasswordPolicies_Alter(t *testing.T) {
 		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
-	t.Run("validation: exactly one field from [opts.Set opts.Unset opts.NewName] should be present", func(t *testing.T) {
+	t.Run("validation: exactly one field from [opts.Set opts.Unset opts.RenameTo] should be present", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterPasswordPolicyOptions", "Set", "Unset", "NewName"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterPasswordPolicyOptions", "Set", "Unset", "RenameTo"))
 	})
 
 	t.Run("validation: at least one of the fields [opts.Set.PasswordMinLength opts.Set.PasswordMaxLength opts.Set.PasswordMinUpperCaseChars opts.Set.PasswordMinLowerCaseChars opts.Set.PasswordMinNumericChars opts.Set.PasswordMinSpecialChars opts.Set.PasswordMinAgeDays opts.Set.PasswordMaxAgeDays opts.Set.PasswordMaxRetries opts.Set.PasswordLockoutTimeMins opts.Set.PasswordHistory opts.Set.Comment] should be set", func(t *testing.T) {
@@ -95,7 +95,7 @@ func TestPasswordPolicies_Alter(t *testing.T) {
 	t.Run("rename", func(t *testing.T) {
 		newID := randomSchemaObjectIdentifierInSchema(id.SchemaId())
 		opts := defaultOpts()
-		opts.NewName = &newID
+		opts.RenameTo = &newID
 		assertOptsValidAndSQLEquals(t, opts, "ALTER PASSWORD POLICY %s RENAME TO %s", id.FullyQualifiedName(), newID.FullyQualifiedName())
 	})
 

--- a/pkg/sdk/password_policies_impl_gen.go
+++ b/pkg/sdk/password_policies_impl_gen.go
@@ -99,7 +99,7 @@ func (r *AlterPasswordPolicyRequest) toOpts() *AlterPasswordPolicyOptions {
 	opts := &AlterPasswordPolicyOptions{
 		IfExists: r.IfExists,
 		name:     r.name,
-		NewName:  r.NewName,
+		RenameTo: r.RenameTo,
 	}
 	if r.Set != nil {
 		opts.Set = &PasswordPolicySet{

--- a/pkg/sdk/password_policies_validations_gen.go
+++ b/pkg/sdk/password_policies_validations_gen.go
@@ -32,8 +32,8 @@ func (opts *AlterPasswordPolicyOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.Set, opts.Unset, opts.NewName) {
-		errs = append(errs, errExactlyOneOf("AlterPasswordPolicyOptions", "Set", "Unset", "NewName"))
+	if !exactlyOneValueSet(opts.Set, opts.Unset, opts.RenameTo) {
+		errs = append(errs, errExactlyOneOf("AlterPasswordPolicyOptions", "Set", "Unset", "RenameTo"))
 	}
 	if valueSet(opts.Set) {
 		if !anyValueSet(opts.Set.PasswordMinLength, opts.Set.PasswordMaxLength, opts.Set.PasswordMinUpperCaseChars, opts.Set.PasswordMinLowerCaseChars, opts.Set.PasswordMinNumericChars, opts.Set.PasswordMinSpecialChars, opts.Set.PasswordMinAgeDays, opts.Set.PasswordMaxAgeDays, opts.Set.PasswordMaxRetries, opts.Set.PasswordLockoutTimeMins, opts.Set.PasswordHistory, opts.Set.Comment) {

--- a/pkg/sdk/schemas_dto_builders_gen.go
+++ b/pkg/sdk/schemas_dto_builders_gen.go
@@ -171,8 +171,8 @@ func (s *AlterSchemaRequest) WithIfExists(ifExists bool) *AlterSchemaRequest {
 	return s
 }
 
-func (s *AlterSchemaRequest) WithNewName(newName DatabaseObjectIdentifier) *AlterSchemaRequest {
-	s.NewName = &newName
+func (s *AlterSchemaRequest) WithRenameTo(renameTo DatabaseObjectIdentifier) *AlterSchemaRequest {
+	s.RenameTo = &renameTo
 	return s
 }
 

--- a/pkg/sdk/schemas_dto_gen.go
+++ b/pkg/sdk/schemas_dto_gen.go
@@ -51,7 +51,7 @@ type CloneSchemaRequest struct {
 type AlterSchemaRequest struct {
 	IfExists             *bool
 	name                 DatabaseObjectIdentifier // required
-	NewName              *DatabaseObjectIdentifier
+	RenameTo             *DatabaseObjectIdentifier
 	SwapWith             *DatabaseObjectIdentifier
 	Set                  *SchemaSetRequest
 	Unset                *SchemaUnsetRequest

--- a/pkg/sdk/schemas_gen.go
+++ b/pkg/sdk/schemas_gen.go
@@ -72,7 +72,7 @@ type AlterSchemaOptions struct {
 	schema               bool                      `ddl:"static" sql:"SCHEMA"`
 	IfExists             *bool                     `ddl:"keyword" sql:"IF EXISTS"`
 	name                 DatabaseObjectIdentifier  `ddl:"identifier"`
-	NewName              *DatabaseObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
+	RenameTo             *DatabaseObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
 	SwapWith             *DatabaseObjectIdentifier `ddl:"identifier" sql:"SWAP WITH"`
 	Set                  *SchemaSet                `ddl:"list,no_parentheses" sql:"SET"`
 	Unset                *SchemaUnset              `ddl:"list,no_parentheses" sql:"UNSET"`

--- a/pkg/sdk/schemas_impl_gen.go
+++ b/pkg/sdk/schemas_impl_gen.go
@@ -128,7 +128,7 @@ func (r *AlterSchemaRequest) toOpts() *AlterSchemaOptions {
 	opts := &AlterSchemaOptions{
 		IfExists:             r.IfExists,
 		name:                 r.name,
-		NewName:              r.NewName,
+		RenameTo:             r.RenameTo,
 		SwapWith:             r.SwapWith,
 		SetTags:              r.SetTags,
 		UnsetTags:            r.UnsetTags,

--- a/pkg/sdk/schemas_test.go
+++ b/pkg/sdk/schemas_test.go
@@ -145,7 +145,7 @@ func TestSchemasAlter(t *testing.T) {
 		opts := &AlterSchemaOptions{
 			name: schemaId,
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterSchemaOptions", "NewName", "SwapWith", "Set", "Unset", "SetTags", "UnsetTags", "EnableManagedAccess", "DisableManagedAccess"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterSchemaOptions", "RenameTo", "SwapWith", "Set", "Unset", "SetTags", "UnsetTags", "EnableManagedAccess", "DisableManagedAccess"))
 	})
 
 	t.Run("validation: exactly one of actions", func(t *testing.T) {
@@ -154,7 +154,7 @@ func TestSchemasAlter(t *testing.T) {
 			Set:   &SchemaSet{},
 			Unset: &SchemaUnset{},
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterSchemaOptions", "NewName", "SwapWith", "Set", "Unset", "SetTags", "UnsetTags", "EnableManagedAccess", "DisableManagedAccess"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterSchemaOptions", "RenameTo", "SwapWith", "Set", "Unset", "SetTags", "UnsetTags", "EnableManagedAccess", "DisableManagedAccess"))
 	})
 
 	t.Run("validation: at least one set option", func(t *testing.T) {
@@ -235,10 +235,10 @@ func TestSchemasAlter(t *testing.T) {
 		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
-	t.Run("validation: invalid NewName identifier", func(t *testing.T) {
+	t.Run("validation: invalid RenameTo identifier", func(t *testing.T) {
 		opts := &AlterSchemaOptions{
-			name:    schemaId,
-			NewName: Pointer(emptyDatabaseObjectIdentifier),
+			name:     schemaId,
+			RenameTo: Pointer(emptyDatabaseObjectIdentifier),
 		}
 		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
@@ -254,7 +254,7 @@ func TestSchemasAlter(t *testing.T) {
 		opts := &AlterSchemaOptions{
 			name:     schemaId,
 			IfExists: Bool(true),
-			NewName:  Pointer(newSchemaId),
+			RenameTo: Pointer(newSchemaId),
 		}
 		assertOptsValidAndSQLEquals(t, opts, `ALTER SCHEMA IF EXISTS %s RENAME TO %s`, schemaId.FullyQualifiedName(), newSchemaId.FullyQualifiedName())
 	})

--- a/pkg/sdk/schemas_validations_gen.go
+++ b/pkg/sdk/schemas_validations_gen.go
@@ -55,10 +55,10 @@ func (opts *AlterSchemaOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.NewName, opts.SwapWith, opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags, opts.EnableManagedAccess, opts.DisableManagedAccess) {
-		errs = append(errs, errExactlyOneOf("AlterSchemaOptions", "NewName", "SwapWith", "Set", "Unset", "SetTags", "UnsetTags", "EnableManagedAccess", "DisableManagedAccess"))
+	if !exactlyOneValueSet(opts.RenameTo, opts.SwapWith, opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags, opts.EnableManagedAccess, opts.DisableManagedAccess) {
+		errs = append(errs, errExactlyOneOf("AlterSchemaOptions", "RenameTo", "SwapWith", "Set", "Unset", "SetTags", "UnsetTags", "EnableManagedAccess", "DisableManagedAccess"))
 	}
-	if opts.NewName != nil && !ValidObjectIdentifier(opts.NewName) {
+	if opts.RenameTo != nil && !ValidObjectIdentifier(opts.RenameTo) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	if opts.SwapWith != nil && !ValidObjectIdentifier(opts.SwapWith) {

--- a/pkg/sdk/tags_dto_builders_gen.go
+++ b/pkg/sdk/tags_dto_builders_gen.go
@@ -108,8 +108,8 @@ func (s *AlterTagRequest) WithUnset(unset TagUnsetRequest) *AlterTagRequest {
 	return s
 }
 
-func (s *AlterTagRequest) WithRename(rename TagRenameRequest) *AlterTagRequest {
-	s.Rename = &rename
+func (s *AlterTagRequest) WithRenameTo(renameTo SchemaObjectIdentifier) *AlterTagRequest {
+	s.RenameTo = &renameTo
 	return s
 }
 
@@ -219,14 +219,6 @@ func NewTagUnsetMaskingPoliciesRequest() *TagUnsetMaskingPoliciesRequest {
 func (s *TagUnsetMaskingPoliciesRequest) WithMaskingPolicies(maskingPolicies []TagMaskingPolicyRequest) *TagUnsetMaskingPoliciesRequest {
 	s.MaskingPolicies = maskingPolicies
 	return s
-}
-
-func NewTagRenameRequest(
-	name SchemaObjectIdentifier,
-) *TagRenameRequest {
-	s := TagRenameRequest{}
-	s.Name = name
-	return &s
 }
 
 func NewShowTagRequest() *ShowTagRequest {

--- a/pkg/sdk/tags_dto_gen.go
+++ b/pkg/sdk/tags_dto_gen.go
@@ -42,7 +42,7 @@ type AlterTagRequest struct {
 	Drop     *TagDropRequest
 	Set      *TagSetRequest
 	Unset    *TagUnsetRequest
-	Rename   *TagRenameRequest
+	RenameTo *SchemaObjectIdentifier
 }
 
 type TagAddRequest struct {
@@ -79,10 +79,6 @@ type TagUnsetRequest struct {
 
 type TagUnsetMaskingPoliciesRequest struct {
 	MaskingPolicies []TagMaskingPolicyRequest
-}
-
-type TagRenameRequest struct {
-	Name SchemaObjectIdentifier // required
 }
 
 type ShowTagRequest struct {

--- a/pkg/sdk/tags_gen.go
+++ b/pkg/sdk/tags_gen.go
@@ -52,15 +52,15 @@ type TagOnConflict struct {
 
 // AlterTagOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-tag.
 type AlterTagOptions struct {
-	alter    bool                   `ddl:"static" sql:"ALTER"`
-	tag      bool                   `ddl:"static" sql:"TAG"`
-	IfExists *bool                  `ddl:"keyword" sql:"IF EXISTS"`
-	name     SchemaObjectIdentifier `ddl:"identifier"`
-	Add      *TagAdd                `ddl:"keyword" sql:"ADD"`
-	Drop     *TagDrop               `ddl:"keyword" sql:"DROP"`
-	Set      *TagSet                `ddl:"keyword" sql:"SET"`
-	Unset    *TagUnset              `ddl:"keyword" sql:"UNSET"`
-	Rename   *TagRename             `ddl:"keyword" sql:"RENAME TO"`
+	alter    bool                    `ddl:"static" sql:"ALTER"`
+	tag      bool                    `ddl:"static" sql:"TAG"`
+	IfExists *bool                   `ddl:"keyword" sql:"IF EXISTS"`
+	name     SchemaObjectIdentifier  `ddl:"identifier"`
+	Add      *TagAdd                 `ddl:"keyword" sql:"ADD"`
+	Drop     *TagDrop                `ddl:"keyword" sql:"DROP"`
+	Set      *TagSet                 `ddl:"keyword" sql:"SET"`
+	Unset    *TagUnset               `ddl:"keyword" sql:"UNSET"`
+	RenameTo *SchemaObjectIdentifier `ddl:"identifier" sql:"RENAME TO"`
 }
 
 type TagAdd struct {
@@ -97,10 +97,6 @@ type TagUnset struct {
 
 type TagUnsetMaskingPolicies struct {
 	MaskingPolicies []TagMaskingPolicy `ddl:"list"`
-}
-
-type TagRename struct {
-	Name SchemaObjectIdentifier `ddl:"identifier"`
 }
 
 // ShowTagOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-tags.

--- a/pkg/sdk/tags_impl_gen.go
+++ b/pkg/sdk/tags_impl_gen.go
@@ -107,6 +107,7 @@ func (r *AlterTagRequest) toOpts() *AlterTagOptions {
 	opts := &AlterTagOptions{
 		IfExists: r.IfExists,
 		name:     r.name,
+		RenameTo: r.RenameTo,
 	}
 	if r.Add != nil {
 		opts.Add = &TagAdd{}
@@ -177,11 +178,6 @@ func (r *AlterTagRequest) toOpts() *AlterTagOptions {
 				}
 				opts.Unset.MaskingPolicies.MaskingPolicies = maskingPolicies
 			}
-		}
-	}
-	if r.Rename != nil {
-		opts.Rename = &TagRename{
-			Name: r.Rename.Name,
 		}
 	}
 	return opts

--- a/pkg/sdk/tags_test.go
+++ b/pkg/sdk/tags_test.go
@@ -219,9 +219,9 @@ func TestTagAlter(t *testing.T) {
 
 	t.Run("alter with rename to and if exists", func(t *testing.T) {
 		opts := defaultOpts()
-		opts.Rename = &TagRename{Name: randomSchemaObjectIdentifierInSchema(id.SchemaId())}
+		opts.RenameTo = Pointer(randomSchemaObjectIdentifierInSchema(id.SchemaId()))
 		opts.IfExists = Pointer(true)
-		assertOptsValidAndSQLEquals(t, opts, `ALTER TAG IF EXISTS %s RENAME TO %s`, id.FullyQualifiedName(), opts.Rename.Name.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, `ALTER TAG IF EXISTS %s RENAME TO %s`, id.FullyQualifiedName(), opts.RenameTo.FullyQualifiedName())
 	})
 
 	t.Run("alter with add", func(t *testing.T) {
@@ -317,7 +317,7 @@ func TestTagAlter(t *testing.T) {
 
 	t.Run("validation: no alter action", func(t *testing.T) {
 		opts := defaultOpts()
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterTagOptions", "Add", "Drop", "Set", "Unset", "Rename"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterTagOptions", "Add", "Drop", "Set", "Unset", "RenameTo"))
 	})
 
 	t.Run("validation: multiple alter actions", func(t *testing.T) {
@@ -328,7 +328,7 @@ func TestTagAlter(t *testing.T) {
 		opts.Unset = &TagUnset{
 			AllowedValues: Bool(true),
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterTagOptions", "Add", "Drop", "Set", "Unset", "Rename"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterTagOptions", "Add", "Drop", "Set", "Unset", "RenameTo"))
 	})
 
 	t.Run("validation: multiple fields in set", func(t *testing.T) {
@@ -358,9 +358,7 @@ func TestTagAlter(t *testing.T) {
 
 	t.Run("validation: invalid new name", func(t *testing.T) {
 		opts := defaultOpts()
-		opts.Rename = &TagRename{
-			Name: emptySchemaObjectIdentifier,
-		}
+		opts.RenameTo = &emptySchemaObjectIdentifier
 		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
 	})
 
@@ -368,9 +366,7 @@ func TestTagAlter(t *testing.T) {
 		newId := randomSchemaObjectIdentifier()
 
 		opts := defaultOpts()
-		opts.Rename = &TagRename{
-			Name: newId,
-		}
+		opts.RenameTo = &newId
 		assertOptsValid(t, opts)
 	})
 

--- a/pkg/sdk/tags_validations_gen.go
+++ b/pkg/sdk/tags_validations_gen.go
@@ -44,8 +44,8 @@ func (opts *AlterTagOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.Add, opts.Drop, opts.Set, opts.Unset, opts.Rename) {
-		errs = append(errs, errExactlyOneOf("AlterTagOptions", "Add", "Drop", "Set", "Unset", "Rename"))
+	if !exactlyOneValueSet(opts.Add, opts.Drop, opts.Set, opts.Unset, opts.RenameTo) {
+		errs = append(errs, errExactlyOneOf("AlterTagOptions", "Add", "Drop", "Set", "Unset", "RenameTo"))
 	}
 	if valueSet(opts.Add) {
 		if valueSet(opts.Add.AllowedValues) {
@@ -78,11 +78,6 @@ func (opts *AlterTagOptions) validate() error {
 			errs = append(errs, errExactlyOneOf("AlterTagOptions.Unset", "MaskingPolicies", "AllowedValues", "Propagate", "OnConflict", "Comment"))
 		}
 		errs = append(errs, opts.Unset.additionalValidations())
-	}
-	if valueSet(opts.Rename) {
-		if !ValidObjectIdentifier(opts.Rename.Name) {
-			errs = append(errs, ErrInvalidObjectIdentifier)
-		}
 	}
 	return JoinErrors(errs...)
 }

--- a/pkg/sdk/tags_validations_gen.go
+++ b/pkg/sdk/tags_validations_gen.go
@@ -44,6 +44,9 @@ func (opts *AlterTagOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
+	if opts.RenameTo != nil && !ValidObjectIdentifier(opts.RenameTo) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
 	if !exactlyOneValueSet(opts.Add, opts.Drop, opts.Set, opts.Unset, opts.RenameTo) {
 		errs = append(errs, errExactlyOneOf("AlterTagOptions", "Add", "Drop", "Set", "Unset", "RenameTo"))
 	}

--- a/pkg/sdk/testint/database_role_integration_test.go
+++ b/pkg/sdk/testint/database_role_integration_test.go
@@ -123,7 +123,7 @@ func TestInt_DatabaseRoles(t *testing.T) {
 		require.NoError(t, err)
 
 		newId := testClientHelper().Ids.RandomDatabaseObjectIdentifier()
-		alterRequest := sdk.NewAlterDatabaseRoleRequest(id).WithRename(newId)
+		alterRequest := sdk.NewAlterDatabaseRoleRequest(id).WithRenameTo(newId)
 
 		err = client.DatabaseRoles.Alter(ctx, alterRequest)
 		if err != nil {
@@ -157,7 +157,7 @@ func TestInt_DatabaseRoles(t *testing.T) {
 		t.Cleanup(cleanupDatabaseRoleProvider(id))
 
 		newId := testClientHelper().Ids.RandomDatabaseObjectIdentifierInDatabase(secondDatabase.ID())
-		alterRequest := sdk.NewAlterDatabaseRoleRequest(id).WithRename(newId)
+		alterRequest := sdk.NewAlterDatabaseRoleRequest(id).WithRenameTo(newId)
 
 		err = client.DatabaseRoles.Alter(ctx, alterRequest)
 		assert.ErrorContains(t, err, sdk.ErrDifferentDatabase.Error())

--- a/pkg/sdk/testint/databases_integration_test.go
+++ b/pkg/sdk/testint/databases_integration_test.go
@@ -418,7 +418,7 @@ func TestInt_DatabasesAlter(t *testing.T) {
 			t.Cleanup(databaseTestCleanup)
 			newName := testClientHelper().Ids.RandomAccountObjectIdentifier()
 
-			err := client.Databases.Alter(ctx, sdk.NewAlterDatabaseRequest(databaseTest.ID()).WithNewName(newName))
+			err := client.Databases.Alter(ctx, sdk.NewAlterDatabaseRequest(databaseTest.ID()).WithRenameTo(newName))
 			require.NoError(t, err)
 			t.Cleanup(testClientHelper().Database.DropDatabaseFunc(t, newName))
 

--- a/pkg/sdk/testint/hybrid_tables_integration_test.go
+++ b/pkg/sdk/testint/hybrid_tables_integration_test.go
@@ -282,7 +282,7 @@ func TestInt_HybridTables(t *testing.T) {
 			t.Cleanup(cleanup)
 
 			newId := testClientHelper().Ids.RandomSchemaObjectIdentifier()
-			err := client.HybridTables.Alter(ctx, sdk.NewAlterHybridTableRequest(id).WithNewName(newId))
+			err := client.HybridTables.Alter(ctx, sdk.NewAlterHybridTableRequest(id).WithRenameTo(newId))
 			require.NoError(t, err)
 			t.Cleanup(testClientHelper().HybridTable.DropFunc(t, newId))
 

--- a/pkg/sdk/testint/masking_policy_integration_test.go
+++ b/pkg/sdk/testint/masking_policy_integration_test.go
@@ -275,13 +275,13 @@ func TestInt_MaskingPolicyAlter(t *testing.T) {
 		oldID := maskingPolicy.ID()
 		t.Cleanup(maskingPolicyCleanup)
 		newID := testClientHelper().Ids.RandomSchemaObjectIdentifier()
-		err := client.MaskingPolicies.Alter(ctx, sdk.NewAlterMaskingPolicyRequest(oldID).WithNewName(newID))
+		err := client.MaskingPolicies.Alter(ctx, sdk.NewAlterMaskingPolicyRequest(oldID).WithRenameTo(newID))
 		require.NoError(t, err)
 		maskingPolicyDetails, err := client.MaskingPolicies.Describe(ctx, newID)
 		require.NoError(t, err)
 		assert.Equal(t, newID.Name(), maskingPolicyDetails.Name)
 		// rename back to original name, so it can be cleaned up
-		err = client.MaskingPolicies.Alter(ctx, sdk.NewAlterMaskingPolicyRequest(newID).WithNewName(oldID))
+		err = client.MaskingPolicies.Alter(ctx, sdk.NewAlterMaskingPolicyRequest(newID).WithRenameTo(oldID))
 		require.NoError(t, err)
 	})
 

--- a/pkg/sdk/testint/password_policy_integration_test.go
+++ b/pkg/sdk/testint/password_policy_integration_test.go
@@ -228,7 +228,7 @@ func TestInt_PasswordPolicies(t *testing.T) {
 		id := passwordPolicy.ID()
 
 		newId := testClientHelper().Ids.RandomSchemaObjectIdentifier()
-		err := client.PasswordPolicies.Alter(ctx, sdk.NewAlterPasswordPolicyRequest(id).WithNewName(newId))
+		err := client.PasswordPolicies.Alter(ctx, sdk.NewAlterPasswordPolicyRequest(id).WithRenameTo(newId))
 		if err != nil {
 			t.Cleanup(testClientHelper().PasswordPolicy.DropPasswordPolicyFunc(t, id))
 		} else {

--- a/pkg/sdk/testint/schemas_integration_test.go
+++ b/pkg/sdk/testint/schemas_integration_test.go
@@ -244,7 +244,7 @@ func TestInt_Schemas(t *testing.T) {
 			require.NoError(t, err)
 		})
 		newID := testClientHelper().Ids.RandomDatabaseObjectIdentifier()
-		err := client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(schema.ID()).WithNewName(newID))
+		err := client.Schemas.Alter(ctx, sdk.NewAlterSchemaRequest(schema.ID()).WithRenameTo(newID))
 		require.NoError(t, err)
 		s, err := client.Schemas.ShowByID(ctx, newID)
 		require.NoError(t, err)

--- a/pkg/sdk/testint/tags_integration_test.go
+++ b/pkg/sdk/testint/tags_integration_test.go
@@ -216,7 +216,7 @@ func TestInt_Tags(t *testing.T) {
 		id := tag.ID()
 
 		nid := testClientHelper().Ids.RandomSchemaObjectIdentifier()
-		err := client.Tags.Alter(ctx, sdk.NewAlterTagRequest(id).WithRename(*sdk.NewTagRenameRequest(nid)))
+		err := client.Tags.Alter(ctx, sdk.NewAlterTagRequest(id).WithRenameTo(nid))
 		if err != nil {
 			t.Cleanup(testClientHelper().Tag.DropTagFunc(t, id))
 		} else {

--- a/pkg/sdk/testint/users_integration_test.go
+++ b/pkg/sdk/testint/users_integration_test.go
@@ -1073,7 +1073,7 @@ func TestInt_Users(t *testing.T) {
 		t.Cleanup(userCleanup)
 
 		newID := testClientHelper().Ids.RandomAccountObjectIdentifier()
-		err := client.Users.Alter(ctx, sdk.NewAlterUserRequest(user.ID()).WithNewName(newID))
+		err := client.Users.Alter(ctx, sdk.NewAlterUserRequest(user.ID()).WithRenameTo(newID))
 		require.NoError(t, err)
 		t.Cleanup(testClientHelper().User.DropUserFunc(t, newID))
 
@@ -2340,7 +2340,7 @@ func TestInt_Users(t *testing.T) {
 
 		// we rename user
 		newId := testClientHelper().Ids.RandomAccountObjectIdentifier()
-		err = client.Users.Alter(ctx, sdk.NewAlterUserRequest(id).WithNewName(newId))
+		err = client.Users.Alter(ctx, sdk.NewAlterUserRequest(id).WithRenameTo(newId))
 		require.NoError(t, err)
 		userDetails, err = client.Users.DescribeDetails(ctx, newId)
 		require.NoError(t, err)

--- a/pkg/sdk/users_dto_builders_gen.go
+++ b/pkg/sdk/users_dto_builders_gen.go
@@ -293,8 +293,8 @@ func (s *AlterUserRequest) WithIfExists(ifExists bool) *AlterUserRequest {
 	return s
 }
 
-func (s *AlterUserRequest) WithNewName(newName AccountObjectIdentifier) *AlterUserRequest {
-	s.NewName = &newName
+func (s *AlterUserRequest) WithRenameTo(renameTo AccountObjectIdentifier) *AlterUserRequest {
+	s.RenameTo = &renameTo
 	return s
 }
 

--- a/pkg/sdk/users_dto_gen.go
+++ b/pkg/sdk/users_dto_gen.go
@@ -88,7 +88,7 @@ type UserObjectParametersRequest struct {
 type AlterUserRequest struct {
 	IfExists                     *bool
 	name                         AccountObjectIdentifier // required
-	NewName                      *AccountObjectIdentifier
+	RenameTo                     *AccountObjectIdentifier
 	ResetPassword                *bool
 	AbortAllQueries              *bool
 	AddDelegatedAuthorization    *AddDelegatedAuthorizationRequest

--- a/pkg/sdk/users_gen.go
+++ b/pkg/sdk/users_gen.go
@@ -118,7 +118,7 @@ type AlterUserOptions struct {
 	user                         bool                          `ddl:"static" sql:"USER"`
 	IfExists                     *bool                         `ddl:"keyword" sql:"IF EXISTS"`
 	name                         AccountObjectIdentifier       `ddl:"identifier"`
-	NewName                      *AccountObjectIdentifier      `ddl:"identifier" sql:"RENAME TO"`
+	RenameTo                     *AccountObjectIdentifier      `ddl:"identifier" sql:"RENAME TO"`
 	ResetPassword                *bool                         `ddl:"keyword" sql:"RESET PASSWORD"`
 	AbortAllQueries              *bool                         `ddl:"keyword" sql:"ABORT ALL QUERIES"`
 	AddDelegatedAuthorization    *AddDelegatedAuthorization    `ddl:"keyword"`

--- a/pkg/sdk/users_impl_gen.go
+++ b/pkg/sdk/users_impl_gen.go
@@ -161,7 +161,7 @@ func (r *AlterUserRequest) toOpts() *AlterUserOptions {
 	opts := &AlterUserOptions{
 		IfExists:        r.IfExists,
 		name:            r.name,
-		NewName:         r.NewName,
+		RenameTo:        r.RenameTo,
 		ResetPassword:   r.ResetPassword,
 		AbortAllQueries: r.AbortAllQueries,
 		SetTags:         r.SetTags,

--- a/pkg/sdk/users_test.go
+++ b/pkg/sdk/users_test.go
@@ -232,7 +232,7 @@ func TestUserAlter(t *testing.T) {
 		opts := &AlterUserOptions{
 			name: id,
 		}
-		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterUserOptions", "NewName", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset", "SetTags", "UnsetTags"))
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("AlterUserOptions", "RenameTo", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset", "SetTags", "UnsetTags"))
 	})
 
 	t.Run("validation: no set", func(t *testing.T) {
@@ -507,8 +507,8 @@ func TestUserAlter(t *testing.T) {
 	t.Run("rename", func(t *testing.T) {
 		newID := randomAccountObjectIdentifier()
 		opts := &AlterUserOptions{
-			name:    id,
-			NewName: &newID,
+			name:     id,
+			RenameTo: &newID,
 		}
 		assertOptsValidAndSQLEquals(t, opts, "ALTER USER %s RENAME TO %s", id.FullyQualifiedName(), newID.FullyQualifiedName())
 	})

--- a/pkg/sdk/users_validations_gen.go
+++ b/pkg/sdk/users_validations_gen.go
@@ -45,8 +45,8 @@ func (opts *AlterUserOptions) validate() error {
 	if !ValidObjectIdentifier(opts.name) {
 		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
-	if !exactlyOneValueSet(opts.NewName, opts.ResetPassword, opts.AbortAllQueries, opts.AddDelegatedAuthorization, opts.RemoveDelegatedAuthorization, opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags) {
-		errs = append(errs, errExactlyOneOf("AlterUserOptions", "NewName", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset", "SetTags", "UnsetTags"))
+	if !exactlyOneValueSet(opts.RenameTo, opts.ResetPassword, opts.AbortAllQueries, opts.AddDelegatedAuthorization, opts.RemoveDelegatedAuthorization, opts.Set, opts.Unset, opts.SetTags, opts.UnsetTags) {
+		errs = append(errs, errExactlyOneOf("AlterUserOptions", "RenameTo", "ResetPassword", "AbortAllQueries", "AddDelegatedAuthorization", "RemoveDelegatedAuthorization", "Set", "Unset", "SetTags", "UnsetTags"))
 	}
 	if valueSet(opts.RemoveDelegatedAuthorization) {
 		if !exactlyOneValueSet(opts.RemoveDelegatedAuthorization.RemoveDelegatedAuthorizationOfRole, opts.RemoveDelegatedAuthorization.Authorizations) {

--- a/pkg/testacc/resource_schema_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_schema_experimental_features_acceptance_test.go
@@ -307,7 +307,7 @@ func TestAcc_Experimental_Schema_HierarchyRenames_Error_SchemaNotFoundForMove(t 
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						planchecks.Execute(func() {
-							testClient().Schema.Alter(t, sdk.NewAlterSchemaRequest(schemaId).WithNewName(sdk.NewDatabaseObjectIdentifier(dbA.ID().Name(), testClient().Ids.Alpha())))
+							testClient().Schema.Alter(t, sdk.NewAlterSchemaRequest(schemaId).WithRenameTo(sdk.NewDatabaseObjectIdentifier(dbA.ID().Name(), testClient().Ids.Alpha())))
 						}),
 					},
 				},

--- a/pkg/testacc/resource_table_experimental_features_acceptance_test.go
+++ b/pkg/testacc/resource_table_experimental_features_acceptance_test.go
@@ -677,7 +677,7 @@ func TestAcc_Experimental_Table_HierarchyRenames_Error_SchemaDroppedExternally(t
 						planchecks.Execute(func() {
 							testClient().Schema.Alter(
 								t, sdk.NewAlterSchemaRequest(schema.ID()).
-									WithNewName(sdk.NewDatabaseObjectIdentifier(dbA.ID().Name(), testClient().Ids.Alpha())),
+									WithRenameTo(sdk.NewDatabaseObjectIdentifier(dbA.ID().Name(), testClient().Ids.Alpha())),
 							)
 						}),
 					},

--- a/pkg/testacc/snowflake_behavior_object_renaming_acceptance_test.go
+++ b/pkg/testacc/snowflake_behavior_object_renaming_acceptance_test.go
@@ -276,7 +276,7 @@ func TestAcc_ShallowHierarchy_IsInConfig_RenamedExternally(t *testing.T) {
 					},
 					{
 						PreConfig: func() {
-							testClient().Database.Alter(t, sdk.NewAlterDatabaseRequest(databaseId).WithNewName(newDatabaseId))
+							testClient().Database.Alter(t, sdk.NewAlterDatabaseRequest(databaseId).WithRenameTo(newDatabaseId))
 							t.Cleanup(testClient().Database.DropDatabaseFunc(t, newDatabaseId))
 						},
 						ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -319,7 +319,7 @@ func TestAcc_ShallowHierarchy_IsInConfig_RenamedExternally_WithoutDependency_Aft
 				// This step has inconsistent results, and it depends on the Terraform execution order which seems to be non-deterministic in this case
 				PreConfig: func() {
 					newDatabaseId := testClient().Ids.RandomAccountObjectIdentifier()
-					testClient().Database.Alter(t, sdk.NewAlterDatabaseRequest(databaseId).WithNewName(newDatabaseId))
+					testClient().Database.Alter(t, sdk.NewAlterDatabaseRequest(databaseId).WithRenameTo(newDatabaseId))
 					t.Cleanup(testClient().Database.DropDatabaseFunc(t, newDatabaseId))
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -360,7 +360,7 @@ func TestAcc_ShallowHierarchy_IsInConfig_RenamedExternally_WithoutDependency_Aft
 			{
 				PreConfig: func() {
 					newDatabaseId := testClient().Ids.RandomAccountObjectIdentifier()
-					testClient().Database.Alter(t, sdk.NewAlterDatabaseRequest(databaseId).WithNewName(newDatabaseId))
+					testClient().Database.Alter(t, sdk.NewAlterDatabaseRequest(databaseId).WithRenameTo(newDatabaseId))
 					t.Cleanup(testClient().Database.DropDatabaseFunc(t, newDatabaseId))
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -416,7 +416,7 @@ func TestAcc_ShallowHierarchy_IsNotInConfig_RenamedExternally(t *testing.T) {
 					},
 					{
 						PreConfig: func() {
-							testClient().Database.Alter(t, sdk.NewAlterDatabaseRequest(databaseId).WithNewName(newDatabaseId))
+							testClient().Database.Alter(t, sdk.NewAlterDatabaseRequest(databaseId).WithRenameTo(newDatabaseId))
 							t.Cleanup(testClient().Database.DropDatabaseFunc(t, newDatabaseId))
 						},
 						ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -636,7 +636,7 @@ func TestAcc_DeepHierarchy_AreInConfig_DatabaseRenamedExternally(t *testing.T) {
 				testSteps = append(
 					testSteps, resource.TestStep{
 						PreConfig: func() {
-							testClient().Database.Alter(t, sdk.NewAlterDatabaseRequest(databaseId).WithNewName(newDatabaseId))
+							testClient().Database.Alter(t, sdk.NewAlterDatabaseRequest(databaseId).WithRenameTo(newDatabaseId))
 						},
 						Config: config.FromModels(t, databaseConfigModelWithNewId) +
 							configSchemaWithReferences(t, databaseConfigModelWithNewId.ResourceReference(), testCase.DatabaseInSchemaDependency, newDatabaseId.Name(), schemaName) +
@@ -703,7 +703,7 @@ func TestAcc_DeepHierarchy_AreInConfig_SchemaRenamedExternally(t *testing.T) {
 				testSteps = append(
 					testSteps, resource.TestStep{
 						PreConfig: func() {
-							testClient().Schema.Alter(t, sdk.NewAlterSchemaRequest(schemaId).WithNewName(newSchemaId))
+							testClient().Schema.Alter(t, sdk.NewAlterSchemaRequest(schemaId).WithRenameTo(newSchemaId))
 						},
 						Config: config.FromModels(t, databaseConfigModel) +
 							configSchemaWithReferences(t, databaseConfigModel.ResourceReference(), testCase.DatabaseInSchemaDependency, databaseId.Name(), newSchemaId.Name()) +
@@ -766,7 +766,7 @@ func TestAcc_DeepHierarchy_AreNotInConfig_DatabaseRenamedExternally(t *testing.T
 					},
 					{
 						PreConfig: func() {
-							testClient().Database.Alter(t, sdk.NewAlterDatabaseRequest(database.ID()).WithNewName(newDatabaseId))
+							testClient().Database.Alter(t, sdk.NewAlterDatabaseRequest(database.ID()).WithRenameTo(newDatabaseId))
 							t.Cleanup(testClient().Database.DropDatabaseFunc(t, newDatabaseId))
 						},
 						Config:      configTableWithReferences(t, "", NoDependency, "", NoDependency, secondStepDatabaseName, schema.ID().Name(), tableName),
@@ -819,7 +819,7 @@ func TestAcc_DeepHierarchy_AreNotInConfig_SchemaRenamedExternally(t *testing.T) 
 					},
 					{
 						PreConfig: func() {
-							testClient().Schema.Alter(t, sdk.NewAlterSchemaRequest(schema.ID()).WithNewName(newSchemaId))
+							testClient().Schema.Alter(t, sdk.NewAlterSchemaRequest(schema.ID()).WithRenameTo(newSchemaId))
 						},
 						Config:      configTableWithReferences(t, "", NoDependency, "", NoDependency, database.ID().Name(), secondStepSchemaName, tableName),
 						ExpectError: testCase.ExpectedSecondStepError,


### PR DESCRIPTION
  **Problem:** The rename field on Alter operations was inconsistently named across SDK definitions — 22 used `"RenameTo"`, 6 used `"NewName"`, and 2 used `"Rename"` (one a wrapper struct).                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                        
  **Field name standardization** — all 9 non-standard definitions updated:                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                        
  | Definition | Old name | New name |                                                                                                                                                                                                                                                                                                                                    
  |---|---|---|                                                                                                                                                                                                                                                                                                                                                         
  | `databases_def.go` | `NewName` | `RenameTo` |                                                                                                                                                                                                                                                                                                                         
  | `hybrid_tables_def.go` | `NewName` | `RenameTo` |                                                                                                                                                                                                                                                                                                                     
  | `masking_policies_def.go` | `NewName` | `RenameTo` |                                                                                                                                                                                                                                                                                                                  
  | `organization_accounts_def.go` | inner `NewName` | `RenameTo` |                                                                                                                                                                                                                                                                                                       
  | `password_policies_def.go` | `NewName` | `RenameTo` |                                                                                                                                                                                                                                                                                                                 
  | `schemas_def.go` | `NewName` | `RenameTo` |                                                                                                                                                                                                                                                                                                                           
  | `users_def.go` | `NewName` | `RenameTo` |                                                                                                                                                                                                                                                                                                                             
  | `database_role_def.go` | `Rename` | `RenameTo` |                                                                                                                                                                                                                                                                                                                      
  | `tags_def.go` | `Rename` (wrapper struct) | `RenameTo` (direct identifier) |                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                          
  **`RenameTo()` generator helper** — extracts the repeated `OptionalIdentifier("RenameTo", KindOfT[...], IdentifierOptions().SQL("RENAME TO"))` pattern into a single zero-argument method, applied to 27 of 30 rename definitions. Three defs keep explicit `OptionalIdentifier` due to intentional type or DDL differences:                                            
  - `procedures_def.go` / `functions_def.go` — rename uses `SchemaObjectIdentifier`, not the interface's `SchemaObjectIdentifierWithArguments`                                                                                                                                                                                                                            
  - `user_programmatic_access_tokens_def.go` — requires `.NoEquals()` DDL option                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                        
  **Generator engine changes** (`pkg/sdk/generator/gen/`)                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                        
  - `identifier_builders.go` — sentinel constants `InterfaceIdentifierKind` / `InterfaceIdentifierPointerKind` replace the old `"<will be replaced>"` string; `Name()` updated; `RenameTo()` added; `identifierField` slot removed from `Name()`                                                                                                                          
  - `query_struct.go` — `identifierField *Field` removed entirely                                                                                                                                                                                                                                                                                                       
  - `instance_method_builders.go` — switched from `"<will be replaced>"` to `InterfaceIdentifierKind`                                                                                                                                                                                                                                                                     
  - `0_defs.go` — `resolveInterfaceIdentifierKinds()` added; called once per operation in `preprocessDefinition` right after `setParent`, replacing the three scattered patches in `operation.go`                                                                                                                                                                         
  - `operation.go` — removed 3 `identifierField.Kind` patches (now handled in `preprocessDefinition`)                                                                                                                                                                                                                                                                     
                                                                                                                                                                         