### PR TITLE
chore: Fix failover group tests

### DIFF
--- a/pkg/sdk/testint/failover_groups_integration_test.go
+++ b/pkg/sdk/testint/failover_groups_integration_test.go
@@ -240,14 +240,14 @@ func TestInt_CreateSecondaryReplicationGroup(t *testing.T) {
 
 	// cleanup failover groups with retry (in case of replication delay)
 	cleanupFailoverGroups := func() {
-		failoverGroupDropped := func() bool {
-			return client.FailoverGroups.Drop(ctx, sdk.NewDropFailoverGroupRequest(failoverGroup.ID())) == nil
-		}
-		assert.Eventually(t, failoverGroupDropped, 10*time.Second, time.Second)
 		secondaryClientFailoverGroupDropped := func() bool {
 			return secondaryClient.FailoverGroups.Drop(ctx, sdk.NewDropFailoverGroupRequest(failoverGroup.ID())) == nil
 		}
 		assert.Eventually(t, secondaryClientFailoverGroupDropped, 10*time.Second, time.Second)
+		failoverGroupDropped := func() bool {
+			return client.FailoverGroups.Drop(ctx, sdk.NewDropFailoverGroupRequest(failoverGroup.ID())) == nil
+		}
+		assert.Eventually(t, failoverGroupDropped, 10*time.Second, time.Second)
 	}
 	t.Cleanup(cleanupFailoverGroups)
 
@@ -589,15 +589,32 @@ func TestInt_FailoverGroupsAlterTarget(t *testing.T) {
 		assert.Equal(t, sdk.FailoverGroupSecondaryStateStarted, failoverGroup.SecondaryState)
 	})
 
+	// TODO [SNOW-1348343]: Use:
+	// SELECT phase_name, start_time, end_time, progress, details
+	//  FROM TABLE(
+	//  INFORMATION_SCHEMA.REPLICATION_GROUP_REFRESH_PROGRESS(
+	//    '...'
+	//  )
+	// );
+	// with the END_TIME = NULL
+	// to know when there is no refresh going on
 	t.Run("refresh target failover group", func(t *testing.T) {
-		err = secondaryClient.FailoverGroups.AlterTarget(ctx, sdk.NewAlterTargetFailoverGroupRequest(failoverGroup.ID()).WithRefresh(true))
-		require.NoError(t, err)
+		// Try a few times to avoid:
+		// 003101 (55000): Replication group "..." is already being refreshed. Only one refresh statement can execute at a time.
+		refresh := func() bool {
+			return secondaryClient.FailoverGroups.AlterTarget(ctx, sdk.NewAlterTargetFailoverGroupRequest(failoverGroup.ID()).WithRefresh(true)) == nil
+		}
+		assert.Eventually(t, refresh, 20*time.Second, 1*time.Second)
 	})
 
 	t.Run("promote secondary to primary", func(t *testing.T) {
 		// promote secondary to primary
-		err = secondaryClient.FailoverGroups.AlterTarget(ctx, sdk.NewAlterTargetFailoverGroupRequest(failoverGroup.ID()).WithPrimary(true))
-		require.NoError(t, err)
+		// Try a few times to avoid:
+		// 003122 (55000): Replication group "..." cannot currently be set as primary because it is being refreshed. Either wait for the refresh to finish or cancel the refresh and try again.
+		promote := func() bool {
+			return secondaryClient.FailoverGroups.AlterTarget(ctx, sdk.NewAlterTargetFailoverGroupRequest(failoverGroup.ID()).WithPrimary(true)) == nil
+		}
+		assert.Eventually(t, promote, 20*time.Second, 1*time.Second)
 
 		// verify that target failover group is promoted
 		failoverGroup, err = secondaryClient.FailoverGroups.ShowByID(ctx, failoverGroup.ID())
@@ -640,7 +657,7 @@ func TestInt_FailoverGroupsShow(t *testing.T) {
 		failoverGroups, err := client.FailoverGroups.Show(ctx, sdk.NewShowFailoverGroupRequest())
 		require.NoError(t, err)
 		assert.LessOrEqual(t, 1, len(failoverGroups))
-		assert.Contains(t, failoverGroups, failoverGroupTest)
+		assert.Contains(t, failoverGroups, *failoverGroupTest)
 	})
 
 	t.Run("with show options", func(t *testing.T) {
@@ -648,12 +665,12 @@ func TestInt_FailoverGroupsShow(t *testing.T) {
 			WithInAccount(testClientHelper().Ids.AccountIdentifierWithLocator()))
 		require.NoError(t, err)
 		assert.LessOrEqual(t, 1, len(failoverGroups))
-		assert.Contains(t, failoverGroups, failoverGroupTest)
+		assert.Contains(t, failoverGroups, *failoverGroupTest)
 	})
 
 	t.Run("when searching a non-existent failover group", func(t *testing.T) {
 		_, err := client.FailoverGroups.ShowByID(ctx, NonExistingAccountObjectIdentifier)
-		require.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
+		require.ErrorIs(t, err, sdk.ErrObjectNotFound)
 	})
 }
 

