### PR TITLE
chore: Adjust account tests

### DIFF
--- a/pkg/acceptance/bettertestspoc/assert/resourceassert/current_account_resource_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceassert/current_account_resource_ext.go
@@ -34,13 +34,16 @@ func (c *CurrentAccountResourceAssert) HasAllDefaultParameters() *CurrentAccount
 		HasDefaultNotebookComputePoolCpuString("SYSTEM_COMPUTE_POOL_CPU").
 		HasDefaultNotebookComputePoolGpuString("SYSTEM_COMPUTE_POOL_GPU").
 		HasDefaultNullOrderingString(string(sdk.DefaultNullOrderingLast)).
-		HasDefaultStreamlitNotebookWarehouseString("REGRESS").
+		// TODO [SNOW-3797718]: changed temporarily - what is the REGRESS warehouse?
+		HasDefaultStreamlitNotebookWarehouseString("SYSTEM$STREAMLIT_NOTEBOOK_WH").
 		HasDisableUiDownloadButtonString("false").
 		HasDisableUserPrivilegeGrantsString("false").
 		HasEnableAutomaticSensitiveDataClassificationLogString("true").
 		HasEnableEgressCostOptimizerString("true").
-		HasEnableIdentifierFirstLoginString("true").
-		HasEnableTriSecretAndRekeyOptOutForImageRepositoryString("false").
+		// TODO [SNOW-3797718]: commented out as some other test rewrites this value
+		// HasEnableIdentifierFirstLoginString("true").
+		// TODO [SNOW-3797718]: commented out as some other test rewrites this value
+		// HasEnableTriSecretAndRekeyOptOutForImageRepositoryString("false").
 		HasEnableTriSecretAndRekeyOptOutForSpcsBlockStorageString("false").
 		HasEnableUnhandledExceptionsReportingString("true").
 		HasEnableUnloadPhysicalTypeOptimizationString("true").

--- a/pkg/acceptance/helpers/1_prerequisites.go
+++ b/pkg/acceptance/helpers/1_prerequisites.go
@@ -111,12 +111,10 @@ func (c *TestClient) EnsureValidNonProdOrganizationAccountIsUsed(t *testing.T) {
 	}
 	organizationAccounts, err := c.context.client.OrganizationAccounts.Show(context.Background(), sdk.NewShowOrganizationAccountRequest())
 	if err != nil {
-		t.Fatalf("Failed to show organization accounts, err = %v.", err)
-	}
-	if len(organizationAccounts) != 1 {
-		t.Fatalf("Wrong number of organization accounts returned. Expected one, got = %d.", len(organizationAccounts))
-	}
-	if organizationAccounts[0].AccountLocator != nonProdModifiableAccountLocator {
+		t.Errorf("Failed to show organization accounts, err = %v.", err)
+	} else if len(organizationAccounts) != 1 {
+		t.Errorf("Wrong number of organization accounts returned. Expected one, got = %d.", len(organizationAccounts))
+	} else if organizationAccounts[0].AccountLocator != nonProdModifiableAccountLocator {
 		t.Skipf("The TEST_SF_TF_NON_PROD_MODIFIABLE_ACCOUNT_LOCATOR does not match the organization account's locator, please adjust the environment variable.")
 	}
 }

--- a/pkg/acceptance/helpers/1_prerequisites.go
+++ b/pkg/acceptance/helpers/1_prerequisites.go
@@ -110,11 +110,12 @@ func (c *TestClient) EnsureValidNonProdOrganizationAccountIsUsed(t *testing.T) {
 		t.Skipf("Current client account locator does not match the required non-prod modifiable account's locator set in %s env variable. Skipping test.", testenvs.TestNonProdModifiableAccountLocator)
 	}
 	organizationAccounts, err := c.context.client.OrganizationAccounts.Show(context.Background(), sdk.NewShowOrganizationAccountRequest())
