### PR TITLE
fix: external_volume no longer removes and re-adds unchanged storage locations

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -54,6 +54,14 @@ The `partition_specs` field in the `show_output` of the Iceberg table resources 
 
 If you have existing state with the old string-based `partition_specs`, refresh the resource (e.g. `terraform apply` or `terraform refresh`) to update it to the new format. No changes to your resource configuration are required, as `partition_specs` is a computed, read-only field.
 
+### *(bug fix)* `snowflake_external_volume` no longer removes and re-adds unchanged storage locations
+
+Previously, adding a new `storage_location` block to an existing [`snowflake_external_volume`](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/external_volume) (or making other partial changes to the `storage_location` list) could cause the provider to unnecessarily issue `ALTER EXTERNAL VOLUME ... REMOVE STORAGE_LOCATION` for an existing, unchanged location before re-adding it. If that location was active (e.g. backing an Iceberg table), Snowflake correctly rejected the removal with error 393926 (42601), blocking the update. The provider now correctly detects unchanged locations and leaves them untouched, issuing only the `ADD`/`REMOVE` operations required for the actual diff.
+
+No changes in configuration are required.
+
+Note that this error can still legitimately occur if your configuration change actually removes the currently active storage location (e.g. removing the block from your configuration, or renaming/replacing it). This is expected Snowflake behavior, not a bug: an active storage location cannot be removed while it is in use (e.g. by an Iceberg table). Reassign the dependent objects to another storage location before removing it from your configuration.
+
 ## v2.17.x ➞ v2.18.0
 
 ### Multiple resources and data sources promoted to stable

--- a/pkg/acceptance/bettertestspoc/config/model/external_volume_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/external_volume_model_ext.go
@@ -58,10 +58,12 @@ func (e *ExternalVolumeModel) WithStorageLocation(storageLocation []sdk.External
 			maps[i] = tfconfig.MapVariable(m)
 		case v.S3CompatStorageLocationParams != nil:
 			m := map[string]tfconfig.Variable{
-				"storage_location_name": tfconfig.StringVariable(v.Name),
-				"storage_provider":      tfconfig.StringVariable(string(sdk.StorageProviderS3compat)),
-				"storage_base_url":      tfconfig.StringVariable(v.S3CompatStorageLocationParams.StorageBaseUrl),
-				"storage_endpoint":      tfconfig.StringVariable(v.S3CompatStorageLocationParams.StorageEndpoint),
+				"storage_location_name":  tfconfig.StringVariable(v.Name),
+				"storage_provider":       tfconfig.StringVariable(string(sdk.StorageProviderS3compat)),
+				"storage_base_url":       tfconfig.StringVariable(v.S3CompatStorageLocationParams.StorageBaseUrl),
+				"storage_endpoint":       tfconfig.StringVariable(v.S3CompatStorageLocationParams.StorageEndpoint),
+				"storage_aws_key_id":     tfconfig.StringVariable(v.S3CompatStorageLocationParams.Credentials.AwsKeyId),
+				"storage_aws_secret_key": tfconfig.StringVariable(v.S3CompatStorageLocationParams.Credentials.AwsSecretKey),
 			}
 			maps[i] = tfconfig.MapVariable(m)
 		}

--- a/pkg/resources/external_volume.go
+++ b/pkg/resources/external_volume.go
@@ -464,11 +464,11 @@ func UpdateContextExternalVolume(ctx context.Context, d *schema.ResourceData, me
 			removedLocations = oldLocations
 			addedLocations = newLocations
 		} else {
-			// Could +1 on the prefix here as the lists until and including this index
-			// are identical, would need to add some more checks for list length to avoid
-			// an array index out of bounds error
-			removedLocations = oldLocations[commonPrefixLastIndex:]
-			addedLocations = newLocations[commonPrefixLastIndex:]
+			// commonPrefixLastIndex is inclusive, so the elements up to and including it are
+			// identical between old and new; slicing from the next index excludes them from
+			// both removed and added, avoiding an unnecessary remove/re-add of unchanged locations.
+			removedLocations = oldLocations[commonPrefixLastIndex+1:]
+			addedLocations = newLocations[commonPrefixLastIndex+1:]
 		}
 
 		if len(removedLocations) == len(oldLocations) {

--- a/pkg/testacc/resource_external_volume_acceptance_test.go
+++ b/pkg/testacc/resource_external_volume_acceptance_test.go
@@ -7,6 +7,7 @@ package testacc
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	r "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
@@ -18,6 +19,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testdatatypes"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/previewfeatures"
@@ -2947,6 +2949,138 @@ func TestAcc_ExternalVolume_BasicUseCase_MultipleProviders(t *testing.T) {
 								},
 							},
 						}),