--- a/pkg/testacc/data_source_failover_groups_acceptance_test.go
+++ b/pkg/testacc/data_source_failover_groups_acceptance_test.go
@@ -17,7 +17,9 @@ func TestAcc_FailoverGroups(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
 
 	failoverGroupId := testClient().Ids.RandomAccountObjectIdentifier()
+	currentAccountId := testClient().Account.GetAccountIdentifier(t)
 	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
+	businessCriticalAccountId := sdk.NewAccountIdentifierFromFullyQualifiedName(accountName)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
@@ -27,30 +29,29 @@ func TestAcc_FailoverGroups(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: failoverGroupsConfig(failoverGroupId, accountName),
+				Config: failoverGroupsConfig(failoverGroupId, currentAccountId, businessCriticalAccountId),
 				Check: resource.ComposeTestCheckFunc(
 					// TODO [SNOW-1348343]: fix these assertions - there might be multiple failover groups if we run tests in parallel
-					resource.TestCheckResourceAttr("data.snowflake_failover_groups.d", "failover_groups.#", "1"),
+					resource.TestCheckResourceAttr("data.snowflake_failover_groups.d", "failover_groups.#", "2"),
 					resource.TestCheckResourceAttr("data.snowflake_failover_groups.d", "failover_groups.0.object_types.#", "1"),
 					resource.TestCheckResourceAttr("data.snowflake_failover_groups.d", "failover_groups.0.object_types.0", "ROLES"),
-					resource.TestCheckResourceAttr("data.snowflake_failover_groups.d", "failover_groups.0.allowed_accounts.#", "1"),
-					resource.TestCheckResourceAttr("data.snowflake_failover_groups.d", "failover_groups.0.allowed_accounts.0", accountName),
+					resource.TestCheckResourceAttr("data.snowflake_failover_groups.d", "failover_groups.0.allowed_accounts.#", "2"),
 				),
 			},
 		},
 	})
 }
 
