### PR TITLE
fix: Recreate warehouse when type changes externally to INTERACTIVE

### DIFF
--- a/pkg/resources/custom_diffs.go
+++ b/pkg/resources/custom_diffs.go
@@ -333,8 +333,15 @@ func RecreateWhenStageCloudChangedExternally(stageCloud sdk.StageCloud) schema.C
 	return RecreateWhenResourceTypeChangedExternally("cloud", stageCloud, sdk.ToStageCloud)
 }
 
+// RecreateWhenWarehouseTypeChangedExternally recreates a warehouse when argument warehouseType is different than in the state.
+func RecreateWhenWarehouseTypeChangedExternally(warehouseType sdk.WarehouseType) schema.CustomizeDiffFunc {
+	return RecreateWhenResourceTypeChangedExternally("warehouse_type", warehouseType, sdk.ToWarehouseType)
+}
+
 // HandleWarehouseExternalTypeChange detects when the warehouse type has been changed externally
 // and plans an update to restore it to warehouseType (without forcing recreation).
+// One exception is when the type was changed externally to INTERACTIVE - because Snowflake does not
+// allow changing WAREHOUSE_TYPE via ALTER to INTERACTIVE, the resource has to be recreated instead.
 func HandleWarehouseExternalTypeChange(warehouseType sdk.WarehouseType) schema.CustomizeDiffFunc {
 	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 		if n := diff.Get("warehouse_type"); n != nil {
@@ -347,6 +354,12 @@ func HandleWarehouseExternalTypeChange(warehouseType sdk.WarehouseType) schema.C
 				return fmt.Errorf("unknown warehouse type: %w", err)
 			}
 			if gotType != warehouseType {
+				if gotType == sdk.WarehouseTypeInteractive {
+					// we have to set here a value instead of just SetNewComputed
+					// because with empty value ForceNew fails
+					// because there are no changes (at least from the SDKv2 point of view) for warehouse_type
+					return errors.Join(diff.SetNew("warehouse_type", "<changed externally>"), diff.ForceNew("warehouse_type"))
+				}
 				return diff.SetNew("warehouse_type", string(warehouseType))
 			}
 		}

--- a/pkg/resources/custom_diffs.go
+++ b/pkg/resources/custom_diffs.go
@@ -333,15 +333,10 @@ func RecreateWhenStageCloudChangedExternally(stageCloud sdk.StageCloud) schema.C
 	return RecreateWhenResourceTypeChangedExternally("cloud", stageCloud, sdk.ToStageCloud)
 }
 
-// RecreateWhenWarehouseTypeChangedExternally recreates a warehouse when argument warehouseType is different than in the state.
-func RecreateWhenWarehouseTypeChangedExternally(warehouseType sdk.WarehouseType) schema.CustomizeDiffFunc {
-	return RecreateWhenResourceTypeChangedExternally("warehouse_type", warehouseType, sdk.ToWarehouseType)
-}
-
 // HandleWarehouseExternalTypeChange detects when the warehouse type has been changed externally
 // and plans an update to restore it to warehouseType (without forcing recreation).
 // One exception is when the type was changed externally to INTERACTIVE - because Snowflake does not
