### PR TITLE
feat: add SDK integration tests for interactive warehouses

### DIFF
--- a/pkg/acceptance/bettertestspoc/assert/objectassert/warehouse_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/warehouse_snowflake_gen.go
@@ -4,11 +4,13 @@ package objectassert
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 )
 
@@ -409,6 +411,22 @@ func (w *WarehouseAssert) HasQueryThroughputMultiplier(expected int) *WarehouseA
 		}
 		if *o.QueryThroughputMultiplier != expected {
 			return fmt.Errorf("expected query throughput multiplier: %v; got: %v", expected, *o.QueryThroughputMultiplier)
+		}
+		return nil
+	})
+	return w
+}
+
+func (w *WarehouseAssert) HasTables(expected ...sdk.SchemaObjectIdentifier) *WarehouseAssert {
+	w.AddAssertion(func(t *testing.T, o *sdk.Warehouse) error {
+		t.Helper()
+		// SHOW WAREHOUSES does not guarantee a stable order for the tables list, so compare order-insensitively.
+		mapped := collections.Map(o.Tables, func(item sdk.SchemaObjectIdentifier) string { return item.FullyQualifiedName() })
+		mappedExpected := collections.Map(expected, func(item sdk.SchemaObjectIdentifier) string { return item.FullyQualifiedName() })
+		slices.Sort(mapped)
+		slices.Sort(mappedExpected)
+		if !slices.Equal(mapped, mappedExpected) {
+			return fmt.Errorf("expected tables: %v; got: %v", expected, o.Tables)
 		}
 		return nil
 	})

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/warehouse_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/warehouse_snowflake_gen.go
@@ -426,7 +426,8 @@ func (w *WarehouseAssert) HasTables(expected ...sdk.SchemaObjectIdentifier) *War
 		slices.Sort(mapped)
 		slices.Sort(mappedExpected)
 		if !slices.Equal(mapped, mappedExpected) {
-			return fmt.Errorf("expected tables: %v; got: %v", expected, o.Tables)
+			return fmt.Errorf("expected tables: %v; got: %v", mappedExpected, mapped)
+
 		}
 		return nil
 	})

--- a/pkg/acceptance/helpers/table_client.go
+++ b/pkg/acceptance/helpers/table_client.go
@@ -32,6 +32,20 @@ func (c *TableClient) Create(t *testing.T) (*sdk.Table, func()) {
 	return c.CreateInSchema(t, c.ids.SchemaId())
 }
 