-func failoverGroupsConfig(failoverGroupId sdk.AccountObjectIdentifier, allowedAccount string) string {
+func failoverGroupsConfig(failoverGroupId sdk.AccountObjectIdentifier, currentAccountId sdk.AccountIdentifier, allowedAccountId sdk.AccountIdentifier) string {
 	return fmt.Sprintf(`
 	resource "snowflake_failover_group" "source_failover_group" {
 		name                      = "%s"
 		object_types              = ["ROLES"]
-		allowed_accounts          = ["%s"]
+		allowed_accounts          = ["%s", "%s"]
 	}
 
 	data "snowflake_failover_groups" "d" {
 		depends_on = [snowflake_failover_group.source_failover_group]
 	}
-	`, failoverGroupId.Name(), allowedAccount)
+	`, failoverGroupId.Name(), currentAccountId.Name(), allowedAccountId.Name())
 }

--- a/pkg/testacc/resource_failover_group_acceptance_test.go
+++ b/pkg/testacc/resource_failover_group_acceptance_test.go
@@ -24,8 +24,11 @@ func TestAcc_FailoverGroupBasic(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
 
 	id := testClient().Ids.RandomAccountObjectIdentifier()
+	currentAccountId := testClient().Account.GetAccountIdentifier(t)
 
 	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
+	businessCriticalAccountId := sdk.NewAccountIdentifierFromFullyQualifiedName(accountName)
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -34,12 +37,12 @@ func TestAcc_FailoverGroupBasic(t *testing.T) {
 		CheckDestroy: CheckDestroy(t, resources.FailoverGroup),
 		Steps: []resource.TestStep{
 			{
-				Config: failoverGroupBasic(id.Name(), accountName, TestDatabaseName),
+				Config: failoverGroupBasic(id, currentAccountId, businessCriticalAccountId, testClient().Ids.DatabaseId()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "name", id.Name()),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "fully_qualified_name", id.FullyQualifiedName()),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "object_types.#", "4"),
-					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "2"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_databases.#", "1"),
 					resource.TestCheckTypeSetElemAttr("snowflake_failover_group.fg", "allowed_integration_types.*", "SECURITY INTEGRATIONS"),
 					resource.TestCheckTypeSetElemAttr("snowflake_failover_group.fg", "allowed_integration_types.*", "API INTEGRATIONS"),
@@ -66,8 +69,10 @@ func TestAcc_FailoverGroupRemoveObjectTypes(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
 
 	id := testClient().Ids.RandomAccountObjectIdentifier()
+	currentAccountId := testClient().Account.GetAccountIdentifier(t)
 
 	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
+	businessCriticalAccountId := sdk.NewAccountIdentifierFromFullyQualifiedName(accountName)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -76,22 +81,22 @@ func TestAcc_FailoverGroupRemoveObjectTypes(t *testing.T) {
 		CheckDestroy: CheckDestroy(t, resources.FailoverGroup),
 		Steps: []resource.TestStep{
 			{
-				Config: failoverGroupWithInterval(id.Name(), accountName, 20, TestDatabaseName),
+				Config: failoverGroupWithInterval(id, currentAccountId, businessCriticalAccountId, 20, testClient().Ids.DatabaseId()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "name", id.Name()),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "object_types.#", "4"),
-					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "2"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_databases.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_integration_types.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "replication_schedule.0.interval", "20"),
 				),
 			},
 			{
-				Config: failoverGroupWithNoWarehouse(id.Name(), accountName, 20),
+				Config: failoverGroupWithNoWarehouse(id, currentAccountId, businessCriticalAccountId, 20),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "name", id.Name()),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "object_types.#", "3"),
-					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "2"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_databases.#", "0"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_integration_types.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "replication_schedule.0.interval", "20"),
@@ -106,8 +111,10 @@ func TestAcc_FailoverGroupInterval(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
 
 	id := testClient().Ids.RandomAccountObjectIdentifier()
+	currentAccountId := testClient().Account.GetAccountIdentifier(t)
 
 	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
+	businessCriticalAccountId := sdk.NewAccountIdentifierFromFullyQualifiedName(accountName)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -116,11 +123,11 @@ func TestAcc_FailoverGroupInterval(t *testing.T) {
 		CheckDestroy: CheckDestroy(t, resources.FailoverGroup),
 		Steps: []resource.TestStep{
 			{
-				Config: failoverGroupWithInterval(id.Name(), accountName, 10, TestDatabaseName),
+				Config: failoverGroupWithInterval(id, currentAccountId, businessCriticalAccountId, 10, testClient().Ids.DatabaseId()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "name", id.Name()),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "object_types.#", "4"),
-					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "2"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_databases.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_integration_types.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "replication_schedule.#", "1"),
@@ -130,11 +137,11 @@ func TestAcc_FailoverGroupInterval(t *testing.T) {
 			},
 			// Update Interval
 			{
-				Config: failoverGroupWithInterval(id.Name(), accountName, 20, TestDatabaseName),
+				Config: failoverGroupWithInterval(id, currentAccountId, businessCriticalAccountId, 20, testClient().Ids.DatabaseId()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "name", id.Name()),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "object_types.#", "4"),
-					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "2"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_databases.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_integration_types.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "replication_schedule.#", "1"),
@@ -144,11 +151,11 @@ func TestAcc_FailoverGroupInterval(t *testing.T) {
 			},
 			// Change to Cron Expression
 			{
-				Config: failoverGroupWithCronExpression(id.Name(), accountName, "0 0 10-20 * TUE,THU", TestDatabaseName),
+				Config: failoverGroupWithCronExpression(id, currentAccountId, businessCriticalAccountId, "0 0 10-20 * TUE,THU", testClient().Ids.DatabaseId()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "name", id.Name()),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "object_types.#", "4"),
-					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "2"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_databases.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_integration_types.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "replication_schedule.#", "1"),
@@ -160,11 +167,11 @@ func TestAcc_FailoverGroupInterval(t *testing.T) {
 			},
 			// Update Cron Expression
 			{
-				Config: failoverGroupWithCronExpression(id.Name(), accountName, "0 0 5-20 * TUE,THU", TestDatabaseName),
+				Config: failoverGroupWithCronExpression(id, currentAccountId, businessCriticalAccountId, "0 0 5-20 * TUE,THU", testClient().Ids.DatabaseId()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "name", id.Name()),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "object_types.#", "4"),
-					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "2"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_databases.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_integration_types.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "replication_schedule.#", "1"),
@@ -176,11 +183,11 @@ func TestAcc_FailoverGroupInterval(t *testing.T) {
 			},
 			// Remove replication schedule
 			{
-				Config: failoverGroupWithoutReplicationSchedule(id.Name(), accountName, TestDatabaseName),
+				Config: failoverGroupWithoutReplicationSchedule(id, currentAccountId, businessCriticalAccountId, testClient().Ids.DatabaseId()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "name", id.Name()),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "object_types.#", "4"),
-					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "2"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_databases.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_integration_types.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "replication_schedule.#", "0"),
@@ -188,11 +195,11 @@ func TestAcc_FailoverGroupInterval(t *testing.T) {
 			},
 			// Change to Interval
 			{
-				Config: failoverGroupWithInterval(id.Name(), accountName, 10, TestDatabaseName),
+				Config: failoverGroupWithInterval(id, currentAccountId, businessCriticalAccountId, 10, testClient().Ids.DatabaseId()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "name", id.Name()),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "object_types.#", "4"),
-					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "2"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_databases.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_integration_types.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "replication_schedule.#", "1"),
@@ -216,8 +223,10 @@ func TestAcc_FailoverGroup_issue2517(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
 
 	id := testClient().Ids.RandomAccountObjectIdentifier()
+	currentAccountId := testClient().Account.GetAccountIdentifier(t)
 
 	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
+	businessCriticalAccountId := sdk.NewAccountIdentifierFromFullyQualifiedName(accountName)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -226,11 +235,11 @@ func TestAcc_FailoverGroup_issue2517(t *testing.T) {
 		CheckDestroy: CheckDestroy(t, resources.FailoverGroup),
 		Steps: []resource.TestStep{
 			{
-				Config: failoverGroupWithAccountParameters(id.Name(), accountName, TestDatabaseName),
+				Config: failoverGroupWithAccountParameters(id, currentAccountId, businessCriticalAccountId, testClient().Ids.DatabaseId()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "name", id.Name()),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "object_types.#", "5"),
-					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "1"),
+					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_accounts.#", "2"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_databases.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "allowed_integration_types.#", "1"),
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "replication_schedule.0.cron.0.expression", "0 0 10-20 * TUE,THU"),
@@ -246,8 +255,11 @@ func TestAcc_FailoverGroup_issue2544(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestFailoverGroups)
 
 	id := testClient().Ids.RandomAccountObjectIdentifier()
+	currentAccountId := testClient().Account.GetAccountIdentifier(t)
 
 	accountName := testenvs.GetOrSkipTest(t, testenvs.BusinessCriticalAccount)
+	businessCriticalAccountId := sdk.NewAccountIdentifierFromFullyQualifiedName(accountName)
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -256,13 +268,13 @@ func TestAcc_FailoverGroup_issue2544(t *testing.T) {
 		CheckDestroy: CheckDestroy(t, resources.FailoverGroup),
 		Steps: []resource.TestStep{
 			{
-				Config: failoverGroupBasic(id.Name(), accountName, TestDatabaseName),
+				Config: failoverGroupBasic(id, currentAccountId, businessCriticalAccountId, testClient().Ids.DatabaseId()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "name", id.Name()),
 				),
 			},
 			{
-				Config: failoverGroupWithChanges(id.Name(), accountName, 20),
+				Config: failoverGroupWithChanges(id, currentAccountId, businessCriticalAccountId, 20),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_failover_group.fg", "name", id.Name()),
 				),
@@ -271,12 +283,14 @@ func TestAcc_FailoverGroup_issue2544(t *testing.T) {
 	})
 }
 
-func failoverGroupBasic(randomCharacters, accountName, databaseName string) string {
+// TODO [SNOW-1348343]: current account id passed on purpose; handle properly during resource rework
+func failoverGroupBasic(failoverGroupId sdk.AccountObjectIdentifier, currentAccountId sdk.AccountIdentifier, allowedAccountId sdk.AccountIdentifier, databaseId sdk.AccountObjectIdentifier) string {
+
 	return fmt.Sprintf(`
 resource "snowflake_failover_group" "fg" {
 	name = "%s"
 	object_types = ["WAREHOUSES", "DATABASES", "INTEGRATIONS", "ROLES"]
-	allowed_accounts= ["%s"]
+	allowed_accounts= ["%s", "%s"]
 	allowed_databases = ["%s"]
 	allowed_integration_types = ["SECURITY INTEGRATIONS", "API INTEGRATIONS", "STORAGE INTEGRATIONS", "EXTERNAL ACCESS INTEGRATIONS", "NOTIFICATION INTEGRATIONS"]
 	replication_schedule {
@@ -286,56 +300,56 @@ resource "snowflake_failover_group" "fg" {
 		}
 	}
 }
-`, randomCharacters, accountName, databaseName)
+`, failoverGroupId.Name(), currentAccountId.Name(), allowedAccountId.Name(), databaseId.Name())
 }
 