-	if err != nil {
+	switch {
+	case err != nil:
 		t.Errorf("Failed to show organization accounts, err = %v.", err)
-	} else if len(organizationAccounts) != 1 {
+	case len(organizationAccounts) != 1:
 		t.Errorf("Wrong number of organization accounts returned. Expected one, got = %d.", len(organizationAccounts))
-	} else if organizationAccounts[0].AccountLocator != nonProdModifiableAccountLocator {
+	case organizationAccounts[0].AccountLocator != nonProdModifiableAccountLocator:
 		t.Skipf("The TEST_SF_TF_NON_PROD_MODIFIABLE_ACCOUNT_LOCATOR does not match the organization account's locator, please adjust the environment variable.")
 	}
 }

--- a/pkg/acceptance/helpers/1_prerequisites.go
+++ b/pkg/acceptance/helpers/1_prerequisites.go
@@ -111,10 +111,10 @@ func (c *TestClient) EnsureValidNonProdOrganizationAccountIsUsed(t *testing.T) {
 	}
 	organizationAccounts, err := c.context.client.OrganizationAccounts.Show(context.Background(), sdk.NewShowOrganizationAccountRequest())
 	if err != nil {
-		t.Errorf("Failed to show organization accounts, err = %v.", err)
+		t.Fatalf("Failed to show organization accounts, err = %v.", err)
 	}
 	if len(organizationAccounts) != 1 {
-		t.Errorf("Wrong number of organization accounts returned. Expected one, got = %d.", len(organizationAccounts))
+		t.Fatalf("Wrong number of organization accounts returned. Expected one, got = %d.", len(organizationAccounts))
 	}
 	if organizationAccounts[0].AccountLocator != nonProdModifiableAccountLocator {
 		t.Skipf("The TEST_SF_TF_NON_PROD_MODIFIABLE_ACCOUNT_LOCATOR does not match the organization account's locator, please adjust the environment variable.")

--- a/pkg/acceptance/helpers/ids_generator.go
+++ b/pkg/acceptance/helpers/ids_generator.go
@@ -48,7 +48,7 @@ func (c *IdsGenerator) RandomAccountObjectIdentifier() sdk.AccountObjectIdentifi
 }
 
 func (c *IdsGenerator) RandomSensitiveAccountObjectIdentifier() sdk.AccountObjectIdentifier {
-	return c.RandomAccountObjectIdentifierWithPrefix(random.SensitiveAlphanumeric())
+	return sdk.NewAccountObjectIdentifier(random.AccountName())
 }
 
 func (c *IdsGenerator) RandomAccountObjectIdentifierWithPrefix(prefix string) sdk.AccountObjectIdentifier {

--- a/pkg/sdk/accounts_ext.go
+++ b/pkg/sdk/accounts_ext.go
@@ -2,40 +2,9 @@ package sdk
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 )
-
-type AccountCreateResponse struct {
-	AccountLocator    string `json:"accountLocator,omitempty"`
-	AccountLocatorUrl string `json:"accountLocatorUrl,omitempty"`
-	OrganizationName  string
-	AccountName       string         `json:"accountName,omitempty"`
-	Url               string         `json:"url,omitempty"`
-	Edition           AccountEdition `json:"edition,omitempty"`
-	RegionGroup       string         `json:"regionGroup,omitempty"`
-	Cloud             string         `json:"cloud,omitempty"`
-	Region            string         `json:"region,omitempty"`
-}
-
-func ToAccountCreateResponse(v string) (*AccountCreateResponse, error) {
-	var res AccountCreateResponse
-	err := json.Unmarshal([]byte(v), &res)
-	if err != nil {
-		return nil, err
-	}
-	if len(res.Url) > 0 {
-		url := strings.TrimPrefix(res.Url, `https://`)
-		url = strings.TrimPrefix(url, `http://`)
-		parts := strings.SplitN(url, "-", 2)
-		if len(parts) == 2 {
-			res.OrganizationName = strings.ToUpper(parts[0])
-		}
-	}
-	return &res, nil
-}
 
 func (opts *CreateAccountOptions) additionalValidations() error {
 	var errs []error

--- a/pkg/sdk/accounts_test.go
+++ b/pkg/sdk/accounts_test.go
@@ -1,12 +1,10 @@
 package sdk
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -747,119 +745,6 @@ func TestAccountShow(t *testing.T) {
 		}
 		assertOptsValidAndSQLEquals(t, opts, `SHOW ACCOUNTS LIKE 'myaccount'`)
 	})
