### PR TITLE
chore: Add bool and identifier create builder helpers

### DIFF
--- a/pkg/resources/oauth_integration_for_custom_clients.go
+++ b/pkg/resources/oauth_integration_for_custom_clients.go
@@ -373,8 +373,8 @@ func CreateContextOauthIntegrationForCustomClients(ctx context.Context, d *schem
 		req.WithOauthRefreshTokenValidity(v)
 	}
 
-	if v, ok := d.GetOk("network_policy"); ok {
-		req.WithNetworkPolicy(sdk.NewAccountObjectIdentifier(v.(string)))
+	if err := accountObjectIdentifierAttributeCreateBuilder(d, "network_policy", req.WithNetworkPolicy); err != nil {
+		return diag.FromErr(err)
 	}
 
 	if v, ok := d.GetOk("oauth_client_rsa_public_key"); ok {

--- a/pkg/resources/resource_helpers_create.go
+++ b/pkg/resources/resource_helpers_create.go
@@ -54,6 +54,13 @@ func boolAttributeCreate(d *schema.ResourceData, key string, createField **bool)
 	return nil
 }
 
+func boolAttributeCreateBuilder[T any](d *schema.ResourceData, key string, setValue func(bool) T) error {
+	if v, ok := d.GetOk(key); ok {
+		setValue(v.(bool))
+	}
+	return nil
+}
+
 func booleanStringAttributeCreate(d *schema.ResourceData, key string, createField **bool) error {
 	if v := d.Get(key).(string); v != BooleanDefault {
 		parsed, err := booleanStringToBool(v)
@@ -111,6 +118,13 @@ func schemaObjectIdentifierAttributeCreate(d *schema.ResourceData, key string, c
 func accountObjectIdentifierAttributeCreate(d *schema.ResourceData, key string, createField **sdk.AccountObjectIdentifier) error {
 	if v, ok := d.GetOk(key); ok {
 		*createField = sdk.Pointer(sdk.NewAccountObjectIdentifier(v.(string)))
+	}
+	return nil
+}
+
+func accountObjectIdentifierAttributeCreateBuilder[T any](d *schema.ResourceData, key string, setValue func(sdk.AccountObjectIdentifier) T) error {
+	if v, ok := d.GetOk(key); ok {
+		setValue(sdk.NewAccountObjectIdentifier(v.(string)))
 	}
 	return nil
 }

--- a/pkg/resources/scim_integration.go
+++ b/pkg/resources/scim_integration.go
@@ -202,8 +202,8 @@ func CreateContextSCIMIntegration(ctx context.Context, d *schema.ResourceData, m
 	runAsRole, _ := scimIntegrationRunAsRoleToAccountObjectIdentifier(runAsRoleRaw)
 	req := sdk.NewCreateScimSecurityIntegrationRequest(id, scimClient, runAsRole).WithEnabled(d.Get("enabled").(bool))
 
-	if v, ok := d.GetOk("network_policy"); ok {
-		req.WithNetworkPolicy(sdk.NewAccountObjectIdentifier(v.(string)))
+	if err := accountObjectIdentifierAttributeCreateBuilder(d, "network_policy", req.WithNetworkPolicy); err != nil {
+		return diag.FromErr(err)
 	}
 
 	if v := d.Get("sync_password").(string); v != BooleanDefault {

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -356,11 +356,11 @@ func CreateWarehouse(ctx context.Context, d *schema.ResourceData, meta any) diag
 		}
 		request.WithAutoResume(parsed)
 	}
-	if v, ok := d.GetOk("initially_suspended"); ok {
-		request.WithInitiallySuspended(v.(bool))
-	}
-	if v, ok := d.GetOk("resource_monitor"); ok {
-		request.WithResourceMonitor(sdk.NewAccountObjectIdentifier(v.(string)))
+	if err := errors.Join(
+		boolAttributeCreateBuilder(d, "initially_suspended", request.WithInitiallySuspended),
+		accountObjectIdentifierAttributeCreateBuilder(d, "resource_monitor", request.WithResourceMonitor),
+	); err != nil {
+		return diag.FromErr(err)
 	}
 	if v, ok := d.GetOk("comment"); ok {
 		request.WithComment(v.(string))

--- a/pkg/resources/warehouse_interactive.go
+++ b/pkg/resources/warehouse_interactive.go
@@ -285,17 +285,10 @@ func CreateWarehouseInteractive(ctx context.Context, d *schema.ResourceData, met
 		}
 		req.WithTables(tables)
 	}
-	if v, ok := d.GetOk("initially_suspended"); ok {
-		req.WithInitiallySuspended(v.(bool))
-	}
-	if v, ok := d.GetOk("resource_monitor"); ok {
-		req.WithResourceMonitor(sdk.NewAccountObjectIdentifier(v.(string)))
-	}
-	if v, ok := d.GetOk("fallback_warehouse"); ok {
-		req.WithFallbackWarehouse(sdk.NewAccountObjectIdentifier(v.(string)))
-	}
-
 	errs := errors.Join(
+		boolAttributeCreateBuilder(d, "initially_suspended", req.WithInitiallySuspended),
+		accountObjectIdentifierAttributeCreateBuilder(d, "resource_monitor", req.WithResourceMonitor),
+		accountObjectIdentifierAttributeCreateBuilder(d, "fallback_warehouse", req.WithFallbackWarehouse),
 		attributeMappedValueCreateBuilder(d, "warehouse_size", req.WithWarehouseSize, sdk.ToWarehouseSize),
 		intAttributeCreateBuilder(d, "max_cluster_count", req.WithMaxClusterCount),
 		intAttributeCreateBuilder(d, "min_cluster_count", req.WithMinClusterCount),


### PR DESCRIPTION
Add `boolAttributeCreateBuilder` and `accountObjectIdentifierAttributeCreateBuilder` to `resource_helpers_create.go`, following up on discussion in #5009 to extract the `GetOk`-guarded builder patterns used by `warehouse_interactive.go`.