### PR TITLE
fix: Use valid AWS STS JWT issuer format in WIF AWS tests

### DIFF
--- a/pkg/sdk/testint/users_integration_test.go
+++ b/pkg/sdk/testint/users_integration_test.go
@@ -635,7 +635,7 @@ func TestInt_Users(t *testing.T) {
 				return awsWifData{
 					accountNumber: accountNumber,
 					arn:           fmt.Sprintf("arn:aws:iam::%s:role/test-role", accountNumber),
-					issuer:        "https://sts.amazonaws.com",
+					issuer:        fmt.Sprintf("https://%s.tokens.sts.global.api.aws", accountNumber),
 				}
 			},
 			wifConfig: func(data any) *sdk.UserObjectWorkloadIdentityPropertiesRequest {

--- a/pkg/testacc/resource_legacy_service_user_wif_acceptance_test.go
+++ b/pkg/testacc/resource_legacy_service_user_wif_acceptance_test.go
@@ -171,7 +171,7 @@ func TestAcc_LegacyServiceUser_WIF_AWS(t *testing.T) {
 	id := testClient().Ids.RandomAccountObjectIdentifier()
 	accountNumber := random.NumericN(12)
 	arn := fmt.Sprintf("arn:aws:iam::%s:role/test-role", accountNumber)
-	issuer := "https://sts.amazonaws.com"
+	issuer := fmt.Sprintf("https://%s.tokens.sts.global.api.aws", accountNumber)
 
 	providerModelWithWIF := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.UserEnableDefaultWorkloadIdentity)

--- a/pkg/testacc/resource_service_user_wif_acceptance_test.go
+++ b/pkg/testacc/resource_service_user_wif_acceptance_test.go
@@ -171,7 +171,7 @@ func TestAcc_ServiceUser_WIF_AWS(t *testing.T) {
 	id := testClient().Ids.RandomAccountObjectIdentifier()
 	accountNumber := random.NumericN(12)
 	arn := fmt.Sprintf("arn:aws:iam::%s:role/test-role", accountNumber)
-	issuer := "https://sts.amazonaws.com"
+	issuer := fmt.Sprintf("https://%s.tokens.sts.global.api.aws", accountNumber)
 
 	providerModelWithWIF := providermodel.SnowflakeProvider().
 		WithExperimentalFeaturesEnabled(experimentalfeatures.UserEnableDefaultWorkloadIdentity)


### PR DESCRIPTION
## Summary
- `TestAcc_LegacyServiceUser_WIF_AWS` was failing with a SQL compilation error: `Invalid ISSUER property in WORKLOAD_IDENTITY of TYPE 'AWS': 'https://sts.amazonaws.com'. ISSUER must be a valid AWS STS JWT issuer URL matching the ARN partition.`
- Snowflake now validates the AWS WIF `ISSUER` more strictly, requiring an account-specific issuer URL rather than the generic `https://sts.amazonaws.com`.
- Updated the issuer used in `TestAcc_LegacyServiceUser_WIF_AWS`, `TestAcc_ServiceUser_WIF_AWS`, and the corresponding SDK integration test to a valid issuer URL format.