-// allow changing WAREHOUSE_TYPE via ALTER to INTERACTIVE, the resource has to be recreated instead.
+// allow changing WAREHOUSE_TYPE via ALTER to or from INTERACTIVE, the resource has to be recreated instead.
 func HandleWarehouseExternalTypeChange(warehouseType sdk.WarehouseType) schema.CustomizeDiffFunc {
 	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 		if n := diff.Get("warehouse_type"); n != nil {
@@ -354,7 +349,7 @@ func HandleWarehouseExternalTypeChange(warehouseType sdk.WarehouseType) schema.C
 				return fmt.Errorf("unknown warehouse type: %w", err)
 			}
 			if gotType != warehouseType {
-				if gotType == sdk.WarehouseTypeInteractive {
+				if gotType == sdk.WarehouseTypeInteractive || warehouseType == sdk.WarehouseTypeInteractive {
 					// we have to set here a value instead of just SetNewComputed
 					// because with empty value ForceNew fails
 					// because there are no changes (at least from the SDKv2 point of view) for warehouse_type

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -218,8 +218,13 @@ func Warehouse() *schema.Resource {
 	)
 
 	forceNewIfChangedToInteractive := func() schema.CustomizeDiffFunc {
-		return customdiff.ForceNewIfChange("warehouse_type", func(ctx context.Context, oldValue, newValue, meta any) bool {
-			return newValue.(string) != string(sdk.WarehouseTypeInteractive)
+		return customdiff.ForceNewIfChange("warehouse_type", func(_ context.Context, oldValue, _, _ any) bool {
+			oldRaw, ok := oldValue.(string)
+			if !ok || oldRaw == "" {
+				return false
+			}
+			oldType, err := sdk.ToWarehouseType(oldRaw)
+			return err == nil && oldType == sdk.WarehouseTypeInteractive
 		})
 	}
 

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -217,6 +217,12 @@ func Warehouse() *schema.Resource {
 		},
 	)
 
+	forceNewIfChangedToInteractive := func() schema.CustomizeDiffFunc {
+		return customdiff.ForceNewIfChange("warehouse_type", func(ctx context.Context, oldValue, newValue, meta any) bool {
+			return newValue.(string) != string(sdk.WarehouseTypeInteractive)
+		})
+	}
+
 	return &schema.Resource{
 		SchemaVersion: 2,
 
@@ -240,6 +246,7 @@ func Warehouse() *schema.Resource {
 				customdiff.ForceNewIfChange("warehouse_size", func(ctx context.Context, old, new, meta any) bool {
 					return old.(string) != "" && new.(string) == ""
 				}),
+				forceNewIfChangedToInteractive(),
 				ParametersCustomDiff(
 					warehouseParametersProvider,
 					parameter[sdk.AccountParameter]{sdk.AccountParameterMaxConcurrencyLevel, valueTypeInt, sdk.ParameterTypeWarehouse},

--- a/pkg/resources/warehouse_interactive.go
+++ b/pkg/resources/warehouse_interactive.go
@@ -193,10 +193,7 @@ func WarehouseInteractive() *schema.Resource {
 				parameter[sdk.WarehouseParameter]{sdk.WarehouseParameterStatementTimeoutInSeconds, valueTypeInt, sdk.ParameterTypeWarehouse},
 				parameter[sdk.WarehouseParameter]{sdk.WarehouseParameterFallbackWarehouse, valueTypeString, sdk.ParameterTypeWarehouse},
 			),
-			// Snowflake does not allow changing WAREHOUSE_TYPE via ALTER (to or from INTERACTIVE),
-			// so if the underlying object is no longer interactive the only way to reconcile is to
-			// recreate it.
-			RecreateWhenWarehouseTypeChangedExternally(sdk.WarehouseTypeInteractive),
+			HandleWarehouseExternalTypeChange(sdk.WarehouseTypeInteractive),
 		)),
 		Timeouts: defaultTimeouts,
 	}

--- a/pkg/resources/warehouse_interactive.go
+++ b/pkg/resources/warehouse_interactive.go
@@ -196,7 +196,7 @@ func WarehouseInteractive() *schema.Resource {
 			// Snowflake does not allow changing WAREHOUSE_TYPE via ALTER (to or from INTERACTIVE),
 			// so if the underlying object is no longer interactive the only way to reconcile is to
 			// recreate it.
-			RecreateWhenResourceTypeChangedExternally("warehouse_type", sdk.WarehouseTypeInteractive, sdk.ToWarehouseType),
+			RecreateWhenWarehouseTypeChangedExternally(sdk.WarehouseTypeInteractive),
 		)),
 		Timeouts: defaultTimeouts,
 	}

--- a/pkg/sdk/warehouses_ext.go
+++ b/pkg/sdk/warehouses_ext.go
@@ -279,7 +279,8 @@ func (r warehouseDBRow) additionalConvert(wh *Warehouse) error {
 				return fmt.Errorf("invalid resource constraint: %s", r.ResourceConstraint.String)
 			}
 		case WarehouseTypeAdaptive:
-			// Adaptive warehouses don't use resource constraints; ignore.
+		case WarehouseTypeInteractive:
+			// Adaptive and interactive warehouses don't use resource constraints; ignore.
 		default:
 			return fmt.Errorf("invalid warehouse type: %s", wh.Type)
 		}

--- a/pkg/sdk/warehouses_ext.go
+++ b/pkg/sdk/warehouses_ext.go
@@ -261,28 +261,18 @@ func (r warehouseDBRow) additionalConvert(wh *Warehouse) error {
 	// ResourceConstraint - conditional on warehouse type.
 	// We use EqualFold instead of the generated ToWarehouseResourceConstraint because
 	// the values contain lowercase "x86" and the generated function uses ToUpper which breaks matching.
-	if r.ResourceConstraint.Valid {
-		switch wh.Type {
-		case WarehouseTypeStandard:
-			// After BCR 2026_02, resource_constraint is NULL for Standard warehouses; generation column is used instead.
-		case WarehouseTypeSnowparkOptimized:
-			var found bool
-			for _, rc := range AllWarehouseResourceConstraints {
-				if strings.EqualFold(string(rc), r.ResourceConstraint.String) {
-					v := rc
-					wh.ResourceConstraint = &v
-					found = true
-					break
-				}
+	if r.ResourceConstraint.Valid && wh.Type == WarehouseTypeSnowparkOptimized {
+		var found bool
+		for _, rc := range AllWarehouseResourceConstraints {
+			if strings.EqualFold(string(rc), r.ResourceConstraint.String) {
+				v := rc
+				wh.ResourceConstraint = &v
+				found = true
+				break
 			}
-			if !found {
-				return fmt.Errorf("invalid resource constraint: %s", r.ResourceConstraint.String)
-			}
-		case WarehouseTypeAdaptive:
-		case WarehouseTypeInteractive:
-			// Adaptive and interactive warehouses don't use resource constraints; ignore.
-		default:
-			return fmt.Errorf("invalid warehouse type: %s", wh.Type)
+		}
+		if !found {
+			return fmt.Errorf("invalid resource constraint: %s", r.ResourceConstraint.String)
 		}
 	}
 

--- a/pkg/testacc/resource_warehouse_acceptance_test.go
+++ b/pkg/testacc/resource_warehouse_acceptance_test.go
@@ -581,6 +581,47 @@ func TestAcc_Warehouse_WarehouseType(t *testing.T) {
 	})
 }
 
+func TestAcc_Warehouse_ExternalTypeChangeToInteractive(t *testing.T) {
+	id := testClient().Ids.RandomAccountObjectIdentifier()
+
+	warehouseModel := model.Warehouse("test", id.Name())
+	ref := warehouseModel.ResourceReference()
+
+	assertions := []assert.TestCheckFuncProvider{
+		resourceshowoutputassert.WarehouseShowOutput(t, ref).
+			HasType(sdk.WarehouseTypeStandard),
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.Warehouse),
+		Steps: []resource.TestStep{
+			{
+				Config: config.FromModels(t, warehouseModel),
+				Check:  assertThat(t, assertions...),
+			},
+			{
+				PreConfig: func() {
+					testClient().Warehouse.CreateInteractiveWithRequest(t,
+						sdk.NewCreateInteractiveWarehouseRequest(id).WithOrReplace(true))
+				},
+				Config: config.FromModels(t, warehouseModel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(ref, plancheck.ResourceActionDestroyBeforeCreate),
+						planchecks.ExpectDrift(ref, "warehouse_type", nil, new(string(sdk.WarehouseTypeInteractive))),
+						planchecks.ExpectChange(ref, "warehouse_type", tfjson.ActionDelete, new(string(sdk.WarehouseTypeInteractive)), nil),
+					},
+				},
+				Check: assertThat(t, assertions...),
+			},
+		},
+	})
+}
+
 func TestAcc_Warehouse_WarehouseSizes(t *testing.T) {
 	id := testClient().Ids.RandomAccountObjectIdentifier()
 

--- a/pkg/testacc/resource_warehouse_adaptive_acceptance_test.go
+++ b/pkg/testacc/resource_warehouse_adaptive_acceptance_test.go
@@ -375,3 +375,46 @@ func TestAcc_WarehouseAdaptive_ExternalTypeChange(t *testing.T) {
 		},
 	})
 }
