### PR TITLE
chore: Consolidate duplicate comma-separated parser logic

### DIFF
--- a/pkg/sdk/generator/defs/warehouse_def.go
+++ b/pkg/sdk/generator/defs/warehouse_def.go
@@ -82,7 +82,7 @@ var warehousePairs = g.StructPair("warehouseDBRow", "Warehouse").
 	Field("generation", "sql.NullString", "*WarehouseGeneration", g.WithManualConvert()).
 	OptionalEnum("max_query_performance_level", maxQueryPerformanceLevelEnum).
 	OptionalNumber("query_throughput_multiplier").
-	Field("tables", "sql.NullString", "[]SchemaObjectIdentifier", g.WithManualConvert())
+	Field("tables", "sql.NullString", "[]SchemaObjectIdentifier", g.WithCustomParser("ParseCommaSeparatedSchemaObjectIdentifierArray"))
 
 var warehouseDetailsPairs = g.StructPair("warehouseDetailsRow", "WarehouseDetails").
 	Time("created_on").

--- a/pkg/sdk/parsers.go
+++ b/pkg/sdk/parsers.go
@@ -2,34 +2,21 @@ package sdk
 
 import (
 	"strings"
-	"time"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
 
-// fix timestamp merge
-func ParseTimestampWithOffset(s string, dateTimeFormat string) (string, error) {
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return err.Error(), err
-	}
-	_, offset := t.Zone()
-	adjustedTime := t.Add(-time.Duration(offset) * time.Second)
-	adjustedTimeFormat := adjustedTime.Format(dateTimeFormat)
-	return adjustedTimeFormat, nil
-}
-
 // ParseCommaSeparatedStringArray can be used to parse Snowflake output containing a list in the format of "[item1, item2, ...]",
 // the assumptions are that:
 // 1. The list may be enclosed by outer [] brackets which are stripped. Brackets shouldn't be a part of any item's value
-// 2. Items are separated by commas, and they shouldn't be a part of any item's value
+// 2. Items are separated by commas. Commas enclosed in double quotes are treated as part of the item's value rather than separators (e.g. `"a,b"` is a single item)
 // 3. Items can have as many spaces in between, but after separation they will be trimmed and shouldn't be a part of any item's value
 func ParseCommaSeparatedStringArray(value string, trimQuotes bool) []string {
 	value = stripOuterBrackets(value)
 	if value == "" {
 		return make([]string, 0)
 	}
-	listItems := strings.Split(value, ",")
+	listItems := splitCommaSeparated(value)
 	return applyFormatting(listItems, trimQuotes)
 }
 
