### PR TITLE
chore: Ignore blocked_roles_list in external OAuth import verify

### DIFF
--- a/pkg/testacc/resource_external_oauth_integration_acceptance_test.go
+++ b/pkg/testacc/resource_external_oauth_integration_acceptance_test.go
@@ -315,6 +315,7 @@ func TestAcc_ExternalOauthIntegration_CompleteUseCase(t *testing.T) {
 					"external_oauth_any_role_mode",
 					"external_oauth_scope_delimiter",
 					"external_oauth_allowed_roles_list",
+					"external_oauth_blocked_roles_list",
 				},
 			},
 		},


### PR DESCRIPTION
TestAcc_ExternalOauthIntegration_CompleteUseCase sets only external_oauth_allowed_roles_list. On older Snowflake versions the blocked list then stayed empty, but on newer versions both lists are always populated, so ACCOUNTADMIN and SECURITYADMIN now show up in the blocked list. ImportStateVerify sees the extra roles and fails.

Ignoring external_oauth_blocked_roles_list on import mirrors the other import steps in this file. It is safe to do so because the read path suppresses the privileged roles via
IgnoreValuesFromSetIfParamSet.