+
+func TestAcc_WarehouseAdaptive_ExternalTypeChangeToInteractive(t *testing.T) {
+	id := testClient().Ids.RandomAccountObjectIdentifier()
+
+	warehouseModel := model.WarehouseAdaptiveWithId(id)
+	ref := warehouseModel.ResourceReference()
+
+	assertions := []assert.TestCheckFuncProvider{
+		resourceassert.WarehouseAdaptiveResource(t, ref).
+			HasWarehouseType(string(sdk.WarehouseTypeAdaptive)),
+		resourceshowoutputassert.WarehouseShowOutput(t, ref).
+			HasType(sdk.WarehouseTypeAdaptive),
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		CheckDestroy: CheckDestroy(t, resources.WarehouseAdaptive),
+		Steps: []resource.TestStep{
+			{
+				Config: accconfig.FromModels(t, warehouseModel),
+				Check:  assertThat(t, assertions...),
+			},
+			{
+				PreConfig: func() {
+					testClient().Warehouse.CreateInteractiveWithRequest(t,
+						sdk.NewCreateInteractiveWarehouseRequest(id).WithOrReplace(true))
+				},
+				Config: accconfig.FromModels(t, warehouseModel),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(ref, plancheck.ResourceActionDestroyBeforeCreate),
+						planchecks.ExpectDrift(ref, "warehouse_type", new(string(sdk.WarehouseTypeAdaptive)), new(string(sdk.WarehouseTypeInteractive))),
+						planchecks.ExpectChange(ref, "warehouse_type", tfjson.ActionDelete, new(string(sdk.WarehouseTypeInteractive)), nil),
+					},
+				},
+				Check: assertThat(t, assertions...),
+			},
+		},
+	})
+}

