### PR TITLE
chore: Add inherited grants support to SDK

### DIFF
--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"database/sql"
 	"log"
 	"strings"
 	"time"
@@ -9,11 +10,17 @@ import (
 
 type Grants interface {
 	GrantPrivilegesToAccountRole(ctx context.Context, privileges *AccountRoleGrantPrivileges, on *AccountRoleGrantOn, role AccountObjectIdentifier, opts *GrantPrivilegesToAccountRoleOptions) error
+	GrantInheritedPrivilegesToAccountRole(ctx context.Context, privileges InheritedAccountRoleGrantPrivileges, onAll PluralObjectType, in InheritedAccountRoleGrantIn, role AccountObjectIdentifier) error
 	RevokePrivilegesFromAccountRole(ctx context.Context, privileges *AccountRoleGrantPrivileges, on *AccountRoleGrantOn, role AccountObjectIdentifier, opts *RevokePrivilegesFromAccountRoleOptions) error
 	RevokePrivilegesFromAccountRoleSafely(ctx context.Context, privileges *AccountRoleGrantPrivileges, on *AccountRoleGrantOn, role AccountObjectIdentifier, opts *RevokePrivilegesFromAccountRoleOptions) error
+	RevokeInheritedPrivilegesFromAccountRole(ctx context.Context, privileges InheritedAccountRoleGrantPrivileges, onAll PluralObjectType, in InheritedAccountRoleGrantIn, role AccountObjectIdentifier) error
+	RevokeInheritedPrivilegesFromAccountRoleSafely(ctx context.Context, privileges InheritedAccountRoleGrantPrivileges, onAll PluralObjectType, in InheritedAccountRoleGrantIn, role AccountObjectIdentifier) error
 	GrantPrivilegesToDatabaseRole(ctx context.Context, privileges *DatabaseRoleGrantPrivileges, on *DatabaseRoleGrantOn, role DatabaseObjectIdentifier, opts *GrantPrivilegesToDatabaseRoleOptions) error
+	GrantInheritedPrivilegesToDatabaseRole(ctx context.Context, privileges InheritedDatabaseRoleGrantPrivileges, onAll PluralObjectType, in InheritedDatabaseRoleGrantIn, role DatabaseObjectIdentifier) error
 	RevokePrivilegesFromDatabaseRole(ctx context.Context, privileges *DatabaseRoleGrantPrivileges, on *DatabaseRoleGrantOn, role DatabaseObjectIdentifier, opts *RevokePrivilegesFromDatabaseRoleOptions) error
 	RevokePrivilegesFromDatabaseRoleSafely(ctx context.Context, privileges *DatabaseRoleGrantPrivileges, on *DatabaseRoleGrantOn, role DatabaseObjectIdentifier, opts *RevokePrivilegesFromDatabaseRoleOptions) error
+	RevokeInheritedPrivilegesFromDatabaseRole(ctx context.Context, privileges InheritedDatabaseRoleGrantPrivileges, onAll PluralObjectType, in InheritedDatabaseRoleGrantIn, role DatabaseObjectIdentifier) error
+	RevokeInheritedPrivilegesFromDatabaseRoleSafely(ctx context.Context, privileges InheritedDatabaseRoleGrantPrivileges, onAll PluralObjectType, in InheritedDatabaseRoleGrantIn, role DatabaseObjectIdentifier) error
 	GrantPrivilegeToShare(ctx context.Context, privileges []ObjectPrivilege, on *ShareGrantOn, to AccountObjectIdentifier) error
 	RevokePrivilegeFromShare(ctx context.Context, privileges []ObjectPrivilege, on *ShareGrantOn, from AccountObjectIdentifier) error
 	RevokePrivilegeFromShareSafely(ctx context.Context, privileges []ObjectPrivilege, on *ShareGrantOn, from AccountObjectIdentifier) error
@@ -78,6 +85,28 @@ type GrantOnSchemaObjectIn struct {
 	InSchema         *DatabaseObjectIdentifier `ddl:"identifier" sql:"IN SCHEMA"`
 }
 
+// grantInheritedPrivilegesToAccountRoleOptions is based on https://docs.snowflake.com/en/user-guide/inherited-grants-using#syntax.
+type grantInheritedPrivilegesToAccountRoleOptions struct {
+	grantInherited bool                                `ddl:"static" sql:"GRANT INHERITED"`
+	privileges     InheritedAccountRoleGrantPrivileges `ddl:"-"`
+	onAll          PluralObjectType                    `ddl:"parameter,no_equals" sql:"ON ALL"`
+	in             InheritedAccountRoleGrantIn         `ddl:"keyword" sql:"IN"`
+	accountRole    AccountObjectIdentifier             `ddl:"identifier" sql:"TO ROLE"`
+}
+
+type InheritedAccountRoleGrantPrivileges struct {
+	AccountObjectPrivileges []AccountObjectPrivilege `ddl:"-"`
+	SchemaPrivileges        []SchemaPrivilege        `ddl:"-"`
+	SchemaObjectPrivileges  []SchemaObjectPrivilege  `ddl:"-"`
+	AllPrivileges           *bool                    `ddl:"keyword" sql:"ALL PRIVILEGES"`
+}
+
+type InheritedAccountRoleGrantIn struct {
+	Account  *bool                     `ddl:"keyword" sql:"ACCOUNT"`
+	Database *AccountObjectIdentifier  `ddl:"identifier" sql:"DATABASE"`
+	Schema   *DatabaseObjectIdentifier `ddl:"identifier" sql:"SCHEMA"`
+}
+
 // RevokePrivilegesFromAccountRoleOptions is based on https://docs.snowflake.com/en/sql-reference/sql/revoke-privilege#syntax.
 type RevokePrivilegesFromAccountRoleOptions struct {
 	revoke         bool                        `ddl:"static" sql:"REVOKE"`
@@ -87,6 +116,15 @@ type RevokePrivilegesFromAccountRoleOptions struct {
 	accountRole    AccountObjectIdentifier     `ddl:"identifier" sql:"FROM ROLE"`
 	Restrict       *bool                       `ddl:"keyword" sql:"RESTRICT"`
 	Cascade        *bool                       `ddl:"keyword" sql:"CASCADE"`
+}
+
+// revokeInheritedPrivilegesFromAccountRoleOptions is based on https://docs.snowflake.com/en/user-guide/inherited-grants-using#syntax.
+type revokeInheritedPrivilegesFromAccountRoleOptions struct {
+	revokeInherited bool                                `ddl:"static" sql:"REVOKE INHERITED"`
+	privileges      InheritedAccountRoleGrantPrivileges `ddl:"-"`
+	onAll           PluralObjectType                    `ddl:"parameter,no_equals" sql:"ON ALL"`
+	in              InheritedAccountRoleGrantIn         `ddl:"keyword" sql:"IN"`
+	accountRole     AccountObjectIdentifier             `ddl:"identifier" sql:"FROM ROLE"`
 }
 
 // GrantPrivilegesToDatabaseRoleOptions is based on https://docs.snowflake.com/en/sql-reference/sql/grant-privilege#syntax.
@@ -111,6 +149,26 @@ type DatabaseRoleGrantOn struct {
 	SchemaObject *GrantOnSchemaObject     `ddl:"-"`
 }
 
+// grantInheritedPrivilegesToDatabaseRoleOptions is based on https://docs.snowflake.com/en/user-guide/inherited-grants-using#syntax.
+type grantInheritedPrivilegesToDatabaseRoleOptions struct {
+	grantInherited bool                                 `ddl:"static" sql:"GRANT INHERITED"`
+	privileges     InheritedDatabaseRoleGrantPrivileges `ddl:"-"`
+	onAll          PluralObjectType                     `ddl:"parameter,no_equals" sql:"ON ALL"`
+	in             InheritedDatabaseRoleGrantIn         `ddl:"keyword" sql:"IN"`
+	databaseRole   DatabaseObjectIdentifier             `ddl:"identifier" sql:"TO DATABASE ROLE"`
+}
+
+type InheritedDatabaseRoleGrantPrivileges struct {
+	SchemaPrivileges       []SchemaPrivilege       `ddl:"-"`
+	SchemaObjectPrivileges []SchemaObjectPrivilege `ddl:"-"`
+	AllPrivileges          *bool                   `ddl:"keyword" sql:"ALL PRIVILEGES"`
+}
+
+type InheritedDatabaseRoleGrantIn struct {
+	Database *AccountObjectIdentifier  `ddl:"identifier" sql:"DATABASE"`
+	Schema   *DatabaseObjectIdentifier `ddl:"identifier" sql:"SCHEMA"`
+}
+
 // RevokePrivilegesFromDatabaseRoleOptions is based on https://docs.snowflake.com/en/sql-reference/sql/revoke-privilege#syntax.
 type RevokePrivilegesFromDatabaseRoleOptions struct {
 	revoke         bool                         `ddl:"static" sql:"REVOKE"`
@@ -120,6 +178,15 @@ type RevokePrivilegesFromDatabaseRoleOptions struct {
 	databaseRole   DatabaseObjectIdentifier     `ddl:"identifier" sql:"FROM DATABASE ROLE"`
 	Restrict       *bool                        `ddl:"keyword" sql:"RESTRICT"`
 	Cascade        *bool                        `ddl:"keyword" sql:"CASCADE"`
+}
+
+// revokeInheritedPrivilegesFromDatabaseRoleOptions is based on https://docs.snowflake.com/en/user-guide/inherited-grants-using#syntax.
+type revokeInheritedPrivilegesFromDatabaseRoleOptions struct {
+	revokeInherited bool                                 `ddl:"static" sql:"REVOKE INHERITED"`
+	privileges      InheritedDatabaseRoleGrantPrivileges `ddl:"-"`
+	onAll           PluralObjectType                     `ddl:"parameter,no_equals" sql:"ON ALL"`
+	in              InheritedDatabaseRoleGrantIn         `ddl:"keyword" sql:"IN"`
+	databaseRole    DatabaseObjectIdentifier             `ddl:"identifier" sql:"FROM DATABASE ROLE"`
 }
 
 // grantPrivilegeToShareOptions is based on https://docs.snowflake.com/en/sql-reference/sql/grant-privilege-share.
@@ -159,16 +226,18 @@ type OnView struct {
 
 // ShowGrantOptions is based on https://docs.snowflake.com/en/sql-reference/sql/show-grants.
 type ShowGrantOptions struct {
-	show   bool          `ddl:"static" sql:"SHOW"`
-	Future *bool         `ddl:"keyword" sql:"FUTURE"`
-	grants bool          `ddl:"static" sql:"GRANTS"`
-	On     *ShowGrantsOn `ddl:"keyword" sql:"ON"`
-	To     *ShowGrantsTo `ddl:"keyword" sql:"TO"`
-	Of     *ShowGrantsOf `ddl:"keyword" sql:"OF"`
-	In     *ShowGrantsIn `ddl:"keyword" sql:"IN"`
+	show      bool          `ddl:"static" sql:"SHOW"`
+	Inherited *bool         `ddl:"keyword" sql:"INHERITED"`
+	Future    *bool         `ddl:"keyword" sql:"FUTURE"`
+	grants    bool          `ddl:"static" sql:"GRANTS"`
+	On        *ShowGrantsOn `ddl:"keyword" sql:"ON"`
+	To        *ShowGrantsTo `ddl:"keyword" sql:"TO"`
+	Of        *ShowGrantsOf `ddl:"keyword" sql:"OF"`
+	In        *ShowGrantsIn `ddl:"keyword" sql:"IN"`
 }
 
 type ShowGrantsIn struct {
+	Account  *bool                     `ddl:"keyword" sql:"ACCOUNT"`
 	Schema   *DatabaseObjectIdentifier `ddl:"identifier" sql:"SCHEMA"`
 	Database *AccountObjectIdentifier  `ddl:"identifier" sql:"DATABASE"`
 }
@@ -210,19 +279,28 @@ type grantRow struct {
 	GranteeName string    `db:"grantee_name"`
 	GrantOption bool      `db:"grant_option"`
 	GrantedBy   string    `db:"granted_by"`
+	// IsInherited column is missing for the SHOW INHERITED GRANTS IN ... syntax.
+	IsInherited           sql.NullString `db:"is_inherited"`
+	InheritedFrom         string         `db:"inherited_from"`
+	InheritedFromDatabase string         `db:"inherited_from_database"`
+	InheritedFromSchema   string         `db:"inherited_from_schema"`
 }
 
 type Grant struct {
-	CreatedOn   time.Time
-	Privilege   string
-	GrantedOn   ObjectType
-	GrantOn     ObjectType
-	Name        ObjectIdentifier
-	GrantedTo   ObjectType
-	GrantTo     ObjectType
-	GranteeName ObjectIdentifier
-	GrantOption bool
-	GrantedBy   AccountObjectIdentifier
+	CreatedOn             time.Time
+	Privilege             string
+	GrantedOn             ObjectType
+	GrantOn               ObjectType
+	Name                  ObjectIdentifier
+	GrantedTo             ObjectType
+	GrantTo               ObjectType
+	GranteeName           ObjectIdentifier
+	GrantOption           bool
+	GrantedBy             AccountObjectIdentifier
+	IsInherited           bool
+	InheritedFrom         *string
+	InheritedFromDatabase *string
+	InheritedFromSchema   *string
 }
 
 func (v *Grant) ID() ObjectIdentifier {
@@ -288,7 +366,7 @@ func (row grantRow) convert() (*Grant, error) {
 		name = NewObjectIdentifierFromFullyQualifiedName(row.Name)
 	}
 
-	return &Grant{
+	grant := Grant{
 		CreatedOn: row.CreatedOn,
 		Privilege: row.Privilege,
 		GrantedOn: grantedOn,
@@ -299,7 +377,28 @@ func (row grantRow) convert() (*Grant, error) {
 		// GranteeName is computed in Show operation. Its format is depending on the grant request options.
 		GrantOption: row.GrantOption,
 		GrantedBy:   NewAccountObjectIdentifier(row.GrantedBy),
-	}, nil
+		IsInherited: isInherited(row.IsInherited),
+	}
+	if row.InheritedFrom != "" {
+		grant.InheritedFrom = new(row.InheritedFrom)
+		if row.InheritedFrom == "SCHEMA" {
+			grant.InheritedFromDatabase = new(row.InheritedFromDatabase)
+			grant.InheritedFromSchema = new(row.InheritedFromSchema)
+		} else if row.InheritedFrom == "DATABASE" {
+			grant.InheritedFromDatabase = new(row.InheritedFromDatabase)
+		}
+	}
+	return &grant, nil
+}
+
+// isInherited determines whether a grant is inherited. When the is_inherited
+// column is missing (dbRow is not valid), we can be sure the grant is inherited,
+// because that column is only absent for the SHOW INHERITED GRANTS IN ... syntax.
+func isInherited(dbRow sql.NullString) bool {
+	if dbRow.Valid {
+		return dbRow.String == "true"
+	}
+	return true
 }
 
 // GrantOwnershipOptions is based on https://docs.snowflake.com/en/sql-reference/sql/grant-ownership#syntax.

--- a/pkg/sdk/grants_impl.go
+++ b/pkg/sdk/grants_impl.go
@@ -61,6 +61,16 @@ func (v *grants) GrantPrivilegesToAccountRole(ctx context.Context, privileges *A
 	return validateAndExec(v.client, ctx, opts)
 }
 
+func (v *grants) GrantInheritedPrivilegesToAccountRole(ctx context.Context, privileges InheritedAccountRoleGrantPrivileges, onAll PluralObjectType, in InheritedAccountRoleGrantIn, role AccountObjectIdentifier) error {
+	opts := &grantInheritedPrivilegesToAccountRoleOptions{
+		privileges:  privileges,
+		onAll:       onAll,
+		in:          in,
+		accountRole: role,
+	}
+	return validateAndExec(v.client, ctx, opts)
+}
+
 func (v *grants) RevokePrivilegesFromAccountRole(ctx context.Context, privileges *AccountRoleGrantPrivileges, on *AccountRoleGrantOn, role AccountObjectIdentifier, opts *RevokePrivilegesFromAccountRoleOptions) error {
 	return v.revokePrivilegesFromAccountRole(ctx, privileges, on, role, opts, noopExecWrapper)
 }
@@ -124,6 +134,33 @@ func (v *grants) revokePrivilegesFromAccountRole(
 	})
 }
 
+func (v *grants) RevokeInheritedPrivilegesFromAccountRole(ctx context.Context, privileges InheritedAccountRoleGrantPrivileges, onAll PluralObjectType, in InheritedAccountRoleGrantIn, role AccountObjectIdentifier) error {
+	return v.revokeInheritedPrivilegesFromAccountRole(ctx, privileges, onAll, in, role, noopExecWrapper)
+}
+
+func (v *grants) RevokeInheritedPrivilegesFromAccountRoleSafely(ctx context.Context, privileges InheritedAccountRoleGrantPrivileges, onAll PluralObjectType, in InheritedAccountRoleGrantIn, role AccountObjectIdentifier) error {
+	return v.revokeInheritedPrivilegesFromAccountRole(ctx, privileges, onAll, in, role, SafeRevokePrivileges)
+}
+
+func (v *grants) revokeInheritedPrivilegesFromAccountRole(
+	ctx context.Context,
+	privileges InheritedAccountRoleGrantPrivileges,
+	onAll PluralObjectType,
+	in InheritedAccountRoleGrantIn,
+	role AccountObjectIdentifier,
+	execWrapper func(func() error) error,
+) error {
+	opts := &revokeInheritedPrivilegesFromAccountRoleOptions{
+		privileges:  privileges,
+		onAll:       onAll,
+		in:          in,
+		accountRole: role,
+	}
+	return execWrapper(func() error {
+		return validateAndExec(v.client, ctx, opts)
+	})
+}
+
 func (v *grants) GrantPrivilegesToDatabaseRole(ctx context.Context, privileges *DatabaseRoleGrantPrivileges, on *DatabaseRoleGrantOn, role DatabaseObjectIdentifier, opts *GrantPrivilegesToDatabaseRoleOptions) error {
 	if opts == nil {
 		opts = &GrantPrivilegesToDatabaseRoleOptions{}
@@ -162,6 +199,16 @@ func (v *grants) GrantPrivilegesToDatabaseRole(ctx context.Context, privileges *
 		)
 	}
 
+	return validateAndExec(v.client, ctx, opts)
+}
+
+func (v *grants) GrantInheritedPrivilegesToDatabaseRole(ctx context.Context, privileges InheritedDatabaseRoleGrantPrivileges, onAll PluralObjectType, in InheritedDatabaseRoleGrantIn, role DatabaseObjectIdentifier) error {
+	opts := &grantInheritedPrivilegesToDatabaseRoleOptions{
+		privileges:   privileges,
+		onAll:        onAll,
+		in:           in,
+		databaseRole: role,
+	}
 	return validateAndExec(v.client, ctx, opts)
 }
 
@@ -219,6 +266,33 @@ func (v *grants) revokePrivilegesFromDatabaseRole(
 		)
 	}
 
+	return execWrapper(func() error {
+		return validateAndExec(v.client, ctx, opts)
+	})
+}
+
+func (v *grants) RevokeInheritedPrivilegesFromDatabaseRole(ctx context.Context, privileges InheritedDatabaseRoleGrantPrivileges, onAll PluralObjectType, in InheritedDatabaseRoleGrantIn, role DatabaseObjectIdentifier) error {
+	return v.revokeInheritedPrivilegesFromDatabaseRole(ctx, privileges, onAll, in, role, noopExecWrapper)
+}
+
+func (v *grants) RevokeInheritedPrivilegesFromDatabaseRoleSafely(ctx context.Context, privileges InheritedDatabaseRoleGrantPrivileges, onAll PluralObjectType, in InheritedDatabaseRoleGrantIn, role DatabaseObjectIdentifier) error {
+	return v.revokeInheritedPrivilegesFromDatabaseRole(ctx, privileges, onAll, in, role, SafeRevokePrivileges)
+}
+
+func (v *grants) revokeInheritedPrivilegesFromDatabaseRole(
+	ctx context.Context,
+	privileges InheritedDatabaseRoleGrantPrivileges,
+	onAll PluralObjectType,
+	in InheritedDatabaseRoleGrantIn,
+	role DatabaseObjectIdentifier,
+	execWrapper func(func() error) error,
+) error {
+	opts := &revokeInheritedPrivilegesFromDatabaseRoleOptions{
+		privileges:   privileges,
+		onAll:        onAll,
+		in:           in,
+		databaseRole: role,
+	}
 	return execWrapper(func() error {
 		return validateAndExec(v.client, ctx, opts)
 	})

--- a/pkg/sdk/grants_test.go
+++ b/pkg/sdk/grants_test.go
@@ -1285,3 +1285,435 @@ func TestGrantShow(t *testing.T) {
 		assertOptsValidAndSQLEquals(t, opts, "SHOW GRANTS OF SHARE %s", shareID.FullyQualifiedName())
 	})
 }
+
+func TestGrantInheritedPrivilegesToAccountRole(t *testing.T) {
+	dbId := randomAccountObjectIdentifier()
+	schemaId := randomDatabaseObjectIdentifierInDatabase(dbId)
+	roleId := randomAccountObjectIdentifier()
+
+	defaultOpts := func() *grantInheritedPrivilegesToAccountRoleOptions {
+		return &grantInheritedPrivilegesToAccountRoleOptions{
+			privileges: InheritedAccountRoleGrantPrivileges{
+				SchemaObjectPrivileges: []SchemaObjectPrivilege{SchemaObjectPrivilegeSelect},
+			},
+			onAll:       PluralObjectTypeTables,
+			in:          InheritedAccountRoleGrantIn{Database: new(dbId)},
+			accountRole: roleId,
+		}
+	}
+
+	t.Run("validation: nil options", func(t *testing.T) {
+		var opts *grantInheritedPrivilegesToAccountRoleOptions
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
+	})
+
+	t.Run("validation: at least one of the fields [opts.privileges.AllPrivileges opts.privileges.AccountObjectPrivileges opts.privileges.SchemaPrivileges opts.privileges.SchemaObjectPrivileges] should be present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedAccountRoleGrantPrivileges{}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedAccountRoleGrantPrivileges", "AllPrivileges", "AccountObjectPrivileges", "SchemaPrivileges", "SchemaObjectPrivileges"))
+	})
+
+	t.Run("validation: at least one of the fields [opts.privileges.AllPrivileges opts.privileges.AccountObjectPrivileges opts.privileges.SchemaPrivileges opts.privileges.SchemaObjectPrivileges] should be present - more present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedAccountRoleGrantPrivileges{
+			AccountObjectPrivileges: []AccountObjectPrivilege{AccountObjectPrivilegeOperate},
+			SchemaObjectPrivileges:  []SchemaObjectPrivilege{SchemaObjectPrivilegeSelect},
+		}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedAccountRoleGrantPrivileges", "AllPrivileges", "AccountObjectPrivileges", "SchemaPrivileges", "SchemaObjectPrivileges"))
+	})
+
+	t.Run("validation: [opts.onAll] should be set", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.onAll = ""
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("grantInheritedPrivilegesToAccountRoleOptions", "onAll"))
+	})
+
+	t.Run("validation: at least one of the fields [opts.in.Account opts.in.Database opts.in.Schema] should be present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedAccountRoleGrantIn{}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedAccountRoleGrantIn", "Account", "Database", "Schema"))
+	})
+
+	t.Run("validation: at least one of the fields [opts.in.Account opts.in.Database opts.in.Schema] should be present - more present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedAccountRoleGrantIn{
+			Account:  new(true),
+			Database: new(dbId),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedAccountRoleGrantIn", "Account", "Database", "Schema"))
+	})
+
+	t.Run("validation: valid identifier for [opts.in.Database]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedAccountRoleGrantIn{
+			Database: new(emptyAccountObjectIdentifier),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: valid identifier for [opts.in.Schema]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedAccountRoleGrantIn{
+			Schema: new(emptyDatabaseObjectIdentifier),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: valid identifier for [opts.accountRole]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.accountRole = emptyAccountObjectIdentifier
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("on all tables in account", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedAccountRoleGrantIn{Account: new(true)}
+		assertOptsValidAndSQLEquals(t, opts, `GRANT INHERITED SELECT ON ALL TABLES IN ACCOUNT TO ROLE %s`, roleId.FullyQualifiedName())
+	})
+
+	t.Run("on all tables in database", func(t *testing.T) {
+		opts := defaultOpts()
+		assertOptsValidAndSQLEquals(t, opts, `GRANT INHERITED SELECT ON ALL TABLES IN DATABASE %s TO ROLE %s`, dbId.FullyQualifiedName(), roleId.FullyQualifiedName())
+	})
+
+	t.Run("on all tables in schema", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedAccountRoleGrantIn{Schema: new(schemaId)}
+		assertOptsValidAndSQLEquals(t, opts, `GRANT INHERITED SELECT ON ALL TABLES IN SCHEMA %s TO ROLE %s`, schemaId.FullyQualifiedName(), roleId.FullyQualifiedName())
+	})
+
+	t.Run("multiple privileges", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedAccountRoleGrantPrivileges{
+			SchemaObjectPrivileges: []SchemaObjectPrivilege{SchemaObjectPrivilegeSelect, SchemaObjectPrivilegeInsert},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `GRANT INHERITED SELECT, INSERT ON ALL TABLES IN DATABASE %s TO ROLE %s`, dbId.FullyQualifiedName(), roleId.FullyQualifiedNameEscaped())
+	})
+
+	t.Run("all privileges", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedAccountRoleGrantPrivileges{AllPrivileges: new(true)}
+		assertOptsValidAndSQLEquals(t, opts, `GRANT INHERITED ALL PRIVILEGES ON ALL TABLES IN DATABASE %s TO ROLE %s`, dbId.FullyQualifiedName(), roleId.FullyQualifiedName())
+	})
+}
+
+func TestRevokeInheritedPrivilegesFromAccountRole(t *testing.T) {
+	dbId := randomAccountObjectIdentifier()
+	schemaId := randomDatabaseObjectIdentifierInDatabase(dbId)
+	roleId := randomAccountObjectIdentifier()
+
+	defaultOpts := func() *revokeInheritedPrivilegesFromAccountRoleOptions {
+		return &revokeInheritedPrivilegesFromAccountRoleOptions{
+			privileges: InheritedAccountRoleGrantPrivileges{
+				SchemaObjectPrivileges: []SchemaObjectPrivilege{SchemaObjectPrivilegeSelect},
+			},
+			onAll:       PluralObjectTypeTables,
+			in:          InheritedAccountRoleGrantIn{Database: new(dbId)},
+			accountRole: roleId,
+		}
+	}
+
+	t.Run("validation: nil options", func(t *testing.T) {
+		var opts *revokeInheritedPrivilegesFromAccountRoleOptions
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
+	})
+
+	t.Run("validation: at least one of the fields [opts.privileges.AllPrivileges opts.privileges.AccountObjectPrivileges opts.privileges.SchemaPrivileges opts.privileges.SchemaObjectPrivileges] should be present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedAccountRoleGrantPrivileges{}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedAccountRoleGrantPrivileges", "AllPrivileges", "AccountObjectPrivileges", "SchemaPrivileges", "SchemaObjectPrivileges"))
+	})
+
+	t.Run("validation: at least one of the fields [opts.privileges.AllPrivileges opts.privileges.AccountObjectPrivileges opts.privileges.SchemaPrivileges opts.privileges.SchemaObjectPrivileges] should be present - more present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedAccountRoleGrantPrivileges{
+			AccountObjectPrivileges: []AccountObjectPrivilege{AccountObjectPrivilegeOperate},
+			SchemaObjectPrivileges:  []SchemaObjectPrivilege{SchemaObjectPrivilegeSelect},
+		}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedAccountRoleGrantPrivileges", "AllPrivileges", "AccountObjectPrivileges", "SchemaPrivileges", "SchemaObjectPrivileges"))
+	})
+
+	t.Run("validation: [opts.onAll] should be set", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.onAll = ""
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("revokeInheritedPrivilegesFromAccountRoleOptions", "onAll"))
+	})
+
+	t.Run("validation: at least one of the fields [opts.in.Account opts.in.Database opts.in.Schema] should be present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedAccountRoleGrantIn{}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedAccountRoleGrantIn", "Account", "Database", "Schema"))
+	})
+
+	t.Run("validation: at least one of the fields [opts.in.Account opts.in.Database opts.in.Schema] should be present - more present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedAccountRoleGrantIn{
+			Account:  new(true),
+			Database: new(dbId),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedAccountRoleGrantIn", "Account", "Database", "Schema"))
+	})
+
+	t.Run("validation: valid identifier for [opts.in.Database]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedAccountRoleGrantIn{
+			Database: new(emptyAccountObjectIdentifier),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: valid identifier for [opts.in.Schema]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedAccountRoleGrantIn{
+			Schema: new(emptyDatabaseObjectIdentifier),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: valid identifier for [opts.accountRole]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.accountRole = emptyAccountObjectIdentifier
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("on all tables in account", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedAccountRoleGrantIn{Account: new(true)}
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE INHERITED SELECT ON ALL TABLES IN ACCOUNT FROM ROLE %s`, roleId.FullyQualifiedName())
+	})
+
+	t.Run("on all tables in database", func(t *testing.T) {
+		opts := defaultOpts()
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE INHERITED SELECT ON ALL TABLES IN DATABASE %s FROM ROLE %s`, dbId.FullyQualifiedName(), roleId.FullyQualifiedName())
+	})
+
+	t.Run("on all tables in schema", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedAccountRoleGrantIn{Schema: new(schemaId)}
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE INHERITED SELECT ON ALL TABLES IN SCHEMA %s FROM ROLE %s`, schemaId.FullyQualifiedName(), roleId.FullyQualifiedName())
+	})
+
+	t.Run("multiple privileges", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedAccountRoleGrantPrivileges{
+			SchemaObjectPrivileges: []SchemaObjectPrivilege{SchemaObjectPrivilegeSelect, SchemaObjectPrivilegeInsert},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE INHERITED SELECT, INSERT ON ALL TABLES IN DATABASE %s FROM ROLE %s`, dbId.FullyQualifiedName(), roleId.FullyQualifiedNameEscaped())
+	})
+
+	t.Run("all privileges", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedAccountRoleGrantPrivileges{AllPrivileges: new(true)}
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE INHERITED ALL PRIVILEGES ON ALL TABLES IN DATABASE %s FROM ROLE %s`, dbId.FullyQualifiedName(), roleId.FullyQualifiedName())
+	})
+}
+
+func TestGrantInheritedPrivilegesToDatabaseRole(t *testing.T) {
+	dbId := randomAccountObjectIdentifier()
+	schemaId := randomDatabaseObjectIdentifierInDatabase(dbId)
+	databaseRoleId := randomDatabaseObjectIdentifier()
+
+	defaultOpts := func() *grantInheritedPrivilegesToDatabaseRoleOptions {
+		return &grantInheritedPrivilegesToDatabaseRoleOptions{
+			privileges: InheritedDatabaseRoleGrantPrivileges{
+				SchemaObjectPrivileges: []SchemaObjectPrivilege{SchemaObjectPrivilegeSelect},
+			},
+			onAll:        PluralObjectTypeTables,
+			in:           InheritedDatabaseRoleGrantIn{Database: new(dbId)},
+			databaseRole: databaseRoleId,
+		}
+	}
+
+	t.Run("validation: nil options", func(t *testing.T) {
+		var opts *grantInheritedPrivilegesToDatabaseRoleOptions
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
+	})
+
+	t.Run("validation: at least one of the fields [opts.privileges.AllPrivileges opts.privileges.SchemaPrivileges opts.privileges.SchemaObjectPrivileges] should be present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedDatabaseRoleGrantPrivileges{}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedDatabaseRoleGrantPrivileges", "AllPrivileges", "SchemaPrivileges", "SchemaObjectPrivileges"))
+	})
+
+	t.Run("validation: at least one of the fields [opts.privileges.AllPrivileges opts.privileges.SchemaPrivileges opts.privileges.SchemaObjectPrivileges] should be present - more present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedDatabaseRoleGrantPrivileges{
+			SchemaPrivileges:       []SchemaPrivilege{SchemaPrivilegeCreateTable},
+			SchemaObjectPrivileges: []SchemaObjectPrivilege{SchemaObjectPrivilegeSelect},
+		}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedDatabaseRoleGrantPrivileges", "AllPrivileges", "SchemaPrivileges", "SchemaObjectPrivileges"))
+	})
+
+	t.Run("validation: [opts.onAll] should be set", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.onAll = ""
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("grantInheritedPrivilegesToDatabaseRoleOptions", "onAll"))
+	})
+
+	t.Run("validation: at least one of the fields [opts.in.Database opts.in.Schema] should be present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedDatabaseRoleGrantIn{}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedDatabaseRoleGrantIn", "Database", "Schema"))
+	})
+
+	t.Run("validation: at least one of the fields [opts.in.Database opts.in.Schema] should be present - more present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedDatabaseRoleGrantIn{
+			Database: new(dbId),
+			Schema:   new(schemaId),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedDatabaseRoleGrantIn", "Database", "Schema"))
+	})
+
+	t.Run("validation: valid identifier for [opts.in.Database]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedDatabaseRoleGrantIn{
+			Database: new(emptyAccountObjectIdentifier),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: valid identifier for [opts.in.Schema]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedDatabaseRoleGrantIn{
+			Schema: new(emptyDatabaseObjectIdentifier),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: valid identifier for [opts.databaseRole]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.databaseRole = emptyDatabaseObjectIdentifier
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("on all tables in database", func(t *testing.T) {
+		opts := defaultOpts()
+		assertOptsValidAndSQLEquals(t, opts, `GRANT INHERITED SELECT ON ALL TABLES IN DATABASE %s TO DATABASE ROLE %s`, dbId.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
+	})
+
+	t.Run("on all tables in schema", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedDatabaseRoleGrantIn{Schema: new(schemaId)}
+		assertOptsValidAndSQLEquals(t, opts, `GRANT INHERITED SELECT ON ALL TABLES IN SCHEMA %s TO DATABASE ROLE %s`, schemaId.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
+	})
+
+	t.Run("multiple privileges", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedDatabaseRoleGrantPrivileges{
+			SchemaObjectPrivileges: []SchemaObjectPrivilege{SchemaObjectPrivilegeSelect, SchemaObjectPrivilegeInsert},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `GRANT INHERITED SELECT, INSERT ON ALL TABLES IN DATABASE %s TO DATABASE ROLE %s`, dbId.FullyQualifiedName(), databaseRoleId.FullyQualifiedNameEscaped())
+	})
+
+	t.Run("all privileges", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedDatabaseRoleGrantPrivileges{AllPrivileges: new(true)}
+		assertOptsValidAndSQLEquals(t, opts, `GRANT INHERITED ALL PRIVILEGES ON ALL TABLES IN DATABASE %s TO DATABASE ROLE %s`, dbId.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
+	})
+}
+
+func TestRevokeInheritedPrivilegesFromDatabaseRole(t *testing.T) {
+	dbId := randomAccountObjectIdentifier()
+	schemaId := randomDatabaseObjectIdentifierInDatabase(dbId)
+	databaseRoleId := randomDatabaseObjectIdentifier()
+
+	defaultOpts := func() *revokeInheritedPrivilegesFromDatabaseRoleOptions {
+		return &revokeInheritedPrivilegesFromDatabaseRoleOptions{
+			privileges: InheritedDatabaseRoleGrantPrivileges{
+				SchemaObjectPrivileges: []SchemaObjectPrivilege{SchemaObjectPrivilegeSelect},
+			},
+			onAll:        PluralObjectTypeTables,
+			in:           InheritedDatabaseRoleGrantIn{Database: new(dbId)},
+			databaseRole: databaseRoleId,
+		}
+	}
+
+	t.Run("validation: nil options", func(t *testing.T) {
+		var opts *revokeInheritedPrivilegesFromDatabaseRoleOptions
+		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)
+	})
+
+	t.Run("validation: at least one of the fields [opts.privileges.AllPrivileges opts.privileges.SchemaPrivileges opts.privileges.SchemaObjectPrivileges] should be present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedDatabaseRoleGrantPrivileges{}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedDatabaseRoleGrantPrivileges", "AllPrivileges", "SchemaPrivileges", "SchemaObjectPrivileges"))
+	})
+
+	t.Run("validation: at least one of the fields [opts.privileges.AllPrivileges opts.privileges.SchemaPrivileges opts.privileges.SchemaObjectPrivileges] should be present - more present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedDatabaseRoleGrantPrivileges{
+			SchemaPrivileges:       []SchemaPrivilege{SchemaPrivilegeCreateTable},
+			SchemaObjectPrivileges: []SchemaObjectPrivilege{SchemaObjectPrivilegeSelect},
+		}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedDatabaseRoleGrantPrivileges", "AllPrivileges", "SchemaPrivileges", "SchemaObjectPrivileges"))
+	})
+
+	t.Run("validation: [opts.onAll] should be set", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.onAll = ""
+		assertOptsInvalidJoinedErrors(t, opts, errNotSet("revokeInheritedPrivilegesFromDatabaseRoleOptions", "onAll"))
+	})
+
+	t.Run("validation: at least one of the fields [opts.in.Database opts.in.Schema] should be present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedDatabaseRoleGrantIn{}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedDatabaseRoleGrantIn", "Database", "Schema"))
+	})
+
+	t.Run("validation: at least one of the fields [opts.in.Database opts.in.Schema] should be present - more present", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedDatabaseRoleGrantIn{
+			Database: new(dbId),
+			Schema:   new(schemaId),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, errExactlyOneOf("InheritedDatabaseRoleGrantIn", "Database", "Schema"))
+	})
+
+	t.Run("validation: valid identifier for [opts.in.Database]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedDatabaseRoleGrantIn{
+			Database: new(emptyAccountObjectIdentifier),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: valid identifier for [opts.in.Schema]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedDatabaseRoleGrantIn{
+			Schema: new(emptyDatabaseObjectIdentifier),
+		}
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("validation: valid identifier for [opts.databaseRole]", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.databaseRole = emptyDatabaseObjectIdentifier
+		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
+	})
+
+	t.Run("on all tables in database", func(t *testing.T) {
+		opts := defaultOpts()
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE INHERITED SELECT ON ALL TABLES IN DATABASE %s FROM DATABASE ROLE %s`, dbId.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
+	})
+
+	t.Run("on all tables in schema", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.in = InheritedDatabaseRoleGrantIn{Schema: new(schemaId)}
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE INHERITED SELECT ON ALL TABLES IN SCHEMA %s FROM DATABASE ROLE %s`, schemaId.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
+	})
+
+	t.Run("multiple privileges", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedDatabaseRoleGrantPrivileges{
+			SchemaObjectPrivileges: []SchemaObjectPrivilege{SchemaObjectPrivilegeSelect, SchemaObjectPrivilegeInsert},
+		}
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE INHERITED SELECT, INSERT ON ALL TABLES IN DATABASE %s FROM DATABASE ROLE %s`, dbId.FullyQualifiedName(), databaseRoleId.FullyQualifiedNameEscaped())
+	})
+
+	t.Run("all privileges", func(t *testing.T) {
+		opts := defaultOpts()
+		opts.privileges = InheritedDatabaseRoleGrantPrivileges{AllPrivileges: new(true)}
+		assertOptsValidAndSQLEquals(t, opts, `REVOKE INHERITED ALL PRIVILEGES ON ALL TABLES IN DATABASE %s FROM DATABASE ROLE %s`, dbId.FullyQualifiedName(), databaseRoleId.FullyQualifiedName())
+	})
+}