-}
-
-func TestToAccountCreateResponse(t *testing.T) {
-	testCases := []struct {
-		Name           string
-		RawInput       string
-		Input          AccountCreateResponse
-		ExpectedOutput *AccountCreateResponse
-		Error          string
-	}{
-		{
-			Name:     "validation: empty input",
-			RawInput: "",
-			Error:    "unexpected end of JSON input",
-		},
-		{
-			Name: "validation: only a few fields filled",
-			Input: AccountCreateResponse{
-				AccountName: "acc_name",
-				Url:         `https://org_name-acc_name.snowflakecomputing.com`,
-				Edition:     AccountEditionStandard,
-				RegionGroup: "region_group",
-				Cloud:       "cloud",
-				Region:      "region",
-			},
-			ExpectedOutput: &AccountCreateResponse{
-				AccountName:      "acc_name",
-				Url:              `https://org_name-acc_name.snowflakecomputing.com`,
-				OrganizationName: "ORG_NAME",
-				Edition:          AccountEditionStandard,
-				RegionGroup:      "region_group",
-				Cloud:            "cloud",
-				Region:           "region",
-			},
-		},
-		{
-			Name: "validation: invalid url",
-			Input: AccountCreateResponse{
-				Url: `https://org_name_acc_name.snowflake.computing.com`,
-			},
-			ExpectedOutput: &AccountCreateResponse{
-				Url: `https://org_name_acc_name.snowflake.computing.com`,
-				// OrganizationName is not filled
-			},
-		},
-		{
-			Name: "validation: valid url",
-			Input: AccountCreateResponse{
-				Url: `https://org_name-acc_name.snowflakecomputing.com`,
-			},
-			ExpectedOutput: &AccountCreateResponse{
-				Url:              `https://org_name-acc_name.snowflakecomputing.com`,
-				OrganizationName: "ORG_NAME",
-			},
-		},
-		{
-			Name: "validation: valid http url",
-			Input: AccountCreateResponse{
-				Url: `http://org_name-acc_name.snowflakecomputing.com`,
-			},
-			ExpectedOutput: &AccountCreateResponse{
-				Url:              `http://org_name-acc_name.snowflakecomputing.com`,
-				OrganizationName: "ORG_NAME",
-			},
-		},
-		{
-			Name: "complete",
-			Input: AccountCreateResponse{
-				AccountLocator:    "locator",
-				AccountLocatorUrl: "locator_url",
-				AccountName:       "acc_name",
-				Url:               `https://org_name-acc_name.snowflakecomputing.com`,
-				Edition:           AccountEditionBusinessCritical,
-				RegionGroup:       "region_group",
-				Cloud:             "cloud",
-				Region:            "region",
-			},
-			ExpectedOutput: &AccountCreateResponse{
-				AccountLocator:    "locator",
-				AccountLocatorUrl: "locator_url",
-				AccountName:       "acc_name",
-				Url:               `https://org_name-acc_name.snowflakecomputing.com`,
-				OrganizationName:  "ORG_NAME",
-				Edition:           AccountEditionBusinessCritical,
-				RegionGroup:       "region_group",
-				Cloud:             "cloud",
-				Region:            "region",
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			input := tc.RawInput
-			if tc.Input != (AccountCreateResponse{}) {
-				bytes, err := json.Marshal(tc.Input)
-				if err != nil {
-					assert.Fail(t, err.Error())
-				}
-				input = string(bytes)
-			}
-
-			createResponse, err := ToAccountCreateResponse(input)
-
-			if tc.Error != "" {
-				assert.EqualError(t, err, tc.Error)
-				assert.Nil(t, createResponse)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tc.ExpectedOutput, createResponse)
-			}
-		})
-	}
 }
 
 func TestToAccountEdition(t *testing.T) {

--- a/pkg/sdk/testint/accounts_integration_test.go
+++ b/pkg/sdk/testint/accounts_integration_test.go
@@ -38,16 +38,19 @@ func TestInt_Account(t *testing.T) {
 		assert.Equal(t, accountName, account.AccountName)
 		assert.Nil(t, account.RegionGroup)
 		assert.NotEmpty(t, account.SnowflakeRegion)
-		assert.Equal(t, sdk.AccountEditionEnterprise, *account.Edition)
+		// TODO [SNOW-3797718]: changed to business critical temporarily
+		assert.Equal(t, sdk.AccountEditionBusinessCritical, *account.Edition)
 		assert.NotEmpty(t, *account.AccountURL)
 		assert.NotEmpty(t, *account.CreatedOn)
-		assert.Equal(t, "SNOWFLAKE", *account.Comment)
+		// TODO [SNOW-3797718]: changed to nil temporarily - having direct dereference panics here; use object assertions
+		assert.Nil(t, account.Comment)
 		assert.NotEmpty(t, account.AccountLocator)
 		assert.NotEmpty(t, *account.AccountLocatorUrl)
 		assert.Zero(t, *account.ManagedAccounts)
 		assert.NotEmpty(t, *account.ConsumptionBillingEntityName)
 		assert.Nil(t, account.MarketplaceConsumerBillingEntityName)
-		assert.NotNil(t, account.MarketplaceProviderBillingEntityName)
+		// TODO [SNOW-3797718]: changed to nil temporarily
+		assert.Nil(t, account.MarketplaceProviderBillingEntityName)
 		assert.Empty(t, *account.OldAccountURL)
 		assert.True(t, *account.IsOrgAdmin)
 		assert.Nil(t, account.AccountOldUrlSavedOn)
@@ -134,6 +137,7 @@ func TestInt_Account(t *testing.T) {
 	})
 
 	t.Run("create: user type legacy service", func(t *testing.T) {
+		t.Skip("SNOW-3797718 - can we drop this test already?")
 		id := sdk.NewAccountObjectIdentifier(random.AccountName())
 		name := random.AdminName()
 		password := random.Password()
@@ -151,6 +155,7 @@ func TestInt_Account(t *testing.T) {
 		require.Equal(t, id, acc.ID())
 	})
 
+	// TODO [SNOW-3797718] - billing entity was removed; use contract number
 	t.Run("create: complete", func(t *testing.T) {
 		id := sdk.NewAccountObjectIdentifier(random.AccountName())
 		name := random.AdminName()
@@ -172,8 +177,7 @@ func TestInt_Account(t *testing.T) {
 			WithEdition(sdk.AccountEditionStandard).
 			WithRegionGroup("PUBLIC").
 			WithRegion(currentRegion.SnowflakeRegion).
-			WithComment(comment).
-			WithConsumptionBillingEntity(defaultConsumptionBillingEntity))
+			WithComment(comment))
 		// TODO(SNOW-1895880): with polaris Snowflake returns an error saying: "invalid property polaris for account"
 		// .WithPolaris(true)
 		require.NoError(t, err)
@@ -253,6 +257,7 @@ func TestInt_Account(t *testing.T) {
 	})
 
 	t.Run("alter: set / unset consumption billing entity", func(t *testing.T) {
+		t.Skip("SNOW-3797718 - address with billing entity removal")
 		account, accountCleanup := testClientHelper().Account.Create(t)
 		t.Cleanup(accountCleanup)
 
@@ -591,6 +596,7 @@ func TestInt_Account_SelfAlter(t *testing.T) {
 	})
 
 	t.Run("unset policy safely", func(t *testing.T) {
+		t.Skip("SNOW-3797718 - No such error is currently thrown")
 		authenticationPolicy, authenticationPolicyCleanup := testClientHelper().AuthenticationPolicy.Create(t)
 		t.Cleanup(authenticationPolicyCleanup)
 

--- a/pkg/testacc/2_check_destroy_test.go
+++ b/pkg/testacc/2_check_destroy_test.go
@@ -117,6 +117,12 @@ func decodeSnowflakeId(rs *terraform.ResourceState, resource resources.Resource)
 	// Handling user separately, due to existing test with "." as part of the identifier.
 	case resources.User:
 		return sdk.ParseAccountObjectIdentifier(rs.Primary.ID)
+	case resources.Account:
+		id, err := sdk.ParseObjectIdentifierString(rs.Primary.ID)
+		if err != nil {
+			return id, err
+		}
+		return sdk.NewAccountObjectIdentifier(id.Name()), nil
 	default:
 		return sdk.ParseObjectIdentifierString(rs.Primary.ID)
 	}

--- a/pkg/testacc/data_source_accounts_acceptance_test.go
+++ b/pkg/testacc/data_source_accounts_acceptance_test.go
@@ -4,6 +4,7 @@ package testacc
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
@@ -22,7 +23,7 @@ import (
 func TestAcc_Accounts_Complete(t *testing.T) {
 	testClient().EnsureValidNonProdAccountIsUsed(t)
 
-	prefix := testClient().Ids.AlphaN(4)
+	prefix := strings.ToUpper(random.AlphaN(4))
 
 	publicKey, _ := random.GenerateRSAPublicKey(t)
 	id1 := sdk.NewAccountObjectIdentifier(fmt.Sprintf("%s_%s", prefix, random.AccountName()))

--- a/pkg/testacc/resource_account_acceptance_test.go
+++ b/pkg/testacc/resource_account_acceptance_test.go
@@ -84,8 +84,8 @@ func TestAcc_Account_Minimal(t *testing.T) {
 						HasAccountLocatorUrlNotEmpty().
 						HasManagedAccounts(0).
 						HasConsumptionBillingEntityNameNotEmpty().
-						HasMarketplaceConsumerBillingEntityName("").
-						HasMarketplaceProviderBillingEntityNameNotEmpty().
+						// TODO [SNOW-3797718]: changed temporarily
+						HasMarketplaceProviderBillingEntityName("").
 						HasOldAccountURL("").
 						HasIsOrgAdmin(false).
 						HasAccountOldUrlSavedOnEmpty().
@@ -132,10 +132,10 @@ func TestAcc_Account_Minimal(t *testing.T) {
 	})
 }
 
+// TODO [SNOW-3797718]: default consumption billing entity removed; address during billing entity removal
 func TestAcc_Account_Complete(t *testing.T) {
 	testClient().EnsureValidNonProdAccountIsUsed(t)
 
-	defaultConsumptionBillingEntity := testClient().Context.DefaultConsumptionBillingEntity(t).Name()
 	organizationName := testClient().Context.CurrentAccountId(t).OrganizationName()
 	id := random.AccountName()
 	accountId := sdk.NewAccountIdentifier(organizationName, id)
@@ -158,7 +158,6 @@ func TestAcc_Account_Complete(t *testing.T) {
 		WithRegionGroup("PUBLIC").
 		WithRegion(region).
 		WithComment(comment).
-		WithConsumptionBillingEntity(defaultConsumptionBillingEntity).
 		WithIsOrgAdmin(r.BooleanFalse)
 
 	resource.Test(t, resource.TestCase{
@@ -185,7 +184,6 @@ func TestAcc_Account_Complete(t *testing.T) {
 						HasRegionGroupString("PUBLIC").
 						HasRegionString(region).
 						HasCommentString(comment).
-						HasConsumptionBillingEntityString(defaultConsumptionBillingEntity).
 						HasIsOrgAdminString(r.BooleanFalse).
 						HasGracePeriodInDaysString("3"),
 					resourceshowoutputassert.AccountShowOutput(t, configModel.ResourceReference()).
@@ -200,9 +198,7 @@ func TestAcc_Account_Complete(t *testing.T) {
 						HasAccountLocatorNotEmpty().
 						HasAccountLocatorUrlNotEmpty().
 						HasManagedAccounts(0).
-						HasConsumptionBillingEntityName(defaultConsumptionBillingEntity).
 						HasMarketplaceConsumerBillingEntityName("").
-						HasMarketplaceProviderBillingEntityNameNotEmpty().
 						HasOldAccountURL("").
 						HasIsOrgAdmin(false).
 						HasAccountOldUrlSavedOnEmpty().
@@ -240,7 +236,6 @@ func TestAcc_Account_Complete(t *testing.T) {
 						HasNoRegionGroup().
 						HasRegionString(region).
 						HasCommentString(comment).
-						HasConsumptionBillingEntityString(defaultConsumptionBillingEntity).
 						HasIsOrgAdminString(r.BooleanFalse).
 						HasNoGracePeriodInDays(),
 				),
@@ -626,7 +621,7 @@ func TestAcc_Account_TryToCreateWithoutOrgadmin(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      config.FromModels(t, providerModel, configModel),
-				ExpectError: regexp.MustCompile("Error: current user doesn't have the orgadmin role in session"),
+				ExpectError: regexp.MustCompile("Insufficient privileges to operate on account '.*'. Your primary role ACCOUNTADMIN must have MANAGE ORGANIZATION ACCOUNTS granted on ACCOUNT .*"),
 			},
 		},
 	})
@@ -663,11 +658,11 @@ func TestAcc_Account_InvalidValues(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      config.FromModels(t, providerModel, configModelInvalidUserType),
-				ExpectError: regexp.MustCompile("invalid user type: invalid_user_type"),
+				ExpectError: regexp.MustCompile("invalid user type: INVALID_USER_TYPE"),
 			},
 			{
 				Config:      config.FromModels(t, providerModel, configModelInvalidAccountEdition),
-				ExpectError: regexp.MustCompile("unknown account edition: invalid_account_edition"),
+				ExpectError: regexp.MustCompile("invalid account edition: INVALID_ACCOUNT_EDITION"),
 			},
 			{
 				Config:      config.FromModels(t, providerModel, configModelInvalidGracePeriodInDays),
@@ -678,6 +673,7 @@ func TestAcc_Account_InvalidValues(t *testing.T) {
 }
 
 func TestAcc_Account_UpgradeFrom_v0_99_0(t *testing.T) {
+	t.Skip("SNOW-3797718: try with old config")
 	testClient().EnsureValidNonProdAccountIsUsed(t)
 
 	id := random.AccountName()

--- a/pkg/testacc/resource_current_account_acceptance_test.go
+++ b/pkg/testacc/resource_current_account_acceptance_test.go
@@ -38,7 +38,10 @@ func TestAcc_CurrentAccount_Parameters(t *testing.T) {
 
 	provider := providermodel.SnowflakeProvider().WithWarehouse(testClient().Ids.WarehouseId().FullyQualifiedName())
 
-	unsetParametersModel := model.CurrentAccount("test")
+	unsetParametersModel := model.CurrentAccount("test").
+		// TODO [SNOW-3797718]: setting these two explicitly as other tests seem to be rewriting these
+		WithEnableIdentifierFirstLogin(true).
+		WithEnableTriSecretAndRekeyOptOutForImageRepository(false)
 
 	setParametersModel := model.CurrentAccount("test").
 		WithAbortDetachedQuery(true).


### PR DESCRIPTION
Moving accounts to SDK generator integration and acceptance tests needed to be run (they are not part of public CI). They required adjustments (as some of them were incorrect/outdated).
   
  - Skip tests for removed consumption billing entity feature (SNOW-3797718)                                                                                                                                                                                                                                                                                                                                                                                                                            
  - Skip legacy service user type test pending removal decision                                                                                                                                                                                                                                                                                                                                                                                                                                       
  - Skip `unset policy safely` test — error no longer thrown by Snowflake                                                                                                                                                                                                                                                                                                                                                                                                                               
  - Adjust assertions for changed account defaults (edition, comment, marketplace provider billing entity, default streamlit notebook warehouse)                                                                                                                                                                                                                                                                                                                                                      
  - Comment out flaky parameter assertions (`EnableIdentifierFirstLogin`, `EnableTriSecretAndRekeyOptOutForImageRepository`) that get rewritten by other tests                                                                                                                                                                                                                                                                                                                                          
  - Fix error message patterns for invalid user type / account edition (now uppercased)                                                                                                                                                                                                                                                                                                                                                                                                                 
  - Fix error message pattern for missing orgadmin role (Snowflake changed the wording)                                                                                                                                                                                                                                                                                                                                                                                                                 
  - Fix `decodeSnowflakeId` for Account resource (ID is `AccountIdentifier`, needs parsing to `AccountObjectIdentifier`)                                                                                                                                                                                                                                                                                                                                                                                
  - Fix `RandomSensitiveAccountObjectIdentifier` to use `random.AccountName()`                                                                                                                                                                                                                                                                                                                                                                                                                        
  - Change `t.Errorf` to `t.Fatalf` in `EnsureValidNonProdOrganizationAccountIsUsed` to prevent cascading nil panics                                                                                                                                                                                                                                                                                                                                                                                    
  - Skip `UpgradeFrom_v0_99_0` test pending config format fix                                                                                                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  ## References                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
  - SNOW-3797718 