### PR TITLE
fix: Avoid storage integration AWS/Azure import diffs

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -26,6 +26,15 @@ for changes required after enabling given [Snowflake BCR Bundle](https://docs.sn
 
 ## v2.18.x ➞ v2.19.0
 
+### *(bug fix)* `snowflake_storage_integration_aws` and `snowflake_storage_integration_azure` import fix
+
+Previously, after importing `snowflake_storage_integration_aws` or `snowflake_storage_integration_azure` (for example, when migrating from the older `snowflake_storage_integration` resource), the next `terraform plan` showed an unavoidable diff trying to unset `storage_aws_external_id` (AWS only) and modify `use_privatelink_endpoint` (AWS and Azure) when you did not set these fields in your configuration.
+
+- `storage_aws_external_id` (AWS only): the diff is now gone. No action is required beyond reimporting the affected resources with the new provider version.
+- `use_privatelink_endpoint` (AWS and Azure): the diff is fixed behind the `IMPORT_BOOLEAN_DEFAULT` experiment. To get the fix, add it to the provider configuration and reimport the affected resources. Without the flag, the behavior stays the same as in previous versions.
+
+References: [#5020](https://github.com/snowflakedb/terraform-provider-snowflake/issues/5020)
+
 ### *(new feature)* New file format resources
 
 We have added new preview resources for file formats:

--- a/pkg/acceptance/helpers/storage_integration_client.go
+++ b/pkg/acceptance/helpers/storage_integration_client.go
@@ -25,9 +25,21 @@ func (c *StorageIntegrationClient) client() sdk.StorageIntegrations {
 	return c.context.client.StorageIntegrations
 }
 
-func (c *StorageIntegrationClient) CreateS3(t *testing.T, awsBucketUrl, awsRoleArn string) (*sdk.StorageIntegration, func()) {
+func (c *StorageIntegrationClient) CreateWithRequest(t *testing.T, id sdk.AccountObjectIdentifier, req *sdk.CreateStorageIntegrationRequest) (*sdk.StorageIntegration, func()) {
 	t.Helper()
 	ctx := context.Background()
+
+	err := c.client().Create(ctx, req)
+	require.NoError(t, err)
+
+	storageIntegration, err := c.client().ShowByID(ctx, id)
+	require.NoError(t, err)
+
+	return storageIntegration, c.DropFunc(t, id)
+}
+
+func (c *StorageIntegrationClient) CreateS3(t *testing.T, awsBucketUrl, awsRoleArn string) (*sdk.StorageIntegration, func()) {
+	t.Helper()
 
 	allowedLocations := func(prefix string) []sdk.StorageLocation {
 		return []sdk.StorageLocation{
@@ -60,18 +72,11 @@ func (c *StorageIntegrationClient) CreateS3(t *testing.T, awsBucketUrl, awsRoleA
 		WithStorageBlockedLocations(s3BlockedLocations).
 		WithComment("some comment")
 
-	err := c.client().Create(ctx, req)
-	require.NoError(t, err)
-
-	integration, err := c.client().ShowByID(ctx, id)
-	require.NoError(t, err)
-
-	return integration, c.DropFunc(t, id)
+	return c.CreateWithRequest(t, id, req)
 }
 
 func (c *StorageIntegrationClient) CreateAzure(t *testing.T, azureBucketUrl string, azureTenantId string) (*sdk.StorageIntegration, func()) {
 	t.Helper()
-	ctx := context.Background()
 
 	allowedLocations := func(prefix string) []sdk.StorageLocation {
 		return []sdk.StorageLocation{
@@ -89,13 +94,7 @@ func (c *StorageIntegrationClient) CreateAzure(t *testing.T, azureBucketUrl stri
 	req := sdk.NewCreateStorageIntegrationRequest(id, true, azureAllowedLocations).
 		WithAzureStorageProviderParams(*sdk.NewAzureStorageParamsRequest(azureTenantId))
 
-	err := c.client().Create(ctx, req)
-	require.NoError(t, err)
-
-	integration, err := c.client().ShowByID(ctx, id)
-	require.NoError(t, err)
-
-	return integration, c.DropFunc(t, id)
+	return c.CreateWithRequest(t, id, req)
 }
 
 func (c *StorageIntegrationClient) DropFunc(t *testing.T, id sdk.AccountObjectIdentifier) func() {

--- a/pkg/resources/storage_integration_aws.go
+++ b/pkg/resources/storage_integration_aws.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -134,7 +135,8 @@ func StorageIntegrationAws() *schema.Resource {
 }
 
 func ImportStorageIntegrationAws(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	client := meta.(*provider.Context).Client
+	providerCtx := meta.(*provider.Context)
+	client := providerCtx.Client
 	id, err := sdk.ParseAccountObjectIdentifier(d.Id())
 	if err != nil {
 		return nil, err
@@ -149,10 +151,16 @@ func ImportStorageIntegrationAws(ctx context.Context, d *schema.ResourceData, me
 		return nil, err
 	}
 
+	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
+
+	usePrivateLinkEndpointValue := booleanStringFromBool(awsDetails.UsePrivatelinkEndpoint)
+	if setDefaults {
+		usePrivateLinkEndpointValue = BooleanDefault
+	}
+
 	errs := errors.Join(
 		d.Set("name", awsDetails.ID().Name()),
-		d.Set("use_privatelink_endpoint", booleanStringFromBool(awsDetails.UsePrivatelinkEndpoint)),
-		d.Set("storage_aws_external_id", awsDetails.ExternalId),
+		d.Set("use_privatelink_endpoint", usePrivateLinkEndpointValue),
 	)
 	if errs != nil {
 		return nil, errs

--- a/pkg/resources/storage_integration_azure.go
+++ b/pkg/resources/storage_integration_azure.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/schemas"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -113,7 +114,8 @@ func StorageIntegrationAzure() *schema.Resource {
 }
 
 func ImportStorageIntegrationAzure(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	client := meta.(*provider.Context).Client
+	providerCtx := meta.(*provider.Context)
+	client := providerCtx.Client
 	id, err := sdk.ParseAccountObjectIdentifier(d.Id())
 	if err != nil {
 		return nil, err
@@ -128,9 +130,16 @@ func ImportStorageIntegrationAzure(ctx context.Context, d *schema.ResourceData, 
 		return nil, fmt.Errorf("expected AZURE storage provider got %s", azureDetails.Provider)
 	}
 
+	setDefaults := experimentalfeatures.IsExperimentEnabled(experimentalfeatures.ImportBooleanDefault, providerCtx.EnabledExperiments)
+
+	usePrivateLinkEndpointValue := booleanStringFromBool(azureDetails.UsePrivatelinkEndpoint)
+	if setDefaults {
+		usePrivateLinkEndpointValue = BooleanDefault
+	}
+
 	errs := errors.Join(
 		d.Set("name", azureDetails.ID().Name()),
-		d.Set("use_privatelink_endpoint", booleanStringFromBool(azureDetails.UsePrivatelinkEndpoint)),
+		d.Set("use_privatelink_endpoint", usePrivateLinkEndpointValue),
 	)
 	if errs != nil {
 		return nil, errs

--- a/pkg/testacc/resource_storage_integration_aws_acceptance_test.go
+++ b/pkg/testacc/resource_storage_integration_aws_acceptance_test.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	r "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	tfjson "github.com/hashicorp/terraform-json"
 
@@ -125,15 +127,16 @@ func TestAcc_StorageIntegrationAws_BasicUseCase(t *testing.T) {
 			},
 			// IMPORT
 			{
-				ResourceName:            storageIntegrationAwsModelNoAttributes.ResourceReference(),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"use_privatelink_endpoint", "storage_aws_external_id"},
+				ResourceName:      storageIntegrationAwsModelNoAttributes.ResourceReference(),
+				ImportState:       true,
+				ImportStateVerify: true,
+				// use_privatelink_endpoint is ignored because IMPORT_BOOLEAN_DEFAULT experiment is not enabled
+				// in this test
+				ImportStateVerifyIgnore: []string{"use_privatelink_endpoint"},
 				ImportStateCheck: assertThatImport(
 					t,
 					resourceassert.ImportedStorageIntegrationAwsResource(t, id.Name()).
-						HasUsePrivatelinkEndpointString(r.BooleanFalse).
-						HasStorageAwsExternalIdNotEmpty(),
+						HasUsePrivatelinkEndpointString(r.BooleanFalse),
 				),
 			},
 			{
@@ -237,12 +240,11 @@ func TestAcc_StorageIntegrationAws_BasicUseCase(t *testing.T) {
 				ResourceName:            storageIntegrationAwsAllAttributesChanged.ResourceReference(),
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"use_privatelink_endpoint"},
+				ImportStateVerifyIgnore: []string{"storage_aws_external_id"},
 				ImportStateCheck: assertThatImport(
 					t,
 					resourceassert.ImportedStorageIntegrationAwsResource(t, id.Name()).
-						HasUsePrivatelinkEndpointString(r.BooleanTrue).
-						HasStorageAwsExternalIdString(externalId2),
+						HasUsePrivatelinkEndpointString(r.BooleanTrue),
 				),
 			},
 			// CHANGE PROP EXTERNALLY
@@ -319,6 +321,87 @@ func TestAcc_StorageIntegrationAws_BasicUseCase(t *testing.T) {
 						HasExternalIdSet().
 						HasObjectAcl(""),
 				),
+			},
+		},
+	})
+}
+
+func TestAcc_StorageIntegrationAws_Import(t *testing.T) {
+	basicId := testClient().Ids.RandomAccountObjectIdentifier()
+	completeId := testClient().Ids.RandomAccountObjectIdentifier()
+
+	awsRoleArn := testenvs.GetOrSkipTest(t, testenvs.AwsExternalRoleArn)
+	awsBucketUrl := testenvs.GetOrSkipTest(t, testenvs.AwsExternalBucketUrl)
+	allowedLocations := []sdk.StorageLocation{
+		{Path: awsBucketUrl + "allowed-location/"},
+	}
+	blockedLocations := []sdk.StorageLocation{
+		{Path: awsBucketUrl + "blocked-location/"},
+	}
+	comment := random.Comment()
+	externalId := "some_external_id"
+
+	providerModel := providermodel.SnowflakeProvider().
+		WithExperimentalFeaturesEnabled(experimentalfeatures.ImportBooleanDefault)
+
+	basicStorageIntegrationAwsModel := model.StorageIntegrationAws("w1", basicId.Name(), false, allowedLocations, awsRoleArn, string(sdk.RegularS3Protocol))
+
+	completeStorageIntegrationAwsModel := model.StorageIntegrationAws("w2", completeId.Name(), false, allowedLocations, awsRoleArn, string(sdk.RegularS3Protocol)).
+		WithStorageBlockedLocations(blockedLocations).
+		WithComment(comment).
+		WithStorageAwsExternalId(externalId).
+		WithUsePrivatelinkEndpoint("true").
+		WithStorageAwsObjectAcl("bucket-owner-full-control")
+
+	basicRef := basicStorageIntegrationAwsModel.ResourceReference()
+	completeRef := completeStorageIntegrationAwsModel.ResourceReference()
+
+	_, storageIntegrationCleanup := testClient().StorageIntegration.CreateWithRequest(t, basicId,
+		sdk.NewCreateStorageIntegrationRequest(basicId, false, allowedLocations).
+			WithS3StorageProviderParams(*sdk.NewS3StorageParamsRequest(sdk.RegularS3Protocol, awsRoleArn)))
+	t.Cleanup(storageIntegrationCleanup)
+
+	_, storageIntegrationCleanup = testClient().StorageIntegration.CreateWithRequest(t, completeId,
+		sdk.NewCreateStorageIntegrationRequest(completeId, false, allowedLocations).
+			WithS3StorageProviderParams(*sdk.NewS3StorageParamsRequest(sdk.RegularS3Protocol, awsRoleArn).
+				WithStorageAwsExternalId(externalId).
+				WithUsePrivatelinkEndpoint(true).
+				WithStorageAwsObjectAcl("bucket-owner-full-control")).
+			WithStorageBlockedLocations(blockedLocations).
+			WithComment(comment))
+	t.Cleanup(storageIntegrationCleanup)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: importBooleanDefaultProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.StorageIntegrationAws),
+		Steps: []resource.TestStep{
+			// Import basic object
+			{
+				Config:             config.FromModels(t, providerModel, basicStorageIntegrationAwsModel),
+				ResourceName:       basicRef,
+				ImportState:        true,
+				ImportStateId:      basicId.FullyQualifiedName(),
+				ImportStatePersist: true,
+			},
+			// Import complete object
+			{
+				Config:             config.FromModels(t, providerModel, basicStorageIntegrationAwsModel, completeStorageIntegrationAwsModel),
+				ResourceName:       completeRef,
+				ImportState:        true,
+				ImportStateId:      completeId.FullyQualifiedName(),
+				ImportStatePersist: true,
+			},
+			// Expect empty plan
+			{
+				Config: config.FromModels(t, providerModel, basicStorageIntegrationAwsModel, completeStorageIntegrationAwsModel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/pkg/testacc/resource_storage_integration_azure_acceptance_test.go
+++ b/pkg/testacc/resource_storage_integration_azure_acceptance_test.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/experimentalfeatures"
 	r "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert/resourceassert"
@@ -105,9 +107,11 @@ func TestAcc_StorageIntegrationAzure_BasicUseCase(t *testing.T) {
 			},
 			// IMPORT
 			{
-				ResourceName:            storageIntegrationAzureModelNoAttributes.ResourceReference(),
-				ImportState:             true,
-				ImportStateVerify:       true,
+				ResourceName:      storageIntegrationAzureModelNoAttributes.ResourceReference(),
+				ImportState:       true,
+				ImportStateVerify: true,
+				// use_privatelink_endpoint is ignored because IMPORT_BOOLEAN_DEFAULT experiment is not enabled
+				// in this test
 				ImportStateVerifyIgnore: []string{"use_privatelink_endpoint"},
 				ImportStateCheck: assertThatImport(
 					t,
@@ -207,9 +211,11 @@ func TestAcc_StorageIntegrationAzure_BasicUseCase(t *testing.T) {
 			},
 			// IMPORT
 			{
-				ResourceName:            storageIntegrationAzureAllAttributesChanged.ResourceReference(),
-				ImportState:             true,
-				ImportStateVerify:       true,
+				ResourceName:      storageIntegrationAzureAllAttributesChanged.ResourceReference(),
+				ImportState:       true,
+				ImportStateVerify: true,
+				// use_privatelink_endpoint is ignored because IMPORT_BOOLEAN_DEFAULT experiment is not enabled
+				// in this test
 				ImportStateVerifyIgnore: []string{"use_privatelink_endpoint"},
 				ImportStateCheck: assertThatImport(
 					t,
@@ -252,6 +258,81 @@ func TestAcc_StorageIntegrationAzure_BasicUseCase(t *testing.T) {
 						HasConsentUrlSet().
 						HasMultiTenantAppNameSet(),
 				),
+			},
+		},
+	})
+}
+
+func TestAcc_StorageIntegrationAzure_Import(t *testing.T) {
+	basicId := testClient().Ids.RandomAccountObjectIdentifier()
+	completeId := testClient().Ids.RandomAccountObjectIdentifier()
+
+	azureBucketUrl := testenvs.GetOrSkipTest(t, testenvs.AzureExternalBucketUrl)
+	azureTenantId := testenvs.GetOrSkipTest(t, testenvs.AzureExternalTenantId)
+	allowedLocations := []sdk.StorageLocation{
+		{Path: azureBucketUrl + "allowed-location/"},
+	}
+	blockedLocations := []sdk.StorageLocation{
+		{Path: azureBucketUrl + "blocked-location/"},
+	}
+	comment := random.Comment()
+
+	providerModel := providermodel.SnowflakeProvider().
+		WithExperimentalFeaturesEnabled(experimentalfeatures.ImportBooleanDefault)
+
+	basicStorageIntegrationAzureModel := model.StorageIntegrationAzure("w1", basicId.Name(), azureTenantId, false, allowedLocations)
+
+	completeStorageIntegrationAzureModel := model.StorageIntegrationAzure("w2", completeId.Name(), azureTenantId, false, allowedLocations).
+		WithStorageBlockedLocations(blockedLocations).
+		WithComment(comment).
+		WithUsePrivatelinkEndpoint("false")
+
+	basicRef := basicStorageIntegrationAzureModel.ResourceReference()
+	completeRef := completeStorageIntegrationAzureModel.ResourceReference()
+
+	_, storageIntegrationCleanup := testClient().StorageIntegration.CreateWithRequest(t, basicId,
+		sdk.NewCreateStorageIntegrationRequest(basicId, false, allowedLocations).
+			WithAzureStorageProviderParams(*sdk.NewAzureStorageParamsRequest(azureTenantId)))
+	t.Cleanup(storageIntegrationCleanup)
+
+	_, storageIntegrationCleanup = testClient().StorageIntegration.CreateWithRequest(t, completeId,
+		sdk.NewCreateStorageIntegrationRequest(completeId, false, allowedLocations).
+			WithAzureStorageProviderParams(*sdk.NewAzureStorageParamsRequest(azureTenantId)).
+			WithStorageBlockedLocations(blockedLocations).
+			WithComment(comment))
+	t.Cleanup(storageIntegrationCleanup)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: importBooleanDefaultProviderFactory,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.StorageIntegrationAzure),
+		Steps: []resource.TestStep{
+			// Import basic object
+			{
+				Config:             config.FromModels(t, providerModel, basicStorageIntegrationAzureModel),
+				ResourceName:       basicRef,
+				ImportState:        true,
+				ImportStateId:      basicId.FullyQualifiedName(),
+				ImportStatePersist: true,
+			},
+			// Import complete object
+			{
+				Config:             config.FromModels(t, providerModel, basicStorageIntegrationAzureModel, completeStorageIntegrationAzureModel),
+				ResourceName:       completeRef,
+				ImportState:        true,
+				ImportStateId:      completeId.FullyQualifiedName(),
+				ImportStatePersist: true,
+			},
+			// Expect empty plan
+			{
+				Config: config.FromModels(t, providerModel, basicStorageIntegrationAzureModel, completeStorageIntegrationAzureModel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
Importing snowflake_storage_integration_aws or
snowflake_storage_integration_azure wrote Snowflake-computed values into state, producing an unavoidable plan diff on fields the user did not configure.

- storage_aws_external_id (AWS) is no longer written to state on import, so no diff is produced.
- use_privatelink_endpoint (AWS and Azure) is set to the "default" sentinel on import when the IMPORT_BOOLEAN_DEFAULT experiment is enabled, matching the pattern used by other resources.

Closes #5020