### PR TITLE
feat: Add columns and table-level constraints to Iceberg table resource

### DIFF
--- a/pkg/acceptance/bettertestspoc/README.md
+++ b/pkg/acceptance/bettertestspoc/README.md
@@ -452,6 +452,7 @@ func (w *WarehouseDatasourceShowOutputAssert) IsEmpty() {
 - SNOW-2048330: add possibility to override the default value (and optionally default level) used in HasAllDefaults -> HasDefaultParameterValueOnLevel parameter assertions (it's required for cases like asserting `NETWORK_POLICY` which is predefined for our testing environments and causes test failures)
 - `Mapper` is just a `func(string) string`, so there is no easy way inside the template to know what mapper is being applied. Because of that, we have the `Identity` mapper which just returns the input string which leads to easier template logic applicable both to cases needed the mapping and not needing it. It leads to more unnecessary code (like for collections comparison in object asserts), so it would be great to change the logic, e.g. by handling the list of mappers (logic allowing the emptiness check, easier piping).
 - Support nested assertions. Snowflake sometimes returns nested objects in DESC. Some of the fields are read-only and set by Snowflake. As a workaround, we write custom comparator functions, check `external_volume_describe_snowflake_ext.go`.
+- Fix comparing slices with uncomparable types (see iceberg table's parititonSpec).
 
 ## Known limitations
 - generating provider config may misbehave when used only with one object/map paramter (like `params`), e.g.:

--- a/pkg/acceptance/bettertestspoc/assert/objectassert/iceberg_table_snowflake_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/iceberg_table_snowflake_ext.go
@@ -2,9 +2,11 @@ package objectassert
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 )
 
@@ -143,6 +145,22 @@ func (i *IcebergTableAssert) HasAutoRefreshStatus(expected sdk.IcebergTableAutoR
 		expected.LastSnapshotTime, expected.LastUpdatedTime = nil, ""
 		if actual != expected {
 			return fmt.Errorf("expected auto refresh status: %+v; got: %+v", expected, actual)
+		}
+		return nil
+	})
+	return i
+}
+
+// HasPartitionSpecs fails with the following panic
+// panic: runtime error: comparing uncomparable type sdk.IcebergTablePartitionSpec [recovered, repanicked]
+// This is a workaround to compare the partition specs using reflect.DeepEqual.
+func (i *IcebergTableAssert) HasPartitionSpecsFixed(expected ...sdk.IcebergTablePartitionSpec) *IcebergTableAssert {
+	i.AddAssertion(func(t *testing.T, o *sdk.IcebergTable) error {
+		t.Helper()
+		mapped := collections.Map(o.PartitionSpecs, func(item sdk.IcebergTablePartitionSpec) any { return item })
+		mappedExpected := collections.Map(expected, func(item sdk.IcebergTablePartitionSpec) any { return item })
+		if !reflect.DeepEqual(mapped, mappedExpected) {
+			return fmt.Errorf("expected partition specs: %v; got: %v", expected, o.PartitionSpecs)
 		}
 		return nil
 	})

--- a/pkg/acceptance/bettertestspoc/assert/resource_assertions.go
+++ b/pkg/acceptance/bettertestspoc/assert/resource_assertions.go
@@ -210,6 +210,14 @@ func (r *ResourceAssert) BoolValueSet(fieldName string, expected bool) {
 	r.AddAssertion(ValueSet(fieldName, strconv.FormatBool(expected)))
 }
 
+func (r *ResourceAssert) OptionalBoolValueSet(fieldName string, expected *bool) {
+	if expected != nil {
+		r.AddAssertion(ValueSet(fieldName, strconv.FormatBool(*expected)))
+	} else {
+		r.AddAssertion(ValueSet(fieldName, ""))
+	}
+}
+
 func (r *ResourceAssert) IntValueSet(fieldName string, expected int) {
 	r.AddAssertion(ValueSet(fieldName, strconv.Itoa(expected)))
 }
@@ -220,6 +228,14 @@ func (r *ResourceAssert) FloatValueSet(fieldName string, expected float64) {
 
 func (r *ResourceAssert) StringValueSet(fieldName string, expected string) {
 	r.AddAssertion(ValueSet(fieldName, expected))
+}
+
+func (r *ResourceAssert) OptionalStringValueSet(fieldName string, expected *string) {
+	if expected != nil {
+		r.AddAssertion(ValueSet(fieldName, *expected))
+	} else {
+		r.AddAssertion(ValueSet(fieldName, ""))
+	}
 }
 
 func (r *ResourceAssert) ValueSet(fieldName string, expected string) {

--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/iceberg_table_resource_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/iceberg_table_resource_ext.go
@@ -77,9 +77,7 @@ func (i *IcebergTableResourceAssert) HasPartitionByHour(index int, column string
 	return i
 }
 
-// ExpectedColumn describes the fields of a single `column` block to assert on. MaskingPolicy and
-// ProjectionPolicy are only checked when non-nil. MaskingPolicyUsing is only checked when MaskingPolicy
-// is non-nil and MaskingPolicyUsing is non-empty.
+// ExpectedColumn describes the fields of a single `column` block to assert on.
 type ExpectedColumn struct {
 	Name               string
 	Type               string
@@ -97,7 +95,7 @@ func (i *IcebergTableResourceAssert) HasColumns(columns ...ExpectedColumn) *Iceb
 		prefix := fmt.Sprintf("column.%d.", index)
 		i.ValueSet(prefix+"name", column.Name)
 		i.ValueSet(prefix+"type", column.Type)
-		i.BoolValueSet(prefix+"not_null", column.NotNull)
+		i.ValueSet(prefix+"not_null", strconv.FormatBool(column.NotNull))
 		i.ValueSet(prefix+"comment", column.Comment)
 
 		if column.DefaultExpression != "" {
@@ -142,13 +140,28 @@ func boolPairExpectation(positive, negative *bool) string {
 	}
 }
 
-func (i *IcebergTableResourceAssert) hasConstraintEnforcementFields(prefix string, enforced, notEnforced, deferrable, notDeferrable, initiallyDeferred, initiallyImmediate, enable, disable, validate, novalidate, rely, norely *bool) *IcebergTableResourceAssert {
-	i.ValueSet(prefix+"enforced", boolPairExpectation(enforced, notEnforced))
-	i.ValueSet(prefix+"deferrable", boolPairExpectation(deferrable, notDeferrable))
-	i.ValueSet(prefix+"initially_deferred", boolPairExpectation(initiallyDeferred, initiallyImmediate))
-	i.ValueSet(prefix+"enable", boolPairExpectation(enable, disable))
-	i.ValueSet(prefix+"validate", boolPairExpectation(validate, novalidate))
-	i.ValueSet(prefix+"rely", boolPairExpectation(rely, norely))
+type ConstraintEnforcementFields struct {
+	Enforced           *bool
+	NotEnforced        *bool
+	Deferrable         *bool
+	NotDeferrable      *bool
+	InitiallyDeferred  *bool
+	InitiallyImmediate *bool
+	Enable             *bool
+	Disable            *bool
+	Validate           *bool
+	Novalidate         *bool
+	Rely               *bool
+	Norely             *bool
+}
+
+func (i *IcebergTableResourceAssert) hasConstraintEnforcementFields(prefix string, fields ConstraintEnforcementFields) *IcebergTableResourceAssert {
+	i.ValueSet(prefix+"enforced", boolPairExpectation(fields.Enforced, fields.NotEnforced))
+	i.ValueSet(prefix+"deferrable", boolPairExpectation(fields.Deferrable, fields.NotDeferrable))
+	i.ValueSet(prefix+"initially_deferred", boolPairExpectation(fields.InitiallyDeferred, fields.InitiallyImmediate))
+	i.ValueSet(prefix+"enable", boolPairExpectation(fields.Enable, fields.Disable))
+	i.ValueSet(prefix+"validate", boolPairExpectation(fields.Validate, fields.Novalidate))
+	i.ValueSet(prefix+"rely", boolPairExpectation(fields.Rely, fields.Norely))
 	return i
 }
 
@@ -162,7 +175,20 @@ func (i *IcebergTableResourceAssert) hasUniquePKConstraintFields(prefix string, 
 	for colIndex, column := range c.Columns {
 		i.ValueSet(fmt.Sprintf("%scolumn.%d", prefix, colIndex), column.Value)
 	}
-	i.hasConstraintEnforcementFields(prefix, c.Enforced, c.NotEnforced, c.Deferrable, c.NotDeferrable, c.InitiallyDeferred, c.InitiallyImmediate, c.Enable, c.Disable, c.Validate, c.Novalidate, c.Rely, c.Norely)
+	i.hasConstraintEnforcementFields(prefix, ConstraintEnforcementFields{
+		Enforced:           c.Enforced,
+		NotEnforced:        c.NotEnforced,
+		Deferrable:         c.Deferrable,
+		NotDeferrable:      c.NotDeferrable,
+		InitiallyDeferred:  c.InitiallyDeferred,
+		InitiallyImmediate: c.InitiallyImmediate,
+		Enable:             c.Enable,
+		Disable:            c.Disable,
+		Validate:           c.Validate,
+		Novalidate:         c.Novalidate,
+		Rely:               c.Rely,
+		Norely:             c.Norely,
+	})
 	return i
 }
 
@@ -212,7 +238,20 @@ func (i *IcebergTableResourceAssert) HasForeignKeyConstraints(constraints ...sdk
 		if c.On != nil && c.On.OnDelete != nil {
 			i.ValueSet(prefix+"on_delete", string(*c.On.OnDelete))
 		}
-		i.hasConstraintEnforcementFields(prefix, c.Enforced, c.NotEnforced, c.Deferrable, c.NotDeferrable, c.InitiallyDeferred, c.InitiallyImmediate, c.Enable, c.Disable, c.Validate, c.Novalidate, c.Rely, c.Norely)
+		i.hasConstraintEnforcementFields(prefix, ConstraintEnforcementFields{
+			Enforced:           c.Enforced,
+			NotEnforced:        c.NotEnforced,
+			Deferrable:         c.Deferrable,
+			NotDeferrable:      c.NotDeferrable,
+			InitiallyDeferred:  c.InitiallyDeferred,
+			InitiallyImmediate: c.InitiallyImmediate,
+			Enable:             c.Enable,
+			Disable:            c.Disable,
+			Validate:           c.Validate,
+			Novalidate:         c.Novalidate,
+			Rely:               c.Rely,
+			Norely:             c.Norely,
+		})
 	}
 	return i
 }

--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/iceberg_table_resource_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/iceberg_table_resource_ext.go
@@ -76,3 +76,156 @@ func (i *IcebergTableResourceAssert) HasPartitionByHour(index int, column string
 	i.ValueSet(fmt.Sprintf("partition_by.%d.hour", index), column)
 	return i
 }
+
+// ExpectedColumn describes the fields of a single `column` block to assert on. MaskingPolicy and
+// ProjectionPolicy are only checked when non-nil. MaskingPolicyUsing is only checked when MaskingPolicy
+// is non-nil and MaskingPolicyUsing is non-empty.
+type ExpectedColumn struct {
+	Name               string
+	Type               string
+	NotNull            bool
+	Comment            string
+	DefaultExpression  string
+	MaskingPolicy      *sdk.SchemaObjectIdentifier
+	MaskingPolicyUsing []string
+	ProjectionPolicy   *sdk.SchemaObjectIdentifier
+}
+
+func (i *IcebergTableResourceAssert) HasColumns(columns ...ExpectedColumn) *IcebergTableResourceAssert {
+	i.CollectionLength("column", len(columns))
+	for index, column := range columns {
+		prefix := fmt.Sprintf("column.%d.", index)
+		i.ValueSet(prefix+"name", column.Name)
+		i.ValueSet(prefix+"type", column.Type)
+		i.BoolValueSet(prefix+"not_null", column.NotNull)
+		i.ValueSet(prefix+"comment", column.Comment)
+
+		if column.DefaultExpression != "" {
+			i.CollectionLength(prefix+"default", 1)
+			i.ValueSet(prefix+"default.0.expression", column.DefaultExpression)
+		} else {
+			i.CollectionLength(prefix+"default", 0)
+		}
+
+		if column.MaskingPolicy != nil {
+			i.CollectionLength(prefix+"masking_policy", 1)
+			i.ValueSet(prefix+"masking_policy.0.policy_name", column.MaskingPolicy.FullyQualifiedName())
+			i.CollectionLength(prefix+"masking_policy.0.using", len(column.MaskingPolicyUsing))
+			for using, columnName := range column.MaskingPolicyUsing {
+				i.ValueSet(fmt.Sprintf("%smasking_policy.0.using.%d", prefix, using), columnName)
+			}
+		} else {
+			i.CollectionLength(prefix+"masking_policy", 0)
+		}
+
+		if column.ProjectionPolicy != nil {
+			i.CollectionLength(prefix+"projection_policy", 1)
+			i.ValueSet(prefix+"projection_policy.0.policy_name", column.ProjectionPolicy.FullyQualifiedName())
+		} else {
+			i.CollectionLength(prefix+"projection_policy", 0)
+		}
+	}
+	return i
+}
+
+// boolPairExpectation renders the expected tri-state boolean string for a constraint enforcement
+// field, given the pair of mutually exclusive SQL keyword flags (e.g. Enforced/NotEnforced). Mirrors
+// model.boolPairVariable so assertions can reuse the same SDK request structs as the config builders.
+func boolPairExpectation(positive, negative *bool) string {
+	switch {
+	case positive != nil && *positive:
+		return "true"
+	case negative != nil && *negative:
+		return "false"
+	default:
+		return "default"
+	}
+}
+
+func (i *IcebergTableResourceAssert) hasConstraintEnforcementFields(prefix string, enforced, notEnforced, deferrable, notDeferrable, initiallyDeferred, initiallyImmediate, enable, disable, validate, novalidate, rely, norely *bool) *IcebergTableResourceAssert {
+	i.ValueSet(prefix+"enforced", boolPairExpectation(enforced, notEnforced))
+	i.ValueSet(prefix+"deferrable", boolPairExpectation(deferrable, notDeferrable))
+	i.ValueSet(prefix+"initially_deferred", boolPairExpectation(initiallyDeferred, initiallyImmediate))
+	i.ValueSet(prefix+"enable", boolPairExpectation(enable, disable))
+	i.ValueSet(prefix+"validate", boolPairExpectation(validate, novalidate))
+	i.ValueSet(prefix+"rely", boolPairExpectation(rely, norely))
+	return i
+}
+
+// hasUniquePKConstraintFields asserts the fields shared by primary_key_constraint and
+// unique_constraint entries, reusing the SDK's TableOutOfLineUniquePKRequest for the expected
+// field set.
+func (i *IcebergTableResourceAssert) hasUniquePKConstraintFields(prefix string, c sdk.TableOutOfLineUniquePKRequest) *IcebergTableResourceAssert {
+	i.OptionalStringValueSet(prefix+"name", c.Name)
+	i.OptionalStringValueSet(prefix+"comment", c.Comment)
+	i.CollectionLength(prefix+"column", len(c.Columns))
+	for colIndex, column := range c.Columns {
+		i.ValueSet(fmt.Sprintf("%scolumn.%d", prefix, colIndex), column.Value)
+	}
+	i.hasConstraintEnforcementFields(prefix, c.Enforced, c.NotEnforced, c.Deferrable, c.NotDeferrable, c.InitiallyDeferred, c.InitiallyImmediate, c.Enable, c.Disable, c.Validate, c.Novalidate, c.Rely, c.Norely)
+	return i
+}
+
+// HasPrimaryKeyConstraints asserts the `primary_key_constraint` attribute, reusing the SDK's
+// TableOutOfLineUniquePKRequest for the expected field set.
+func (i *IcebergTableResourceAssert) HasPrimaryKeyConstraints(constraints ...sdk.TableOutOfLineUniquePKRequest) *IcebergTableResourceAssert {
+	i.CollectionLength("primary_key_constraint", len(constraints))
+	for index, c := range constraints {
+		i.hasUniquePKConstraintFields(fmt.Sprintf("primary_key_constraint.%d.", index), c)
+	}
+	return i
+}
+
+// HasUniqueConstraints asserts the `unique_constraint` attribute, reusing the SDK's
+// TableOutOfLineUniquePKRequest for the expected field set.
+func (i *IcebergTableResourceAssert) HasUniqueConstraints(constraints ...sdk.TableOutOfLineUniquePKRequest) *IcebergTableResourceAssert {
+	i.CollectionLength("unique_constraint", len(constraints))
+	for index, c := range constraints {
+		i.hasUniquePKConstraintFields(fmt.Sprintf("unique_constraint.%d.", index), c)
+	}
+	return i
+}
+
+// HasForeignKeyConstraints asserts the `foreign_key_constraint` attribute, reusing the SDK's
+// TableOutOfLineFKRequest for the expected field set.
+func (i *IcebergTableResourceAssert) HasForeignKeyConstraints(constraints ...sdk.TableOutOfLineFKRequest) *IcebergTableResourceAssert {
+	i.CollectionLength("foreign_key_constraint", len(constraints))
+	for index, c := range constraints {
+		prefix := fmt.Sprintf("foreign_key_constraint.%d.", index)
+		i.OptionalStringValueSet(prefix+"name", c.Name)
+		i.ValueSet(prefix+"table_name", c.References.FullyQualifiedName())
+		i.OptionalStringValueSet(prefix+"comment", c.Comment)
+		i.CollectionLength(prefix+"column", len(c.Columns))
+		for colIndex, column := range c.Columns {
+			i.ValueSet(fmt.Sprintf("%scolumn.%d", prefix, colIndex), column.Value)
+		}
+		i.CollectionLength(prefix+"ref_column", len(c.RefColumns))
+		for colIndex, column := range c.RefColumns {
+			i.ValueSet(fmt.Sprintf("%sref_column.%d", prefix, colIndex), column.Value)
+		}
+		if c.Match != nil {
+			i.ValueSet(prefix+"match", string(*c.Match))
+		}
+		if c.On != nil && c.On.OnUpdate != nil {
+			i.ValueSet(prefix+"on_update", string(*c.On.OnUpdate))
+		}
+		if c.On != nil && c.On.OnDelete != nil {
+			i.ValueSet(prefix+"on_delete", string(*c.On.OnDelete))
+		}
+		i.hasConstraintEnforcementFields(prefix, c.Enforced, c.NotEnforced, c.Deferrable, c.NotDeferrable, c.InitiallyDeferred, c.InitiallyImmediate, c.Enable, c.Disable, c.Validate, c.Novalidate, c.Rely, c.Norely)
+	}
+	return i
+}
+
+// HasCheckConstraints asserts the `check_constraint` attribute, reusing the SDK's
+// TableOutOfLineCHRequest for the expected field set.
+func (i *IcebergTableResourceAssert) HasCheckConstraints(constraints ...sdk.TableOutOfLineCHRequest) *IcebergTableResourceAssert {
+	i.CollectionLength("check_constraint", len(constraints))
+	for index, c := range constraints {
+		prefix := fmt.Sprintf("check_constraint.%d.", index)
+		i.OptionalStringValueSet(prefix+"name", c.Name)
+		i.ValueSet(prefix+"expression", c.Expression)
+		i.ValueSet(prefix+"validate", boolPairExpectation(c.EnableValidate, c.EnableNovalidate))
+	}
+	return i
+}

--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/iceberg_table_resource_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/iceberg_table_resource_gen.go
@@ -69,6 +69,8 @@ func (i *IcebergTableResourceAssert) HasChangeTracking(expected string) *Iceberg
 	return i
 }
 
+// typed assert for "check_constraint" (type: List, subtype: Map) is not currently supported
+
 func (i *IcebergTableResourceAssert) HasClusterBy(expected ...string) *IcebergTableResourceAssert {
 	i.ListContainsExactlyStringValuesInOrder("cluster_by", expected...)
 	return i
@@ -106,6 +108,8 @@ func (i *IcebergTableResourceAssert) HasExternalVolume(expected string) *Iceberg
 	return i
 }
 
+// typed assert for "foreign_key_constraint" (type: List, subtype: Map) is not currently supported
+
 func (i *IcebergTableResourceAssert) HasFullyQualifiedName(expected string) *IcebergTableResourceAssert {
 	i.StringValueSet("fully_qualified_name", expected)
 	return i
@@ -128,6 +132,8 @@ func (i *IcebergTableResourceAssert) HasPathLayout(expected string) *IcebergTabl
 	return i
 }
 
+// typed assert for "primary_key_constraint" (type: List, subtype: Map) is not currently supported
+
 // typed assert for "row_access_policy" (type: List, subtype: Map) is not currently supported
 
 func (i *IcebergTableResourceAssert) HasStorageSerializationPolicy(expected string) *IcebergTableResourceAssert {
@@ -139,6 +145,8 @@ func (i *IcebergTableResourceAssert) HasTargetFileSize(expected string) *Iceberg
 	i.StringValueSet("target_file_size", expected)
 	return i
 }
+
+// typed assert for "unique_constraint" (type: List, subtype: Map) is not currently supported
 
 ///////////////////////////////////
 // Attribute value string checks //
@@ -367,6 +375,11 @@ func (i *IcebergTableResourceAssert) HasChangeTrackingEmpty() *IcebergTableResou
 	return i
 }
 
+func (i *IcebergTableResourceAssert) HasCheckConstraintEmpty() *IcebergTableResourceAssert {
+	i.ValueSet("check_constraint.#", "0")
+	return i
+}
+
 func (i *IcebergTableResourceAssert) HasClusterByEmpty() *IcebergTableResourceAssert {
 	i.ValueSet("cluster_by.#", "0")
 	return i
@@ -402,6 +415,11 @@ func (i *IcebergTableResourceAssert) HasExternalVolumeEmpty() *IcebergTableResou
 	return i
 }
 
+func (i *IcebergTableResourceAssert) HasForeignKeyConstraintEmpty() *IcebergTableResourceAssert {
+	i.ValueSet("foreign_key_constraint.#", "0")
+	return i
+}
+
 func (i *IcebergTableResourceAssert) HasFullyQualifiedNameEmpty() *IcebergTableResourceAssert {
 	i.ValueSet("fully_qualified_name", "")
 	return i
@@ -427,6 +445,11 @@ func (i *IcebergTableResourceAssert) HasPathLayoutEmpty() *IcebergTableResourceA
 	return i
 }
 
+func (i *IcebergTableResourceAssert) HasPrimaryKeyConstraintEmpty() *IcebergTableResourceAssert {
+	i.ValueSet("primary_key_constraint.#", "0")
+	return i
+}
+
 func (i *IcebergTableResourceAssert) HasRowAccessPolicyEmpty() *IcebergTableResourceAssert {
 	i.ValueSet("row_access_policy.#", "0")
 	return i
@@ -439,6 +462,11 @@ func (i *IcebergTableResourceAssert) HasStorageSerializationPolicyEmpty() *Icebe
 
 func (i *IcebergTableResourceAssert) HasTargetFileSizeEmpty() *IcebergTableResourceAssert {
 	i.ValueSet("target_file_size", "")
+	return i
+}
+
+func (i *IcebergTableResourceAssert) HasUniqueConstraintEmpty() *IcebergTableResourceAssert {
+	i.ValueSet("unique_constraint.#", "0")
 	return i
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/iceberg_table_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/iceberg_table_model_ext.go
@@ -5,19 +5,176 @@ import (
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 )
 
 // WithColumn satisfies the generated constructor's call for the complex list `column` attribute.
 func (i *IcebergTableModel) WithColumn(column []sdk.TableColumnSignature) *IcebergTableModel {
 	columns := make([]tfconfig.Variable, len(column))
 	for idx, v := range column {
-		columns[idx] = tfconfig.MapVariable(map[string]tfconfig.Variable{
+		columns[idx] = tfconfig.ObjectVariable(map[string]tfconfig.Variable{
 			"name": tfconfig.StringVariable(v.Name),
 			"type": tfconfig.StringVariable(v.Type.ToSql()),
 		})
 	}
 	i.Column = tfconfig.ListVariable(columns...)
 	return i
+}
+
+// IcebergTableColumnRequest describes a single entry of the `column` attribute, covering the fields
+// that go beyond name + type (not_null, comment, default expression, masking_policy, projection_policy).
+type IcebergTableColumnRequest struct {
+	Name               string
+	Type               datatypes.DataType
+	NotNull            bool
+	Comment            string
+	DefaultExpression  string
+	MaskingPolicy      *sdk.SchemaObjectIdentifier
+	MaskingPolicyUsing []string
+	ProjectionPolicy   *sdk.SchemaObjectIdentifier
+}
+
+// WithColumnRequests is like WithColumn, but supports setting the full set of per-column fields
+// (not_null, comment, default expression, masking_policy, projection_policy).
+func (i *IcebergTableModel) WithColumnRequests(columns ...IcebergTableColumnRequest) *IcebergTableModel {
+	vars := make([]tfconfig.Variable, len(columns))
+	for idx, c := range columns {
+		m := map[string]tfconfig.Variable{
+			"name": tfconfig.StringVariable(c.Name),
+			"type": tfconfig.StringVariable(c.Type.ToSql()),
+		}
+		if c.NotNull {
+			m["not_null"] = tfconfig.BoolVariable(true)
+		}
+		if c.Comment != "" {
+			m["comment"] = tfconfig.StringVariable(c.Comment)
+		}
+		if c.DefaultExpression != "" {
+			m["default"] = tfconfig.ObjectVariable(map[string]tfconfig.Variable{
+				"expression": tfconfig.StringVariable(c.DefaultExpression),
+			})
+		}
+		if c.MaskingPolicy != nil {
+			maskingPolicy := map[string]tfconfig.Variable{
+				"policy_name": tfconfig.StringVariable(c.MaskingPolicy.FullyQualifiedName()),
+			}
+			if len(c.MaskingPolicyUsing) > 0 {
+				maskingPolicy["using"] = tfconfig.ListVariable(collections.Map(c.MaskingPolicyUsing, func(s string) tfconfig.Variable {
+					return tfconfig.StringVariable(s)
+				})...)
+			}
+			m["masking_policy"] = tfconfig.ObjectVariable(maskingPolicy)
+		}
+		if c.ProjectionPolicy != nil {
+			m["projection_policy"] = tfconfig.ObjectVariable(map[string]tfconfig.Variable{
+				"policy_name": tfconfig.StringVariable(c.ProjectionPolicy.FullyQualifiedName()),
+			})
+		}
+		vars[idx] = tfconfig.ObjectVariable(m)
+	}
+	i.Column = tfconfig.ListVariable(vars...)
+	return i
+}
+
+func columnsVariable(columns []sdk.Column) tfconfig.Variable {
+	return tfconfig.ListVariable(collections.Map(columns, func(c sdk.Column) tfconfig.Variable { return tfconfig.StringVariable(c.Value) })...)
+}
+
+func setStringIfNotNil(m map[string]tfconfig.Variable, key string, value *string) {
+	if value != nil {
+		m[key] = tfconfig.StringVariable(*value)
+	}
+}
+
+func setBoolPairIfNotNil(m map[string]tfconfig.Variable, key string, trueVal, falseVal *bool) {
+	if trueVal != nil {
+		m[key] = tfconfig.BoolVariable(true)
+	}
+	if falseVal != nil {
+		m[key] = tfconfig.BoolVariable(false)
+	}
+}
+
+// uniquePKConstraintVariable builds the fields shared by primary_key_constraint and
+// unique_constraint entries, reusing the SDK's TableOutOfLineUniquePKRequest for the field set.
+func uniquePKConstraintVariable(c sdk.TableOutOfLineUniquePKRequest) tfconfig.Variable {
+	m := map[string]tfconfig.Variable{
+		"column": columnsVariable(c.Columns),
+	}
+	setStringIfNotNil(m, "name", c.Name)
+	setStringIfNotNil(m, "comment", c.Comment)
+	setBoolPairIfNotNil(m, "enforced", c.Enforced, c.NotEnforced)
+	setBoolPairIfNotNil(m, "deferrable", c.Deferrable, c.NotDeferrable)
+	setBoolPairIfNotNil(m, "initially_deferred", c.InitiallyDeferred, c.InitiallyImmediate)
+	setBoolPairIfNotNil(m, "enable", c.Enable, c.Disable)
+	setBoolPairIfNotNil(m, "validate", c.Validate, c.Novalidate)
+	setBoolPairIfNotNil(m, "rely", c.Rely, c.Norely)
+	return tfconfig.ObjectVariable(m)
+}
+
+// WithPrimaryKeyConstraints sets the `primary_key_constraint` attribute (table-level PRIMARY KEY
+// constraints), reusing the SDK's TableOutOfLineUniquePKRequest for the field set.
+func (i *IcebergTableModel) WithPrimaryKeyConstraints(constraints ...sdk.TableOutOfLineUniquePKRequest) *IcebergTableModel {
+	vars := collections.Map(constraints, uniquePKConstraintVariable)
+	return i.WithPrimaryKeyConstraintValue(tfconfig.ListVariable(vars...))
+}
+
+// WithUniqueConstraints sets the `unique_constraint` attribute (table-level UNIQUE constraints),
+// reusing the SDK's TableOutOfLineUniquePKRequest for the field set.
+func (i *IcebergTableModel) WithUniqueConstraints(constraints ...sdk.TableOutOfLineUniquePKRequest) *IcebergTableModel {
+	vars := collections.Map(constraints, uniquePKConstraintVariable)
+	return i.WithUniqueConstraintValue(tfconfig.ListVariable(vars...))
+}
+
+// WithForeignKeyConstraints sets the `foreign_key_constraint` attribute, reusing the SDK's
+// TableOutOfLineFKRequest for the field set.
+func (i *IcebergTableModel) WithForeignKeyConstraints(constraints ...sdk.TableOutOfLineFKRequest) *IcebergTableModel {
+	vars := make([]tfconfig.Variable, len(constraints))
+	for idx, c := range constraints {
+		m := map[string]tfconfig.Variable{
+			"column":     columnsVariable(c.Columns),
+			"table_name": tfconfig.StringVariable(c.References.FullyQualifiedName()),
+		}
+		setStringIfNotNil(m, "name", c.Name)
+		if len(c.RefColumns) > 0 {
+			m["ref_column"] = columnsVariable(c.RefColumns)
+		}
+		if c.Match != nil {
+			m["match"] = tfconfig.StringVariable(string(*c.Match))
+		}
+		if c.On != nil {
+			if c.On.OnUpdate != nil {
+				m["on_update"] = tfconfig.StringVariable(string(*c.On.OnUpdate))
+			}
+			if c.On.OnDelete != nil {
+				m["on_delete"] = tfconfig.StringVariable(string(*c.On.OnDelete))
+			}
+		}
+		setStringIfNotNil(m, "comment", c.Comment)
+		setBoolPairIfNotNil(m, "enforced", c.Enforced, c.NotEnforced)
+		setBoolPairIfNotNil(m, "deferrable", c.Deferrable, c.NotDeferrable)
+		setBoolPairIfNotNil(m, "initially_deferred", c.InitiallyDeferred, c.InitiallyImmediate)
+		setBoolPairIfNotNil(m, "enable", c.Enable, c.Disable)
+		setBoolPairIfNotNil(m, "validate", c.Validate, c.Novalidate)
+		setBoolPairIfNotNil(m, "rely", c.Rely, c.Norely)
+		vars[idx] = tfconfig.ObjectVariable(m)
+	}
+	return i.WithForeignKeyConstraintValue(tfconfig.ListVariable(vars...))
+}
+
+// WithCheckConstraints sets the `check_constraint` attribute, reusing the SDK's TableOutOfLineCHRequest
+// for the field set.
+func (i *IcebergTableModel) WithCheckConstraints(constraints ...sdk.TableOutOfLineCHRequest) *IcebergTableModel {
+	vars := make([]tfconfig.Variable, len(constraints))
+	for idx, c := range constraints {
+		m := map[string]tfconfig.Variable{
+			"expression": tfconfig.StringVariable(c.Expression),
+		}
+		setStringIfNotNil(m, "name", c.Name)
+		setBoolPairIfNotNil(m, "validate", c.EnableValidate, c.EnableNovalidate)
+		vars[idx] = tfconfig.ObjectVariable(m)
+	}
+	return i.WithCheckConstraintValue(tfconfig.ListVariable(vars...))
 }
 
 func (i *IcebergTableModel) WithRowAccessPolicy(rap sdk.SchemaObjectIdentifier, on string) *IcebergTableModel {

--- a/pkg/acceptance/bettertestspoc/config/model/iceberg_table_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/iceberg_table_model_ext.go
@@ -26,7 +26,7 @@ func (i *IcebergTableModel) WithColumn(column []sdk.TableColumnSignature) *Icebe
 type IcebergTableColumnRequest struct {
 	Name               string
 	Type               datatypes.DataType
-	NotNull            bool
+	NotNull            *string
 	Comment            string
 	DefaultExpression  string
 	MaskingPolicy      *sdk.SchemaObjectIdentifier
@@ -34,17 +34,17 @@ type IcebergTableColumnRequest struct {
 	ProjectionPolicy   *sdk.SchemaObjectIdentifier
 }
 
-// WithColumnRequests is like WithColumn, but supports setting the full set of per-column fields
+// WithColumns is like WithColumn, but supports setting the full set of per-column fields
 // (not_null, comment, default expression, masking_policy, projection_policy).
-func (i *IcebergTableModel) WithColumnRequests(columns ...IcebergTableColumnRequest) *IcebergTableModel {
+func (i *IcebergTableModel) WithColumns(columns ...IcebergTableColumnRequest) *IcebergTableModel {
 	vars := make([]tfconfig.Variable, len(columns))
 	for idx, c := range columns {
 		m := map[string]tfconfig.Variable{
 			"name": tfconfig.StringVariable(c.Name),
 			"type": tfconfig.StringVariable(c.Type.ToSql()),
 		}
-		if c.NotNull {
-			m["not_null"] = tfconfig.BoolVariable(true)
+		if c.NotNull != nil {
+			m["not_null"] = tfconfig.StringVariable(*c.NotNull)
 		}
 		if c.Comment != "" {
 			m["comment"] = tfconfig.StringVariable(c.Comment)
@@ -74,25 +74,6 @@ func (i *IcebergTableModel) WithColumnRequests(columns ...IcebergTableColumnRequ
 	}
 	i.Column = tfconfig.ListVariable(vars...)
 	return i
-}
-
-func columnsVariable(columns []sdk.Column) tfconfig.Variable {
-	return tfconfig.ListVariable(collections.Map(columns, func(c sdk.Column) tfconfig.Variable { return tfconfig.StringVariable(c.Value) })...)
-}
-
-func setStringIfNotNil(m map[string]tfconfig.Variable, key string, value *string) {
-	if value != nil {
-		m[key] = tfconfig.StringVariable(*value)
-	}
-}
-
-func setBoolPairIfNotNil(m map[string]tfconfig.Variable, key string, trueVal, falseVal *bool) {
-	if trueVal != nil {
-		m[key] = tfconfig.BoolVariable(true)
-	}
-	if falseVal != nil {
-		m[key] = tfconfig.BoolVariable(false)
-	}
 }
 
 // uniquePKConstraintVariable builds the fields shared by primary_key_constraint and

--- a/pkg/acceptance/bettertestspoc/config/model/iceberg_table_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/iceberg_table_model_gen.go
@@ -20,6 +20,7 @@ type IcebergTableModel struct {
 	Catalog                    tfconfig.Variable `json:"catalog,omitempty"`
 	CatalogSync                tfconfig.Variable `json:"catalog_sync,omitempty"`
 	ChangeTracking             tfconfig.Variable `json:"change_tracking,omitempty"`
+	CheckConstraint            tfconfig.Variable `json:"check_constraint,omitempty"`
 	ClusterBy                  tfconfig.Variable `json:"cluster_by,omitempty"`
 	Column                     tfconfig.Variable `json:"column,omitempty"`
 	Comment                    tfconfig.Variable `json:"comment,omitempty"`
@@ -28,14 +29,17 @@ type IcebergTableModel struct {
 	EnableIcebergMergeOnRead   tfconfig.Variable `json:"enable_iceberg_merge_on_read,omitempty"`
 	ErrorLogging               tfconfig.Variable `json:"error_logging,omitempty"`
 	ExternalVolume             tfconfig.Variable `json:"external_volume,omitempty"`
+	ForeignKeyConstraint       tfconfig.Variable `json:"foreign_key_constraint,omitempty"`
 	FullyQualifiedName         tfconfig.Variable `json:"fully_qualified_name,omitempty"`
 	IcebergVersion             tfconfig.Variable `json:"iceberg_version,omitempty"`
 	MaxDataExtensionTimeInDays tfconfig.Variable `json:"max_data_extension_time_in_days,omitempty"`
 	PartitionBy                tfconfig.Variable `json:"partition_by,omitempty"`
 	PathLayout                 tfconfig.Variable `json:"path_layout,omitempty"`
+	PrimaryKeyConstraint       tfconfig.Variable `json:"primary_key_constraint,omitempty"`
 	RowAccessPolicy            tfconfig.Variable `json:"row_access_policy,omitempty"`
 	StorageSerializationPolicy tfconfig.Variable `json:"storage_serialization_policy,omitempty"`
 	TargetFileSize             tfconfig.Variable `json:"target_file_size,omitempty"`
+	UniqueConstraint           tfconfig.Variable `json:"unique_constraint,omitempty"`
 
 	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
 
@@ -148,6 +152,8 @@ func (i *IcebergTableModel) WithChangeTracking(changeTracking string) *IcebergTa
 	return i
 }
 
+// check_constraint attribute type is not yet supported, so WithCheckConstraint can't be generated
+
 // cluster_by attribute type is not yet supported, so WithClusterBy can't be generated
 
 // column attribute type is not yet supported, so WithColumn can't be generated
@@ -182,6 +188,8 @@ func (i *IcebergTableModel) WithExternalVolume(externalVolume string) *IcebergTa
 	return i
 }
 
+// foreign_key_constraint attribute type is not yet supported, so WithForeignKeyConstraint can't be generated
+
 func (i *IcebergTableModel) WithFullyQualifiedName(fullyQualifiedName string) *IcebergTableModel {
 	i.FullyQualifiedName = tfconfig.StringVariable(fullyQualifiedName)
 	return i
@@ -204,6 +212,8 @@ func (i *IcebergTableModel) WithPathLayout(pathLayout string) *IcebergTableModel
 	return i
 }
 
+// primary_key_constraint attribute type is not yet supported, so WithPrimaryKeyConstraint can't be generated
+
 // row_access_policy attribute type is not yet supported, so WithRowAccessPolicy can't be generated
 
 func (i *IcebergTableModel) WithStorageSerializationPolicy(storageSerializationPolicy string) *IcebergTableModel {
@@ -215,6 +225,8 @@ func (i *IcebergTableModel) WithTargetFileSize(targetFileSize string) *IcebergTa
 	i.TargetFileSize = tfconfig.StringVariable(targetFileSize)
 	return i
 }
+
+// unique_constraint attribute type is not yet supported, so WithUniqueConstraint can't be generated
 
 //////////////////////////////////////////
 // below it's possible to set any value //
@@ -260,6 +272,11 @@ func (i *IcebergTableModel) WithChangeTrackingValue(value tfconfig.Variable) *Ic
 	return i
 }
 
+func (i *IcebergTableModel) WithCheckConstraintValue(value tfconfig.Variable) *IcebergTableModel {
+	i.CheckConstraint = value
+	return i
+}
+
 func (i *IcebergTableModel) WithClusterByValue(value tfconfig.Variable) *IcebergTableModel {
 	i.ClusterBy = value
 	return i
@@ -300,6 +317,11 @@ func (i *IcebergTableModel) WithExternalVolumeValue(value tfconfig.Variable) *Ic
 	return i
 }
 
+func (i *IcebergTableModel) WithForeignKeyConstraintValue(value tfconfig.Variable) *IcebergTableModel {
+	i.ForeignKeyConstraint = value
+	return i
+}
+
 func (i *IcebergTableModel) WithFullyQualifiedNameValue(value tfconfig.Variable) *IcebergTableModel {
 	i.FullyQualifiedName = value
 	return i
@@ -325,6 +347,11 @@ func (i *IcebergTableModel) WithPathLayoutValue(value tfconfig.Variable) *Iceber
 	return i
 }
 
+func (i *IcebergTableModel) WithPrimaryKeyConstraintValue(value tfconfig.Variable) *IcebergTableModel {
+	i.PrimaryKeyConstraint = value
+	return i
+}
+
 func (i *IcebergTableModel) WithRowAccessPolicyValue(value tfconfig.Variable) *IcebergTableModel {
 	i.RowAccessPolicy = value
 	return i
@@ -337,5 +364,10 @@ func (i *IcebergTableModel) WithStorageSerializationPolicyValue(value tfconfig.V
 
 func (i *IcebergTableModel) WithTargetFileSizeValue(value tfconfig.Variable) *IcebergTableModel {
 	i.TargetFileSize = value
+	return i
+}
+
+func (i *IcebergTableModel) WithUniqueConstraintValue(value tfconfig.Variable) *IcebergTableModel {
+	i.UniqueConstraint = value
 	return i
 }

--- a/pkg/acceptance/bettertestspoc/config/model/table_common.go
+++ b/pkg/acceptance/bettertestspoc/config/model/table_common.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
+)
+
+func columnsVariable(columns []sdk.Column) tfconfig.Variable {
+	return tfconfig.ListVariable(collections.Map(columns, func(c sdk.Column) tfconfig.Variable { return tfconfig.StringVariable(c.Value) })...)
+}
+
+func setStringIfNotNil(m map[string]tfconfig.Variable, key string, value *string) {
+	if value != nil {
+		m[key] = tfconfig.StringVariable(*value)
+	}
+}
+
+func setBoolPairIfNotNil(m map[string]tfconfig.Variable, key string, trueVal, falseVal *bool) {
+	if trueVal != nil {
+		m[key] = tfconfig.StringVariable(resources.BooleanTrue)
+	}
+	if falseVal != nil {
+		m[key] = tfconfig.StringVariable(resources.BooleanFalse)
+	}
+}

--- a/pkg/resources/diff_suppressions.go
+++ b/pkg/resources/diff_suppressions.go
@@ -273,9 +273,11 @@ func IgnoreNewEmptyListOrSubfields(ignoredSubfields ...string) schema.SchemaDiff
 }
 
 // IgnoreMatchingColumnNameAndMaskingPolicyUsingFirstElem ignores when the first element of USING is matching the column name.
+// columnNameField is the name of the schema field holding the column's own name (this differs
+// between resources, e.g. "column_name" for views vs "name" for tables).
 // see USING section in https://docs.snowflake.com/en/sql-reference/sql/create-view#optional-parameters
 // TODO(SNOW-1852423): improve docs and add more tests
-func IgnoreMatchingColumnNameAndMaskingPolicyUsingFirstElem() schema.SchemaDiffSuppressFunc {
+func IgnoreMatchingColumnNameAndMaskingPolicyUsingFirstElem(columnNameField string) schema.SchemaDiffSuppressFunc {
 	return func(k, old, new string, d *schema.ResourceData) bool {
 		// suppress diff when the name of the column matches the name of using
 		parts := strings.SplitN(k, ".", 6)
@@ -287,7 +289,7 @@ func IgnoreMatchingColumnNameAndMaskingPolicyUsingFirstElem() schema.SchemaDiffS
 		if parts[5] == "#" && old == "1" && new == "0" {
 			return true
 		}
-		colNameKey := strings.Join([]string{parts[0], parts[1], "column_name"}, ".")
+		colNameKey := strings.Join([]string{parts[0], parts[1], columnNameField}, ".")
 		colName := d.Get(colNameKey).(string)
 
 		return new == "" && old == colName

--- a/pkg/resources/diff_suppressions_test.go
+++ b/pkg/resources/diff_suppressions_test.go
@@ -352,7 +352,7 @@ func Test_IgnoreMatchingColumnNameAndMaskingPolicyUsingFirstElem(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.wantSuppress, resources.IgnoreMatchingColumnNameAndMaskingPolicyUsingFirstElem()(tt.key, tt.old, tt.new, tt.resourceData))
+			require.Equal(t, tt.wantSuppress, resources.IgnoreMatchingColumnNameAndMaskingPolicyUsingFirstElem("column_name")(tt.key, tt.old, tt.new, tt.resourceData))
 		})
 	}
 }

--- a/pkg/resources/iceberg_table.go
+++ b/pkg/resources/iceberg_table.go
@@ -157,22 +157,19 @@ func CreateIcebergTable(ctx context.Context, d *schema.ResourceData, meta any) d
 		return diag.FromErr(err)
 	}
 
-	if v := d.Get("row_access_policy"); len(v.([]any)) > 0 {
-		policyId, columns, err := extractPolicyWithColumnsSet(v, "on")
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	// TODO(SNOW-3785067): Deduplicate code with views
+	if policyId, columns, ok, err := rowAccessPolicyCreateRequest(d); err != nil {
+		return diag.FromErr(err)
+	} else if ok {
 		req.WithRowAccessPolicy(*sdk.NewIcebergTableRowAccessPolicyRequest(policyId, columns))
 	}
 
-	if v := d.Get("aggregation_policy"); len(v.([]any)) > 0 {
-		id, columns, err := extractPolicyWithColumnsSet(v, "entity_key")
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		aggregationPolicyReq := sdk.NewIcebergTableAggregationPolicyRequest(id)
-		if len(columns) > 0 {
-			aggregationPolicyReq.WithEntityKey(columns)
+	if policyId, entityKey, ok, err := aggregationPolicyCreateRequest(d); err != nil {
+		return diag.FromErr(err)
+	} else if ok {
+		aggregationPolicyReq := sdk.NewIcebergTableAggregationPolicyRequest(policyId)
+		if len(entityKey) > 0 {
+			aggregationPolicyReq.WithEntityKey(entityKey)
 		}
 		req.WithAggregationPolicy(*aggregationPolicyReq)
 	}
@@ -280,11 +277,8 @@ func ReadIcebergTableFunc(withExternalChangesMarking bool) schema.ReadContextFun
 			if err != nil {
 				return err
 			}
-			policyRefs, err := client.PolicyReferences.GetForEntity(ctx, sdk.NewGetForEntityPolicyReferenceRequest(id, sdk.PolicyEntityDomainTable))
+			policyRefs, err := readRootLevelPolicies(ctx, client, id, sdk.PolicyEntityDomainTable, d)
 			if err != nil {
-				return err
-			}
-			if err := handlePolicyReferences(policyRefs, d); err != nil {
 				return err
 			}
 
@@ -362,13 +356,7 @@ func UpdateIcebergTable(ctx context.Context, d *schema.ResourceData, meta any) d
 	}
 
 	if d.HasChange("row_access_policy") {
-		var addReq *sdk.ViewAddRowAccessPolicyRequest
-		var dropReq *sdk.ViewDropRowAccessPolicyRequest
-		err := rowAccessPolicyAlterRequests(d, func(id sdk.SchemaObjectIdentifier, columns []sdk.Column) {
-			addReq = sdk.NewViewAddRowAccessPolicyRequest(id, columns)
-		}, func(id sdk.SchemaObjectIdentifier) {
-			dropReq = sdk.NewViewDropRowAccessPolicyRequest(id)
-		})
+		addReq, dropReq, err := rowAccessPolicyUpdateRequests(d)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -380,9 +368,9 @@ func UpdateIcebergTable(ctx context.Context, d *schema.ResourceData, meta any) d
 				*sdk.NewIcebergTableAddRowAccessPolicyRequest(addReq.RowAccessPolicy, addReq.On),
 			))
 		case addReq != nil:
-			alterReq.WithAddRowAccessPolicy(*sdk.NewViewAddRowAccessPolicyRequest(addReq.RowAccessPolicy, addReq.On))
+			alterReq.WithAddRowAccessPolicy(*addReq)
 		case dropReq != nil:
-			alterReq.WithDropRowAccessPolicy(*sdk.NewViewDropRowAccessPolicyRequest(dropReq.RowAccessPolicy))
+			alterReq.WithDropRowAccessPolicy(*dropReq)
 		}
 		if err := client.IcebergTables.Alter(ctx, alterReq); err != nil {
 			return diag.FromErr(fmt.Errorf("error updating row access policy on %v err = %w", d.Id(), err))
@@ -390,20 +378,16 @@ func UpdateIcebergTable(ctx context.Context, d *schema.ResourceData, meta any) d
 	}
 
 	if d.HasChange("aggregation_policy") {
-		newId, newColumns, isSet, err := aggregationPolicyAlterState(d)
+		setReq, unsetReq, err := aggregationPolicyUpdateRequests(d)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		if isSet {
-			aggregationPolicyReq := sdk.NewViewSetAggregationPolicyRequest(newId)
-			if len(newColumns) > 0 {
-				aggregationPolicyReq.WithEntityKey(newColumns)
-			}
-			if err := client.IcebergTables.Alter(ctx, sdk.NewAlterIcebergTableRequest(id).WithSetAggregationPolicy(*aggregationPolicyReq.WithForce(true))); err != nil {
+		if setReq != nil {
+			if err := client.IcebergTables.Alter(ctx, sdk.NewAlterIcebergTableRequest(id).WithSetAggregationPolicy(*setReq)); err != nil {
 				return diag.FromErr(fmt.Errorf("error setting aggregation policy for iceberg table %v: %w", d.Id(), err))
 			}
 		} else {
-			if err := client.IcebergTables.Alter(ctx, sdk.NewAlterIcebergTableRequest(id).WithUnsetAggregationPolicy(*sdk.NewViewUnsetAggregationPolicyRequest())); err != nil {
+			if err := client.IcebergTables.Alter(ctx, sdk.NewAlterIcebergTableRequest(id).WithUnsetAggregationPolicy(*unsetReq)); err != nil {
 				return diag.FromErr(fmt.Errorf("error unsetting aggregation policy for iceberg table %v: %w", d.Id(), err))
 			}
 		}

--- a/pkg/resources/iceberg_table.go
+++ b/pkg/resources/iceberg_table.go
@@ -22,16 +22,19 @@ import (
 
 // TODO (next PRs): the following CreateIcebergTableOptions fields are not yet supported by this resource:
 //   - CopyGrants and CopyTags
+//   - Use ALTER TABLE for handling column changes
 //   - ICEBERG_MERGE_ON_READ_BEHAVIOR (needs to be added to SDK)
-//   - column-level extras (part of ColumnsAndConstraints): out-of-line constraints, and per-column
-//     DefaultValue, NotNull, InlineConstraint, MaskingPolicy, ProjectionPolicy, Comment...
 //   - https://docs.snowflake.com/en/sql-reference/parameters#label-iceberg-default-ddl-collation
 var icebergTableSchema = collections.MergeMaps(
 	icebergTableCommonSchema(),
 	map[string]*schema.Schema{
-		"column":             basicColumnSchema(),
-		"row_access_policy":  rowAccessPolicyFieldSchema("Iceberg table"),
-		"aggregation_policy": aggregationPolicySchema("Iceberg table"),
+		"column":                 columnSchema(),
+		"primary_key_constraint": primaryKeyConstraintSchema(),
+		"unique_constraint":      uniqueConstraintSchema(),
+		"foreign_key_constraint": foreignKeyConstraintSchema(),
+		"check_constraint":       checkConstraintSchema(),
+		"row_access_policy":      rowAccessPolicyFieldSchema("Iceberg table"),
+		"aggregation_policy":     aggregationPolicySchema("Iceberg table"),
 		"base_location": {
 			Type:             schema.TypeString,
 			Optional:         true,
@@ -116,11 +119,15 @@ func CreateIcebergTable(ctx context.Context, d *schema.ResourceData, meta any) d
 	name := d.Get("name").(string)
 	id := sdk.NewSchemaObjectIdentifier(databaseName, schemaName, name)
 
-	columns, err := parseBasicColumns(d.Get("column").([]any))
+	columns, err := parseColumns(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	columnsAndConstraints := *sdk.NewIcebergTableColumnsAndConstraintsRequest().WithColumns(toIcebergTableColumnRequests(columns))
+	outOfLineConstraints, err := parseOutOfLineConstraints(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	columnsAndConstraints := *sdk.NewIcebergTableColumnsAndConstraintsRequest().WithColumns(columns).WithOutOfLineConstraint(outOfLineConstraints)
 	req := sdk.NewCreateIcebergTableRequest(id, columnsAndConstraints)
 
 	if err := errors.Join(
@@ -227,8 +234,12 @@ func ReadIcebergTableFunc(withExternalChangesMarking bool) schema.ReadContextFun
 			// rather than the original DDL text, so external changes cannot be reliably detected. See
 			// https://docs.snowflake.com/en/user-guide/tables-clustering-keys#defining-a-clustering-key-for-a-table
 			// add these limitations to the documentation and report this to Snowflake
+			columnsState, err := handleIcebergTableColumns(details, policyRefs)
+			if err != nil {
+				return err
+			}
 			return errors.Join(
-				d.Set("column", icebergTableColumnsToSchema(details)),
+				d.Set("column", columnsState),
 				d.Set("partition_by", partitionBy),
 			)
 		})
@@ -365,18 +376,29 @@ func handleIcebergTableSnowflakeManagedParametersUpdate(d *schema.ResourceData, 
 	)
 }
 
-func toIcebergTableColumnRequests(columns []basicColumn) []sdk.IcebergTableColumnRequest {
-	return collections.Map(columns, func(c basicColumn) sdk.IcebergTableColumnRequest {
-		return *sdk.NewIcebergTableColumnRequest(c.Name, c.DataType)
-	})
-}
+func handleIcebergTableColumns(columns []sdk.IcebergTableDetails, policyRefs []sdk.PolicyReference) ([]map[string]any, error) {
+	if len(columns) == 0 {
+		return nil, nil
+	}
 
-func icebergTableColumnsToSchema(details []sdk.IcebergTableDetails) []map[string]any {
-	return collections.Map(details, func(d sdk.IcebergTableDetails) map[string]any {
-		return map[string]any{
-			"name": d.Name,
-			"type": d.Type.ToSql(),
+	return collections.MapErr(columns, func(column sdk.IcebergTableDetails) (map[string]any, error) {
+		columnState := map[string]any{
+			"name":     column.Name,
+			"type":     column.Type.ToSql(),
+			"not_null": !column.IsNullable,
 		}
+		if column.Comment != nil {
+			columnState["comment"] = *column.Comment
+		}
+		if column.Default != nil {
+			columnState["default"] = []map[string]any{{"expression": *column.Default}}
+		}
+		columnPoliciesState, err := columnPoliciesToState(column.Name, policyRefs)
+		if err != nil {
+			return nil, fmt.Errorf("converting column policies to state: %w", err)
+		}
+		columnState = collections.MergeMaps(columnState, columnPoliciesState)
+		return columnState, nil
 	})
 }
 

--- a/pkg/resources/iceberg_table.go
+++ b/pkg/resources/iceberg_table.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"regexp"
 	"strconv"
 	"strings"
@@ -14,6 +15,8 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -100,7 +103,7 @@ func IcebergTable() *schema.Resource {
 		Timeouts: defaultTimeouts,
 		CustomizeDiff: customdiff.All(
 			ComputedIfAnyAttributeChanged(icebergTableSchema, ShowOutputAttributeName, "comment"),
-			ComputedIfAnyAttributeChanged(icebergTableSchema, DescribeOutputAttributeName, "column"),
+			// ComputedIf is missing on purpose - diff suppression is not enough to avoid the output field being marked as computed.
 			ComputedIfAnyAttributeChanged(
 				icebergTableSchema, ParametersAttributeName,
 				"external_volume", "catalog", "target_file_size", "storage_serialization_policy",
@@ -119,7 +122,7 @@ func CreateIcebergTable(ctx context.Context, d *schema.ResourceData, meta any) d
 	name := d.Get("name").(string)
 	id := sdk.NewSchemaObjectIdentifier(databaseName, schemaName, name)
 
-	columns, err := parseColumns(d)
+	columns, err := parseIcebergTableColumns(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -127,7 +130,10 @@ func CreateIcebergTable(ctx context.Context, d *schema.ResourceData, meta any) d
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	columnsAndConstraints := *sdk.NewIcebergTableColumnsAndConstraintsRequest().WithColumns(columns).WithOutOfLineConstraint(outOfLineConstraints)
+	columnsAndConstraints := *sdk.NewIcebergTableColumnsAndConstraintsRequest(columns)
+	if len(outOfLineConstraints) > 0 {
+		columnsAndConstraints.WithOutOfLineConstraint(outOfLineConstraints)
+	}
 	req := sdk.NewCreateIcebergTableRequest(id, columnsAndConstraints)
 
 	if err := errors.Join(
@@ -184,6 +190,71 @@ func CreateIcebergTable(ctx context.Context, d *schema.ResourceData, meta any) d
 	return ReadIcebergTableFunc(false)(ctx, d, meta)
 }
 
+// parseIcebergTableColumns parses the "column" list from the resource data into IcebergTableColumnRequests.
+func parseIcebergTableColumns(d *schema.ResourceData) ([]sdk.IcebergTableColumnRequest, error) {
+	raw := d.Get("column").([]any)
+	indices := make([]int, len(raw))
+	for i := range indices {
+		indices[i] = i
+	}
+	return collections.MapErr(indices, func(i int) (sdk.IcebergTableColumnRequest, error) {
+		return parseIcebergTableColumn(d, i)
+	})
+}
+
+// parseIcebergTableColumn parses a single column at the given index (e.g. "column.0.") into an IcebergTableColumnRequest.
+func parseIcebergTableColumn(d *schema.ResourceData, index int) (sdk.IcebergTableColumnRequest, error) {
+	prefix := fmt.Sprintf("column.%d.", index)
+	name := d.Get(prefix + "name").(string)
+	dataType, err := datatypes.ParseDataType(d.Get(prefix + "type").(string))
+	if err != nil {
+		return sdk.IcebergTableColumnRequest{}, fmt.Errorf("parsing data type of column %q: %w", name, err)
+	}
+	req := sdk.NewIcebergTableColumnRequest(name, dataType)
+	if err := booleanStringAttributeCreate(d, prefix+"not_null", &req.NotNull); err != nil {
+		return sdk.IcebergTableColumnRequest{}, fmt.Errorf("parsing not_null for column %q: %w", name, err)
+	}
+
+	if err := errors.Join(
+		stringAttributeCreateBuilder(d, prefix+"comment", func(v string) *sdk.IcebergTableColumnRequest { return req.WithComment(v) }),
+		attributeMappedValueCreateBuilderNested(d, prefix+"default", func(v sdk.ColumnDefaultValue) *sdk.IcebergTableColumnRequest {
+			return req.WithDefaultValue(v)
+		}, func(d *schema.ResourceData) (sdk.ColumnDefaultValue, error) {
+			return parseIcebergColumnDefaultValue(d, index)
+		}),
+		attributeMappedValueCreateBuilderNested(d, prefix+"masking_policy", func(v sdk.TableColumnMaskingPolicyRequest) *sdk.IcebergTableColumnRequest {
+			return req.WithMaskingPolicy(v)
+		}, func(d *schema.ResourceData) (sdk.TableColumnMaskingPolicyRequest, error) {
+			return parseColumnMaskingPolicy(d, prefix+"masking_policy.0.")
+		}),
+		attributeMappedValueCreateBuilderNested(d, prefix+"projection_policy", func(v sdk.TableColumnProjectionPolicyRequest) *sdk.IcebergTableColumnRequest {
+			return req.WithProjectionPolicy(v)
+		}, func(d *schema.ResourceData) (sdk.TableColumnProjectionPolicyRequest, error) {
+			return parseColumnProjectionPolicy(d, prefix+"projection_policy.0.")
+		}),
+	); err != nil {
+		return sdk.IcebergTableColumnRequest{}, fmt.Errorf("parsing column %q: %w", name, err)
+	}
+
+	return *req, nil
+}
+
+// parseIcebergColumnDefaultValue reads the default expression directly from the raw config (rather than
+// d.GetOk) so that an explicitly configured empty-string expression is not mistaken for an unset one.
+func parseIcebergColumnDefaultValue(d *schema.ResourceData, index int) (sdk.ColumnDefaultValue, error) {
+	defaultValue := sdk.ColumnDefaultValue{}
+	path := cty.GetAttrPath("column").IndexInt(index).GetAttr("default").IndexInt(0).GetAttr("expression")
+	configValue, diags := d.GetRawConfigAt(path)
+	if diags.HasError() {
+		return defaultValue, fmt.Errorf("reading raw config for column %d default expression: %v", index, diags)
+	}
+	if !configValue.IsNull() {
+		expression := configValue.AsString()
+		defaultValue.Expression = &expression
+	}
+	return defaultValue, nil
+}
+
 func ReadIcebergTableFunc(withExternalChangesMarking bool) schema.ReadContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 		client := meta.(*provider.Context).Client
@@ -234,12 +305,8 @@ func ReadIcebergTableFunc(withExternalChangesMarking bool) schema.ReadContextFun
 			// rather than the original DDL text, so external changes cannot be reliably detected. See
 			// https://docs.snowflake.com/en/user-guide/tables-clustering-keys#defining-a-clustering-key-for-a-table
 			// add these limitations to the documentation and report this to Snowflake
-			columnsState, err := handleIcebergTableColumns(details, policyRefs)
-			if err != nil {
-				return err
-			}
 			return errors.Join(
-				d.Set("column", columnsState),
+				d.Set("column", handleIcebergTableColumns(details, policyRefs)),
 				d.Set("partition_by", partitionBy),
 			)
 		})
@@ -376,16 +443,16 @@ func handleIcebergTableSnowflakeManagedParametersUpdate(d *schema.ResourceData, 
 	)
 }
 
-func handleIcebergTableColumns(columns []sdk.IcebergTableDetails, policyRefs []sdk.PolicyReference) ([]map[string]any, error) {
+func handleIcebergTableColumns(columns []sdk.IcebergTableDetails, policyRefs []sdk.PolicyReference) []map[string]any {
 	if len(columns) == 0 {
-		return nil, nil
+		return nil
 	}
 
-	return collections.MapErr(columns, func(column sdk.IcebergTableDetails) (map[string]any, error) {
+	return collections.Map(columns, func(column sdk.IcebergTableDetails) map[string]any {
 		columnState := map[string]any{
 			"name":     column.Name,
 			"type":     column.Type.ToSql(),
-			"not_null": !column.IsNullable,
+			"not_null": booleanStringFromBool(!column.IsNullable),
 		}
 		if column.Comment != nil {
 			columnState["comment"] = *column.Comment
@@ -395,10 +462,9 @@ func handleIcebergTableColumns(columns []sdk.IcebergTableDetails, policyRefs []s
 		}
 		columnPoliciesState, err := columnPoliciesToState(column.Name, policyRefs)
 		if err != nil {
-			return nil, fmt.Errorf("converting column policies to state: %w", err)
+			log.Printf("[DEBUG] could not convert column policies to state for column %q: %v", column.Name, err)
 		}
-		columnState = collections.MergeMaps(columnState, columnPoliciesState)
-		return columnState, nil
+		return collections.MergeMaps(columnState, columnPoliciesState)
 	})
 }
 

--- a/pkg/resources/resource_helpers_create.go
+++ b/pkg/resources/resource_helpers_create.go
@@ -47,6 +47,13 @@ func intAttributeWithSpecialDefaultCreateBuilder[T any](d *schema.ResourceData, 
 	return nil
 }
 
+func boolAttributeCreate(d *schema.ResourceData, key string, createField **bool) error {
+	if v, ok := d.GetOk(key); ok {
+		*createField = sdk.Bool(v.(bool))
+	}
+	return nil
+}
+
 func booleanStringAttributeCreate(d *schema.ResourceData, key string, createField **bool) error {
 	if v := d.Get(key).(string); v != BooleanDefault {
 		parsed, err := booleanStringToBool(v)
@@ -65,6 +72,27 @@ func booleanStringAttributeCreateBuilder[T any](d *schema.ResourceData, key stri
 			return err
 		}
 		setValue(parsed)
+	}
+	return nil
+}
+
+// booleanStringPairAttributeCreate reads a tri-state boolean string field and sets exactly one of the
+// two given pointer fields: positiveField when the value is "true", negativeField when it is "false".
+// Both are left untouched when the value is BooleanDefault. Useful for squashing a pair of mutually
+// exclusive SQL keywords (e.g. ENFORCED / NOT ENFORCED) into a single schema field.
+func booleanStringPairAttributeCreate(d *schema.ResourceData, key string, positiveField, negativeField **bool) error {
+	v := d.Get(key).(string)
+	if v == BooleanDefault {
+		return nil
+	}
+	parsed, err := booleanStringToBool(v)
+	if err != nil {
+		return err
+	}
+	if parsed {
+		*positiveField = new(true)
+	} else {
+		*negativeField = new(true)
 	}
 	return nil
 }

--- a/pkg/resources/table_column_commons.go
+++ b/pkg/resources/table_column_commons.go
@@ -1,22 +1,15 @@
 package resources
 
 import (
-	"fmt"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// basicColumn is a minimal column definition (name + type) shared by table-like resources.
-// It intentionally omits constraints, policies, defaults, etc. so it can be reused by resources
-// that only need the essential column shape.
-type basicColumn struct {
-	Name     string
-	DataType datatypes.DataType
-}
-
-func basicColumnSchema() *schema.Schema {
+// columnSchema builds the rich "column" schema shared by table-like resources that support the
+// full per-column capabilities (name, type, not_null, comment, default, masking_policy, projection_policy).
+func columnSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Required:    true,
@@ -39,19 +32,115 @@ func basicColumnSchema() *schema.Schema {
 					ValidateDiagFunc: IsDataTypeValid,
 					DiffSuppressFunc: DiffSuppressDataTypes,
 				},
+				"not_null": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					Default:          BooleanDefault,
+					ValidateDiagFunc: validateBooleanString,
+					DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+						return (oldValue == BooleanTrue || oldValue == BooleanFalse) && (newValue == BooleanDefault)
+					},
+					Description: "Whether to restrict the column to NOT NULL values.",
+				},
+				"default": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					ForceNew:    true,
+					MaxItems:    1,
+					Description: "Defines the column default value.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"expression": {
+								Type:        schema.TypeString,
+								Required:    true,
+								ForceNew:    true,
+								Description: "The default expression value for the column.",
+							},
+						},
+					},
+				},
+				"masking_policy":    columnMaskingPolicySchema(true, IgnoreMatchingColumnNameAndMaskingPolicyUsingFirstElem("name")),
+				"projection_policy": columnProjectionPolicySchema(),
+				"comment": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					ForceNew:    true,
+					Description: "Column comment.",
+				},
 			},
 		},
 	}
 }
 
-func parseBasicColumns(raw []any) ([]basicColumn, error) {
-	return collections.MapErr(raw, func(r any) (basicColumn, error) {
-		c := r.(map[string]any)
-		name := c["name"].(string)
-		dataType, err := datatypes.ParseDataType(c["type"].(string))
-		if err != nil {
-			return basicColumn{}, fmt.Errorf("parsing data type of column %q: %w", name, err)
-		}
-		return basicColumn{Name: name, DataType: dataType}, nil
-	})
+func columnMaskingPolicySchema(forceNew bool, usingDiffSuppress schema.SchemaDiffSuppressFunc) *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		ForceNew:    forceNew,
+		MaxItems:    1,
+		Description: relatedResourceDescription("Specifies the masking policy to set on a column.", resources.MaskingPolicy),
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"policy_name": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         forceNew,
+					DiffSuppressFunc: suppressIdentifierQuoting,
+					ValidateDiagFunc: IsValidIdentifier[sdk.SchemaObjectIdentifier](),
+					Description:      relatedResourceDescription("Masking policy name.", resources.MaskingPolicy),
+				},
+				"using": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					ForceNew:         forceNew,
+					Elem:             &schema.Schema{Type: schema.TypeString},
+					DiffSuppressFunc: usingDiffSuppress,
+					Description:      "Specifies the arguments to pass into the conditional masking policy SQL expression, in order. The first column in the list specifies the column for the policy conditions to mask or tokenize the data and must match the column to which the masking policy is set. The additional columns specify the columns to evaluate to determine whether to mask or tokenize the data in each row of the query result when a query is made on the first column. If the USING clause is omitted, Snowflake treats the conditional masking policy as a normal masking policy.",
+				},
+			},
+		},
+	}
+}
+
+func columnProjectionPolicySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		ForceNew:    true,
+		MaxItems:    1,
+		Description: "Specifies the projection policy to set on a column.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"policy_name": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					DiffSuppressFunc: suppressIdentifierQuoting,
+					ValidateDiagFunc: IsValidIdentifier[sdk.SchemaObjectIdentifier](),
+					Description:      "Projection policy name.",
+				},
+			},
+		},
+	}
+}
+
+func parseColumnMaskingPolicy(d *schema.ResourceData, prefix string) (sdk.TableColumnMaskingPolicyRequest, error) {
+	id, err := sdk.ParseSchemaObjectIdentifier(d.Get(prefix + "policy_name").(string))
+	if err != nil {
+		return sdk.TableColumnMaskingPolicyRequest{}, err
+	}
+	req := sdk.TableColumnMaskingPolicyRequest{MaskingPolicy: id}
+	if usingRaw := d.Get(prefix + "using").([]any); len(usingRaw) > 0 {
+		req.Using = collections.Map(expandStringList(usingRaw), func(v string) sdk.Column { return sdk.Column{Value: v} })
+	}
+	return req, nil
+}
+
+func parseColumnProjectionPolicy(d *schema.ResourceData, prefix string) (sdk.TableColumnProjectionPolicyRequest, error) {
+	id, err := sdk.ParseSchemaObjectIdentifier(d.Get(prefix + "policy_name").(string))
+	if err != nil {
+		return sdk.TableColumnProjectionPolicyRequest{}, err
+	}
+	return sdk.TableColumnProjectionPolicyRequest{ProjectionPolicy: id}, nil
 }

--- a/pkg/resources/table_commons.go
+++ b/pkg/resources/table_commons.go
@@ -8,200 +8,8 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-// columnSchema builds the rich "column" schema shared by table-like resources that support the
-// full per-column capabilities (as opposed to basicColumnSchema, which only supports name + type).
-func columnSchema() *schema.Schema {
-	return &schema.Schema{
-		Type:        schema.TypeList,
-		Required:    true,
-		ForceNew:    true,
-		MinItems:    1,
-		Description: "Definitions of the columns to create in the table. Minimum one required.",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"name": {
-					Type:        schema.TypeString,
-					Required:    true,
-					ForceNew:    true,
-					Description: "Column name.",
-				},
-				"type": {
-					Type:             schema.TypeString,
-					Required:         true,
-					ForceNew:         true,
-					Description:      "Column type, e.g. VARIANT. For a full list of column types, see [Summary of Data Types](https://docs.snowflake.com/en/sql-reference/intro-summary-data-types).",
-					ValidateDiagFunc: IsDataTypeValid,
-					DiffSuppressFunc: DiffSuppressDataTypes,
-				},
-				"not_null": {
-					Type:        schema.TypeBool,
-					Optional:    true,
-					ForceNew:    true,
-					Default:     false,
-					Description: "Whether to restrict the column to NOT NULL values.",
-				},
-				"default": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					ForceNew:    true,
-					MaxItems:    1,
-					Description: "Defines the column default value.",
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"expression": {
-								Type:        schema.TypeString,
-								Optional:    true,
-								ForceNew:    true,
-								Description: "The default expression value for the column.",
-							},
-						},
-					},
-				},
-				"masking_policy":    columnMaskingPolicySchema(true, IgnoreMatchingColumnNameAndMaskingPolicyUsingFirstElem("name")),
-				"projection_policy": columnProjectionPolicySchema(),
-				"comment": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					ForceNew:    true,
-					Description: "Column comment.",
-				},
-			},
-		},
-	}
-}
-
-// parseColumns parses the "column" list from the resource data into IcebergTableColumnRequests.
-func parseColumns(d *schema.ResourceData) ([]sdk.IcebergTableColumnRequest, error) {
-	raw := d.Get("column").([]any)
-	columns := make([]sdk.IcebergTableColumnRequest, len(raw))
-	for i := range raw {
-		column, err := parseColumn(d, fmt.Sprintf("column.%d.", i))
-		if err != nil {
-			return nil, err
-		}
-		columns[i] = column
-	}
-	return columns, nil
-}
-
-// parseColumn parses a single column at the given prefix (e.g. "column.0.") into an IcebergTableColumnRequest.
-func parseColumn(d *schema.ResourceData, prefix string) (sdk.IcebergTableColumnRequest, error) {
-	name := d.Get(prefix + "name").(string)
-	dataType, err := datatypes.ParseDataType(d.Get(prefix + "type").(string))
-	if err != nil {
-		return sdk.IcebergTableColumnRequest{}, fmt.Errorf("parsing data type of column %q: %w", name, err)
-	}
-	req := sdk.NewIcebergTableColumnRequest(name, dataType)
-
-	if err := errors.Join(
-		boolAttributeCreate(d, prefix+"not_null", &req.NotNull),
-		stringAttributeCreateBuilder(d, prefix+"comment", func(v string) *sdk.IcebergTableColumnRequest { return req.WithComment(v) }),
-		attributeMappedValueCreateBuilderNested(d, prefix+"default", func(v sdk.ColumnDefaultValue) *sdk.IcebergTableColumnRequest {
-			return req.WithDefaultValue(v)
-		}, func(d *schema.ResourceData) (sdk.ColumnDefaultValue, error) {
-			return parseColumnDefaultValue(d, prefix+"default.0."), nil
-		}),
-		attributeMappedValueCreateBuilderNested(d, prefix+"masking_policy", func(v sdk.TableColumnMaskingPolicyRequest) *sdk.IcebergTableColumnRequest {
-			return req.WithMaskingPolicy(v)
-		}, func(d *schema.ResourceData) (sdk.TableColumnMaskingPolicyRequest, error) {
-			return parseColumnMaskingPolicy(d, prefix+"masking_policy.0.")
-		}),
-		attributeMappedValueCreateBuilderNested(d, prefix+"projection_policy", func(v sdk.TableColumnProjectionPolicyRequest) *sdk.IcebergTableColumnRequest {
-			return req.WithProjectionPolicy(v)
-		}, func(d *schema.ResourceData) (sdk.TableColumnProjectionPolicyRequest, error) {
-			return parseColumnProjectionPolicy(d, prefix+"projection_policy.0.")
-		}),
-	); err != nil {
-		return sdk.IcebergTableColumnRequest{}, fmt.Errorf("parsing column %q: %w", name, err)
-	}
-
-	return *req, nil
-}
-
-func parseColumnDefaultValue(d *schema.ResourceData, prefix string) sdk.ColumnDefaultValue {
-	defaultValue := sdk.ColumnDefaultValue{}
-	if v, ok := d.GetOk(prefix + "expression"); ok {
-		expression := v.(string)
-		defaultValue.Expression = &expression
-	}
-	return defaultValue
-}
-
-func columnMaskingPolicySchema(forceNew bool, usingDiffSuppress schema.SchemaDiffSuppressFunc) *schema.Schema {
-	return &schema.Schema{
-		Type:        schema.TypeList,
-		Optional:    true,
-		ForceNew:    forceNew,
-		MaxItems:    1,
-		Description: relatedResourceDescription("Specifies the masking policy to set on a column.", resources.MaskingPolicy),
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"policy_name": {
-					Type:             schema.TypeString,
-					Required:         true,
-					ForceNew:         forceNew,
-					DiffSuppressFunc: suppressIdentifierQuoting,
-					ValidateDiagFunc: IsValidIdentifier[sdk.SchemaObjectIdentifier](),
-					Description:      relatedResourceDescription("Masking policy name.", resources.MaskingPolicy),
-				},
-				"using": {
-					Type:             schema.TypeList,
-					Optional:         true,
-					ForceNew:         forceNew,
-					Elem:             &schema.Schema{Type: schema.TypeString},
-					DiffSuppressFunc: usingDiffSuppress,
-					Description:      "Specifies the arguments to pass into the conditional masking policy SQL expression, in order. The first column in the list specifies the column for the policy conditions to mask or tokenize the data and must match the column to which the masking policy is set. The additional columns specify the columns to evaluate to determine whether to mask or tokenize the data in each row of the query result when a query is made on the first column. If the USING clause is omitted, Snowflake treats the conditional masking policy as a normal masking policy.",
-				},
-			},
-		},
-	}
-}
-
-func columnProjectionPolicySchema() *schema.Schema {
-	return &schema.Schema{
-		Type:        schema.TypeList,
-		Optional:    true,
-		ForceNew:    true,
-		MaxItems:    1,
-		Description: "Specifies the projection policy to set on a column.",
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"policy_name": {
-					Type:             schema.TypeString,
-					Required:         true,
-					ForceNew:         true,
-					DiffSuppressFunc: suppressIdentifierQuoting,
-					ValidateDiagFunc: IsValidIdentifier[sdk.SchemaObjectIdentifier](),
-					Description:      "Projection policy name.",
-				},
-			},
-		},
-	}
-}
-
-func parseColumnMaskingPolicy(d *schema.ResourceData, prefix string) (sdk.TableColumnMaskingPolicyRequest, error) {
-	id, err := sdk.ParseSchemaObjectIdentifier(d.Get(prefix + "policy_name").(string))
-	if err != nil {
-		return sdk.TableColumnMaskingPolicyRequest{}, err
-	}
-	req := sdk.TableColumnMaskingPolicyRequest{MaskingPolicy: id}
-	if usingRaw := d.Get(prefix + "using").([]any); len(usingRaw) > 0 {
-		req.Using = collections.Map(expandStringList(usingRaw), func(v string) sdk.Column { return sdk.Column{Value: v} })
-	}
-	return req, nil
-}
-
-func parseColumnProjectionPolicy(d *schema.ResourceData, prefix string) (sdk.TableColumnProjectionPolicyRequest, error) {
-	id, err := sdk.ParseSchemaObjectIdentifier(d.Get(prefix + "policy_name").(string))
-	if err != nil {
-		return sdk.TableColumnProjectionPolicyRequest{}, err
-	}
-	return sdk.TableColumnProjectionPolicyRequest{ProjectionPolicy: id}, nil
-}
 
 // constraintEnforcementSchemaFields builds the enforcement-related fields shared by the UNIQUE/PRIMARY KEY
 // and FOREIGN KEY out-of-line constraint schemas. Each field squashes a pair of mutually exclusive SQL
