### PR TITLE
fix: Correct format_name assertion in ExternalS3CompatStage FileFormat test

### DIFF
--- a/pkg/testacc/resource_external_s3_compatible_stage_acceptance_test.go
+++ b/pkg/testacc/resource_external_s3_compatible_stage_acceptance_test.go
@@ -460,7 +460,7 @@ func TestAcc_ExternalS3CompatStage_FileFormat_SwitchBetweenTypes(t *testing.T) {
 						HasFileFormatCsv(),
 					assert.Check(resource.TestCheckResourceAttr(modelWithCsvFormat.ResourceReference(), "describe_output.0.file_format.#", "1")),
 					assert.Check(resource.TestCheckResourceAttr(modelWithCsvFormat.ResourceReference(), "describe_output.0.file_format.0.csv.#", "1")),
-					assert.Check(resource.TestCheckResourceAttr(modelWithCsvFormat.ResourceReference(), "describe_output.0.file_format.0.format_name", fileFormat.ID().FullyQualifiedName())),
+					assert.Check(resource.TestCheckResourceAttr(modelWithCsvFormat.ResourceReference(), "describe_output.0.file_format.0.format_name", "")),
 				),
 			},
 			// Switch to named format


### PR DESCRIPTION
## Summary
- `TestAcc_ExternalS3CompatStage_FileFormat_SwitchBetweenTypes` step 1 applies an inline CSV file format, so `describe_output.0.file_format.0.format_name` should be empty at that point.
- #5031 accidentally changed this assertion to expect the named file format's fully qualified name instead — that value is only valid once the resource switches to the named format in a later step.
- Reverts the assertion to expect `""`, fixing the acceptance test failure.