### PR TITLE
fix: Nil check for parquet NULL_IF in stage config model builder

### DIFF
--- a/pkg/acceptance/bettertestspoc/config/model/stage_common.go
+++ b/pkg/acceptance/bettertestspoc/config/model/stage_common.go
@@ -300,7 +300,7 @@ func stageFileFormatParquet(opts sdk.FileFormatParquetOptions) tfconfig.Variable
 	if opts.ReplaceInvalidCharacters != nil {
 		parquetMap["replace_invalid_characters"] = tfconfig.BoolVariable(*opts.ReplaceInvalidCharacters)
 	}
-	if len(opts.NullIf.NullIf) > 0 {
+	if opts.NullIf != nil {
 		nullIfVars := make([]tfconfig.Variable, len(opts.NullIf.NullIf))
 		for idx, v := range opts.NullIf.NullIf {
 			nullIfVars[idx] = tfconfig.StringVariable(v.S)


### PR DESCRIPTION
## Description

`stageFileFormatParquet` in `pkg/acceptance/bettertestspoc/config/model/stage_common.go` dereferenced `opts.NullIf` before checking it for nil:

```go
if len(opts.NullIf.NullIf) > 0 {
```

Any `WithFileFormatParquet(...)` call that did not set `NullIf` therefore panicked while building the test config. This is what broke `TestAcc_Stages_CompleteUseCase` — its parquet step sets only `Compression`.

The guard is now `opts.NullIf != nil`, matching the four sibling helpers (csv, json, avro, orc), which already did the nil check. Parquet was the only outlier.

Test-only change, no user-facing impact, so no migration guide entry.

## References

n/a