### PR TITLE
chore: simplify streamlit external access integrations to use inline list assignment

### DIFF
--- a/pkg/resources/streamlit.go
+++ b/pkg/resources/streamlit.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"reflect"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
@@ -238,9 +239,7 @@ func CreateContextStreamlit(ctx context.Context, d *schema.ResourceData, meta an
 		for i, v := range raw {
 			integrations[i] = sdk.NewAccountObjectIdentifier(v)
 		}
-		req.WithExternalAccessIntegrations(sdk.ExternalAccessIntegrationsRequest{
-			ExternalAccessIntegrations: integrations,
-		})
+		req.WithExternalAccessIntegrations(integrations)
 	}
 
 	if err := client.Streamlits.Create(ctx, req); err != nil {
@@ -397,20 +396,22 @@ func UpdateContextStreamlit(ctx context.Context, d *schema.ResourceData, meta an
 
 	if d.HasChange("external_access_integrations") {
 		raw := expandStringList(d.Get("external_access_integrations").(*schema.Set).List())
-		integrations := make([]sdk.AccountObjectIdentifier, len(raw))
-		for i, v := range raw {
-			integrationId, err := sdk.ParseAccountObjectIdentifier(v)
-			if err != nil {
-				return diag.FromErr(err)
+		if len(raw) == 0 {
+			unset.WithExternalAccessIntegrations(true)
+		} else {
+			integrations := make([]sdk.AccountObjectIdentifier, len(raw))
+			for i, v := range raw {
+				integrationId, err := sdk.ParseAccountObjectIdentifier(v)
+				if err != nil {
+					return diag.FromErr(err)
+				}
+				integrations[i] = integrationId
 			}
-			integrations[i] = integrationId
+			set.WithExternalAccessIntegrations(integrations)
 		}
-		set.WithExternalAccessIntegrations(sdk.ExternalAccessIntegrationsRequest{
-			ExternalAccessIntegrations: integrations,
-		})
 	}
 
-	if (*set != sdk.StreamlitSetRequest{}) {
+	if !reflect.DeepEqual(*set, sdk.StreamlitSetRequest{}) {
 		if err := client.Streamlits.Alter(ctx, sdk.NewAlterStreamlitRequest(id).WithSet(*set)); err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/sdk/generator/defs/streamlits_def.go
+++ b/pkg/sdk/generator/defs/streamlits_def.go
@@ -6,14 +6,11 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/generator/gen/sdkcommons"
 )
 
-var externalAccessIntegrations = g.NewQueryStruct("ExternalAccessIntegrations").
-	List("ExternalAccessIntegrations", "AccountObjectIdentifier", g.ListOptions().Required().MustParentheses())
-
 var streamlitSet = g.NewQueryStruct("StreamlitSet").
 	OptionalTextAssignment("ROOT_LOCATION", g.ParameterOptions().SingleQuotes()).
 	OptionalTextAssignment("MAIN_FILE", g.ParameterOptions().SingleQuotes()).
 	OptionalIdentifier("QueryWarehouse", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().Equals().SQL("QUERY_WAREHOUSE")).
-	OptionalQueryStructField("ExternalAccessIntegrations", externalAccessIntegrations, g.ParameterOptions().SQL("EXTERNAL_ACCESS_INTEGRATIONS").Parentheses()).
+	ListAssignment("EXTERNAL_ACCESS_INTEGRATIONS", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.ParameterOptions().Parentheses()).
 	OptionalTextAssignment("COMMENT", g.ParameterOptions().SingleQuotes()).
 	OptionalTextAssignment("TITLE", g.ParameterOptions().SingleQuotes()).
 	WithValidation(g.ValidIdentifierIfSet, "QueryWarehouse").
@@ -23,7 +20,8 @@ var streamlitUnset = g.NewQueryStruct("StreamlitUnset").
 	OptionalSQL("QUERY_WAREHOUSE").
 	OptionalSQL("COMMENT").
 	OptionalSQL("TITLE").
-	WithValidation(g.AtLeastOneValueSet, "QueryWarehouse", "Title", "Comment")
+	OptionalSQL("EXTERNAL_ACCESS_INTEGRATIONS").
+	WithValidation(g.AtLeastOneValueSet, "QueryWarehouse", "Title", "Comment", "ExternalAccessIntegrations")
 
 var streamlitsDef = g.NewInterface(
 	"Streamlits",
@@ -40,7 +38,7 @@ var streamlitsDef = g.NewInterface(
 		TextAssignment("ROOT_LOCATION", g.ParameterOptions().SingleQuotes().Required()).
 		TextAssignment("MAIN_FILE", g.ParameterOptions().SingleQuotes().Required()).
 		OptionalIdentifier("QueryWarehouse", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.IdentifierOptions().Equals().SQL("QUERY_WAREHOUSE")).
-		OptionalQueryStructField("ExternalAccessIntegrations", externalAccessIntegrations, g.ParameterOptions().SQL("EXTERNAL_ACCESS_INTEGRATIONS").Parentheses()).
+		ListAssignment("EXTERNAL_ACCESS_INTEGRATIONS", g.KindOfT[sdkcommons.AccountObjectIdentifier](), g.ParameterOptions().Parentheses()).
 		OptionalTextAssignment("TITLE", g.ParameterOptions().SingleQuotes()).
 		OptionalTextAssignment("COMMENT", g.ParameterOptions().SingleQuotes()).
 		WithValidation(g.ValidIdentifier, "name").

--- a/pkg/sdk/streamlits_dto_builders_gen.go
+++ b/pkg/sdk/streamlits_dto_builders_gen.go
@@ -29,8 +29,8 @@ func (s *CreateStreamlitRequest) WithQueryWarehouse(queryWarehouse AccountObject
 	return s
 }
 
-func (s *CreateStreamlitRequest) WithExternalAccessIntegrations(externalAccessIntegrations ExternalAccessIntegrationsRequest) *CreateStreamlitRequest {
-	s.ExternalAccessIntegrations = &externalAccessIntegrations
+func (s *CreateStreamlitRequest) WithExternalAccessIntegrations(externalAccessIntegrations []AccountObjectIdentifier) *CreateStreamlitRequest {
+	s.ExternalAccessIntegrations = externalAccessIntegrations
 	return s
 }
 
@@ -42,14 +42,6 @@ func (s *CreateStreamlitRequest) WithTitle(title string) *CreateStreamlitRequest
 func (s *CreateStreamlitRequest) WithComment(comment string) *CreateStreamlitRequest {
 	s.Comment = &comment
 	return s
-}
-
-func NewExternalAccessIntegrationsRequest(
-	externalAccessIntegrations []AccountObjectIdentifier,
-) *ExternalAccessIntegrationsRequest {
-	s := ExternalAccessIntegrationsRequest{}
-	s.ExternalAccessIntegrations = externalAccessIntegrations
-	return &s
 }
 
 func NewAlterStreamlitRequest(
@@ -100,8 +92,8 @@ func (s *StreamlitSetRequest) WithQueryWarehouse(queryWarehouse AccountObjectIde
 	return s
 }
 
-func (s *StreamlitSetRequest) WithExternalAccessIntegrations(externalAccessIntegrations ExternalAccessIntegrationsRequest) *StreamlitSetRequest {
-	s.ExternalAccessIntegrations = &externalAccessIntegrations
+func (s *StreamlitSetRequest) WithExternalAccessIntegrations(externalAccessIntegrations []AccountObjectIdentifier) *StreamlitSetRequest {
+	s.ExternalAccessIntegrations = externalAccessIntegrations
 	return s
 }
 
@@ -132,6 +124,11 @@ func (s *StreamlitUnsetRequest) WithComment(comment bool) *StreamlitUnsetRequest
 
 func (s *StreamlitUnsetRequest) WithTitle(title bool) *StreamlitUnsetRequest {
 	s.Title = &title
+	return s
+}
+
+func (s *StreamlitUnsetRequest) WithExternalAccessIntegrations(externalAccessIntegrations bool) *StreamlitUnsetRequest {
+	s.ExternalAccessIntegrations = &externalAccessIntegrations
 	return s
 }
 

--- a/pkg/sdk/streamlits_dto_gen.go
+++ b/pkg/sdk/streamlits_dto_gen.go
@@ -17,13 +17,9 @@ type CreateStreamlitRequest struct {
 	RootLocation               string                 // required
 	MainFile                   string                 // required
 	QueryWarehouse             *AccountObjectIdentifier
-	ExternalAccessIntegrations *ExternalAccessIntegrationsRequest
+	ExternalAccessIntegrations []AccountObjectIdentifier
 	Title                      *string
 	Comment                    *string
-}
-
-type ExternalAccessIntegrationsRequest struct {
-	ExternalAccessIntegrations []AccountObjectIdentifier // required
 }
 
 type AlterStreamlitRequest struct {
@@ -38,15 +34,16 @@ type StreamlitSetRequest struct {
 	RootLocation               *string
 	MainFile                   *string
 	QueryWarehouse             *AccountObjectIdentifier
-	ExternalAccessIntegrations *ExternalAccessIntegrationsRequest
+	ExternalAccessIntegrations []AccountObjectIdentifier
 	Comment                    *string
 	Title                      *string
 }
 
 type StreamlitUnsetRequest struct {
-	QueryWarehouse *bool
-	Comment        *bool
-	Title          *bool
+	QueryWarehouse             *bool
+	Comment                    *bool
+	Title                      *bool
+	ExternalAccessIntegrations *bool
 }
 
 type DropStreamlitRequest struct {

--- a/pkg/sdk/streamlits_gen.go
+++ b/pkg/sdk/streamlits_gen.go
@@ -20,21 +20,17 @@ type Streamlits interface {
 
 // CreateStreamlitOptions is based on https://docs.snowflake.com/en/sql-reference/sql/create-streamlit.
 type CreateStreamlitOptions struct {
-	create                     bool                        `ddl:"static" sql:"CREATE"`
-	OrReplace                  *bool                       `ddl:"keyword" sql:"OR REPLACE"`
-	streamlit                  bool                        `ddl:"static" sql:"STREAMLIT"`
-	IfNotExists                *bool                       `ddl:"keyword" sql:"IF NOT EXISTS"`
-	name                       SchemaObjectIdentifier      `ddl:"identifier"`
-	RootLocation               string                      `ddl:"parameter,single_quotes" sql:"ROOT_LOCATION"`
-	MainFile                   string                      `ddl:"parameter,single_quotes" sql:"MAIN_FILE"`
-	QueryWarehouse             *AccountObjectIdentifier    `ddl:"identifier,equals" sql:"QUERY_WAREHOUSE"`
-	ExternalAccessIntegrations *ExternalAccessIntegrations `ddl:"parameter,parentheses" sql:"EXTERNAL_ACCESS_INTEGRATIONS"`
-	Title                      *string                     `ddl:"parameter,single_quotes" sql:"TITLE"`
-	Comment                    *string                     `ddl:"parameter,single_quotes" sql:"COMMENT"`
-}
-
-type ExternalAccessIntegrations struct {
-	ExternalAccessIntegrations []AccountObjectIdentifier `ddl:"list,must_parentheses"`
+	create                     bool                      `ddl:"static" sql:"CREATE"`
+	OrReplace                  *bool                     `ddl:"keyword" sql:"OR REPLACE"`
+	streamlit                  bool                      `ddl:"static" sql:"STREAMLIT"`
+	IfNotExists                *bool                     `ddl:"keyword" sql:"IF NOT EXISTS"`
+	name                       SchemaObjectIdentifier    `ddl:"identifier"`
+	RootLocation               string                    `ddl:"parameter,single_quotes" sql:"ROOT_LOCATION"`
+	MainFile                   string                    `ddl:"parameter,single_quotes" sql:"MAIN_FILE"`
+	QueryWarehouse             *AccountObjectIdentifier  `ddl:"identifier,equals" sql:"QUERY_WAREHOUSE"`
+	ExternalAccessIntegrations []AccountObjectIdentifier `ddl:"parameter,parentheses" sql:"EXTERNAL_ACCESS_INTEGRATIONS"`
+	Title                      *string                   `ddl:"parameter,single_quotes" sql:"TITLE"`
+	Comment                    *string                   `ddl:"parameter,single_quotes" sql:"COMMENT"`
 }
 
 // AlterStreamlitOptions is based on https://docs.snowflake.com/en/sql-reference/sql/alter-streamlit.
@@ -49,18 +45,19 @@ type AlterStreamlitOptions struct {
 }
 
 type StreamlitSet struct {
-	RootLocation               *string                     `ddl:"parameter,single_quotes" sql:"ROOT_LOCATION"`
-	MainFile                   *string                     `ddl:"parameter,single_quotes" sql:"MAIN_FILE"`
-	QueryWarehouse             *AccountObjectIdentifier    `ddl:"identifier,equals" sql:"QUERY_WAREHOUSE"`
-	ExternalAccessIntegrations *ExternalAccessIntegrations `ddl:"parameter,parentheses" sql:"EXTERNAL_ACCESS_INTEGRATIONS"`
-	Comment                    *string                     `ddl:"parameter,single_quotes" sql:"COMMENT"`
-	Title                      *string                     `ddl:"parameter,single_quotes" sql:"TITLE"`
+	RootLocation               *string                   `ddl:"parameter,single_quotes" sql:"ROOT_LOCATION"`
+	MainFile                   *string                   `ddl:"parameter,single_quotes" sql:"MAIN_FILE"`
+	QueryWarehouse             *AccountObjectIdentifier  `ddl:"identifier,equals" sql:"QUERY_WAREHOUSE"`
+	ExternalAccessIntegrations []AccountObjectIdentifier `ddl:"parameter,parentheses" sql:"EXTERNAL_ACCESS_INTEGRATIONS"`
+	Comment                    *string                   `ddl:"parameter,single_quotes" sql:"COMMENT"`
+	Title                      *string                   `ddl:"parameter,single_quotes" sql:"TITLE"`
 }
 
 type StreamlitUnset struct {
-	QueryWarehouse *bool `ddl:"keyword" sql:"QUERY_WAREHOUSE"`
-	Comment        *bool `ddl:"keyword" sql:"COMMENT"`
-	Title          *bool `ddl:"keyword" sql:"TITLE"`
+	QueryWarehouse             *bool `ddl:"keyword" sql:"QUERY_WAREHOUSE"`
+	Comment                    *bool `ddl:"keyword" sql:"COMMENT"`
+	Title                      *bool `ddl:"keyword" sql:"TITLE"`
+	ExternalAccessIntegrations *bool `ddl:"keyword" sql:"EXTERNAL_ACCESS_INTEGRATIONS"`
 }
 
 // DropStreamlitOptions is based on https://docs.snowflake.com/en/sql-reference/sql/drop-streamlit.

--- a/pkg/sdk/streamlits_gen_test.go
+++ b/pkg/sdk/streamlits_gen_test.go
@@ -112,10 +112,10 @@ func TestStreamlits_Alter(t *testing.T) {
 		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterStreamlitOptions.Set", "RootLocation", "MainFile", "QueryWarehouse", "ExternalAccessIntegrations", "Comment", "Title"))
 	})
 
-	t.Run("validation: at least one of the fields [opts.Unset.QueryWarehouse opts.Unset.Title opts.Unset.Comment] should be set", func(t *testing.T) {
+	t.Run("validation: at least one of the fields [opts.Unset.QueryWarehouse opts.Unset.Title opts.Unset.Comment opts.Unset.ExternalAccessIntegrations] should be set", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Unset = new(StreamlitUnset)
-		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterStreamlitOptions.Unset", "QueryWarehouse", "Title", "Comment"))
+		assertOptsInvalidJoinedErrors(t, opts, errAtLeastOneOf("AlterStreamlitOptions.Unset", "QueryWarehouse", "Title", "Comment", "ExternalAccessIntegrations"))
 	})
 
 	// all variants added manually
@@ -128,7 +128,7 @@ func TestStreamlits_Alter(t *testing.T) {
 			RootLocation:               String("@test"),
 			MainFile:                   String("manifest.yml"),
 			QueryWarehouse:             &warehouse,
-			ExternalAccessIntegrations: &ExternalAccessIntegrations{[]AccountObjectIdentifier{integration}},
+			ExternalAccessIntegrations: []AccountObjectIdentifier{integration},
 			Comment:                    String("test"),
 			Title:                      String("foo"),
 		}
@@ -138,11 +138,12 @@ func TestStreamlits_Alter(t *testing.T) {
 	t.Run("alter: unset options", func(t *testing.T) {
 		opts := defaultOpts()
 		opts.Unset = &StreamlitUnset{
-			QueryWarehouse: Pointer(true),
-			Comment:        Pointer(true),
-			Title:          Pointer(true),
+			QueryWarehouse:             Pointer(true),
+			Comment:                    Pointer(true),
+			Title:                      Pointer(true),
+			ExternalAccessIntegrations: Pointer(true),
 		}
-		assertOptsValidAndSQLEquals(t, opts, `ALTER STREAMLIT IF EXISTS %s UNSET QUERY_WAREHOUSE, COMMENT, TITLE`, id.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, `ALTER STREAMLIT IF EXISTS %s UNSET QUERY_WAREHOUSE, COMMENT, TITLE, EXTERNAL_ACCESS_INTEGRATIONS`, id.FullyQualifiedName())
 	})
 
 	t.Run("alter: rename", func(t *testing.T) {

--- a/pkg/sdk/streamlits_impl_gen.go
+++ b/pkg/sdk/streamlits_impl_gen.go
@@ -74,19 +74,15 @@ func (v *streamlits) Describe(ctx context.Context, id SchemaObjectIdentifier) (*
 
 func (r *CreateStreamlitRequest) toOpts() *CreateStreamlitOptions {
 	opts := &CreateStreamlitOptions{
-		OrReplace:      r.OrReplace,
-		IfNotExists:    r.IfNotExists,
-		name:           r.name,
-		RootLocation:   r.RootLocation,
-		MainFile:       r.MainFile,
-		QueryWarehouse: r.QueryWarehouse,
-		Title:          r.Title,
-		Comment:        r.Comment,
-	}
-	if r.ExternalAccessIntegrations != nil {
-		opts.ExternalAccessIntegrations = &ExternalAccessIntegrations{
-			ExternalAccessIntegrations: r.ExternalAccessIntegrations.ExternalAccessIntegrations,
-		}
+		OrReplace:                  r.OrReplace,
+		IfNotExists:                r.IfNotExists,
+		name:                       r.name,
+		RootLocation:               r.RootLocation,
+		MainFile:                   r.MainFile,
+		QueryWarehouse:             r.QueryWarehouse,
+		ExternalAccessIntegrations: r.ExternalAccessIntegrations,
+		Title:                      r.Title,
+		Comment:                    r.Comment,
 	}
 	return opts
 }
@@ -99,23 +95,20 @@ func (r *AlterStreamlitRequest) toOpts() *AlterStreamlitOptions {
 	}
 	if r.Set != nil {
 		opts.Set = &StreamlitSet{
-			RootLocation:   r.Set.RootLocation,
-			MainFile:       r.Set.MainFile,
-			QueryWarehouse: r.Set.QueryWarehouse,
-			Comment:        r.Set.Comment,
-			Title:          r.Set.Title,
-		}
-		if r.Set.ExternalAccessIntegrations != nil {
-			opts.Set.ExternalAccessIntegrations = &ExternalAccessIntegrations{
-				ExternalAccessIntegrations: r.Set.ExternalAccessIntegrations.ExternalAccessIntegrations,
-			}
+			RootLocation:               r.Set.RootLocation,
+			MainFile:                   r.Set.MainFile,
+			QueryWarehouse:             r.Set.QueryWarehouse,
+			ExternalAccessIntegrations: r.Set.ExternalAccessIntegrations,
+			Comment:                    r.Set.Comment,
+			Title:                      r.Set.Title,
 		}
 	}
 	if r.Unset != nil {
 		opts.Unset = &StreamlitUnset{
-			QueryWarehouse: r.Unset.QueryWarehouse,
-			Comment:        r.Unset.Comment,
-			Title:          r.Unset.Title,
+			QueryWarehouse:             r.Unset.QueryWarehouse,
+			Comment:                    r.Unset.Comment,
+			Title:                      r.Unset.Title,
+			ExternalAccessIntegrations: r.Unset.ExternalAccessIntegrations,
 		}
 	}
 	return opts

--- a/pkg/sdk/streamlits_validations_gen.go
+++ b/pkg/sdk/streamlits_validations_gen.go
@@ -50,8 +50,8 @@ func (opts *AlterStreamlitOptions) validate() error {
 		}
 	}
 	if valueSet(opts.Unset) {
-		if !anyValueSet(opts.Unset.QueryWarehouse, opts.Unset.Title, opts.Unset.Comment) {
-			errs = append(errs, errAtLeastOneOf("AlterStreamlitOptions.Unset", "QueryWarehouse", "Title", "Comment"))
+		if !anyValueSet(opts.Unset.QueryWarehouse, opts.Unset.Title, opts.Unset.Comment, opts.Unset.ExternalAccessIntegrations) {
+			errs = append(errs, errAtLeastOneOf("AlterStreamlitOptions.Unset", "QueryWarehouse", "Title", "Comment", "ExternalAccessIntegrations"))
 		}
 	}
 	return JoinErrors(errs...)

--- a/pkg/sdk/testint/streamlits_integration_test.go
+++ b/pkg/sdk/testint/streamlits_integration_test.go
@@ -246,20 +246,29 @@ func TestInt_Streamlits(t *testing.T) {
 		t.Cleanup(cleanupStage)
 		warehouse, warehouseCleanup := testClientHelper().Warehouse.CreateWarehouse(t)
 		t.Cleanup(warehouseCleanup)
+		networkRule, networkRuleCleanup := testClientHelper().NetworkRule.Create(t)
+		t.Cleanup(networkRuleCleanup)
+		eaiId, eaiCleanup := testClientHelper().ExternalAccessIntegration.CreateExternalAccessIntegration(t, networkRule.ID())
+		t.Cleanup(eaiCleanup)
 
 		manifest := "manifest.yml"
 		e := createStreamlitHandle(t, stage, manifest, func(r *sdk.CreateStreamlitRequest) {
-			r.WithComment("foo").WithTitle("foo").WithQueryWarehouse(warehouse.ID())
+			r.WithComment("foo").WithTitle("foo").WithQueryWarehouse(warehouse.ID()).WithExternalAccessIntegrations([]sdk.AccountObjectIdentifier{eaiId})
 		})
 
 		id := e.ID()
 		unset := sdk.NewStreamlitUnsetRequest().
 			WithTitle(true).
 			WithQueryWarehouse(true).
-			WithComment(true)
+			WithComment(true).
+			WithExternalAccessIntegrations(true)
 		err := client.Streamlits.Alter(ctx, sdk.NewAlterStreamlitRequest(id).WithUnset(*unset))
 		require.NoError(t, err)
 		assertStreamlit(t, id, "", "")
+
+		details, err := client.Streamlits.Describe(ctx, id)
+		require.NoError(t, err)
+		require.Empty(t, details.ExternalAccessIntegrations)
 	})
 
 	t.Run("alter function: rename", func(t *testing.T) {

--- a/pkg/testacc/resource_streamlit_acceptance_test.go
+++ b/pkg/testacc/resource_streamlit_acceptance_test.go
@@ -212,7 +212,7 @@ func TestAcc_Streamlit_BasicUseCase(t *testing.T) {
 							WithRootLocation(rootLocationWithCatalog).
 							WithTitle(title).
 							WithQueryWarehouse(warehouse.ID()).
-							WithExternalAccessIntegrations(*sdk.NewExternalAccessIntegrationsRequest([]sdk.AccountObjectIdentifier{externalAccessIntegrationId})).
+							WithExternalAccessIntegrations([]sdk.AccountObjectIdentifier{externalAccessIntegrationId}).
 							WithComment(comment),
 					))
 				},


### PR DESCRIPTION
## Changes

Removes the `ExternalAccessIntegrations` sub-struct from the streamlit SDK and replaces it with an inline `ListAssignment` in both the Create and Alter Set operations. Also adds `EXTERNAL_ACCESS_INTEGRATIONS` to the `StreamlitUnset` struct.

## Motivation

The upcoming SDK work for external access integrations ([SNOW-1348341]) introduces a new `ExternalAccessIntegrations` interface. The existing `ExternalAccessIntegrations` struct in the streamlit SDK would cause a naming collision. Removing the sub-struct in favour of a direct `ListAssignment` is simpler and follows the same pattern used by other list fields in the codebase.

Adding `UNSET EXTERNAL_ACCESS_INTEGRATIONS` is a necessary consequence of the simplification. The old `*StreamlitExternalAccessIntegrations` pointer-to-struct had its inner list tagged with `must_parentheses`, which caused the DDL builder to emit `EXTERNAL_ACCESS_INTEGRATIONS = ()` even for an empty list, effectively clearing EAI via SET. The new flat `[]AccountObjectIdentifier` field is tagged `parentheses`, so the DDL builder silently drops empty slices and there is no longer a way to clear EAI through SET. Explicit `UNSET` support is therefore required.

Unit tests covering the new `StreamlitUnset.ExternalAccessIntegrations` field were added to `streamlits_gen_test.go`, and the integration test `alter streamlit: unset` in `streamlits_integration_test.go` was extended to set EAI on create and verify it is cleared after unset.

## Local tests

Acceptance test:
```
--- PASS: TestAcc_Streamlit_BasicUseCase (37.90s)
PASS
```

Integration tests:
```
--- PASS: TestInt_Streamlits (58.11s)
    --- PASS: TestInt_Streamlits/create_streamlit (4.47s)
    --- PASS: TestInt_Streamlits/create_streamlit_with_lower_case_warehouse_fails (2.81s)
    --- PASS: TestInt_Streamlits/grant_privilege_to_streamlits_to_role (9.56s)
    --- PASS: TestInt_Streamlits/grant_privilege_to_streamlits_to_database_role (7.25s)
    --- PASS: TestInt_Streamlits/alter_streamlit:_set (7.03s)
    --- PASS: TestInt_Streamlits/alter_streamlit:_unset (11.36s)
    --- PASS: TestInt_Streamlits/alter_function:_rename (6.59s)
    --- PASS: TestInt_Streamlits/show_streamlit:_with_like (3.66s)
    --- PASS: TestInt_Streamlits/show_streamlit:_terse_with_like (2.99s)
    --- PASS: TestInt_Streamlits/describe_streamlit (2.37s)
PASS
```

[SNOW-1348341]: https://snowflakecomputing.atlassian.net/browse/SNOW-1348341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