@@ -38,7 +25,7 @@ func ParseCommaSeparatedStringArray(value string, trimQuotes bool) []string {
 // The assumptions are that:
 // 1. The list may be enclosed by outer [] brackets which are stripped
 // 2. Brackets have special meaning (they denote list boundaries) and shouldn't be a part of any item's value
-// 3. Items are separated by top-level commas (commas inside nested brackets are preserved)
+// 3. Items are separated by top-level commas (commas inside nested brackets or double quotes are preserved)
 // 4. Items can have as many spaces in between, but after separation they will be trimmed and shouldn't be a part of any item's value
 // 5. Quote trimming only applies to top-level items. Nested items are returned as a raw string
 func ParseOuterCommaSeparatedStringArray(value string, trimQuotes bool) []string {
@@ -87,15 +74,22 @@ func applyFormatting(listItems []string, trimQuotes bool) []string {
 func splitOuter(value string) []string {
 	depth := 0
 	idx := 0
+	inQuotes := false
 	var parts []string
 	for i, ch := range value {
 		switch ch {
+		case '"':
+			inQuotes = !inQuotes
 		case '[':
-			depth++
+			if !inQuotes {
+				depth++
+			}
 		case ']':
-			depth--
+			if !inQuotes {
+				depth--
+			}
 		case ',':
-			if depth <= 0 {
+			if !inQuotes && depth <= 0 {
 				parts = append(parts, value[idx:i])
 				idx = i + 1
 			}
@@ -111,11 +105,11 @@ func emptyIfNull(s string) string {
 	return s
 }
 
-// splitCommaSeparatedIdentifiers splits a comma-separated list of identifiers, treating commas
-// enclosed in double quotes as part of an identifier rather than separators. Snowflake identifiers
-// may contain commas when quoted (e.g. `DB.SCHEMA."a,b"`), so a naive strings.Split(",") would break
-// such identifiers apart. The returned parts are raw (not trimmed or parsed).
-func splitCommaSeparatedIdentifiers(s string) []string {
+// splitCommaSeparated splits a comma-separated string, treating commas enclosed in double
+// quotes as part of a value rather than separators. Snowflake identifiers may contain commas
+// when quoted (e.g. `DB.SCHEMA."a,b"`), so a naive strings.Split(",") would break such values
+// apart. The returned parts are raw (not trimmed or parsed).
+func splitCommaSeparated(s string) []string {
 	var parts []string
 	var current strings.Builder
 	inQuotes := false
@@ -131,6 +125,5 @@ func splitCommaSeparatedIdentifiers(s string) []string {
 			current.WriteRune(r)
 		}
 	}
-	parts = append(parts, current.String())
-	return parts
+	return append(parts, current.String())
 }

--- a/pkg/sdk/parsers_test.go
+++ b/pkg/sdk/parsers_test.go
@@ -96,6 +96,25 @@ var commaSeparatedStringArrayTestCases = []struct {
 		TrimQuotes: true,
 		Result:     []string{"one", "two", "three"},
 	},
+	{
+		Name:       "comma inside double-quoted identifier",
+		Value:      `TESTDB.TESTSCHEMA.IT1,TESTDB.TESTSCHEMA."I,T2"`,
+		TrimQuotes: false,
+		Result:     []string{`TESTDB.TESTSCHEMA.IT1`, `TESTDB.TESTSCHEMA."I,T2"`},
+	},
+	{
+		Name:       "comma inside double-quoted identifier - multiple",
+		Value:      `A."x,y",B."z,w"`,
+		TrimQuotes: false,
+		Result:     []string{`A."x,y"`, `B."z,w"`},
+	},
+	{
+		// doubled quotes ("") escape a quote inside a quoted identifier; the comma inside stays protected
+		Name:       "comma inside doubled-quoted identifier with escaped quote",
+		Value:      `A.B."a""b,c",D.E.F`,
+		TrimQuotes: false,
+		Result:     []string{`A.B."a""b,c"`, `D.E.F`},
+	},
 }
 
 func TestParseCommaSeparatedStringArray(t *testing.T) {
@@ -143,6 +162,30 @@ func TestParseOuterCommaSeparatedStringArray(t *testing.T) {
 			Value:      "['one', 'tw]]]o', 'three']",
 			TrimQuotes: true,
 			Result:     []string{"one", "tw]]]o", "three"},
+		},
+		{
+			Name:       "comma inside double-quoted value alongside a nested list",
+			Value:      `["a,b", [1, 2]]`,
+			TrimQuotes: true,
+			Result:     []string{"a,b", "[1, 2]"},
+		},
+		{
+			Name:       "opening bracket inside a double-quoted value does not increase depth",
+			Value:      `["a[b", "c"]`,
+			TrimQuotes: true,
+			Result:     []string{"a[b", "c"},
+		},
+		{
+			Name:       "closing bracket inside a double-quoted value does not decrease depth",
+			Value:      `["a]b", "c,d"]`,
+			TrimQuotes: true,
+			Result:     []string{"a]b", "c,d"},
+		},
+		{
+			Name:       "comma and brackets both inside a double-quoted value",
+			Value:      `["a,[b]", "c"]`,
+			TrimQuotes: true,
+			Result:     []string{"a,[b]", "c"},
 		},
 	}...)
 
@@ -345,27 +388,6 @@ func TestParseCommaSeparatedAccountIdentifierArray_Invalid(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			_, err := ParseCommaSeparatedAccountIdentifierArray(tc.Value)
 			require.ErrorContains(t, err, tc.Error)
-		})
-	}
-}
-
-func TestSplitCommaSeparatedIdentifiers(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected []string
-	}{
-		{"", []string{""}},
-		{"A.B.C", []string{"A.B.C"}},
-		{"A.B.C,D.E.F", []string{"A.B.C", "D.E.F"}},
-		{`TESTDB.TESTSCHEMA.IT1,TESTDB.TESTSCHEMA."I,T2"`, []string{"TESTDB.TESTSCHEMA.IT1", `TESTDB.TESTSCHEMA."I,T2"`}},
-		{`A."x,y",B."z,w"`, []string{`A."x,y"`, `B."z,w"`}},
-		// doubled quotes ("") escape a quote inside a quoted identifier; the comma inside stays protected
-		{`A.B."a""b,c",D.E.F`, []string{`A.B."a""b,c"`, "D.E.F"}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			result := splitCommaSeparatedIdentifiers(tt.input)
-			require.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/sdk/warehouses_ext.go
+++ b/pkg/sdk/warehouses_ext.go
@@ -284,26 +284,6 @@ func (r warehouseDBRow) additionalConvert(wh *Warehouse) error {
 			return fmt.Errorf("invalid warehouse type: %s", wh.Type)
 		}
 	}
-
-	// Tables - only present for interactive warehouses; may be NULL. SHOW WAREHOUSES returns the
-	// associated tables as a comma-separated list of fully-qualified names. Identifiers can contain
-	// commas when quoted, so we split in a quote-aware manner rather than using strings.Split.
-	if r.Tables.Valid {
-		if tables := strings.TrimSpace(r.Tables.String); tables != "" {
-			for _, raw := range splitCommaSeparatedIdentifiers(tables) {
-				raw = strings.TrimSpace(raw)
-				if raw == "" {
-					continue
-				}
-				id, err := ParseSchemaObjectIdentifier(raw)
-				if err != nil {
-					return fmt.Errorf("parsing table identifier %q: %w", raw, err)
-				}
-				wh.Tables = append(wh.Tables, id)
-			}
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/sdk/warehouses_impl_gen.go
+++ b/pkg/sdk/warehouses_impl_gen.go
@@ -263,6 +263,13 @@ func (r warehouseDBRow) convert() (*Warehouse, error) {
 	mapNullStringToNonNullableField(&result.OwnerRoleType, r.OwnerRoleType)
 	mapNullStringWithMapping(&result.MaxQueryPerformanceLevel, r.MaxQueryPerformanceLevel, ToMaxQueryPerformanceLevel)
 	mapNullInt(&result.QueryThroughputMultiplier, r.QueryThroughputMultiplier)
+	if r.Tables.Valid {
+		if v, err := ParseCommaSeparatedSchemaObjectIdentifierArray(r.Tables.String); err != nil {
+			return nil, fmt.Errorf("parsing schema object identifier: %w", err)
+		} else {
+			result.Tables = v
+		}
+	}
 	if err := r.additionalConvert(result); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The quote-aware splitCommaSeparatedIdentifiers duplicated the widely used ParseCommaSeparatedStringArray. Rename it to splitCommaSeparated and use it in ParseCommaSeparatedStringArray so quoted commas are handled there too, and make splitOuter quote-aware as well.

Warehouse tables are now parsed through the generated ParseCommaSeparatedSchemaObjectIdentifierArray custom parser instead of a hand-written conversion.