+				),
+			},
+		},
+	})
+}
+
+// Regression test for SNOW-3794939: appending a new storage_location must not remove and
+// re-add an existing, unchanged storage_location. If that location is active (backing an
+// Iceberg table), Snowflake rejects the unnecessary REMOVE with error 393926 (42601).
+func TestAcc_ExternalVolume_AddStorageLocation_WhileLastIsActive(t *testing.T) {
+	awsBaseUrl := testenvs.GetOrSkipTest(t, testenvs.AwsExternalBucketUrl)
+	awsKeyId := testenvs.GetOrSkipTest(t, testenvs.AwsExternalKeyId)
+	awsSecretKey := testenvs.GetOrSkipTest(t, testenvs.AwsExternalSecretKey)
+
+	s3CompatBaseUrl := strings.Replace(awsBaseUrl, "s3://", "s3compat://", 1)
+	s3CompatEndpoint := "s3.us-west-2.amazonaws.com"
+
+	id := testClient().Ids.RandomAccountObjectIdentifier()
+	externalVolumeName := id.Name()
+	ref := "snowflake_external_volume.complete"
+
+	primaryLocationName := "primary"
+	secondLocationName := "secondary"
+
+	s3CompatStorageLocationRequest := func(locName string) sdk.ExternalVolumeStorageLocationRequest {
+		return *sdk.NewExternalVolumeStorageLocationRequest(locName).WithS3CompatStorageLocationParams(
+			*sdk.NewS3CompatStorageLocationParamsRequest(
+				s3CompatBaseUrl,
+				s3CompatEndpoint,
+				*sdk.NewExternalVolumeS3CompatCredentialsRequest(awsKeyId, awsSecretKey),
+			),
+		)
+	}
+
+	basicModel := model.ExternalVolume("complete", externalVolumeName, []sdk.ExternalVolumeStorageLocationRequest{
+		s3CompatStorageLocationRequest(primaryLocationName),
+	})
+
+	modelWithExtraLocation := model.ExternalVolume("complete", externalVolumeName, []sdk.ExternalVolumeStorageLocationRequest{
+		s3CompatStorageLocationRequest(primaryLocationName),
+		s3CompatStorageLocationRequest(secondLocationName),
+	})
+	providerModel := providermodel.SnowflakeProvider().WithPreviewFeaturesEnabled(string(previewfeatures.ExternalVolumeResource))
+
+	// The cleanup is stored on purpose. In order to remove the whole external volume, we need to remove the iceberg table first.
+	var icebergTableCleanup func()
+	createActiveIcebergTable := func() func() {
+		icebergTableId := testClient().Ids.RandomSchemaObjectIdentifier()
+		_, cleanup := testClient().IcebergTable.CreateWithRequest(
+			t,
+			sdk.NewCreateIcebergTableRequest(icebergTableId, sdk.IcebergTableColumnsAndConstraintsRequest{
+				Columns: []sdk.IcebergTableColumnRequest{{Name: "ID", ColumnType: testdatatypes.DataTypeNumber}},
+			}).
+				WithCatalog(sdk.IcebergTableCatalogSnowflake).
+				WithExternalVolume(id).
+				WithBaseLocation("external_volume_active_location_test_table"),
+		)
+		return cleanup
+	}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.ExternalVolume),
+		Steps: []resource.TestStep{
+			// v2.18.0: create with a single storage location
+			{
+				ExternalProviders: ExternalProviderWithExactVersion("2.18.0"),
+				Config: tfconfig.FromModels(
+					t,
+					providerModel,
+					basicModel,
+				),
+				Check: assertThat(
+					t,
+					resourceassert.ExternalVolumeResource(t, ref).
+						HasNameString(externalVolumeName).
+						HasStorageLocationLength(1),
+				),
+			},
+			// v2.18.0: make the first storage location active by creating an Iceberg table on it, then
+			// append a second storage location - reproduces the bug: the provider unnecessarily removes
+			// the now-active first location, which Snowflake rejects with error 393926 (42601)
+			{
+				ExternalProviders: ExternalProviderWithExactVersion("2.18.0"),
+				PreConfig: func() {
+					icebergTableCleanup = createActiveIcebergTable()
+				},
+				Config: tfconfig.FromModels(
+					t,
+					providerModel,
+					modelWithExtraLocation,
+				),
+				ExpectError: regexp.MustCompile(`393926 \(42601\): The active storage location .* cannot be removed on external volume`),
+			},
+			// current version: the very same operation must now succeed, without removing the active location
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(ref, plancheck.ResourceActionUpdate),
+					},
+				},
+				Config: tfconfig.FromModels(
+					t,
+					providerModel,
+					modelWithExtraLocation,
+				),
+				Check: assertThat(
+					t,
+					resourceassert.ExternalVolumeResource(t, ref).
+						HasNameString(externalVolumeName).
+						HasStorageLocationLength(2),
+				),
+			},
+			// drop the Iceberg table before the external volume gets destroyed at the end of the test
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				PreConfig: func() {
+					icebergTableCleanup()
+				},
+				Config: tfconfig.FromModels(
+					t,
+					providerModel,
+					modelWithExtraLocation,
+				),
+				Check: assertThat(
+					t,
+					resourceassert.ExternalVolumeResource(t, ref).
+						HasNameString(externalVolumeName).
+						HasStorageLocationLength(2),
 				),
 			},
 		},


### PR DESCRIPTION
## Summary
- Fixes an off-by-one in `UpdateContextExternalVolume`'s common-prefix slicing that caused unchanged storage locations at the prefix boundary to be unnecessarily removed and re-added when appending a new `storage_location`.
- If the unnecessarily-removed location was active (e.g. backing an Iceberg table), Snowflake rejected the update with error 393926 (42601), blocking legitimate config changes like appending a new location.
- Adds a regression acceptance test (`TestAcc_ExternalVolume_AddStorageLocation_WhileFirstIsActive`) that reproduces the bug against the last released provider version (v2.18.0) with a real Iceberg table, then verifies the fix against the current version.
- Extends the `ExternalVolumeModel` test-model builder to emit `storage_aws_key_id`/`storage_aws_secret_key` for S3-compat storage locations (previously missing).
- Adds a MIGRATION_GUIDE entry.