-func failoverGroupWithInterval(randomCharacters, accountName string, interval int, databaseName string) string {
+func failoverGroupWithInterval(id sdk.AccountObjectIdentifier, currentAccountId sdk.AccountIdentifier, allowedAccountId sdk.AccountIdentifier, interval int, databaseId sdk.AccountObjectIdentifier) string {
 	return fmt.Sprintf(`
 resource "snowflake_failover_group" "fg" {
 	name = "%s"
 	object_types = ["WAREHOUSES","DATABASES", "INTEGRATIONS", "ROLES"]
-	allowed_accounts= ["%s"]
+	allowed_accounts= ["%s", "%s"]
 	allowed_databases = ["%s"]
 	allowed_integration_types = ["SECURITY INTEGRATIONS"]
 	replication_schedule {
 		interval = %d
 	}
 }
-`, randomCharacters, accountName, databaseName, interval)
+`, id.Name(), currentAccountId.Name(), allowedAccountId.Name(), databaseId.Name(), interval)
 }
 
-func failoverGroupWithoutReplicationSchedule(randomCharacters, accountName string, databaseName string) string {
+func failoverGroupWithoutReplicationSchedule(id sdk.AccountObjectIdentifier, currentAccountId sdk.AccountIdentifier, allowedAccountId sdk.AccountIdentifier, databaseId sdk.AccountObjectIdentifier) string {
 	return fmt.Sprintf(`
 resource "snowflake_failover_group" "fg" {
 	name = "%s"
 	object_types = ["WAREHOUSES","DATABASES", "INTEGRATIONS", "ROLES"]
-	allowed_accounts= ["%s"]
+	allowed_accounts= ["%s", "%s"]
 	allowed_databases = ["%s"]
 	allowed_integration_types = ["SECURITY INTEGRATIONS"]
 }
-`, randomCharacters, accountName, databaseName)
+`, id.Name(), currentAccountId.Name(), allowedAccountId.Name(), databaseId.Name())
 }
 