+// CreateInteractiveTable creates an interactive table (required for associating with interactive warehouses)
+// via raw SQL, since the SDK does not model interactive tables. It returns the table id and a cleanup.
+func (c *TableClient) CreateInteractiveTable(t *testing.T) (sdk.SchemaObjectIdentifier, func()) {
+	t.Helper()
+	ctx := context.Background()
+	id := c.ids.RandomSchemaObjectIdentifier()
+	_, err := c.context.client.ExecForTests(ctx, fmt.Sprintf(`CREATE INTERACTIVE TABLE %s (id INT) CLUSTER BY (id)`, id.FullyQualifiedName()))
+	require.NoError(t, err)
+	return id, func() {
+		_, err := c.context.client.ExecForTests(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, id.FullyQualifiedName()))
+		require.NoError(t, err)
+	}
+}
+
 func (c *TableClient) CreateWithName(t *testing.T, name string) (*sdk.Table, func()) {
 	t.Helper()
 

--- a/pkg/acceptance/helpers/warehouse_client.go
+++ b/pkg/acceptance/helpers/warehouse_client.go
@@ -206,3 +206,22 @@ func (c *WarehouseClient) CreateAdaptiveWithRequest(t *testing.T, request *sdk.C
 
 	return warehouse, c.DropWarehouseFunc(t, id)
 }
+
+func (c *WarehouseClient) CreateInteractive(t *testing.T) (*sdk.Warehouse, func()) {
+	t.Helper()
+	return c.CreateInteractiveWithRequest(t, sdk.NewCreateInteractiveWarehouseRequest(c.ids.RandomAccountObjectIdentifier()))
+}
+
+func (c *WarehouseClient) CreateInteractiveWithRequest(t *testing.T, request *sdk.CreateInteractiveWarehouseRequest) (*sdk.Warehouse, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	id := request.ID()
+	err := c.client().CreateInteractive(ctx, request)
+	require.NoError(t, err)
+
+	warehouse, err := c.client().ShowByID(ctx, id)
+	require.NoError(t, err)
+
+	return warehouse, c.DropWarehouseFunc(t, id)
+}

--- a/pkg/sdk/testint/warehouses_integration_test.go
+++ b/pkg/sdk/testint/warehouses_integration_test.go
@@ -967,18 +967,6 @@ func TestInt_Warehouses_Interactive(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)
 
-	// createInteractiveTable creates an interactive table fixture and returns its id with a cleanup.
-	createInteractiveTable := func(t *testing.T) sdk.SchemaObjectIdentifier {
-		t.Helper()
-		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
-		_, err := client.ExecForTests(ctx, fmt.Sprintf(`CREATE INTERACTIVE TABLE %s (id INT) CLUSTER BY (id)`, id.FullyQualifiedName()))
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			_, _ = client.ExecForTests(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, id.FullyQualifiedName()))
-		})
-		return id
-	}
-
 	t.Run("create interactive: minimal", func(t *testing.T) {
 		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
 		err := client.Warehouses.CreateInteractive(ctx, sdk.NewCreateInteractiveWarehouseRequest(id))
@@ -993,8 +981,10 @@ func TestInt_Warehouses_Interactive(t *testing.T) {
 	})
 
 	t.Run("create interactive: with tables", func(t *testing.T) {
-		table1 := createInteractiveTable(t)
-		table2 := createInteractiveTable(t)
+		table1, table1Cleanup := testClientHelper().Table.CreateInteractiveTable(t)
+		t.Cleanup(table1Cleanup)
+		table2, table2Cleanup := testClientHelper().Table.CreateInteractiveTable(t)
+		t.Cleanup(table2Cleanup)
 
 		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
 		err := client.Warehouses.CreateInteractive(ctx, sdk.NewCreateInteractiveWarehouseRequest(id).
@@ -1012,8 +1002,10 @@ func TestInt_Warehouses_Interactive(t *testing.T) {
 	})
 
 	t.Run("alter: add and drop tables", func(t *testing.T) {
-		table1 := createInteractiveTable(t)
-		table2 := createInteractiveTable(t)
+		table1, table1Cleanup := testClientHelper().Table.CreateInteractiveTable(t)
+		t.Cleanup(table1Cleanup)
+		table2, table2Cleanup := testClientHelper().Table.CreateInteractiveTable(t)
+		t.Cleanup(table2Cleanup)
 
 		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
 		err := client.Warehouses.CreateInteractive(ctx, sdk.NewCreateInteractiveWarehouseRequest(id).

--- a/pkg/sdk/testint/warehouses_integration_test.go
+++ b/pkg/sdk/testint/warehouses_integration_test.go
@@ -973,11 +973,31 @@ func TestInt_Warehouses_Interactive(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(testClientHelper().Warehouse.DropWarehouseFunc(t, id))
 
-		w, err := client.Warehouses.ShowByID(ctx, id)
-		require.NoError(t, err)
-		assert.Equal(t, id.Name(), w.Name)
-		assert.True(t, w.IsInteractiveWarehouse())
-		assert.Empty(t, w.Tables)
+		assertThatObject(
+			t, objectassert.Warehouse(t, id).
+				HasName(id.Name()).
+				HasType(sdk.WarehouseTypeInteractive).
+				HasComment("").
+				HasSize(sdk.WarehouseSizeXSmall).
+				HasMaxClusterCount(1).
+				HasMinClusterCount(1).
+				HasAutoSuspend(86400).
+				HasAutoResume(true).
+				HasScalingPolicy(sdk.ScalingPolicyStandard).
+				HasEnableQueryAcceleration(false).
+				HasQueryAccelerationMaxScaleFactor(8).
+				HasNoResourceConstraint().
+				HasNoGeneration().
+				HasNoMaxQueryPerformanceLevel().
+				HasNoQueryThroughputMultiplier().
+				HasTables(),
+		)
+		assertThatObject(
+			t, objectparametersassert.WarehouseParameters(t, id).
+				HasMaxConcurrencyLevel(8).
+				HasStatementQueuedTimeoutInSeconds(0).
+				HasStatementTimeoutInSeconds(172800),
+		)
 	})
 
 	t.Run("create interactive: with tables", func(t *testing.T) {
@@ -994,11 +1014,31 @@ func TestInt_Warehouses_Interactive(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(testClientHelper().Warehouse.DropWarehouseFunc(t, id))
 
-		w, err := client.Warehouses.ShowByID(ctx, id)
-		require.NoError(t, err)
-		assert.True(t, w.IsInteractiveWarehouse())
-		assert.Equal(t, "interactive warehouse", w.Comment)
-		assert.ElementsMatch(t, []sdk.SchemaObjectIdentifier{table1, table2}, w.Tables)
+		assertThatObject(
+			t, objectassert.Warehouse(t, id).
+				HasName(id.Name()).
+				HasType(sdk.WarehouseTypeInteractive).
+				HasComment("interactive warehouse").
+				HasSize(sdk.WarehouseSizeXSmall).
+				HasMaxClusterCount(1).
+				HasMinClusterCount(1).
+				HasAutoSuspend(86400).
+				HasAutoResume(true).
+				HasScalingPolicy(sdk.ScalingPolicyStandard).
+				HasEnableQueryAcceleration(false).
+				HasQueryAccelerationMaxScaleFactor(8).
+				HasNoResourceConstraint().
+				HasNoGeneration().
+				HasNoMaxQueryPerformanceLevel().
+				HasNoQueryThroughputMultiplier().
+				HasTables(table1, table2),
+		)
+		assertThatObject(
+			t, objectparametersassert.WarehouseParameters(t, id).
+				HasMaxConcurrencyLevel(8).
+				HasStatementQueuedTimeoutInSeconds(0).
+				HasStatementTimeoutInSeconds(172800),
+		)
 	})
 
 	t.Run("alter: add and drop tables", func(t *testing.T) {
@@ -1015,17 +1055,11 @@ func TestInt_Warehouses_Interactive(t *testing.T) {
 
 		err = client.Warehouses.Alter(ctx, sdk.NewAlterWarehouseRequest(id).WithAddTables([]sdk.SchemaObjectIdentifier{table2}))
 		require.NoError(t, err)
-
-		w, err := client.Warehouses.ShowByID(ctx, id)
-		require.NoError(t, err)
-		assert.ElementsMatch(t, []sdk.SchemaObjectIdentifier{table1, table2}, w.Tables)
+		assertThatObject(t, objectassert.Warehouse(t, id).HasTables(table1, table2))
 
 		err = client.Warehouses.Alter(ctx, sdk.NewAlterWarehouseRequest(id).WithDropTables([]sdk.SchemaObjectIdentifier{table1}))
 		require.NoError(t, err)
-
-		w, err = client.Warehouses.ShowByID(ctx, id)
-		require.NoError(t, err)
-		assert.ElementsMatch(t, []sdk.SchemaObjectIdentifier{table2}, w.Tables)
+		assertThatObject(t, objectassert.Warehouse(t, id).HasTables(table2))
 	})
 
 	t.Run("alter: set and unset fallback warehouse", func(t *testing.T) {

--- a/pkg/sdk/testint/warehouses_integration_test.go
+++ b/pkg/sdk/testint/warehouses_integration_test.go
@@ -962,3 +962,109 @@ func TestInt_Warehouses_Experimental(t *testing.T) {
 		assert.Equal(t, warehouseId2.Name(), warehouses[0].Name)
 	})
 }
+
+func TestInt_Warehouses_Interactive(t *testing.T) {
+	client := testClient(t)
+	ctx := testContext(t)
+
+	// createInteractiveTable creates an interactive table fixture and returns its id with a cleanup.
+	createInteractiveTable := func(t *testing.T) sdk.SchemaObjectIdentifier {
+		t.Helper()
+		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
+		_, err := client.ExecForTests(ctx, fmt.Sprintf(`CREATE INTERACTIVE TABLE %s (id INT) CLUSTER BY (id)`, id.FullyQualifiedName()))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, _ = client.ExecForTests(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, id.FullyQualifiedName()))
+		})
+		return id
+	}
+
+	t.Run("create interactive: minimal", func(t *testing.T) {
+		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
+		err := client.Warehouses.CreateInteractive(ctx, sdk.NewCreateInteractiveWarehouseRequest(id))
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().Warehouse.DropWarehouseFunc(t, id))
+
+		w, err := client.Warehouses.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, id.Name(), w.Name)
+		assert.True(t, w.IsInteractiveWarehouse())
+		assert.Empty(t, w.Tables)
+	})
+
+	t.Run("create interactive: with tables", func(t *testing.T) {
+		table1 := createInteractiveTable(t)
+		table2 := createInteractiveTable(t)
+
+		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
+		err := client.Warehouses.CreateInteractive(ctx, sdk.NewCreateInteractiveWarehouseRequest(id).
+			WithTables([]sdk.SchemaObjectIdentifier{table1, table2}).
+			WithWarehouseSize(sdk.WarehouseSizeXSmall).
+			WithComment("interactive warehouse"))
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().Warehouse.DropWarehouseFunc(t, id))
+
+		w, err := client.Warehouses.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assert.True(t, w.IsInteractiveWarehouse())
+		assert.Equal(t, "interactive warehouse", w.Comment)
+		assert.ElementsMatch(t, []sdk.SchemaObjectIdentifier{table1, table2}, w.Tables)
+	})
+
+	t.Run("alter: add and drop tables", func(t *testing.T) {
+		table1 := createInteractiveTable(t)
+		table2 := createInteractiveTable(t)
+
+		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
+		err := client.Warehouses.CreateInteractive(ctx, sdk.NewCreateInteractiveWarehouseRequest(id).
+			WithTables([]sdk.SchemaObjectIdentifier{table1}))
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().Warehouse.DropWarehouseFunc(t, id))
+
+		err = client.Warehouses.Alter(ctx, sdk.NewAlterWarehouseRequest(id).WithAddTables([]sdk.SchemaObjectIdentifier{table2}))
+		require.NoError(t, err)
+
+		w, err := client.Warehouses.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []sdk.SchemaObjectIdentifier{table1, table2}, w.Tables)
+
+		err = client.Warehouses.Alter(ctx, sdk.NewAlterWarehouseRequest(id).WithDropTables([]sdk.SchemaObjectIdentifier{table1}))
+		require.NoError(t, err)
+
+		w, err = client.Warehouses.ShowByID(ctx, id)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []sdk.SchemaObjectIdentifier{table2}, w.Tables)
+	})
+
+	t.Run("alter: set and unset fallback warehouse", func(t *testing.T) {
+		fallback, fallbackCleanup := testClientHelper().Warehouse.CreateWarehouse(t)
+		t.Cleanup(fallbackCleanup)
+
+		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
+		err := client.Warehouses.CreateInteractive(ctx, sdk.NewCreateInteractiveWarehouseRequest(id))
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().Warehouse.DropWarehouseFunc(t, id))
+
+		// FALLBACK_WAREHOUSE is exposed as a warehouse parameter, not a SHOW WAREHOUSES column.
+		fallbackParam := func() string {
+			parameters, err := client.Warehouses.ShowParameters(ctx, id)
+			require.NoError(t, err)
+			for _, p := range parameters {
+				if p.Key == "FALLBACK_WAREHOUSE" {
+					return p.Value
+				}
+			}
+			return ""
+		}
+
+		err = client.Warehouses.Alter(ctx, sdk.NewAlterWarehouseRequest(id).
+			WithSet(*sdk.NewWarehouseSetRequest().WithFallbackWarehouse(fallback.ID())))
+		require.NoError(t, err)
+		assert.Equal(t, fallback.ID().Name(), fallbackParam())
+
+		err = client.Warehouses.Alter(ctx, sdk.NewAlterWarehouseRequest(id).
+			WithUnset(*sdk.NewWarehouseUnsetRequest().WithFallbackWarehouse(true)))
+		require.NoError(t, err)
+		assert.Empty(t, fallbackParam())
+	})
+}