@@ -256,12 +64,14 @@ func outOfLineUniqueOrPKConstraintSchemaFields() map[string]*schema.Schema {
 }
 
 // primaryKeyConstraintSchema builds the primary_key_constraint schema shared by table-like resources,
-// covering a table-level PRIMARY KEY constraint.
+// covering a table-level PRIMARY KEY constraint. MaxItems is capped at 1 because a table can have at
+// most one PRIMARY KEY constraint.
 func primaryKeyConstraintSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
 		ForceNew:    true,
+		MaxItems:    1,
 		Description: "Defines a table-level PRIMARY KEY constraint.",
 		Elem: &schema.Resource{
 			Schema: outOfLineUniqueOrPKConstraintSchemaFields(),
@@ -623,7 +433,7 @@ func extractPolicyWithColumnsList(v any, columnsKey string) (sdk.SchemaObjectIde
 // AlterIcebergTableRequest, so the diffing logic can be shared even though the two resources wire the result into
 // different top-level alter requests.
 func rowAccessPolicyAlterRequests(
-	d ResourceValueGetter,
+	d *schema.ResourceData,
 	addRowAccessPolicyFunc func(id sdk.SchemaObjectIdentifier, columns []sdk.Column),
 	dropRowAccessPolicyFunc func(id sdk.SchemaObjectIdentifier),
 ) error {
@@ -647,7 +457,7 @@ func rowAccessPolicyAlterRequests(
 
 // aggregationPolicyAlterState extracts the desired aggregation policy state (id + entity key) from the
 // aggregation_policy field, or reports that the policy should be unset.
-func aggregationPolicyAlterState(d ResourceValueGetter) (id sdk.SchemaObjectIdentifier, entityKey []sdk.Column, isSet bool, err error) {
+func aggregationPolicyAlterState(d *schema.ResourceData) (id sdk.SchemaObjectIdentifier, entityKey []sdk.Column, isSet bool, err error) {
 	v, ok := d.GetOk("aggregation_policy")
 	if !ok {
 		return sdk.SchemaObjectIdentifier{}, nil, false, nil
@@ -659,14 +469,8 @@ func aggregationPolicyAlterState(d ResourceValueGetter) (id sdk.SchemaObjectIden
 	return id, entityKey, true, nil
 }
 
-// ResourceValueGetter is the subset of *schema.ResourceData used by the shared policy helpers.
-type ResourceValueGetter interface {
-	GetChange(key string) (any, any)
-	GetOk(key string) (any, bool)
-}
-
 // handlePolicyReferences populates row_access_policy and aggregation_policy from the given policy references.
-func handlePolicyReferences(policyRefs []sdk.PolicyReference, d ResourceValueSetter) error {
+func handlePolicyReferences(policyRefs []sdk.PolicyReference, d *schema.ResourceData) error {
 	var aggregationPolicies []map[string]any
 	var rowAccessPolicies []map[string]any
 	for _, p := range policyRefs {
@@ -703,10 +507,12 @@ func handlePolicyReferences(policyRefs []sdk.PolicyReference, d ResourceValueSet
 	return nil
 }
 
-func columnPoliciesToState(columnName string, policyRefs []sdk.PolicyReference) (map[string]any, error) {
-	columnPolicies := make(map[string]any)
-	maskingPolicies := make(map[string]sdk.PolicyReference)
-	projectionPolicies := make(map[string]sdk.PolicyReference)
+// buildColumnPolicyLookups indexes policyRefs by referenced column name, once, so that
+// columnPoliciesToState can look up a column's masking/projection policy in O(1) instead of
+// rescanning the full policyRefs slice for every column.
+func buildColumnPolicyLookups(policyRefs []sdk.PolicyReference) (maskingPolicies, projectionPolicies map[string]sdk.PolicyReference) {
+	maskingPolicies = make(map[string]sdk.PolicyReference)
+	projectionPolicies = make(map[string]sdk.PolicyReference)
 	for _, p := range policyRefs {
 		if p.RefColumnName == nil {
 			continue
@@ -718,23 +524,31 @@ func columnPoliciesToState(columnName string, policyRefs []sdk.PolicyReference) 
 			projectionPolicies[*p.RefColumnName] = p
 		}
 	}
+	return maskingPolicies, projectionPolicies
+}
+
+// columnPoliciesToState converts columnName's masking/projection policy (if any) into column state
+// fields. The two lookups are independent: a conversion error on one policy is reported but does not
+// prevent the other, valid, policy from being included in the returned state.
+func columnPoliciesToState(columnName string, policyRefs []sdk.PolicyReference) (map[string]any, error) {
+	maskingPolicies, projectionPolicies := buildColumnPolicyLookups(policyRefs)
+	columnPolicies := make(map[string]any)
+	var errs []error
 	if p, ok := maskingPolicies[columnName]; ok {
-		maskingPolicyState, err := maskingPolicyToState(p)
-		if err != nil {
-			return nil, fmt.Errorf("converting masking policy to state: %w", err)
+		if maskingPolicyState, err := maskingPolicyToState(p); err != nil {
+			errs = append(errs, fmt.Errorf("converting masking policy to state: %w", err))
 		} else {
 			columnPolicies["masking_policy"] = []map[string]any{maskingPolicyState}
 		}
 	}
 	if p, ok := projectionPolicies[columnName]; ok {
-		projectionPolicyState, err := projectionPolicyToState(p)
-		if err != nil {
-			return nil, fmt.Errorf("converting projection policy to state: %w", err)
+		if projectionPolicyState, err := projectionPolicyToState(p); err != nil {
+			errs = append(errs, fmt.Errorf("converting projection policy to state: %w", err))
 		} else {
 			columnPolicies["projection_policy"] = []map[string]any{projectionPolicyState}
 		}
 	}
-	return columnPolicies, nil
+	return columnPolicies, errors.Join(errs...)
 }
 
 func maskingPolicyToState(maskingPolicy sdk.PolicyReference) (map[string]any, error) {

--- a/pkg/resources/table_commons.go
+++ b/pkg/resources/table_commons.go
@@ -1,14 +1,539 @@
 package resources
 
 import (
+	"errors"
 	"fmt"
 	"log"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// columnSchema builds the rich "column" schema shared by table-like resources that support the
+// full per-column capabilities (as opposed to basicColumnSchema, which only supports name + type).
+func columnSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Required:    true,
+		ForceNew:    true,
+		MinItems:    1,
+		Description: "Definitions of the columns to create in the table. Minimum one required.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:        schema.TypeString,
+					Required:    true,
+					ForceNew:    true,
+					Description: "Column name.",
+				},
+				"type": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					Description:      "Column type, e.g. VARIANT. For a full list of column types, see [Summary of Data Types](https://docs.snowflake.com/en/sql-reference/intro-summary-data-types).",
+					ValidateDiagFunc: IsDataTypeValid,
+					DiffSuppressFunc: DiffSuppressDataTypes,
+				},
+				"not_null": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					ForceNew:    true,
+					Default:     false,
+					Description: "Whether to restrict the column to NOT NULL values.",
+				},
+				"default": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					ForceNew:    true,
+					MaxItems:    1,
+					Description: "Defines the column default value.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"expression": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								ForceNew:    true,
+								Description: "The default expression value for the column.",
+							},
+						},
+					},
+				},
+				"masking_policy":    columnMaskingPolicySchema(true, IgnoreMatchingColumnNameAndMaskingPolicyUsingFirstElem("name")),
+				"projection_policy": columnProjectionPolicySchema(),
+				"comment": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					ForceNew:    true,
+					Description: "Column comment.",
+				},
+			},
+		},
+	}
+}
+
+// parseColumns parses the "column" list from the resource data into IcebergTableColumnRequests.
+func parseColumns(d *schema.ResourceData) ([]sdk.IcebergTableColumnRequest, error) {
+	raw := d.Get("column").([]any)
+	columns := make([]sdk.IcebergTableColumnRequest, len(raw))
+	for i := range raw {
+		column, err := parseColumn(d, fmt.Sprintf("column.%d.", i))
+		if err != nil {
+			return nil, err
+		}
+		columns[i] = column
+	}
+	return columns, nil
+}
+
+// parseColumn parses a single column at the given prefix (e.g. "column.0.") into an IcebergTableColumnRequest.
+func parseColumn(d *schema.ResourceData, prefix string) (sdk.IcebergTableColumnRequest, error) {
+	name := d.Get(prefix + "name").(string)
+	dataType, err := datatypes.ParseDataType(d.Get(prefix + "type").(string))
+	if err != nil {
+		return sdk.IcebergTableColumnRequest{}, fmt.Errorf("parsing data type of column %q: %w", name, err)
+	}
+	req := sdk.NewIcebergTableColumnRequest(name, dataType)
+
+	if err := errors.Join(
+		boolAttributeCreate(d, prefix+"not_null", &req.NotNull),
+		stringAttributeCreateBuilder(d, prefix+"comment", func(v string) *sdk.IcebergTableColumnRequest { return req.WithComment(v) }),
+		attributeMappedValueCreateBuilderNested(d, prefix+"default", func(v sdk.ColumnDefaultValue) *sdk.IcebergTableColumnRequest {
+			return req.WithDefaultValue(v)
+		}, func(d *schema.ResourceData) (sdk.ColumnDefaultValue, error) {
+			return parseColumnDefaultValue(d, prefix+"default.0."), nil
+		}),
+		attributeMappedValueCreateBuilderNested(d, prefix+"masking_policy", func(v sdk.TableColumnMaskingPolicyRequest) *sdk.IcebergTableColumnRequest {
+			return req.WithMaskingPolicy(v)
+		}, func(d *schema.ResourceData) (sdk.TableColumnMaskingPolicyRequest, error) {
+			return parseColumnMaskingPolicy(d, prefix+"masking_policy.0.")
+		}),
+		attributeMappedValueCreateBuilderNested(d, prefix+"projection_policy", func(v sdk.TableColumnProjectionPolicyRequest) *sdk.IcebergTableColumnRequest {
+			return req.WithProjectionPolicy(v)
+		}, func(d *schema.ResourceData) (sdk.TableColumnProjectionPolicyRequest, error) {
+			return parseColumnProjectionPolicy(d, prefix+"projection_policy.0.")
+		}),
+	); err != nil {
+		return sdk.IcebergTableColumnRequest{}, fmt.Errorf("parsing column %q: %w", name, err)
+	}
+
+	return *req, nil
+}
+
+func parseColumnDefaultValue(d *schema.ResourceData, prefix string) sdk.ColumnDefaultValue {
+	defaultValue := sdk.ColumnDefaultValue{}
+	if v, ok := d.GetOk(prefix + "expression"); ok {
+		expression := v.(string)
+		defaultValue.Expression = &expression
+	}
+	return defaultValue
+}
+
+func columnMaskingPolicySchema(forceNew bool, usingDiffSuppress schema.SchemaDiffSuppressFunc) *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		ForceNew:    forceNew,
+		MaxItems:    1,
+		Description: relatedResourceDescription("Specifies the masking policy to set on a column.", resources.MaskingPolicy),
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"policy_name": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         forceNew,
+					DiffSuppressFunc: suppressIdentifierQuoting,
+					ValidateDiagFunc: IsValidIdentifier[sdk.SchemaObjectIdentifier](),
+					Description:      relatedResourceDescription("Masking policy name.", resources.MaskingPolicy),
+				},
+				"using": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					ForceNew:         forceNew,
+					Elem:             &schema.Schema{Type: schema.TypeString},
+					DiffSuppressFunc: usingDiffSuppress,
+					Description:      "Specifies the arguments to pass into the conditional masking policy SQL expression, in order. The first column in the list specifies the column for the policy conditions to mask or tokenize the data and must match the column to which the masking policy is set. The additional columns specify the columns to evaluate to determine whether to mask or tokenize the data in each row of the query result when a query is made on the first column. If the USING clause is omitted, Snowflake treats the conditional masking policy as a normal masking policy.",
+				},
+			},
+		},
+	}
+}
+
+func columnProjectionPolicySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		ForceNew:    true,
+		MaxItems:    1,
+		Description: "Specifies the projection policy to set on a column.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"policy_name": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					DiffSuppressFunc: suppressIdentifierQuoting,
+					ValidateDiagFunc: IsValidIdentifier[sdk.SchemaObjectIdentifier](),
+					Description:      "Projection policy name.",
+				},
+			},
+		},
+	}
+}
+
+func parseColumnMaskingPolicy(d *schema.ResourceData, prefix string) (sdk.TableColumnMaskingPolicyRequest, error) {
+	id, err := sdk.ParseSchemaObjectIdentifier(d.Get(prefix + "policy_name").(string))
+	if err != nil {
+		return sdk.TableColumnMaskingPolicyRequest{}, err
+	}
+	req := sdk.TableColumnMaskingPolicyRequest{MaskingPolicy: id}
+	if usingRaw := d.Get(prefix + "using").([]any); len(usingRaw) > 0 {
+		req.Using = collections.Map(expandStringList(usingRaw), func(v string) sdk.Column { return sdk.Column{Value: v} })
+	}
+	return req, nil
+}
+
+func parseColumnProjectionPolicy(d *schema.ResourceData, prefix string) (sdk.TableColumnProjectionPolicyRequest, error) {
+	id, err := sdk.ParseSchemaObjectIdentifier(d.Get(prefix + "policy_name").(string))
+	if err != nil {
+		return sdk.TableColumnProjectionPolicyRequest{}, err
+	}
+	return sdk.TableColumnProjectionPolicyRequest{ProjectionPolicy: id}, nil
+}
+
+// constraintEnforcementSchemaFields builds the enforcement-related fields shared by the UNIQUE/PRIMARY KEY
+// and FOREIGN KEY out-of-line constraint schemas. Each field squashes a pair of mutually exclusive SQL
+// keywords (e.g. ENFORCED / NOT ENFORCED) into a single tri-state boolean string field.
+func constraintEnforcementSchemaFields() map[string]*schema.Schema {
+	boolStringField := func(description string) *schema.Schema {
+		return &schema.Schema{
+			Type:             schema.TypeString,
+			Optional:         true,
+			ForceNew:         true,
+			Default:          BooleanDefault,
+			ValidateDiagFunc: validateBooleanString,
+			Description:      booleanStringFieldDescription(description),
+		}
+	}
+	return map[string]*schema.Schema{
+		"enforced":           boolStringField("Whether the constraint is enforced (`true`) or not enforced (`false`)."),
+		"deferrable":         boolStringField("Whether the constraint is deferrable (`true`) or not deferrable (`false`)."),
+		"initially_deferred": boolStringField("Whether the constraint is initially deferred (`true`) or initially immediate (`false`)."),
+		"enable":             boolStringField("Whether the constraint is enabled (`true`) or disabled (`false`)."),
+		"validate":           boolStringField("Whether to validate existing data on the table when the constraint is created (`true`) or skip validation (`false`)."),
+		"rely":               boolStringField("Whether a constraint in NOVALIDATE mode is taken into account (`true`) or not (`false`) during query rewrite."),
+	}
+}
+
+// outOfLineUniqueOrPKConstraintSchemaFields builds the fields shared by the primary_key_constraint
+// and unique_constraint schemas. The two attributes are distinguished by their own name (there is
+// no boolean discriminator field inside the block).
+func outOfLineUniqueOrPKConstraintSchemaFields() map[string]*schema.Schema {
+	return collections.MergeMaps(constraintEnforcementSchemaFields(), map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+			Description: "Name of the constraint.",
+		},
+		"column": {
+			Type:        schema.TypeList,
+			Required:    true,
+			ForceNew:    true,
+			MinItems:    1,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "The column(s) the constraint applies to.",
+		},
+		"comment": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			ForceNew:    true,
+			Description: "Constraint comment.",
+		},
+	})
+}
+
+// primaryKeyConstraintSchema builds the primary_key_constraint schema shared by table-like resources,
+// covering a table-level PRIMARY KEY constraint.
+func primaryKeyConstraintSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		ForceNew:    true,
+		Description: "Defines a table-level PRIMARY KEY constraint.",
+		Elem: &schema.Resource{
+			Schema: outOfLineUniqueOrPKConstraintSchemaFields(),
+		},
+	}
+}
+
+// uniqueConstraintSchema builds the unique_constraint schema shared by table-like resources,
+// covering a table-level UNIQUE constraint.
+func uniqueConstraintSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		ForceNew:    true,
+		Description: "Defines a table-level UNIQUE constraint.",
+		Elem: &schema.Resource{
+			Schema: outOfLineUniqueOrPKConstraintSchemaFields(),
+		},
+	}
+}
+
+// foreignKeyConstraintSchema builds the foreign_key_constraint schema shared by table-like resources,
+// covering a table-level FOREIGN KEY constraint.
+func foreignKeyConstraintSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		ForceNew:    true,
+		Description: "Defines a table-level FOREIGN KEY constraint.",
+		Elem: &schema.Resource{
+			Schema: collections.MergeMaps(constraintEnforcementSchemaFields(), map[string]*schema.Schema{
+				"name": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					ForceNew:    true,
+					Description: "Name of the constraint.",
+				},
+				"column": {
+					Type:        schema.TypeList,
+					Required:    true,
+					ForceNew:    true,
+					MinItems:    1,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+					Description: "The local column(s) the foreign key is defined on.",
+				},
+				"table_name": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ForceNew:         true,
+					DiffSuppressFunc: suppressIdentifierQuoting,
+					ValidateDiagFunc: IsValidIdentifier[sdk.SchemaObjectIdentifier](),
+					Description:      "The table that the foreign key references.",
+				},
+				"ref_column": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					ForceNew:    true,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+					Description: "The column(s) in the referenced table that the foreign key references.",
+				},
+				"match": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: sdkValidation(sdk.ToMatchType),
+					Description:      fmt.Sprintf("The match type for the foreign key. Valid values are: %v.", sdk.AllMatchTypes),
+				},
+				"on_update": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: sdkValidation(sdk.ToForeignKeyAction),
+					Description:      fmt.Sprintf("Specifies the action to perform when the referenced primary/unique key is updated. Valid values are: %v.", sdk.AllForeignKeyActions),
+				},
+				"on_delete": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					ValidateDiagFunc: sdkValidation(sdk.ToForeignKeyAction),
+					Description:      fmt.Sprintf("Specifies the action to perform when the referenced primary/unique key is deleted. Valid values are: %v.", sdk.AllForeignKeyActions),
+				},
+				"comment": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					ForceNew:    true,
+					Description: "Constraint comment.",
+				},
+			}),
+		},
+	}
+}
+
+// checkConstraintSchema builds the check_constraint schema shared by table-like resources, covering
+// a table-level CHECK constraint.
+func checkConstraintSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		ForceNew:    true,
+		Description: "Defines a table-level CHECK constraint.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					ForceNew:    true,
+					Description: "Name of the constraint.",
+				},
+				"expression": {
+					Type:        schema.TypeString,
+					Required:    true,
+					ForceNew:    true,
+					Description: "The CHECK constraint expression.",
+				},
+				"validate": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					Default:          BooleanDefault,
+					ValidateDiagFunc: validateBooleanString,
+					Description:      booleanStringFieldDescription("Whether existing data is validated against the constraint (`true`, `ENABLE VALIDATE`) or not (`false`, `ENABLE NOVALIDATE`)."),
+				},
+			},
+		},
+	}
+}
+
+// parseOutOfLineConstraints parses the "primary_key_constraint", "unique_constraint",
+// "foreign_key_constraint", and "check_constraint" lists from the resource data into
+// TableOutOfLineConstraintRequests.
+func parseOutOfLineConstraints(d *schema.ResourceData) ([]sdk.TableOutOfLineConstraintRequest, error) {
+	var constraints []sdk.TableOutOfLineConstraintRequest
+
+	primaryKeyRaw := d.Get("primary_key_constraint").([]any)
+	for i := range primaryKeyRaw {
+		primaryKey, err := parseOutOfLinePrimaryKey(d, fmt.Sprintf("primary_key_constraint.%d.", i))
+		if err != nil {
+			return nil, err
+		}
+		constraints = append(constraints, sdk.TableOutOfLineConstraintRequest{UniquePK: &primaryKey})
+	}
+
+	uniqueRaw := d.Get("unique_constraint").([]any)
+	for i := range uniqueRaw {
+		unique, err := parseOutOfLineUnique(d, fmt.Sprintf("unique_constraint.%d.", i))
+		if err != nil {
+			return nil, err
+		}
+		constraints = append(constraints, sdk.TableOutOfLineConstraintRequest{UniquePK: &unique})
+	}
+
+	foreignKeyRaw := d.Get("foreign_key_constraint").([]any)
+	for i := range foreignKeyRaw {
+		fk, err := parseOutOfLineForeignKey(d, fmt.Sprintf("foreign_key_constraint.%d.", i))
+		if err != nil {
+			return nil, err
+		}
+		constraints = append(constraints, sdk.TableOutOfLineConstraintRequest{FK: &fk})
+	}
+
+	checkRaw := d.Get("check_constraint").([]any)
+	for i := range checkRaw {
+		prefix := fmt.Sprintf("check_constraint.%d.", i)
+		ch := sdk.TableOutOfLineCHRequest{Expression: d.Get(prefix + "expression").(string)}
+		if err := errors.Join(
+			stringAttributeCreate(d, prefix+"name", &ch.Name),
+			booleanStringPairAttributeCreate(d, prefix+"validate", &ch.EnableValidate, &ch.EnableNovalidate),
+		); err != nil {
+			return nil, err
+		}
+		constraints = append(constraints, sdk.TableOutOfLineConstraintRequest{CH: &ch})
+	}
+
+	return constraints, nil
+}
+
+// parseOutOfLineUniquePKCommon parses the fields shared by primary_key_constraint and
+// unique_constraint. Callers set the Unique/PrimaryKey discriminator themselves.
+func parseOutOfLineUniquePKCommon(d *schema.ResourceData, prefix string) (sdk.TableOutOfLineUniquePKRequest, error) {
+	uniquePK := sdk.TableOutOfLineUniquePKRequest{}
+	if err := errors.Join(
+		stringAttributeCreate(d, prefix+"name", &uniquePK.Name),
+		stringAttributeCreate(d, prefix+"comment", &uniquePK.Comment),
+		booleanStringPairAttributeCreate(d, prefix+"enforced", &uniquePK.Enforced, &uniquePK.NotEnforced),
+		booleanStringPairAttributeCreate(d, prefix+"deferrable", &uniquePK.Deferrable, &uniquePK.NotDeferrable),
+		booleanStringPairAttributeCreate(d, prefix+"initially_deferred", &uniquePK.InitiallyDeferred, &uniquePK.InitiallyImmediate),
+		booleanStringPairAttributeCreate(d, prefix+"enable", &uniquePK.Enable, &uniquePK.Disable),
+		booleanStringPairAttributeCreate(d, prefix+"validate", &uniquePK.Validate, &uniquePK.Novalidate),
+		booleanStringPairAttributeCreate(d, prefix+"rely", &uniquePK.Rely, &uniquePK.Norely),
+	); err != nil {
+		return sdk.TableOutOfLineUniquePKRequest{}, err
+	}
+	if columnRaw := d.Get(prefix + "column").([]any); len(columnRaw) > 0 {
+		uniquePK.Columns = collections.Map(expandStringList(columnRaw), func(c string) sdk.Column { return sdk.Column{Value: c} })
+	}
+	return uniquePK, nil
+}
+
+// parseOutOfLinePrimaryKey parses a single primary_key_constraint entry.
+func parseOutOfLinePrimaryKey(d *schema.ResourceData, prefix string) (sdk.TableOutOfLineUniquePKRequest, error) {
+	primaryKey, err := parseOutOfLineUniquePKCommon(d, prefix)
+	if err != nil {
+		return sdk.TableOutOfLineUniquePKRequest{}, err
+	}
+	primaryKey.PrimaryKey = new(true)
+	return primaryKey, nil
+}
+
+// parseOutOfLineUnique parses a single unique_constraint entry.
+func parseOutOfLineUnique(d *schema.ResourceData, prefix string) (sdk.TableOutOfLineUniquePKRequest, error) {
+	unique, err := parseOutOfLineUniquePKCommon(d, prefix)
+	if err != nil {
+		return sdk.TableOutOfLineUniquePKRequest{}, err
+	}
+	unique.Unique = new(true)
+	return unique, nil
+}
+
+func parseOutOfLineForeignKey(d *schema.ResourceData, prefix string) (sdk.TableOutOfLineFKRequest, error) {
+	id, err := sdk.ParseSchemaObjectIdentifier(d.Get(prefix + "table_name").(string))
+	if err != nil {
+		return sdk.TableOutOfLineFKRequest{}, err
+	}
+	fk := sdk.TableOutOfLineFKRequest{References: id}
+
+	if err := errors.Join(
+		stringAttributeCreate(d, prefix+"name", &fk.Name),
+		stringAttributeCreate(d, prefix+"comment", &fk.Comment),
+		attributeMappedValueCreate(d, prefix+"match", &fk.Match, func(v any) (*sdk.MatchType, error) {
+			matchType, err := sdk.ToMatchType(v.(string))
+			return &matchType, err
+		}),
+		booleanStringPairAttributeCreate(d, prefix+"enforced", &fk.Enforced, &fk.NotEnforced),
+		booleanStringPairAttributeCreate(d, prefix+"deferrable", &fk.Deferrable, &fk.NotDeferrable),
+		booleanStringPairAttributeCreate(d, prefix+"initially_deferred", &fk.InitiallyDeferred, &fk.InitiallyImmediate),
+		booleanStringPairAttributeCreate(d, prefix+"enable", &fk.Enable, &fk.Disable),
+		booleanStringPairAttributeCreate(d, prefix+"validate", &fk.Validate, &fk.Novalidate),
+		booleanStringPairAttributeCreate(d, prefix+"rely", &fk.Rely, &fk.Norely),
+	); err != nil {
+		return sdk.TableOutOfLineFKRequest{}, err
+	}
+
+	if columnRaw := d.Get(prefix + "column").([]any); len(columnRaw) > 0 {
+		fk.Columns = collections.Map(expandStringList(columnRaw), func(c string) sdk.Column { return sdk.Column{Value: c} })
+	}
+	if refColumnRaw := d.Get(prefix + "ref_column").([]any); len(refColumnRaw) > 0 {
+		fk.RefColumns = collections.Map(expandStringList(refColumnRaw), func(c string) sdk.Column { return sdk.Column{Value: c} })
+	}
+
+	onUpdate, onUpdateOk := d.GetOk(prefix + "on_update")
+	onDelete, onDeleteOk := d.GetOk(prefix + "on_delete")
+	if onUpdateOk || onDeleteOk {
+		on := &sdk.ForeignKeyOnAction{}
+		if onUpdateOk {
+			action, err := sdk.ToForeignKeyAction(onUpdate.(string))
+			if err != nil {
+				return sdk.TableOutOfLineFKRequest{}, err
+			}
+			on.OnUpdate = &action
+		}
+		if onDeleteOk {
+			action, err := sdk.ToForeignKeyAction(onDelete.(string))
+			if err != nil {
+				return sdk.TableOutOfLineFKRequest{}, err
+			}
+			on.OnDelete = &action
+		}
+		fk.On = on
+	}
+
+	return fk, nil
+}
 
 func rowAccessPolicyFieldSchema(objectKind string) *schema.Schema {
 	return &schema.Schema{
@@ -176,4 +701,61 @@ func handlePolicyReferences(policyRefs []sdk.PolicyReference, d ResourceValueSet
 		return err
 	}
 	return nil
+}
+
+func columnPoliciesToState(columnName string, policyRefs []sdk.PolicyReference) (map[string]any, error) {
+	columnPolicies := make(map[string]any)
+	maskingPolicies := make(map[string]sdk.PolicyReference)
+	projectionPolicies := make(map[string]sdk.PolicyReference)
+	for _, p := range policyRefs {
+		if p.RefColumnName == nil {
+			continue
+		}
+		switch p.PolicyKind {
+		case sdk.PolicyKindMaskingPolicy:
+			maskingPolicies[*p.RefColumnName] = p
+		case sdk.PolicyKindProjectionPolicy:
+			projectionPolicies[*p.RefColumnName] = p
+		}
+	}
+	if p, ok := maskingPolicies[columnName]; ok {
+		maskingPolicyState, err := maskingPolicyToState(p)
+		if err != nil {
+			return nil, fmt.Errorf("converting masking policy to state: %w", err)
+		} else {
+			columnPolicies["masking_policy"] = []map[string]any{maskingPolicyState}
+		}
+	}
+	if p, ok := projectionPolicies[columnName]; ok {
+		projectionPolicyState, err := projectionPolicyToState(p)
+		if err != nil {
+			return nil, fmt.Errorf("converting projection policy to state: %w", err)
+		} else {
+			columnPolicies["projection_policy"] = []map[string]any{projectionPolicyState}
+		}
+	}
+	return columnPolicies, nil
+}
+
+func maskingPolicyToState(maskingPolicy sdk.PolicyReference) (map[string]any, error) {
+	if maskingPolicy.PolicyDb == nil || maskingPolicy.PolicySchema == nil {
+		return nil, fmt.Errorf("policy db and schema can not be empty")
+	}
+	var usingArgs []string
+	if maskingPolicy.RefArgColumnNames != nil {
+		usingArgs = sdk.ParseCommaSeparatedStringArray(*maskingPolicy.RefArgColumnNames, true)
+	}
+	return map[string]any{
+		"policy_name": sdk.NewSchemaObjectIdentifier(*maskingPolicy.PolicyDb, *maskingPolicy.PolicySchema, maskingPolicy.PolicyName).FullyQualifiedName(),
+		"using":       append([]string{*maskingPolicy.RefColumnName}, usingArgs...),
+	}, nil
+}
+
+func projectionPolicyToState(projectionPolicy sdk.PolicyReference) (map[string]any, error) {
+	if projectionPolicy.PolicyDb == nil || projectionPolicy.PolicySchema == nil {
+		return nil, fmt.Errorf("policy db and schema can not be empty")
+	}
+	return map[string]any{
+		"policy_name": sdk.NewSchemaObjectIdentifier(*projectionPolicy.PolicyDb, *projectionPolicy.PolicySchema, projectionPolicy.PolicyName).FullyQualifiedName(),
+	}, nil
 }

--- a/pkg/resources/table_commons.go
+++ b/pkg/resources/table_commons.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -428,38 +429,48 @@ func extractPolicyWithColumnsList(v any, columnsKey string) (sdk.SchemaObjectIde
 	return id, collections.Map(columnsRaw, func(c string) sdk.Column { return sdk.Column{Value: c} }), nil
 }
 
-// rowAccessPolicyAlterRequests computes the ViewAddRowAccessPolicyRequest/ViewDropRowAccessPolicyRequest to apply
+// rowAccessPolicyCreateRequest extracts the row_access_policy field, if set, into a ready-to-use
+// ViewRowAccessPolicyRequest-shaped id + columns pair for use on create. ok is false when the field is unset.
+func rowAccessPolicyCreateRequest(d *schema.ResourceData) (id sdk.SchemaObjectIdentifier, columns []sdk.Column, ok bool, err error) {
+	v := d.Get("row_access_policy")
+	if len(v.([]any)) == 0 {
+		return sdk.SchemaObjectIdentifier{}, nil, false, nil
+	}
+	id, columns, err = extractPolicyWithColumnsSet(v, "on")
+	if err != nil {
+		return sdk.SchemaObjectIdentifier{}, nil, false, err
+	}
+	return id, columns, true, nil
+}
+
+// rowAccessPolicyUpdateRequests computes the ready-to-use ViewAddRowAccessPolicyRequest/ViewDropRowAccessPolicyRequest
 // for a row_access_policy diff. These request types are shared verbatim between AlterViewRequest and
 // AlterIcebergTableRequest, so the diffing logic can be shared even though the two resources wire the result into
 // different top-level alter requests.
-func rowAccessPolicyAlterRequests(
-	d *schema.ResourceData,
-	addRowAccessPolicyFunc func(id sdk.SchemaObjectIdentifier, columns []sdk.Column),
-	dropRowAccessPolicyFunc func(id sdk.SchemaObjectIdentifier),
-) error {
+func rowAccessPolicyUpdateRequests(d *schema.ResourceData) (add *sdk.ViewAddRowAccessPolicyRequest, drop *sdk.ViewDropRowAccessPolicyRequest, err error) {
 	oldRaw, newRaw := d.GetChange("row_access_policy")
 	if len(oldRaw.([]any)) > 0 {
 		oldId, _, err := extractPolicyWithColumnsSet(oldRaw, "on")
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
-		dropRowAccessPolicyFunc(oldId)
+		drop = sdk.NewViewDropRowAccessPolicyRequest(oldId)
 	}
 	if len(newRaw.([]any)) > 0 {
 		newId, newColumns, err := extractPolicyWithColumnsSet(newRaw, "on")
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
-		addRowAccessPolicyFunc(newId, newColumns)
+		add = sdk.NewViewAddRowAccessPolicyRequest(newId, newColumns)
 	}
-	return nil
+	return add, drop, nil
 }
 
-// aggregationPolicyAlterState extracts the desired aggregation policy state (id + entity key) from the
-// aggregation_policy field, or reports that the policy should be unset.
-func aggregationPolicyAlterState(d *schema.ResourceData) (id sdk.SchemaObjectIdentifier, entityKey []sdk.Column, isSet bool, err error) {
-	v, ok := d.GetOk("aggregation_policy")
-	if !ok {
+// aggregationPolicyCreateRequest extracts the aggregation_policy field, if set, into a ready-to-use
+// ViewAggregationPolicyRequest-shaped id + columns pair for use on create. ok is false when the field is unset.
+func aggregationPolicyCreateRequest(d *schema.ResourceData) (id sdk.SchemaObjectIdentifier, entityKey []sdk.Column, ok bool, err error) {
+	v := d.Get("aggregation_policy")
+	if len(v.([]any)) == 0 {
 		return sdk.SchemaObjectIdentifier{}, nil, false, nil
 	}
 	id, entityKey, err = extractPolicyWithColumnsSet(v, "entity_key")
@@ -467,6 +478,25 @@ func aggregationPolicyAlterState(d *schema.ResourceData) (id sdk.SchemaObjectIde
 		return sdk.SchemaObjectIdentifier{}, nil, false, err
 	}
 	return id, entityKey, true, nil
+}
+
+// aggregationPolicyUpdateRequests computes the ready-to-use ViewSetAggregationPolicyRequest/ViewUnsetAggregationPolicyRequest
+// for the desired aggregation_policy state. These request types are shared verbatim between AlterViewRequest and
+// AlterIcebergTableRequest.
+func aggregationPolicyUpdateRequests(d *schema.ResourceData) (set *sdk.ViewSetAggregationPolicyRequest, unset *sdk.ViewUnsetAggregationPolicyRequest, err error) {
+	v, ok := d.GetOk("aggregation_policy")
+	if !ok {
+		return nil, sdk.NewViewUnsetAggregationPolicyRequest(), nil
+	}
+	id, entityKey, err := extractPolicyWithColumnsSet(v, "entity_key")
+	if err != nil {
+		return nil, nil, err
+	}
+	set = sdk.NewViewSetAggregationPolicyRequest(id)
+	if len(entityKey) > 0 {
+		set.WithEntityKey(entityKey)
+	}
+	return set.WithForce(true), nil, nil
 }
 
 // handlePolicyReferences populates row_access_policy and aggregation_policy from the given policy references.
@@ -505,6 +535,20 @@ func handlePolicyReferences(policyRefs []sdk.PolicyReference, d *schema.Resource
 		return err
 	}
 	return nil
+}
+
+// readRootLevelPolicies fetches the policy references for id in the given domain, populates
+// row_access_policy and aggregation_policy in the resource state, and returns the fetched references
+// so callers can also derive column-level (masking/projection) policy state from them.
+func readRootLevelPolicies(ctx context.Context, client *sdk.Client, id sdk.SchemaObjectIdentifier, domain sdk.PolicyEntityDomain, d *schema.ResourceData) ([]sdk.PolicyReference, error) {
+	policyRefs, err := client.PolicyReferences.GetForEntity(ctx, sdk.NewGetForEntityPolicyReferenceRequest(id, domain))
+	if err != nil {
+		return nil, err
+	}
+	if err := handlePolicyReferences(policyRefs, d); err != nil {
+		return nil, err
+	}
+	return policyRefs, nil
 }
 
 // buildColumnPolicyLookups indexes policyRefs by referenced column name, once, so that

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -169,7 +169,7 @@ var viewSchema = map[string]*schema.Schema{
 								Elem: &schema.Schema{
 									Type: schema.TypeString,
 								},
-								DiffSuppressFunc: IgnoreMatchingColumnNameAndMaskingPolicyUsingFirstElem(),
+								DiffSuppressFunc: IgnoreMatchingColumnNameAndMaskingPolicyUsingFirstElem("column_name"),
 								Description:      "Specifies the arguments to pass into the conditional masking policy SQL expression. The first column in the list specifies the column for the policy conditions to mask or tokenize the data and must match the column to which the masking policy is set. The additional columns specify the columns to evaluate to determine whether to mask or tokenize the data in each row of the query result when a query is made on the first column. If the USING clause is omitted, Snowflake treats the conditional masking policy as a normal masking policy.",
 							},
 						},
@@ -661,47 +661,20 @@ func handleColumns(d ResourceValueSetter, columns []sdk.ViewDetails, policyRefs 
 	}
 	columnsRaw := make([]map[string]any, len(columns))
 	for i, column := range columns {
-		columnsRaw[i] = map[string]any{
+		columnState := map[string]any{
 			"column_name": column.Name,
 		}
 		if column.Comment != nil {
-			columnsRaw[i]["comment"] = *column.Comment
+			columnState["comment"] = *column.Comment
 		} else {
-			columnsRaw[i]["comment"] = nil
+			columnState["comment"] = nil
 		}
-		projectionPolicy, err := collections.FindFirst(policyRefs, func(r sdk.PolicyReference) bool {
-			return r.PolicyKind == sdk.PolicyKindProjectionPolicy && r.RefColumnName != nil && *r.RefColumnName == column.Name
-		})
-		if err == nil {
-			if projectionPolicy.PolicyDb != nil && projectionPolicy.PolicySchema != nil {
-				columnsRaw[i]["projection_policy"] = []map[string]any{
-					{
-						"policy_name": sdk.NewSchemaObjectIdentifier(*projectionPolicy.PolicyDb, *projectionPolicy.PolicySchema, projectionPolicy.PolicyName).FullyQualifiedName(),
-					},
-				}
-			} else {
-				log.Printf("[DEBUG] could not store projection policy name: policy db and schema can not be empty")
-			}
+		columnPoliciesState, err := columnPoliciesToState(column.Name, policyRefs)
+		if err != nil {
+			log.Printf("[DEBUG] could not convert column policies to state: %v", err)
 		}
-		maskingPolicy, err := collections.FindFirst(policyRefs, func(r sdk.PolicyReference) bool {
-			return r.PolicyKind == sdk.PolicyKindMaskingPolicy && r.RefColumnName != nil && *r.RefColumnName == column.Name
-		})
-		if err == nil {
-			if maskingPolicy.PolicyDb != nil && maskingPolicy.PolicySchema != nil {
-				var usingArgs []string
-				if maskingPolicy.RefArgColumnNames != nil {
-					usingArgs = sdk.ParseCommaSeparatedStringArray(*maskingPolicy.RefArgColumnNames, true)
-				}
-				columnsRaw[i]["masking_policy"] = []map[string]any{
-					{
-						"policy_name": sdk.NewSchemaObjectIdentifier(*maskingPolicy.PolicyDb, *maskingPolicy.PolicySchema, maskingPolicy.PolicyName).FullyQualifiedName(),
-						"using":       append([]string{*maskingPolicy.RefColumnName}, usingArgs...),
-					},
-				}
-			} else {
-				log.Printf("[DEBUG] could not store masking policy name: policy db and schema can not be empty")
-			}
-		}
+		columnState = collections.MergeMaps(columnState, columnPoliciesState)
+		columnsRaw[i] = columnState
 	}
 	return d.Set("column", columnsRaw)
 }

--- a/pkg/resources/view.go
+++ b/pkg/resources/view.go
@@ -360,22 +360,18 @@ func CreateView(orReplace bool) schema.CreateContextFunc {
 			req.WithColumns(columns)
 		}
 
-		if v := d.Get("row_access_policy"); len(v.([]any)) > 0 {
-			id, columns, err := extractPolicyWithColumnsSet(v, "on")
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			req.WithRowAccessPolicy(*sdk.NewViewRowAccessPolicyRequest(id, columns))
+		if policyId, columns, ok, err := rowAccessPolicyCreateRequest(d); err != nil {
+			return diag.FromErr(err)
+		} else if ok {
+			req.WithRowAccessPolicy(*sdk.NewViewRowAccessPolicyRequest(policyId, columns))
 		}
 
-		if v := d.Get("aggregation_policy"); len(v.([]any)) > 0 {
-			id, columns, err := extractPolicyWithColumnsSet(v, "entity_key")
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			aggregationPolicyReq := sdk.NewViewAggregationPolicyRequest(id)
-			if len(columns) > 0 {
-				aggregationPolicyReq.WithEntityKey(columns)
+		if policyId, entityKey, ok, err := aggregationPolicyCreateRequest(d); err != nil {
+			return diag.FromErr(err)
+		} else if ok {
+			aggregationPolicyReq := sdk.NewViewAggregationPolicyRequest(policyId)
+			if len(entityKey) > 0 {
+				aggregationPolicyReq.WithEntityKey(entityKey)
 			}
 			req.WithAggregationPolicy(*aggregationPolicyReq)
 		}
@@ -564,13 +560,9 @@ func ReadView(withExternalChangesMarking bool) schema.ReadContextFunc {
 		}); err != nil {
 			return diag.FromErr(err)
 		}
-		policyRefs, err := client.PolicyReferences.GetForEntity(ctx, sdk.NewGetForEntityPolicyReferenceRequest(id, sdk.PolicyEntityDomainView))
+		policyRefs, err := readRootLevelPolicies(ctx, client, id, sdk.PolicyEntityDomainView, d)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("getting policy references for view: %w", err))
-		}
-		err = handlePolicyReferences(policyRefs, d)
-		if err != nil {
-			return diag.FromErr(err)
 		}
 		err = handleDataMetricFunctions(ctx, client, id, d)
 		if err != nil {
@@ -900,13 +892,7 @@ func UpdateView(ctx context.Context, d *schema.ResourceData, meta any) diag.Diag
 	}
 
 	if d.HasChange("row_access_policy") {
-		var addReq *sdk.ViewAddRowAccessPolicyRequest
-		var dropReq *sdk.ViewDropRowAccessPolicyRequest
-		err := rowAccessPolicyAlterRequests(d, func(id sdk.SchemaObjectIdentifier, columns []sdk.Column) {
-			addReq = sdk.NewViewAddRowAccessPolicyRequest(id, columns)
-		}, func(id sdk.SchemaObjectIdentifier) {
-			dropReq = sdk.NewViewDropRowAccessPolicyRequest(id)
-		})
+		addReq, dropReq, err := rowAccessPolicyUpdateRequests(d)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -923,20 +909,16 @@ func UpdateView(ctx context.Context, d *schema.ResourceData, meta any) diag.Diag
 		}
 	}
 	if d.HasChange("aggregation_policy") {
-		newId, newColumns, isSet, err := aggregationPolicyAlterState(d)
+		setReq, unsetReq, err := aggregationPolicyUpdateRequests(d)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		if isSet {
-			aggregationPolicyReq := sdk.NewViewSetAggregationPolicyRequest(newId)
-			if len(newColumns) > 0 {
-				aggregationPolicyReq.WithEntityKey(newColumns)
-			}
-			if err := client.Views.Alter(ctx, sdk.NewAlterViewRequest(id).WithSetAggregationPolicy(*aggregationPolicyReq.WithForce(true))); err != nil {
+		if setReq != nil {
+			if err := client.Views.Alter(ctx, sdk.NewAlterViewRequest(id).WithSetAggregationPolicy(*setReq)); err != nil {
 				return diag.FromErr(fmt.Errorf("error setting aggregation policy for view %v: %w", d.Id(), err))
 			}
 		} else {
-			if err := client.Views.Alter(ctx, sdk.NewAlterViewRequest(id).WithUnsetAggregationPolicy(*sdk.NewViewUnsetAggregationPolicyRequest())); err != nil {
+			if err := client.Views.Alter(ctx, sdk.NewAlterViewRequest(id).WithUnsetAggregationPolicy(*unsetReq)); err != nil {
 				return diag.FromErr(fmt.Errorf("error unsetting aggregation policy for view %v", d.Id()))
 			}
 		}

--- a/pkg/sdk/generator/defs/iceberg_tables_def.go
+++ b/pkg/sdk/generator/defs/iceberg_tables_def.go
@@ -53,7 +53,7 @@ var icebergTableColumn = g.NewQueryStruct("IcebergTableColumn").
 	OptionalTextAssignment("COMMENT", g.ParameterOptions().NoEquals().SingleQuotes())
 
 var icebergTableColumnsAndConstraints = g.NewQueryStruct("IcebergTableColumnsAndConstraints").
-	ListQueryStructField("Columns", icebergTableColumn, g.KeywordOptions()).
+	ListQueryStructField("Columns", icebergTableColumn, g.KeywordOptions().Required()).
 	ListQueryStructField("OutOfLineConstraint", tableOutOfLineConstraint(), g.KeywordOptions())
 
 var icebergTablePartitionBucketArgs = g.NewQueryStruct("IcebergTablePartitionBucketArgs").

--- a/pkg/sdk/iceberg_tables_dto_builders_gen.go
+++ b/pkg/sdk/iceberg_tables_dto_builders_gen.go
@@ -139,14 +139,12 @@ func (s *CreateIcebergTableRequest) WithContact(contact []TableContact) *CreateI
 	return s
 }
 
-func NewIcebergTableColumnsAndConstraintsRequest() *IcebergTableColumnsAndConstraintsRequest {
+func NewIcebergTableColumnsAndConstraintsRequest(
+	columns []IcebergTableColumnRequest,
+) *IcebergTableColumnsAndConstraintsRequest {
 	s := IcebergTableColumnsAndConstraintsRequest{}
-	return &s
-}
-
-func (s *IcebergTableColumnsAndConstraintsRequest) WithColumns(columns []IcebergTableColumnRequest) *IcebergTableColumnsAndConstraintsRequest {
 	s.Columns = columns
-	return s
+	return &s
 }
 
 func (s *IcebergTableColumnsAndConstraintsRequest) WithOutOfLineConstraint(outOfLineConstraint []TableOutOfLineConstraintRequest) *IcebergTableColumnsAndConstraintsRequest {

--- a/pkg/sdk/iceberg_tables_dto_gen.go
+++ b/pkg/sdk/iceberg_tables_dto_gen.go
@@ -47,7 +47,7 @@ type CreateIcebergTableRequest struct {
 }
 
 type IcebergTableColumnsAndConstraintsRequest struct {
-	Columns             []IcebergTableColumnRequest
+	Columns             []IcebergTableColumnRequest // required
 	OutOfLineConstraint []TableOutOfLineConstraintRequest
 }
 

--- a/pkg/sdk/testint/iceberg_tables_integration_test.go
+++ b/pkg/sdk/testint/iceberg_tables_integration_test.go
@@ -607,6 +607,57 @@ func TestInt_IcebergTables(t *testing.T) {
 		)
 	})
 
+	t.Run("create Snowflake managed: inline constraint enforcement options", func(t *testing.T) {
+		fkRefTable, fkRefCleanup := testClientHelper().Table.CreateWithPredefinedColumnsForIcebergTable(t)
+		t.Cleanup(fkRefCleanup)
+
+		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
+		err := client.IcebergTables.Create(ctx, sdk.NewCreateIcebergTableRequest(id, sdk.IcebergTableColumnsAndConstraintsRequest{
+			Columns: []sdk.IcebergTableColumnRequest{
+				{
+					Name:       "ID",
+					ColumnType: testdatatypes.DataTypeNumber,
+					InlineConstraint: &sdk.TableColumnInlineConstraintRequest{
+						UniquePK: &sdk.TableColumnInlineUniquePKRequest{
+							Name:              new("pk_id_enforced"),
+							PrimaryKey:        new(true),
+							Enforced:          new(true),
+							Deferrable:        new(true),
+							InitiallyDeferred: new(true),
+							Enable:            new(true),
+							Validate:          new(true),
+							Rely:              new(true),
+						},
+					},
+				},
+				{
+					Name:       "FK_ID",
+					ColumnType: testdatatypes.DataTypeNumber,
+					InlineConstraint: &sdk.TableColumnInlineConstraintRequest{
+						FK: &sdk.TableColumnInlineFKRequest{
+							Name:               new("fk_ref_not_enforced"),
+							References:         fkRefTable.ID(),
+							RefColumn:          []sdk.Column{{Value: "ID"}},
+							NotEnforced:        new(true),
+							NotDeferrable:      new(true),
+							InitiallyImmediate: new(true),
+							Disable:            new(true),
+							Novalidate:         new(true),
+							Norely:             new(true),
+						},
+					},
+				},
+			},
+		}))
+		require.NoError(t, err)
+		t.Cleanup(testClientHelper().IcebergTable.DropFunc(t, id))
+
+		constraints, err := client.Tables.SelectTableConstraints(ctx, sdk.NewSelectTableConstraintsTableRequest(id.DatabaseId(), id.SchemaName(), id.Name()))
+		require.NoError(t, err)
+		// TODO (next PRs): report this to Snowflake
+		require.Len(t, constraints, 2)
+	})
+
 	t.Run("create Snowflake managed: cluster by", func(t *testing.T) {
 		// PARTITION BY and CLUSTER BY are mutually exclusive for Iceberg tables (err 099207), so clustering is
 		// tested in a separate table from the partitioned "all options" one above.

--- a/pkg/sdk/testint/iceberg_tables_integration_test.go
+++ b/pkg/sdk/testint/iceberg_tables_integration_test.go
@@ -111,7 +111,7 @@ func TestInt_IcebergTables(t *testing.T) {
 				HasOwnerRoleType("ROLE").
 				HasCatalogSyncName("").
 				HasNoAutoRefreshStatus().
-				HasPartitionSpecs(sdk.IcebergTablePartitionSpec{
+				HasPartitionSpecsFixed(sdk.IcebergTablePartitionSpec{
 					SpecId: 0,
 					Fields: []sdk.IcebergTablePartitionSpecField{},
 				}).
@@ -182,7 +182,7 @@ func TestInt_IcebergTables(t *testing.T) {
 				HasCatalogSyncName("").
 				HasNoAutoRefreshStatus().
 				HasCurrentPartitionSpecId(0).
-				HasPartitionSpecs(sdk.IcebergTablePartitionSpec{
+				HasPartitionSpecsFixed(sdk.IcebergTablePartitionSpec{
 					SpecId: 0,
 					Fields: []sdk.IcebergTablePartitionSpecField{
 						{FieldId: 1000, Name: "REGION", SourceId: 4, Transform: "identity"},

--- a/pkg/testacc/resource_iceberg_table_acceptance_test.go
+++ b/pkg/testacc/resource_iceberg_table_acceptance_test.go
@@ -595,6 +595,148 @@ func TestAcc_IcebergTable_BasicUseCase(t *testing.T) {
 	})
 }
 
+func TestAcc_IcebergTable_BasicUseCase_Columns(t *testing.T) {
+	// Snowflake-managed Iceberg tables require an external volume, which needs preconfigured AWS storage.
+	awsBaseUrl := testenvs.GetOrSkipTest(t, testenvs.AwsExternalBucketUrl)
+	awsKeyId := testenvs.GetOrSkipTest(t, testenvs.AwsExternalKeyId)
+	awsSecretKey := testenvs.GetOrSkipTest(t, testenvs.AwsExternalSecretKey)
+
+	s3CompatBaseUrl := strings.Replace(awsBaseUrl, "s3://", "s3compat://", 1)
+	s3CompatEndpoint := "s3.us-west-2.amazonaws.com"
+
+	externalVolumeId, externalVolumeCleanup := testClient().ExternalVolume.CreateS3Compat(t, s3CompatBaseUrl, s3CompatEndpoint, awsKeyId, awsSecretKey)
+	t.Cleanup(externalVolumeCleanup)
+
+	// Create a dedicated database with the external volume set at db level so the Snowflake-managed table
+	// can be created without specifying the external volume explicitly on the resource.
+	db, dbCleanup := testClient().Database.CreateDatabaseWithRequest(t, testClient().Database.TestParametersSet(testClient().Ids.RandomAccountObjectIdentifier()).WithExternalVolume(externalVolumeId))
+	t.Cleanup(dbCleanup)
+	schemaId := sdk.NewDatabaseObjectIdentifier(db.ID().Name(), "PUBLIC")
+
+	id := testClient().Ids.RandomSchemaObjectIdentifierInSchema(schemaId)
+
+	maskingPolicy, maskingPolicyCleanup := testClient().MaskingPolicy.CreateMaskingPolicyIdentity(t, testdatatypes.DataTypeVarcharIceberg)
+	t.Cleanup(maskingPolicyCleanup)
+	maskingPolicyId := maskingPolicy.ID()
+
+	conditionalMaskingPolicy, conditionalMaskingPolicyCleanup := testClient().MaskingPolicy.CreateMaskingPolicy(t)
+	t.Cleanup(conditionalMaskingPolicyCleanup)
+	conditionalMaskingPolicyId := conditionalMaskingPolicy.ID()
+
+	projectionPolicyId, projectionPolicyCleanup := testClient().ProjectionPolicy.CreateProjectionPolicy(t)
+	t.Cleanup(projectionPolicyCleanup)
+
+	// FK constraints must reference a column backed by a UNIQUE or PRIMARY KEY constraint on the target table.
+	fkRefTable, fkRefTableCleanup := testClient().Table.CreateWithPredefinedColumnsForIcebergTable(t)
+	t.Cleanup(fkRefTableCleanup)
+
+	idComment := random.Comment()
+	nameComment := random.Comment()
+	statusDefault := "'active'"
+
+	pkConstraintName := random.AlphaN(6)
+	uniqueConstraintName := random.AlphaN(6)
+	fkConstraintName := random.AlphaN(6)
+	checkConstraintName := random.AlphaN(6)
+
+	columns := []model.IcebergTableColumnRequest{
+		{Name: "ID", Type: testdatatypes.DataTypeNumber_38_0, NotNull: true, Comment: idComment},
+		{Name: "NAME", Type: testdatatypes.DataTypeVarcharIceberg, Comment: nameComment, MaskingPolicy: &maskingPolicyId},
+		{Name: "REGION", Type: testdatatypes.DataTypeVarcharIceberg, ProjectionPolicy: &projectionPolicyId},
+		{Name: "STATUS", Type: testdatatypes.DataTypeVarcharIceberg, DefaultExpression: statusDefault},
+		{Name: "CATEGORY", Type: testdatatypes.DataTypeVarcharIceberg, MaskingPolicy: &conditionalMaskingPolicyId, MaskingPolicyUsing: []string{"CATEGORY", "STATUS"}},
+		{Name: "REF_ID", Type: testdatatypes.DataTypeNumber_38_0},
+	}
+
+	primaryKeyConstraint := sdk.TableOutOfLineUniquePKRequest{
+		Name:               new(pkConstraintName),
+		PrimaryKey:         new(true),
+		Columns:            []sdk.Column{{Value: "ID"}},
+		NotEnforced:        new(true),
+		NotDeferrable:      new(true),
+		InitiallyImmediate: new(true),
+		Disable:            new(true),
+		Novalidate:         new(true),
+		Rely:               new(true),
+	}
+	uniqueConstraint := sdk.TableOutOfLineUniquePKRequest{
+		Name:    new(uniqueConstraintName),
+		Unique:  new(true),
+		Columns: []sdk.Column{{Value: "NAME"}},
+	}
+	foreignKeyConstraint := sdk.TableOutOfLineFKRequest{
+		Name:       new(fkConstraintName),
+		Columns:    []sdk.Column{{Value: "REF_ID"}},
+		References: fkRefTable.ID(),
+		RefColumns: []sdk.Column{{Value: "id"}},
+		Match:      new(sdk.SimpleMatchType),
+		On: &sdk.ForeignKeyOnAction{
+			OnUpdate: new(sdk.ForeignKeyCascadeAction),
+			OnDelete: new(sdk.ForeignKeySetNullAction),
+		},
+	}
+	checkConstraint := sdk.TableOutOfLineCHRequest{
+		Name:           new(checkConstraintName),
+		Expression:     "ID > 0",
+		EnableValidate: new(true),
+	}
+
+	modelWithColumns := model.IcebergTableWithDefaultMeta(id.DatabaseName(), id.SchemaName(), id.Name(), nil).
+		WithColumnRequests(columns...).
+		WithPrimaryKeyConstraints(primaryKeyConstraint).
+		WithUniqueConstraints(uniqueConstraint).
+		WithForeignKeyConstraints(foreignKeyConstraint).
+		WithCheckConstraints(checkConstraint)
+
+	ref := modelWithColumns.ResourceReference()
+
+	columnAssertions := resourceassert.IcebergTableResource(t, ref).
+		HasDatabaseString(id.DatabaseName()).
+		HasSchemaString(id.SchemaName()).
+		HasNameString(id.Name()).
+		HasColumns(
+			resourceassert.ExpectedColumn{Name: "ID", Type: testdatatypes.DataTypeNumber_38_0.ToSql(), NotNull: true, Comment: idComment},
+			resourceassert.ExpectedColumn{Name: "NAME", Type: testdatatypes.DataTypeVarcharIceberg.ToSql(), Comment: nameComment, MaskingPolicy: &maskingPolicyId, MaskingPolicyUsing: []string{"NAME"}},
+			resourceassert.ExpectedColumn{Name: "REGION", Type: testdatatypes.DataTypeVarcharIceberg.ToSql(), ProjectionPolicy: &projectionPolicyId},
+			resourceassert.ExpectedColumn{Name: "STATUS", Type: testdatatypes.DataTypeVarcharIceberg.ToSql(), DefaultExpression: statusDefault},
+			resourceassert.ExpectedColumn{Name: "CATEGORY", Type: testdatatypes.DataTypeVarcharIceberg.ToSql(), MaskingPolicy: &conditionalMaskingPolicyId, MaskingPolicyUsing: []string{"CATEGORY", "STATUS"}},
+			resourceassert.ExpectedColumn{Name: "REF_ID", Type: testdatatypes.DataTypeNumber_38_0.ToSql()},
+		).
+		HasPrimaryKeyConstraints(primaryKeyConstraint).
+		HasUniqueConstraints(uniqueConstraint).
+		HasForeignKeyConstraints(foreignKeyConstraint).
+		HasCheckConstraints(checkConstraint)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.IcebergTable),
+		Steps: []resource.TestStep{
+			// Create with columns exercising not_null, comment, default, masking_policy (plain and conditional
+			// with using), projection_policy, and all constraint kinds: primary key, unique, foreign key, check.
+			{
+				Config: accconfig.FromModels(t, modelWithColumns),
+				Check:  assertThat(t, columnAssertions),
+			},
+			// Import
+			{
+				Config:            accconfig.FromModels(t, modelWithColumns),
+				ResourceName:      ref,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Out-of-line constraints are ForceNew-only and are not read back by the resource, so they
+				// cannot be verified against imported state.
+				ImportStateVerifyIgnore: []string{
+					"change_tracking", "error_logging", "path_layout", "iceberg_version", "base_location",
+					"primary_key_constraint", "unique_constraint", "foreign_key_constraint", "check_constraint",
+				},
+			},
+		},
+	})
+}
+
 func TestAcc_IcebergTable_CompleteUseCase(t *testing.T) {
 	awsBaseUrl := testenvs.GetOrSkipTest(t, testenvs.AwsExternalBucketUrl)
 	awsKeyId := testenvs.GetOrSkipTest(t, testenvs.AwsExternalKeyId)

--- a/pkg/testacc/resource_iceberg_table_acceptance_test.go
+++ b/pkg/testacc/resource_iceberg_table_acceptance_test.go
@@ -633,6 +633,7 @@ func TestAcc_IcebergTable_BasicUseCase_Columns(t *testing.T) {
 	idComment := random.Comment()
 	nameComment := random.Comment()
 	statusDefault := "'active'"
+	emptyDefault := "''"
 
 	pkConstraintName := random.AlphaN(6)
 	uniqueConstraintName := random.AlphaN(6)
@@ -640,10 +641,11 @@ func TestAcc_IcebergTable_BasicUseCase_Columns(t *testing.T) {
 	checkConstraintName := random.AlphaN(6)
 
 	columns := []model.IcebergTableColumnRequest{
-		{Name: "ID", Type: testdatatypes.DataTypeNumber_38_0, NotNull: true, Comment: idComment},
+		{Name: "ID", Type: testdatatypes.DataTypeNumber_38_0, NotNull: new("true"), Comment: idComment},
 		{Name: "NAME", Type: testdatatypes.DataTypeVarcharIceberg, Comment: nameComment, MaskingPolicy: &maskingPolicyId},
 		{Name: "REGION", Type: testdatatypes.DataTypeVarcharIceberg, ProjectionPolicy: &projectionPolicyId},
 		{Name: "STATUS", Type: testdatatypes.DataTypeVarcharIceberg, DefaultExpression: statusDefault},
+		{Name: "NOTES", Type: testdatatypes.DataTypeVarcharIceberg, DefaultExpression: emptyDefault},
 		{Name: "CATEGORY", Type: testdatatypes.DataTypeVarcharIceberg, MaskingPolicy: &conditionalMaskingPolicyId, MaskingPolicyUsing: []string{"CATEGORY", "STATUS"}},
 		{Name: "REF_ID", Type: testdatatypes.DataTypeNumber_38_0},
 	}
@@ -682,7 +684,7 @@ func TestAcc_IcebergTable_BasicUseCase_Columns(t *testing.T) {
 	}
 
 	modelWithColumns := model.IcebergTableWithDefaultMeta(id.DatabaseName(), id.SchemaName(), id.Name(), nil).
-		WithColumnRequests(columns...).
+		WithColumns(columns...).
 		WithPrimaryKeyConstraints(primaryKeyConstraint).
 		WithUniqueConstraints(uniqueConstraint).
 		WithForeignKeyConstraints(foreignKeyConstraint).
@@ -699,6 +701,7 @@ func TestAcc_IcebergTable_BasicUseCase_Columns(t *testing.T) {
 			resourceassert.ExpectedColumn{Name: "NAME", Type: testdatatypes.DataTypeVarcharIceberg.ToSql(), Comment: nameComment, MaskingPolicy: &maskingPolicyId, MaskingPolicyUsing: []string{"NAME"}},
 			resourceassert.ExpectedColumn{Name: "REGION", Type: testdatatypes.DataTypeVarcharIceberg.ToSql(), ProjectionPolicy: &projectionPolicyId},
 			resourceassert.ExpectedColumn{Name: "STATUS", Type: testdatatypes.DataTypeVarcharIceberg.ToSql(), DefaultExpression: statusDefault},
+			resourceassert.ExpectedColumn{Name: "NOTES", Type: testdatatypes.DataTypeVarcharIceberg.ToSql(), DefaultExpression: emptyDefault},
 			resourceassert.ExpectedColumn{Name: "CATEGORY", Type: testdatatypes.DataTypeVarcharIceberg.ToSql(), MaskingPolicy: &conditionalMaskingPolicyId, MaskingPolicyUsing: []string{"CATEGORY", "STATUS"}},
 			resourceassert.ExpectedColumn{Name: "REF_ID", Type: testdatatypes.DataTypeNumber_38_0.ToSql()},
 		).


### PR DESCRIPTION
## Summary
- Adds rich per-column support to `snowflake_iceberg_table` (`not_null`, `comment`, `default`, `masking_policy` incl. conditional `using`, `projection_policy`) instead of just name+type.
- Adds table-level out-of-line constraints: `primary_key_constraint`, `unique_constraint`, `foreign_key_constraint`, `check_constraint`, including enforcement options (`enforced`, `deferrable`, `initially_deferred`, `enable`, `validate`, `rely`).
- Extends config model builders and resource assertions for the new column/constraint fields to support acceptance testing.
- Extends `TestAcc_IcebergTable_BasicUseCase_Columns` to cover the new column features and all constraint kinds.