-func failoverGroupWithNoWarehouse(randomCharacters, accountName string, interval int) string {
+func failoverGroupWithNoWarehouse(id sdk.AccountObjectIdentifier, currentAccountId sdk.AccountIdentifier, allowedAccountId sdk.AccountIdentifier, interval int) string {
 	return fmt.Sprintf(`
 resource "snowflake_failover_group" "fg" {
 	name = "%s"
 	object_types = ["DATABASES", "INTEGRATIONS", "ROLES"]
-	allowed_accounts= ["%s"]
+	allowed_accounts= ["%s", "%s"]
 	allowed_integration_types = ["SECURITY INTEGRATIONS"]
 	replication_schedule {
 		interval = %d
 	}
 }
-`, randomCharacters, accountName, interval)
+`, id.Name(), currentAccountId.Name(), allowedAccountId.Name(), interval)
 }
 
-func failoverGroupWithCronExpression(randomCharacters, accountName, expression, databaseName string) string {
+func failoverGroupWithCronExpression(id sdk.AccountObjectIdentifier, currentAccountId sdk.AccountIdentifier, allowedAccountId sdk.AccountIdentifier, expression string, databaseId sdk.AccountObjectIdentifier) string {
 	return fmt.Sprintf(`
 resource "snowflake_failover_group" "fg" {
 	name = "%s"
 	object_types = ["WAREHOUSES","DATABASES", "INTEGRATIONS", "ROLES"]
-	allowed_accounts= ["%s"]
+	allowed_accounts= ["%s", "%s"]
 	allowed_databases = ["%s"]
 	allowed_integration_types = ["SECURITY INTEGRATIONS"]
 	replication_schedule {
@@ -345,15 +359,15 @@ resource "snowflake_failover_group" "fg" {
 		}
 	}
 }
-`, randomCharacters, accountName, databaseName, expression)
+`, id.Name(), currentAccountId.Name(), allowedAccountId.Name(), databaseId.Name(), expression)
 }
 