--- a/pkg/testacc/resource_warehouse_interactive_acceptance_test.go
+++ b/pkg/testacc/resource_warehouse_interactive_acceptance_test.go
@@ -12,9 +12,11 @@ import (
 	accconfig "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/planchecks"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	r "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -119,6 +121,22 @@ func TestAcc_WarehouseInteractive_BasicUseCase(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(ref, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: assertThat(t, basicAssertions...),
+			},
+			// change "warehouse_type" externally
+			{
+				PreConfig: func() {
+					testClient().Warehouse.CreateWarehouseWithRequest(t,
+						sdk.NewCreateWarehouseRequest(warehouseId).WithOrReplace(true))
+				},
+				Config: accconfig.FromModels(t, basic),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(ref, plancheck.ResourceActionDestroyBeforeCreate),
+						planchecks.ExpectDrift(ref, "warehouse_type", new(string(sdk.WarehouseTypeInteractive)), new(string(sdk.WarehouseTypeStandard))),
+						planchecks.ExpectChange(ref, "warehouse_type", tfjson.ActionDelete, new(string(sdk.WarehouseTypeStandard)), nil),
 					},
 				},
 				Check: assertThat(t, basicAssertions...),


### PR DESCRIPTION
Snowflake does not allow changing WAREHOUSE_TYPE via ALTER to INTERACTIVE. Previously the warehouse and warehouse_adaptive resources planned an in-place update when the underlying object was changed externally to INTERACTIVE, which fails on apply.

Both resources now force resource recreation in that case:
- warehouse: a ForceNewIfChange custom diff on warehouse_type.
- warehouse_adaptive: HandleWarehouseExternalTypeChange forces recreation when the external type is INTERACTIVE.