--- a/pkg/sdk/grants_validations.go
+++ b/pkg/sdk/grants_validations.go
@@ -10,9 +10,13 @@ import (
 
 var (
 	_ validatable = new(GrantPrivilegesToAccountRoleOptions)
+	_ validatable = new(grantInheritedPrivilegesToAccountRoleOptions)
 	_ validatable = new(RevokePrivilegesFromAccountRoleOptions)
+	_ validatable = new(revokeInheritedPrivilegesFromAccountRoleOptions)
 	_ validatable = new(GrantPrivilegesToDatabaseRoleOptions)
+	_ validatable = new(grantInheritedPrivilegesToDatabaseRoleOptions)
 	_ validatable = new(RevokePrivilegesFromDatabaseRoleOptions)
+	_ validatable = new(revokeInheritedPrivilegesFromDatabaseRoleOptions)
 	_ validatable = new(grantPrivilegeToShareOptions)
 	_ validatable = new(revokePrivilegeFromShareOptions)
 	_ validatable = new(GrantOwnershipOptions)
@@ -395,6 +399,51 @@ func (v *GrantOnSchemaObjectIn) validate() error {
 	return nil
 }
 
+func (opts *grantInheritedPrivilegesToAccountRoleOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
+	var errs []error
+	if err := opts.privileges.validate(); err != nil {
+		errs = append(errs, err)
+	}
+	if opts.onAll == "" {
+		errs = append(errs, errNotSet("grantInheritedPrivilegesToAccountRoleOptions", "onAll"))
+	}
+	if err := opts.in.validate(); err != nil {
+		errs = append(errs, err)
+	}
+	if !ValidObjectIdentifier(opts.accountRole) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	return errors.Join(errs...)
+}
+
+func (v InheritedAccountRoleGrantPrivileges) validate() error {
+	if !exactlyOneValueSet(v.AllPrivileges, v.AccountObjectPrivileges, v.SchemaPrivileges, v.SchemaObjectPrivileges) {
+		return errExactlyOneOf("InheritedAccountRoleGrantPrivileges", "AllPrivileges", "AccountObjectPrivileges", "SchemaPrivileges", "SchemaObjectPrivileges")
+	}
+	return errors.Join(
+		validatePrivileges(v.AccountObjectPrivileges),
+		validatePrivileges(v.SchemaPrivileges),
+		validatePrivileges(v.SchemaObjectPrivileges),
+	)
+}
+
+func (v InheritedAccountRoleGrantIn) validate() error {
+	var errs []error
+	if !exactlyOneValueSet(v.Account, v.Database, v.Schema) {
+		errs = append(errs, errExactlyOneOf("InheritedAccountRoleGrantIn", "Account", "Database", "Schema"))
+	}
+	if v.Database != nil && !ValidObjectIdentifier(*v.Database) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	if v.Schema != nil && !ValidObjectIdentifier(*v.Schema) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	return errors.Join(errs...)
+}
+
 func (opts *RevokePrivilegesFromAccountRoleOptions) validate() error {
 	if opts == nil {
 		return errors.Join(ErrNilOptions)
@@ -419,6 +468,26 @@ func (opts *RevokePrivilegesFromAccountRoleOptions) validate() error {
 	}
 	if everyValueSet(opts.Restrict, opts.Cascade) {
 		errs = append(errs, errOneOf("RevokePrivilegesFromAccountRoleOptions", "Restrict", "Cascade"))
+	}
+	return errors.Join(errs...)
+}
+
+func (opts *revokeInheritedPrivilegesFromAccountRoleOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
+	var errs []error
+	if err := opts.privileges.validate(); err != nil {
+		errs = append(errs, err)
+	}
+	if opts.onAll == "" {
+		errs = append(errs, errNotSet("revokeInheritedPrivilegesFromAccountRoleOptions", "onAll"))
+	}
+	if err := opts.in.validate(); err != nil {
+		errs = append(errs, err)
+	}
+	if !ValidObjectIdentifier(opts.accountRole) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	return errors.Join(errs...)
 }
@@ -474,6 +543,50 @@ func (v *DatabaseRoleGrantOn) validate() error {
 	return errors.Join(errs...)
 }
 
+func (opts *grantInheritedPrivilegesToDatabaseRoleOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
+	var errs []error
+	if err := opts.privileges.validate(); err != nil {
+		errs = append(errs, err)
+	}
+	if opts.onAll == "" {
+		errs = append(errs, errNotSet("grantInheritedPrivilegesToDatabaseRoleOptions", "onAll"))
+	}
+	if err := opts.in.validate(); err != nil {
+		errs = append(errs, err)
+	}
+	if !ValidObjectIdentifier(opts.databaseRole) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	return errors.Join(errs...)
+}
+
+func (v InheritedDatabaseRoleGrantPrivileges) validate() error {
+	if !exactlyOneValueSet(v.AllPrivileges, v.SchemaPrivileges, v.SchemaObjectPrivileges) {
+		return errExactlyOneOf("InheritedDatabaseRoleGrantPrivileges", "AllPrivileges", "SchemaPrivileges", "SchemaObjectPrivileges")
+	}
+	return errors.Join(
+		validatePrivileges(v.SchemaPrivileges),
+		validatePrivileges(v.SchemaObjectPrivileges),
+	)
+}
+
+func (v InheritedDatabaseRoleGrantIn) validate() error {
+	var errs []error
+	if !exactlyOneValueSet(v.Database, v.Schema) {
+		errs = append(errs, errExactlyOneOf("InheritedDatabaseRoleGrantIn", "Database", "Schema"))
+	}
+	if v.Database != nil && !ValidObjectIdentifier(*v.Database) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	if v.Schema != nil && !ValidObjectIdentifier(*v.Schema) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
+	}
+	return errors.Join(errs...)
+}
+
 func (opts *RevokePrivilegesFromDatabaseRoleOptions) validate() error {
 	if opts == nil {
 		return errors.Join(ErrNilOptions)
@@ -498,6 +611,26 @@ func (opts *RevokePrivilegesFromDatabaseRoleOptions) validate() error {
 	}
 	if everyValueSet(opts.Restrict, opts.Cascade) {
 		errs = append(errs, errOneOf("RevokePrivilegesFromDatabaseRoleOptions", "Restrict", "Cascade"))
+	}
+	return errors.Join(errs...)
+}
+
+func (opts *revokeInheritedPrivilegesFromDatabaseRoleOptions) validate() error {
+	if opts == nil {
+		return errors.Join(ErrNilOptions)
+	}
+	var errs []error
+	if err := opts.privileges.validate(); err != nil {
+		errs = append(errs, err)
+	}
+	if opts.onAll == "" {
+		errs = append(errs, errNotSet("revokeInheritedPrivilegesFromDatabaseRoleOptions", "onAll"))
+	}
+	if err := opts.in.validate(); err != nil {
+		errs = append(errs, err)
+	}
+	if !ValidObjectIdentifier(opts.databaseRole) {
+		errs = append(errs, ErrInvalidObjectIdentifier)
 	}
 	return errors.Join(errs...)
 }
@@ -643,8 +776,12 @@ func (v *RevokeOwnershipGrantOn) validate() error {
 
 // TODO: add validations for ShowGrantsOn, ShowGrantsTo, ShowGrantsOf and ShowGrantsIn
 func (opts *ShowGrantOptions) validate() error {
+	var errs []error
 	if moreThanOneValueSet(opts.On, opts.To, opts.Of, opts.In) {
-		return errOneOf("ShowGrantOptions", "On", "To", "Of", "In")
+		errs = append(errs, errOneOf("ShowGrantOptions", "On", "To", "Of", "In"))
 	}
-	return nil
+	if everyValueSet(opts.Inherited, opts.Future) {
+		errs = append(errs, errOneOf("ShowGrantOptions", "Inherited", "Future"))
+	}
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
Add GRANT/REVOKE INHERITED privileges to account and database roles, and SHOW INHERITED GRANTS support, including the four new SHOW GRANTS columns (is_inherited, inherited_from, inherited_from_database, inherited_from_schema).