-func failoverGroupWithAccountParameters(randomCharacters, accountName, databaseName string) string {
+func failoverGroupWithAccountParameters(id sdk.AccountObjectIdentifier, currentAccountId sdk.AccountIdentifier, allowedAccountId sdk.AccountIdentifier, databaseId sdk.AccountObjectIdentifier) string {
 	return fmt.Sprintf(`
 resource "snowflake_failover_group" "fg" {
 	name = "%s"
 	object_types = ["ACCOUNT PARAMETERS", "WAREHOUSES", "DATABASES", "INTEGRATIONS", "ROLES"]
-	allowed_accounts= ["%s"]
+	allowed_accounts= ["%s", "%s"]
 	allowed_databases = ["%s"]
 	allowed_integration_types = ["SECURITY INTEGRATIONS"]
 	replication_schedule {
@@ -363,21 +377,21 @@ resource "snowflake_failover_group" "fg" {
 		}
 	}
 }
-`, randomCharacters, accountName, databaseName)
+`, id.Name(), currentAccountId.Name(), allowedAccountId.Name(), databaseId.Name())
 }
 
-func failoverGroupWithChanges(randomCharacters string, accountName string, interval int) string {
+func failoverGroupWithChanges(id sdk.AccountObjectIdentifier, currentAccountId sdk.AccountIdentifier, allowedAccountId sdk.AccountIdentifier, interval int) string {
 	return fmt.Sprintf(`
 resource "snowflake_failover_group" "fg" {
 	name = "%[1]s"
 	object_types = ["DATABASES", "INTEGRATIONS"]
-	allowed_accounts= ["%[2]s"]
+	allowed_accounts= ["%[2]s", "%[3]s"]
 	allowed_integration_types = ["NOTIFICATION INTEGRATIONS"]
 	replication_schedule {
 		interval = %d
 	}
 }
-`, randomCharacters, accountName, interval)
+`, id.Name(), currentAccountId.Name(), allowedAccountId.Name(), interval)
 }
 
 func TestAcc_FailoverGroup_UpdateAllowedAccounts(t *testing.T) {
@@ -485,9 +499,6 @@ resource "snowflake_failover_group" "fg" {
 func TestAcc_FailoverGroup_InvalidObjectType(t *testing.T) {
 	id := testClient().Ids.RandomAccountObjectIdentifier()
 
-	providerModel := providermodel.SnowflakeProvider().
-		WithPreviewFeaturesEnabled(string(previewfeatures.FailoverGroupResource))
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -497,7 +508,7 @@ func TestAcc_FailoverGroup_InvalidObjectType(t *testing.T) {
 		Steps: []resource.TestStep{
 			// An object type outside the supported plural object type set is rejected during create.
 			{
-				Config:      config.FromModels(t, providerModel) + failoverGroupWithObjectTypes(id.Name(), `"DATABASES", "INVALID OBJECT TYPE;"`),
+				Config:      failoverGroupWithObjectTypes(id.Name(), `"DATABASES", "INVALID OBJECT TYPE;"`),
 				ExpectError: regexp.MustCompile("invalid plural object type: INVALID OBJECT TYPE;"),
 			},
 		},

--- a/pkg/testacc/resource_failover_group_acceptance_test.go
+++ b/pkg/testacc/resource_failover_group_acceptance_test.go
@@ -285,7 +285,6 @@ func TestAcc_FailoverGroup_issue2544(t *testing.T) {
 
 // TODO [SNOW-1348343]: current account id passed on purpose; handle properly during resource rework
 func failoverGroupBasic(failoverGroupId sdk.AccountObjectIdentifier, currentAccountId sdk.AccountIdentifier, allowedAccountId sdk.AccountIdentifier, databaseId sdk.AccountObjectIdentifier) string {
-
 	return fmt.Sprintf(`
 resource "snowflake_failover_group" "fg" {
 	name = "%s"


### PR DESCRIPTION
Failover group tests are not run as part of CI. There were quite outdated.

  - Refactor failover group acceptance test config functions to use typed SDK identifiers (`sdk.AccountObjectIdentifier`, `sdk.AccountIdentifier`) instead of raw strings                                                                                                                                                                                                                                                                                                                               
  - Add `currentAccountId` to all failover group config functions, including both the current account and the business critical account in `allowed_accounts`                                                                                                                                                                                                                                                                                                                                         
  - Update failover group integration test to use typed identifiers and include current account in `allowed_accounts`                                                                                                                                                                                                                                                                                                                                                                                   
  - Update `allowed_accounts.#` assertions from `"1"` to `"2"` to reflect the additional account                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  All config helper functions (`failoverGroupWithInterval`, `failoverGroupWithCronExpression`, `failoverGroupWithoutReplicationSchedule`, `failoverGroupWithNoWarehouse`, `failoverGroupWithAccountParameters`, `failoverGroupWithChanges`, `failoverGroupsConfig`) now follow the same pattern as `failoverGroupBasic`: typed parameters with `.Name()` extraction in templates.                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
## Tests
Tests were run manually:
```
  TEST_SF_TF_GENERATED_RANDOM_VALUE=ABC123 TEST_SF_TF_TEST_FAILOVER_GROUPS=1 SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT=<org_name>.<acc_name> go test -tags=non_account_level_tests -run "^TestInt_FailoverGroup|^TestInt_Issue2544|^TestInt_CreateSecondaryReplicationGroup" -v -timeout=10m ./pkg/sdk/testint
  SF_TF_ACC_TEST_ENABLE_ALL_PREVIEW_FEATURES=true TEST_SF_TF_GENERATED_RANDOM_VALUE=ABC123 TEST_SF_TF_TEST_FAILOVER_GROUPS=1 SNOWFLAKE_BUSINESS_CRITICAL_ACCOUNT=<org_name>.<acc_name> TF_ACC=1 TF_LOG=DEBUG go test -tags=non_account_level_tests -run "^TestAcc_FailoverGroup|^TestAcc_FailoverGroups$" -v -timeout=10m ./pkg/testacc
```
resulting in
```
  2026/07/17 15:08:06 [DEBUG] tests took 1m28.082661333s
  ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/testint  89.326s
  2026/07/17 15:15:58 [INFO] Timer stop: acceptance tests took 2m17.055462208s
  ok      github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testacc      139.692s
```