--- a/pkg/sdk/warehouses_ext.go
+++ b/pkg/sdk/warehouses_ext.go
@@ -379,3 +379,9 @@ func (s *CreateAdaptiveWarehouseRequest) ID() AccountObjectIdentifier {
 func (s *CreateInteractiveWarehouseRequest) ID() AccountObjectIdentifier {
 	return s.name
 }
+
+// IsInteractiveWarehouse reports whether the warehouse is interactive. Snowflake surfaces this
+// through the type column (type = INTERACTIVE); there is no separate is_interactive column.
+func (w *Warehouse) IsInteractiveWarehouse() bool {
+	return w.Type == WarehouseTypeInteractive
+}


### PR DESCRIPTION
## Description

PR 2 (of 3) in the interactive-warehouse series. Adds SDK integration tests that validate the interactive-warehouse SDK behavior (added in #4987) against a live Snowflake connection.

## Changes

- **`TestInt_Warehouses_Interactive`** covering:
  - `CreateInteractive` with and without table associations,
  - `ALTER ... ADD TABLES` / `DROP TABLES` and asserting the resulting `Tables` on `SHOW`,
  - `SET`/`UNSET FALLBACK_WAREHOUSE`, asserting the value via `SHOW PARAMETERS ... IN WAREHOUSE` (fallback is exposed as a warehouse **parameter**, not a `SHOW WAREHOUSES` column),
- **`Warehouse.IsInteractiveWarehouse()`** helper introduced. It reports `type == INTERACTIVE`; also used by the resource (next PR)
- **Test client helpers:**
  - `Warehouse.CreateInteractive` / `CreateInteractiveWithRequest`
  - `Table.CreateInteractiveTable` — creates an interactive table fixture via raw SQL.

## Test Plan

Run against an account with interactive warehouses enabled:

```
go test -tags account_level_tests ./pkg/sdk/testint/ -run '^TestInt_Warehouses_Interactive$'
```

Validated against a QA account — all subtests pass.

## References

Part of the interactive-warehouse feature. Builds on the SDK PR; the `snowflake_warehouse_interactive` resource follows.